### PR TITLE
US-3.1: Style tags and lyrics CLI parameters

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -147,13 +147,16 @@ def generate(
         output_path = Path.cwd()
     output_path.mkdir(parents=True, exist_ok=True)
 
-    # Resolve lyrics: --lyrics-file overrides --lyrics
     resolved_lyrics = lyrics
     if lyrics_file is not None:
-        if not lyrics_file.exists():
+        if not lyrics_file.is_file():
             console.print(f"[red]Lyrics file not found: {lyrics_file}[/red]")
             raise typer.Exit(code=1)
-        resolved_lyrics = lyrics_file.read_text()
+        try:
+            resolved_lyrics = lyrics_file.read_text()
+        except OSError as exc:
+            console.print(f"[red]Cannot read lyrics file {lyrics_file}: {exc}[/red]")
+            raise typer.Exit(code=1)
 
     slug = make_slug(prompt)
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
@@ -177,7 +180,7 @@ def generate(
                 safe_name=safe_name,
                 style=style,
                 lyrics=resolved_lyrics,
-                vocal_language=vocal_language,
+                vocal_language=vocal_language if vocal_language is not None else "auto",
                 instrumental=instrumental,
             )
             return

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -123,10 +123,16 @@ def generate(
     output: Optional[Path] = typer.Option(None, "--output", help="Directory to save generated files."),
     name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix (e.g. 'demo' → demo-1.wav)."),
     backend: str = typer.Option("ace-step", "--backend", help="AI backend: 'ace-step' (default) or 'elevenlabs'."),
-    style: Optional[str] = typer.Option(None, "--style", help="Comma-separated style descriptors (e.g. 'dark electro, punchy drums')."),
-    lyrics: Optional[str] = typer.Option(None, "--lyrics", help="Inline lyrics text (supports structure tags like [Verse])."),
+    style: Optional[str] = typer.Option(
+        None, "--style", help="Comma-separated style descriptors (e.g. 'dark electro, punchy drums')."
+    ),
+    lyrics: Optional[str] = typer.Option(
+        None, "--lyrics", help="Inline lyrics text (supports structure tags like [Verse])."
+    ),
     lyrics_file: Optional[Path] = typer.Option(None, "--lyrics-file", help="Path to a text file containing lyrics."),
-    vocal_language: Optional[str] = typer.Option(None, "--vocal-language", help="ISO 639-1 vocal language code (ACE-Step only, e.g. 'en', 'ja')."),
+    vocal_language: Optional[str] = typer.Option(
+        None, "--vocal-language", help="ISO 639-1 vocal language code (ACE-Step only, e.g. 'en', 'ja')."
+    ),
     instrumental: bool = typer.Option(False, "--instrumental", help="Suppress vocals entirely."),
 ) -> None:
     """Generate music from a text prompt using the ACE-Step model or ElevenLabs cloud."""

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -153,7 +153,7 @@ def generate(
             console.print(f"[red]Lyrics file not found: {lyrics_file}[/red]")
             raise typer.Exit(code=1)
         try:
-            resolved_lyrics = lyrics_file.read_text()
+            resolved_lyrics = lyrics_file.read_text(encoding="utf-8")
         except OSError as exc:
             console.print(f"[red]Cannot read lyrics file {lyrics_file}: {exc}[/red]")
             raise typer.Exit(code=1)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -123,6 +123,11 @@ def generate(
     output: Optional[Path] = typer.Option(None, "--output", help="Directory to save generated files."),
     name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix (e.g. 'demo' → demo-1.wav)."),
     backend: str = typer.Option("ace-step", "--backend", help="AI backend: 'ace-step' (default) or 'elevenlabs'."),
+    style: Optional[str] = typer.Option(None, "--style", help="Comma-separated style descriptors (e.g. 'dark electro, punchy drums')."),
+    lyrics: Optional[str] = typer.Option(None, "--lyrics", help="Inline lyrics text (supports structure tags like [Verse])."),
+    lyrics_file: Optional[Path] = typer.Option(None, "--lyrics-file", help="Path to a text file containing lyrics."),
+    vocal_language: Optional[str] = typer.Option(None, "--vocal-language", help="ISO 639-1 vocal language code (ACE-Step only, e.g. 'en', 'ja')."),
+    instrumental: bool = typer.Option(False, "--instrumental", help="Suppress vocals entirely."),
 ) -> None:
     """Generate music from a text prompt using the ACE-Step model or ElevenLabs cloud."""
     config = load_config()
@@ -135,6 +140,14 @@ def generate(
     else:
         output_path = Path.cwd()
     output_path.mkdir(parents=True, exist_ok=True)
+
+    # Resolve lyrics: --lyrics-file overrides --lyrics
+    resolved_lyrics = lyrics
+    if lyrics_file is not None:
+        if not lyrics_file.exists():
+            console.print(f"[red]Lyrics file not found: {lyrics_file}[/red]")
+            raise typer.Exit(code=1)
+        resolved_lyrics = lyrics_file.read_text()
 
     slug = make_slug(prompt)
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
@@ -156,6 +169,10 @@ def generate(
                 slug=slug,
                 timestamp=timestamp,
                 safe_name=safe_name,
+                style=style,
+                lyrics=resolved_lyrics,
+                vocal_language=vocal_language,
+                instrumental=instrumental,
             )
             return
         except AceStepError as exc:
@@ -178,6 +195,10 @@ def generate(
                 "[red]ELEVENLABS_API_KEY is not configured. " "Set it in .env to use the ElevenLabs backend.[/red]"
             )
             raise typer.Exit(code=1)
+        if vocal_language is not None:
+            console.print(
+                "[yellow]Warning: --vocal-language is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
+            )
         el_client = ElevenLabsClient(
             api_key=config.elevenlabs_api_key,
             output_format=config.elevenlabs_output_format,
@@ -192,6 +213,9 @@ def generate(
             timestamp=timestamp,
             safe_name=safe_name,
             output_format=config.elevenlabs_output_format,
+            style=style,
+            lyrics=resolved_lyrics,
+            instrumental=instrumental,
         )
         return
 
@@ -210,12 +234,25 @@ def _generate_via_ace_step(
     slug: str,
     timestamp: str,
     safe_name: Optional[str],
+    style: Optional[str] = None,
+    lyrics: Optional[str] = None,
+    vocal_language: Optional[str] = None,
+    instrumental: bool = False,
 ) -> None:
     """Submit, poll, and download audio via the ACE-Step backend."""
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
     poll_interval = 2.0
 
-    task_id = ace_client.submit_task(prompt=prompt, num_clips=num_clips, audio_duration=duration, format=format)
+    task_id = ace_client.submit_task(
+        prompt=prompt,
+        num_clips=num_clips,
+        audio_duration=duration,
+        format=format,
+        style=style,
+        lyrics=lyrics,
+        vocal_language=vocal_language,
+        instrumental=instrumental,
+    )
     console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
 
     start = time.monotonic()
@@ -292,6 +329,9 @@ def _generate_via_elevenlabs(
     timestamp: str,
     safe_name: Optional[str],
     output_format: str,
+    style: Optional[str] = None,
+    lyrics: Optional[str] = None,
+    instrumental: bool = False,
 ) -> None:
     """Generate N clips sequentially via ElevenLabs and save them to disk."""
     ext = _elevenlabs_ext(output_format)
@@ -299,7 +339,13 @@ def _generate_via_elevenlabs(
     for i in range(1, num_clips + 1):
         with console.status(f"[bold green]Clip {i}/{num_clips}…[/bold green]", spinner="dots"):
             try:
-                data = el_client.generate(prompt=prompt, duration=duration)
+                data = el_client.generate(
+                    prompt=prompt,
+                    duration=duration,
+                    instrumental=instrumental,
+                    style=style,
+                    lyrics=lyrics,
+                )
             except ElevenLabsError as exc:
                 console.print(f"[red]ElevenLabs error: {exc}[/red]")
                 raise typer.Exit(code=1)

--- a/src/acemusic/client.py
+++ b/src/acemusic/client.py
@@ -56,6 +56,10 @@ class AceStepClient:
         num_clips: int = 2,
         audio_duration: float | None = None,
         format: str = "wav",
+        style: str | None = None,
+        lyrics: str | None = None,
+        vocal_language: str | None = None,
+        instrumental: bool = False,
     ) -> str:
         """Submit a generation task via POST /release_task and return the task_id.
 
@@ -64,6 +68,10 @@ class AceStepClient:
             num_clips: Number of audio clips to generate (maps to batch_size).
             audio_duration: Target duration in seconds, or None for server default.
             format: Output audio format (maps to audio_format).
+            style: Comma-separated style descriptors (e.g. "dark electro, punchy drums").
+            lyrics: Inline lyrics text (may include structure tags like [Verse]).
+            vocal_language: ISO 639-1 vocal language code (e.g. "en", "ja").
+            instrumental: If True, suppresses vocals.
 
         Raises:
             AceStepError: on HTTP error, connection failure, or missing task_id.
@@ -71,6 +79,14 @@ class AceStepClient:
         payload: dict = {"prompt": prompt, "batch_size": num_clips, "audio_format": format}
         if audio_duration is not None:
             payload["audio_duration"] = audio_duration
+        if style is not None:
+            payload["style"] = style
+        if lyrics is not None:
+            payload["lyrics"] = lyrics
+        if vocal_language is not None:
+            payload["vocal_language"] = vocal_language
+        if instrumental:
+            payload["instrumental"] = True
         try:
             response = httpx.post(
                 f"{self.base_url}/release_task",

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -25,6 +25,8 @@ class ElevenLabsClient:
         prompt: str,
         duration: float | None = None,
         instrumental: bool = False,
+        style: str | None = None,
+        lyrics: str | None = None,
     ) -> bytes:
         """Generate music via POST /v1/music and return the raw audio bytes.
 
@@ -32,6 +34,8 @@ class ElevenLabsClient:
             prompt: Text description of the music.
             duration: Target duration in seconds (converted to music_length_ms).
             instrumental: If True, sets force_instrumental in the request body.
+            style: Comma-separated style descriptors forwarded to the API.
+            lyrics: Inline lyrics text forwarded to the API.
 
         Raises:
             ElevenLabsError: On HTTP error or connection failure.
@@ -41,6 +45,10 @@ class ElevenLabsClient:
             body["music_length_ms"] = int(duration * 1000)
         if instrumental:
             body["force_instrumental"] = True
+        if style is not None:
+            body["style"] = style
+        if lyrics is not None:
+            body["lyrics"] = lyrics
 
         try:
             response = httpx.post(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -537,7 +537,16 @@ class TestStyleLyricsElevenLabs:
         ):
             result = runner.invoke(
                 app,
-                ["generate", "pop song", "--backend", "elevenlabs", "--style", "dark electro", "--output", str(tmp_path)],
+                [
+                    "generate",
+                    "pop song",
+                    "--backend",
+                    "elevenlabs",
+                    "--style",
+                    "dark electro",
+                    "--output",
+                    str(tmp_path),
+                ],
             )
 
         assert result.exit_code == 0, result.output
@@ -567,7 +576,16 @@ class TestStyleLyricsElevenLabs:
         ):
             result = runner.invoke(
                 app,
-                ["generate", "pop song", "--backend", "elevenlabs", "--lyrics", "[Chorus]\nSing", "--output", str(tmp_path)],
+                [
+                    "generate",
+                    "pop song",
+                    "--backend",
+                    "elevenlabs",
+                    "--lyrics",
+                    "[Chorus]\nSing",
+                    "--output",
+                    str(tmp_path),
+                ],
             )
 
         assert result.exit_code == 0, result.output
@@ -640,4 +658,8 @@ class TestStyleLyricsElevenLabs:
             )
 
         assert result.exit_code == 0, result.output
-        assert "warning" in result.output.lower() or "ignored" in result.output.lower() or "elevenlabs" in result.output.lower()
+        assert (
+            "warning" in result.output.lower()
+            or "ignored" in result.output.lower()
+            or "elevenlabs" in result.output.lower()
+        )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -362,3 +362,282 @@ class TestGenerateOutputNaming:
 
         assert result.exit_code == 0, result.output
         assert len(list(tmp_path.glob("*.wav"))) == 2
+
+
+# ---------------------------------------------------------------------------
+# US-3.1: Style, lyrics, vocal-language, instrumental flags
+# ---------------------------------------------------------------------------
+
+
+class TestStyleLyricsFlags:
+    """Tests for US-3.1: --style, --lyrics, --lyrics-file, --vocal-language, --instrumental."""
+
+    def test_style_flag_passed_to_submit_task(self, monkeypatch, tmp_path):
+        """--style value is forwarded as 'style' kwarg to AceStepClient.submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop song", "--style", "upbeat, synth-pop", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs.kwargs.get("style") == "upbeat, synth-pop" or "upbeat, synth-pop" in str(call_kwargs)
+
+    def test_lyrics_flag_passed_to_submit_task(self, monkeypatch, tmp_path):
+        """--lyrics value is forwarded as 'lyrics' kwarg to AceStepClient.submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop song", "--lyrics", "[Verse]\nHello world", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs.kwargs.get("lyrics") == "[Verse]\nHello world" or "[Verse]" in str(call_kwargs)
+
+    def test_lyrics_file_flag_reads_file_and_passes_content(self, monkeypatch, tmp_path):
+        """--lyrics-file reads lyrics from disk and sends file content to the API."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        lyrics_file = tmp_path / "song.txt"
+        lyrics_file.write_text("[Verse]\nHello world\n[Chorus]\nSing along")
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop song", "--lyrics-file", str(lyrics_file), "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = client_mock.submit_task.call_args
+        assert "Hello world" in str(call_kwargs)
+
+    def test_lyrics_file_missing_exits_one(self, monkeypatch, tmp_path):
+        """--lyrics-file with a missing path exits 1 with a clear error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        result = runner.invoke(
+            app,
+            ["generate", "pop song", "--lyrics-file", "/nonexistent/lyrics.txt", "--output", str(tmp_path)],
+        )
+
+        assert result.exit_code != 0
+
+    def test_vocal_language_passed_to_submit_task(self, monkeypatch, tmp_path):
+        """--vocal-language is forwarded as 'vocal_language' kwarg to AceStepClient.submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop song", "--vocal-language", "ja", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs.kwargs.get("vocal_language") == "ja" or "ja" in str(call_kwargs)
+
+    def test_instrumental_flag_passed_to_submit_task(self, monkeypatch, tmp_path):
+        """--instrumental is forwarded as instrumental=True to AceStepClient.submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop song", "--instrumental", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs.kwargs.get("instrumental") is True or "True" in str(call_kwargs)
+
+    def test_all_three_inputs_ace_step(self, monkeypatch, tmp_path):
+        """All three inputs (prompt + style + lyrics) are passed together to ACE-Step."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "generate",
+                    "pop song",
+                    "--style",
+                    "upbeat, synth-pop",
+                    "--lyrics",
+                    "[Verse]\nHello world",
+                    "--output",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_str = str(client_mock.submit_task.call_args)
+        assert "upbeat, synth-pop" in call_str
+        assert "Hello world" in call_str
+
+
+class TestStyleLyricsElevenLabs:
+    """Tests for US-3.1: --style, --lyrics, --instrumental forwarded to ElevenLabs."""
+
+    def test_style_forwarded_to_elevenlabs(self, monkeypatch, tmp_path):
+        """--style is forwarded to ElevenLabsClient.generate() as 'style'."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop song", "--backend", "elevenlabs", "--style", "dark electro", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_str = str(el_mock.generate.call_args)
+        assert "dark electro" in call_str
+
+    def test_lyrics_forwarded_to_elevenlabs(self, monkeypatch, tmp_path):
+        """--lyrics is forwarded to ElevenLabsClient.generate() as 'lyrics'."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop song", "--backend", "elevenlabs", "--lyrics", "[Chorus]\nSing", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_str = str(el_mock.generate.call_args)
+        assert "Sing" in call_str
+
+    def test_instrumental_forwarded_to_elevenlabs(self, monkeypatch, tmp_path):
+        """--instrumental is forwarded to ElevenLabsClient.generate() as instrumental=True."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop song", "--backend", "elevenlabs", "--instrumental", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_str = str(el_mock.generate.call_args)
+        assert "True" in call_str or "instrumental=True" in call_str
+
+    def test_vocal_language_elevenlabs_prints_warning(self, monkeypatch, tmp_path):
+        """--vocal-language with ElevenLabs backend prints a warning and is ignored."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "generate",
+                    "pop song",
+                    "--backend",
+                    "elevenlabs",
+                    "--vocal-language",
+                    "ja",
+                    "--output",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "warning" in result.output.lower() or "ignored" in result.output.lower() or "elevenlabs" in result.output.lower()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -364,11 +364,6 @@ class TestGenerateOutputNaming:
         assert len(list(tmp_path.glob("*.wav"))) == 2
 
 
-# ---------------------------------------------------------------------------
-# US-3.1: Style, lyrics, vocal-language, instrumental flags
-# ---------------------------------------------------------------------------
-
-
 class TestStyleLyricsFlags:
     """Tests for US-3.1: --style, --lyrics, --lyrics-file, --vocal-language, --instrumental."""
 
@@ -388,8 +383,8 @@ class TestStyleLyricsFlags:
             )
 
         assert result.exit_code == 0, result.output
-        call_kwargs = client_mock.submit_task.call_args
-        assert call_kwargs.kwargs.get("style") == "upbeat, synth-pop" or "upbeat, synth-pop" in str(call_kwargs)
+        assert client_mock.submit_task.call_args is not None
+        assert client_mock.submit_task.call_args.kwargs["style"] == "upbeat, synth-pop"
 
     def test_lyrics_flag_passed_to_submit_task(self, monkeypatch, tmp_path):
         """--lyrics value is forwarded as 'lyrics' kwarg to AceStepClient.submit_task."""
@@ -407,8 +402,8 @@ class TestStyleLyricsFlags:
             )
 
         assert result.exit_code == 0, result.output
-        call_kwargs = client_mock.submit_task.call_args
-        assert call_kwargs.kwargs.get("lyrics") == "[Verse]\nHello world" or "[Verse]" in str(call_kwargs)
+        assert client_mock.submit_task.call_args is not None
+        assert client_mock.submit_task.call_args.kwargs["lyrics"] == "[Verse]\nHello world"
 
     def test_lyrics_file_flag_reads_file_and_passes_content(self, monkeypatch, tmp_path):
         """--lyrics-file reads lyrics from disk and sends file content to the API."""
@@ -441,7 +436,8 @@ class TestStyleLyricsFlags:
             ["generate", "pop song", "--lyrics-file", "/nonexistent/lyrics.txt", "--output", str(tmp_path)],
         )
 
-        assert result.exit_code != 0
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower() or "lyrics" in result.output.lower()
 
     def test_vocal_language_passed_to_submit_task(self, monkeypatch, tmp_path):
         """--vocal-language is forwarded as 'vocal_language' kwarg to AceStepClient.submit_task."""
@@ -459,8 +455,8 @@ class TestStyleLyricsFlags:
             )
 
         assert result.exit_code == 0, result.output
-        call_kwargs = client_mock.submit_task.call_args
-        assert call_kwargs.kwargs.get("vocal_language") == "ja" or "ja" in str(call_kwargs)
+        assert client_mock.submit_task.call_args is not None
+        assert client_mock.submit_task.call_args.kwargs["vocal_language"] == "ja"
 
     def test_instrumental_flag_passed_to_submit_task(self, monkeypatch, tmp_path):
         """--instrumental is forwarded as instrumental=True to AceStepClient.submit_task."""
@@ -478,8 +474,8 @@ class TestStyleLyricsFlags:
             )
 
         assert result.exit_code == 0, result.output
-        call_kwargs = client_mock.submit_task.call_args
-        assert call_kwargs.kwargs.get("instrumental") is True or "True" in str(call_kwargs)
+        assert client_mock.submit_task.call_args is not None
+        assert client_mock.submit_task.call_args.kwargs["instrumental"] is True
 
     def test_all_three_inputs_ace_step(self, monkeypatch, tmp_path):
         """All three inputs (prompt + style + lyrics) are passed together to ACE-Step."""
@@ -550,8 +546,8 @@ class TestStyleLyricsElevenLabs:
             )
 
         assert result.exit_code == 0, result.output
-        call_str = str(el_mock.generate.call_args)
-        assert "dark electro" in call_str
+        assert el_mock.generate.call_args is not None
+        assert el_mock.generate.call_args.kwargs["style"] == "dark electro"
 
     def test_lyrics_forwarded_to_elevenlabs(self, monkeypatch, tmp_path):
         """--lyrics is forwarded to ElevenLabsClient.generate() as 'lyrics'."""
@@ -589,8 +585,8 @@ class TestStyleLyricsElevenLabs:
             )
 
         assert result.exit_code == 0, result.output
-        call_str = str(el_mock.generate.call_args)
-        assert "Sing" in call_str
+        assert el_mock.generate.call_args is not None
+        assert el_mock.generate.call_args.kwargs["lyrics"] == "[Chorus]\nSing"
 
     def test_instrumental_forwarded_to_elevenlabs(self, monkeypatch, tmp_path):
         """--instrumental is forwarded to ElevenLabsClient.generate() as instrumental=True."""
@@ -619,8 +615,8 @@ class TestStyleLyricsElevenLabs:
             )
 
         assert result.exit_code == 0, result.output
-        call_str = str(el_mock.generate.call_args)
-        assert "True" in call_str or "instrumental=True" in call_str
+        assert el_mock.generate.call_args is not None
+        assert el_mock.generate.call_args.kwargs["instrumental"] is True
 
     def test_vocal_language_elevenlabs_prints_warning(self, monkeypatch, tmp_path):
         """--vocal-language with ElevenLabs backend prints a warning and is ignored."""
@@ -658,8 +654,4 @@ class TestStyleLyricsElevenLabs:
             )
 
         assert result.exit_code == 0, result.output
-        assert (
-            "warning" in result.output.lower()
-            or "ignored" in result.output.lower()
-            or "elevenlabs" in result.output.lower()
-        )
+        assert "warning" in result.output.lower() or "ignored" in result.output.lower()


### PR DESCRIPTION
## Summary

- Adds `--style`, `--lyrics`, `--lyrics-file`, `--vocal-language`, and `--instrumental` flags to `acemusic generate`
- Style and lyrics are sent as **separate API parameters** (not merged into the prompt)
- `--lyrics-file` reads from disk and exits 1 with a clear error if the file is not found
- `--vocal-language` is ACE-Step-specific — a warning is printed and the flag is ignored when using the ElevenLabs backend
- All new params are forwarded through `AceStepClient.submit_task` and `ElevenLabsClient.generate`

Closes #19

## Test plan

- [x] `test_style_flag_passed_to_submit_task` — style value forwarded to ACE-Step
- [x] `test_lyrics_flag_passed_to_submit_task` — inline lyrics forwarded to ACE-Step
- [x] `test_lyrics_file_flag_reads_file_and_passes_content` — file content forwarded to ACE-Step
- [x] `test_lyrics_file_missing_exits_one` — missing file exits 1
- [x] `test_vocal_language_passed_to_submit_task` — vocal_language forwarded to ACE-Step
- [x] `test_instrumental_flag_passed_to_submit_task` — instrumental forwarded to ACE-Step
- [x] `test_all_three_inputs_ace_step` — prompt + style + lyrics together (AC1)
- [x] `test_style_forwarded_to_elevenlabs` — style forwarded to ElevenLabs
- [x] `test_lyrics_forwarded_to_elevenlabs` — lyrics forwarded to ElevenLabs
- [x] `test_instrumental_forwarded_to_elevenlabs` — instrumental forwarded (AC3)
- [x] `test_vocal_language_elevenlabs_prints_warning` — warning printed, flag ignored (AC4)
- [x] All 97 unit tests pass, 87% coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added style, lyrics, lyrics-file, vocal-language, and instrumental options to the generate command
  * Lyrics file input overrides inline lyrics and is loaded automatically
  * New options are forwarded to supported backends during audio generation

* **Bug Fixes**
  * CLI exits with an error when a specified lyrics file cannot be read
  * Emits a warning when vocal-language is provided for a backend that ignores it

* **Tests**
  * Added tests for new flags, file loading, warning behavior, and backend forwarding
<!-- end of auto-generated comment: release notes by coderabbit.ai -->