### PR TITLE
feat: US-3.3 quality/speed tradeoff and creative parameters

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -201,6 +201,12 @@ def generate(
         console.print(f"[red]Invalid --format: {format!r}. Allowed values: {', '.join(sorted(_VALID_FORMATS))}[/red]")
         raise typer.Exit(code=1)
 
+    if inference_steps is not None and inference_steps <= 0:
+        console.print(
+            f"[red]Invalid --inference-steps: {inference_steps}. --inference-steps must be a positive integer.[/red]"
+        )
+        raise typer.Exit(code=1)
+
     if not (0 <= weirdness <= 100):
         console.print(f"[red]Invalid --weirdness: {weirdness}. Must be between 0 and 100.[/red]")
         raise typer.Exit(code=1)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -187,16 +187,18 @@ def generate(
     inference_steps: Optional[int] = typer.Option(
         None, "--inference-steps", help="Number of diffusion steps (Turbo: 8, Standard: 32-64). ACE-Step only."
     ),
-    weirdness: int = typer.Option(50, "--weirdness", help="Deviation from conventional structures (0-100). ACE-Step only."),
-    style_influence: int = typer.Option(50, "--style-influence", help="Adherence to style descriptors (0-100). ACE-Step only."),
+    weirdness: int = typer.Option(
+        50, "--weirdness", help="Deviation from conventional structures (0-100). ACE-Step only."
+    ),
+    style_influence: int = typer.Option(
+        50, "--style-influence", help="Adherence to style descriptors (0-100). ACE-Step only."
+    ),
     thinking: bool = typer.Option(False, "--thinking", help="Enable Chain-of-Thought mode. ACE-Step only."),
 ) -> None:
     """Generate music from a text prompt using the ACE-Step model or ElevenLabs cloud."""
     _VALID_FORMATS = {"wav", "flac", "mp3", "aac", "opus"}
     if format not in _VALID_FORMATS:
-        console.print(
-            f"[red]Invalid --format: {format!r}. Allowed values: {', '.join(sorted(_VALID_FORMATS))}[/red]"
-        )
+        console.print(f"[red]Invalid --format: {format!r}. Allowed values: {', '.join(sorted(_VALID_FORMATS))}[/red]")
         raise typer.Exit(code=1)
 
     if not (0 <= weirdness <= 100):
@@ -326,17 +328,13 @@ def generate(
                 "[yellow]Warning: --inference-steps is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
             )
         if weirdness != 50:
-            console.print(
-                "[yellow]Warning: --weirdness is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
-            )
+            console.print("[yellow]Warning: --weirdness is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]")
         if style_influence != 50:
             console.print(
                 "[yellow]Warning: --style-influence is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
             )
         if thinking:
-            console.print(
-                "[yellow]Warning: --thinking is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
-            )
+            console.print("[yellow]Warning: --thinking is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]")
 
         prompt_additions: list[str] = []
         if parsed_bpm is not None and parsed_bpm != "auto":

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -184,8 +184,29 @@ def generate(
     seed: Optional[int] = typer.Option(
         None, "--seed", help="Fixed seed for reproducibility (-1 for random). ACE-Step only."
     ),
+    inference_steps: Optional[int] = typer.Option(
+        None, "--inference-steps", help="Number of diffusion steps (Turbo: 8, Standard: 32-64). ACE-Step only."
+    ),
+    weirdness: int = typer.Option(50, "--weirdness", help="Deviation from conventional structures (0-100). ACE-Step only."),
+    style_influence: int = typer.Option(50, "--style-influence", help="Adherence to style descriptors (0-100). ACE-Step only."),
+    thinking: bool = typer.Option(False, "--thinking", help="Enable Chain-of-Thought mode. ACE-Step only."),
 ) -> None:
     """Generate music from a text prompt using the ACE-Step model or ElevenLabs cloud."""
+    _VALID_FORMATS = {"wav", "flac", "mp3", "aac", "opus"}
+    if format not in _VALID_FORMATS:
+        console.print(
+            f"[red]Invalid --format: {format!r}. Allowed values: {', '.join(sorted(_VALID_FORMATS))}[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if not (0 <= weirdness <= 100):
+        console.print(f"[red]Invalid --weirdness: {weirdness}. Must be between 0 and 100.[/red]")
+        raise typer.Exit(code=1)
+
+    if not (0 <= style_influence <= 100):
+        console.print(f"[red]Invalid --style-influence: {style_influence}. Must be between 0 and 100.[/red]")
+        raise typer.Exit(code=1)
+
     parsed_bpm: int | str | None = None
     if bpm is not None:
         try:
@@ -270,6 +291,10 @@ def generate(
                 key=key,
                 time_signature=time_signature,
                 seed=seed,
+                inference_steps=inference_steps,
+                weirdness=weirdness,
+                style_influence=style_influence,
+                thinking=thinking,
             )
             return
         except AceStepError as exc:
@@ -295,6 +320,22 @@ def generate(
         if vocal_language is not None:
             console.print(
                 "[yellow]Warning: --vocal-language is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
+            )
+        if inference_steps is not None:
+            console.print(
+                "[yellow]Warning: --inference-steps is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
+            )
+        if weirdness != 50:
+            console.print(
+                "[yellow]Warning: --weirdness is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
+            )
+        if style_influence != 50:
+            console.print(
+                "[yellow]Warning: --style-influence is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
+            )
+        if thinking:
+            console.print(
+                "[yellow]Warning: --thinking is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
             )
 
         prompt_additions: list[str] = []
@@ -373,6 +414,10 @@ def _generate_via_ace_step(
     key: Optional[str] = None,
     time_signature: Optional[str] = None,
     seed: Optional[int] = None,
+    inference_steps: Optional[int] = None,
+    weirdness: int = 50,
+    style_influence: int = 50,
+    thinking: bool = False,
 ) -> None:
     """Submit, poll, and download audio via the ACE-Step backend."""
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
@@ -391,6 +436,10 @@ def _generate_via_ace_step(
         key=key,
         time_signature=time_signature,
         seed=seed,
+        inference_steps=inference_steps,
+        weirdness=weirdness,
+        style_influence=style_influence,
+        thinking=thinking,
     )
     console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
 

--- a/src/acemusic/client.py
+++ b/src/acemusic/client.py
@@ -64,6 +64,10 @@ class AceStepClient:
         key: str | None = None,
         time_signature: str | None = None,
         seed: int | None = None,
+        inference_steps: int | None = None,
+        weirdness: int | None = None,
+        style_influence: int | None = None,
+        thinking: bool = False,
     ) -> str:
         """Submit a generation task via POST /release_task and return the task_id.
 
@@ -80,6 +84,10 @@ class AceStepClient:
             key: Tonal center (e.g. "C major") or "any".
             time_signature: Meter (e.g. "4/4", "3/4", "6/8", "5/4", "7/8").
             seed: Fixed seed for reproducibility (-1 or None for random).
+            inference_steps: Number of diffusion steps (Turbo: 8, Standard: 32–64).
+            weirdness: Deviation from conventional structures (0–100).
+            style_influence: Adherence to style descriptors (0–100).
+            thinking: If True, enables Chain-of-Thought mode.
 
         Raises:
             AceStepError: on HTTP error, connection failure, or missing task_id.
@@ -103,6 +111,14 @@ class AceStepClient:
             payload["time_signature"] = time_signature
         if seed is not None:
             payload["seed"] = seed
+        if inference_steps is not None:
+            payload["inference_steps"] = inference_steps
+        if weirdness is not None:
+            payload["weirdness"] = weirdness
+        if style_influence is not None:
+            payload["style_influence"] = style_influence
+        if thinking:
+            payload["thinking"] = True
         try:
             response = httpx.post(
                 f"{self.base_url}/release_task",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -120,6 +120,78 @@ class TestSubmitTask:
         payload = mock_post.call_args.kwargs["json"]
         assert "audio_duration" not in payload
 
+    def test_includes_inference_steps_when_provided(self):
+        """Includes inference_steps in the POST payload when provided."""
+        resp = _make_response(200, _wrapped({"task_id": "t1"}))
+        client = AceStepClient("http://localhost:8001")
+        with patch("acemusic.client.httpx.post", return_value=resp) as mock_post:
+            client.submit_task("pop", inference_steps=8)
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["inference_steps"] == 8
+
+    def test_omits_inference_steps_when_none(self):
+        """Omits inference_steps from the POST payload when None."""
+        resp = _make_response(200, _wrapped({"task_id": "t1"}))
+        client = AceStepClient("http://localhost:8001")
+        with patch("acemusic.client.httpx.post", return_value=resp) as mock_post:
+            client.submit_task("pop", inference_steps=None)
+        payload = mock_post.call_args.kwargs["json"]
+        assert "inference_steps" not in payload
+
+    def test_includes_weirdness_when_provided(self):
+        """Includes weirdness in the POST payload when provided."""
+        resp = _make_response(200, _wrapped({"task_id": "t1"}))
+        client = AceStepClient("http://localhost:8001")
+        with patch("acemusic.client.httpx.post", return_value=resp) as mock_post:
+            client.submit_task("pop", weirdness=75)
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["weirdness"] == 75
+
+    def test_omits_weirdness_when_none(self):
+        """Omits weirdness from the POST payload when None."""
+        resp = _make_response(200, _wrapped({"task_id": "t1"}))
+        client = AceStepClient("http://localhost:8001")
+        with patch("acemusic.client.httpx.post", return_value=resp) as mock_post:
+            client.submit_task("pop", weirdness=None)
+        payload = mock_post.call_args.kwargs["json"]
+        assert "weirdness" not in payload
+
+    def test_includes_style_influence_when_provided(self):
+        """Includes style_influence in the POST payload when provided."""
+        resp = _make_response(200, _wrapped({"task_id": "t1"}))
+        client = AceStepClient("http://localhost:8001")
+        with patch("acemusic.client.httpx.post", return_value=resp) as mock_post:
+            client.submit_task("pop", style_influence=80)
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["style_influence"] == 80
+
+    def test_omits_style_influence_when_none(self):
+        """Omits style_influence from the POST payload when None."""
+        resp = _make_response(200, _wrapped({"task_id": "t1"}))
+        client = AceStepClient("http://localhost:8001")
+        with patch("acemusic.client.httpx.post", return_value=resp) as mock_post:
+            client.submit_task("pop", style_influence=None)
+        payload = mock_post.call_args.kwargs["json"]
+        assert "style_influence" not in payload
+
+    def test_includes_thinking_true_when_set(self):
+        """Includes thinking=True in the POST payload when enabled."""
+        resp = _make_response(200, _wrapped({"task_id": "t1"}))
+        client = AceStepClient("http://localhost:8001")
+        with patch("acemusic.client.httpx.post", return_value=resp) as mock_post:
+            client.submit_task("pop", thinking=True)
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["thinking"] is True
+
+    def test_omits_thinking_when_false(self):
+        """Omits thinking from the POST payload when False (default)."""
+        resp = _make_response(200, _wrapped({"task_id": "t1"}))
+        client = AceStepClient("http://localhost:8001")
+        with patch("acemusic.client.httpx.post", return_value=resp) as mock_post:
+            client.submit_task("pop", thinking=False)
+        payload = mock_post.call_args.kwargs["json"]
+        assert "thinking" not in payload
+
 
 # ---------------------------------------------------------------------------
 # query_result

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -988,3 +988,268 @@ class TestMusicalParametersElevenLabs:
         assert "key" in result.output.lower()
         prompt_sent = el_mock.generate.call_args.kwargs["prompt"]
         assert "any" not in prompt_sent.lower()
+
+
+# ---------------------------------------------------------------------------
+# US-3.3: Quality/speed and creative parameters
+# ---------------------------------------------------------------------------
+
+
+class TestQualityCreativeParamsAceStep:
+    """Tests for US-3.3: --inference-steps, --weirdness, --style-influence, --thinking forwarded to ACE-Step."""
+
+    def test_inference_steps_forwarded(self, monkeypatch, tmp_path):
+        """--inference-steps 8 forwards inference_steps=8 to submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--inference-steps", "8", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["inference_steps"] == 8
+
+    def test_inference_steps_default_is_none(self, monkeypatch, tmp_path):
+        """When --inference-steps not given, inference_steps=None is forwarded."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["inference_steps"] is None
+
+    def test_weirdness_forwarded(self, monkeypatch, tmp_path):
+        """--weirdness 75 forwards weirdness=75 to submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--weirdness", "75", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["weirdness"] == 75
+
+    def test_style_influence_forwarded(self, monkeypatch, tmp_path):
+        """--style-influence 80 forwards style_influence=80 to submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--style-influence", "80", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["style_influence"] == 80
+
+    def test_thinking_forwarded(self, monkeypatch, tmp_path):
+        """--thinking forwards thinking=True to submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--thinking", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["thinking"] is True
+
+    def test_thinking_default_is_false(self, monkeypatch, tmp_path):
+        """When --thinking not given, thinking=False is forwarded."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["thinking"] is False
+
+    def test_weirdness_too_low_exits_one(self, monkeypatch, tmp_path):
+        """--weirdness -1 exits 1 with a validation error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["generate", "pop", "--weirdness", "-1", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "weirdness" in result.output.lower()
+        assert "Traceback" not in result.output
+
+    def test_weirdness_too_high_exits_one(self, monkeypatch, tmp_path):
+        """--weirdness 101 exits 1 with a validation error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["generate", "pop", "--weirdness", "101", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "weirdness" in result.output.lower()
+        assert "Traceback" not in result.output
+
+    def test_style_influence_too_low_exits_one(self, monkeypatch, tmp_path):
+        """--style-influence -1 exits 1 with a validation error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["generate", "pop", "--style-influence", "-1", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "style-influence" in result.output.lower() or "style_influence" in result.output.lower()
+        assert "Traceback" not in result.output
+
+    def test_style_influence_too_high_exits_one(self, monkeypatch, tmp_path):
+        """--style-influence 101 exits 1 with a validation error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["generate", "pop", "--style-influence", "101", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "style-influence" in result.output.lower() or "style_influence" in result.output.lower()
+        assert "Traceback" not in result.output
+
+
+class TestFormatValidation:
+    """Tests for US-3.3: --format validation."""
+
+    def test_valid_format_wav_accepted(self, monkeypatch, tmp_path):
+        """--format wav is accepted."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--format", "wav", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+
+    def test_valid_format_mp3_accepted(self, monkeypatch, tmp_path):
+        """--format mp3 is accepted."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--format", "mp3", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+
+    def test_valid_formats_all_accepted(self, monkeypatch, tmp_path):
+        """All valid formats (wav, flac, mp3, aac, opus) are accepted."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        for fmt in ("wav", "flac", "mp3", "aac", "opus"):
+            client_mock = _make_client_mock([COMPLETED_RESULT])
+            with (
+                patch("acemusic.cli.AceStepClient", return_value=client_mock),
+                patch("acemusic.cli.get_duration", return_value=3.0),
+            ):
+                result = runner.invoke(
+                    app, ["generate", "pop", "--format", fmt, "--output", str(tmp_path)]
+                )
+            assert result.exit_code == 0, f"Format {fmt!r} was rejected: {result.output}"
+
+    def test_invalid_format_exits_one(self, monkeypatch, tmp_path):
+        """--format ogg exits 1 with a validation error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["generate", "pop", "--format", "ogg", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "format" in result.output.lower()
+        assert "Traceback" not in result.output
+
+    def test_invalid_format_mp4_exits_one(self, monkeypatch, tmp_path):
+        """--format mp4 exits 1 with a validation error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["generate", "pop", "--format", "mp4", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "format" in result.output.lower()
+        assert "Traceback" not in result.output
+
+
+class TestQualityCreativeParamsElevenLabs:
+    """Tests for US-3.3: ElevenLabs warnings for ACE-Step-only quality params."""
+
+    def _el_config(self, monkeypatch):
+        from acemusic.config import AceConfig
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="el-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+    def _el_mock(self):
+        el_mock = MagicMock()
+        el_mock.generate.return_value = FAKE_WAV
+        return el_mock
+
+    def test_inference_steps_warns_on_elevenlabs(self, monkeypatch, tmp_path):
+        """--inference-steps warns when used with ElevenLabs backend."""
+        self._el_config(monkeypatch)
+        el_mock = self._el_mock()
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop", "--backend", "elevenlabs", "--inference-steps", "8", "--output", str(tmp_path)],
+            )
+        assert result.exit_code == 0, result.output
+        assert "inference" in result.output.lower() or "warning" in result.output.lower()
+
+    def test_weirdness_nondefault_warns_on_elevenlabs(self, monkeypatch, tmp_path):
+        """--weirdness 75 (non-default) warns when used with ElevenLabs backend."""
+        self._el_config(monkeypatch)
+        el_mock = self._el_mock()
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop", "--backend", "elevenlabs", "--weirdness", "75", "--output", str(tmp_path)],
+            )
+        assert result.exit_code == 0, result.output
+        assert "weirdness" in result.output.lower()
+
+    def test_weirdness_default_no_warning(self, monkeypatch, tmp_path):
+        """--weirdness 50 (default) does NOT warn when used with ElevenLabs backend."""
+        self._el_config(monkeypatch)
+        el_mock = self._el_mock()
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop", "--backend", "elevenlabs", "--weirdness", "50", "--output", str(tmp_path)],
+            )
+        assert result.exit_code == 0, result.output
+        assert "--weirdness is ace-step-specific" not in result.output.lower()
+
+    def test_style_influence_nondefault_warns_on_elevenlabs(self, monkeypatch, tmp_path):
+        """--style-influence 80 (non-default) warns when used with ElevenLabs backend."""
+        self._el_config(monkeypatch)
+        el_mock = self._el_mock()
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop", "--backend", "elevenlabs", "--style-influence", "80", "--output", str(tmp_path)],
+            )
+        assert result.exit_code == 0, result.output
+        assert "style-influence" in result.output.lower() or "style_influence" in result.output.lower()
+
+    def test_thinking_warns_on_elevenlabs(self, monkeypatch, tmp_path):
+        """--thinking warns when used with ElevenLabs backend."""
+        self._el_config(monkeypatch)
+        el_mock = self._el_mock()
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop", "--backend", "elevenlabs", "--thinking", "--output", str(tmp_path)],
+            )
+        assert result.exit_code == 0, result.output
+        assert "thinking" in result.output.lower()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1070,6 +1070,22 @@ class TestQualityCreativeParamsAceStep:
         assert result.exit_code == 0, result.output
         assert client_mock.submit_task.call_args.kwargs["thinking"] is False
 
+    def test_inference_steps_zero_exits_one(self, monkeypatch, tmp_path):
+        """--inference-steps 0 exits 1 with a validation error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["generate", "pop", "--inference-steps", "0", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "inference-steps" in result.output.lower()
+        assert "Traceback" not in result.output
+
+    def test_inference_steps_negative_exits_one(self, monkeypatch, tmp_path):
+        """--inference-steps -1 exits 1 with a validation error."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["generate", "pop", "--inference-steps", "-1", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "inference-steps" in result.output.lower()
+        assert "Traceback" not in result.output
+
     def test_weirdness_too_low_exits_one(self, monkeypatch, tmp_path):
         """--weirdness -1 exits 1 with a validation error."""
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1137,9 +1137,7 @@ class TestFormatValidation:
                 patch("acemusic.cli.AceStepClient", return_value=client_mock),
                 patch("acemusic.cli.get_duration", return_value=3.0),
             ):
-                result = runner.invoke(
-                    app, ["generate", "pop", "--format", fmt, "--output", str(tmp_path)]
-                )
+                result = runner.invoke(app, ["generate", "pop", "--format", fmt, "--output", str(tmp_path)])
             assert result.exit_code == 0, f"Format {fmt!r} was rejected: {result.output}"
 
     def test_invalid_format_exits_one(self, monkeypatch, tmp_path):
@@ -1164,6 +1162,7 @@ class TestQualityCreativeParamsElevenLabs:
 
     def _el_config(self, monkeypatch):
         from acemusic.config import AceConfig
+
         monkeypatch.setattr(
             "acemusic.cli.load_config",
             lambda: AceConfig(


### PR DESCRIPTION
## Summary

Closes #21

- **`--inference-steps N`** — diffusion step count (Turbo: 8, Standard: 32–64); omitted from payload when not set, letting server pick the default
- **`--weirdness 0–100`** — deviation from conventional structures (default 50)
- **`--style-influence 0–100`** — adherence to style descriptors (default 50)
- **`--thinking`** — enables Chain-of-Thought mode
- **`--format` validation** — restricts to `{wav, flac, mp3, aac, opus}`, exits 1 on invalid value
- ElevenLabs warnings follow the existing `--vocal-language` pattern

## Test plan

- [x] `test_client.py::TestSubmitTask` — 8 new tests for payload inclusion/omission
- [x] `test_generate.py::TestQualityCreativeParamsAceStep` — forwarding + range validation
- [x] `test_generate.py::TestFormatValidation` — valid/invalid format handling
- [x] `test_generate.py::TestQualityCreativeParamsElevenLabs` — warning messages
- [x] Full suite: 148 passed, 88% coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--inference-steps`, `--weirdness` (default 50), `--style-influence` (default 50), and `--thinking` parameters to music generation.
  * Added audio format validation supporting `wav`, `flac`, `mp3`, `aac`, and `opus`.

* **Bug Fixes**
  * Implemented input validation for weirdness and style-influence values (range 0–100) with clear error messages.
  * Added warnings when ACE-Step-only parameters are used with incompatible backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->