### PR TITLE
feat: US-3.4 model selection CLI — list and choose ACE-Step variants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ ACEMUSIC_API_KEY=
 # Base URL for the ACE-Step API (local or remote proxy)
 ACEMUSIC_BASE_URL=
 
+# Default ACE-Step model variant (turbo, base, sft, xl-base, xl-sft, xl-turbo)
+# Leave blank to use the server's built-in default
+ACEMUSIC_DEFAULT_MODEL=
+
 # URL of the local ACE-Step REST API server (default: http://localhost:8001)
 ACESTEP_LOCAL_URL=http://localhost:8001
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -21,6 +21,53 @@ from acemusic.utils import get_duration, make_filename, make_slug
 app = typer.Typer(help="acemusic — AI music generation CLI")
 console = Console()
 
+# ACE-Step model registry (US-3.4)
+MODELS: dict[str, dict] = {
+    "turbo": {
+        "name": "ACE-Step Turbo (2B)",
+        "description": "Fastest generation; best for quick drafts and iteration",
+        "vram": "~2.4GB",
+        "steps": "8",
+        "dit_size": "2B",
+    },
+    "base": {
+        "name": "ACE-Step Base (2B)",
+        "description": "Balanced quality/speed; general-purpose generation",
+        "vram": "~2.4GB",
+        "steps": "32-64",
+        "dit_size": "2B",
+    },
+    "sft": {
+        "name": "ACE-Step SFT (2B)",
+        "description": "Fine-tuned on supervised data; improved coherence",
+        "vram": "~2.4GB",
+        "steps": "32-64",
+        "dit_size": "2B",
+    },
+    "xl-base": {
+        "name": "ACE-Step XL Base (4B)",
+        "description": "Highest quality; best for professional-grade output",
+        "vram": "~8GB",
+        "steps": "32-64",
+        "dit_size": "4B",
+    },
+    "xl-sft": {
+        "name": "ACE-Step XL SFT (4B)",
+        "description": "XL fine-tuned; premium quality with improved coherence",
+        "vram": "~8GB",
+        "steps": "32-64",
+        "dit_size": "4B",
+    },
+    "xl-turbo": {
+        "name": "ACE-Step XL Turbo (4B)",
+        "description": "Fast XL generation; high quality with reduced steps",
+        "vram": "~8GB",
+        "steps": "8",
+        "dit_size": "4B",
+    },
+}
+VALID_MODELS: frozenset[str] = frozenset(MODELS.keys())
+
 
 def _version_callback(value: bool) -> None:
     """Print version string and exit when --version flag is set."""
@@ -44,7 +91,7 @@ def main(
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())
         raise typer.Exit(0)
-    else:
+    elif ctx.invoked_subcommand not in ("models",):
         config = load_config()
         if not config.api_url:
             typer.echo("ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml")
@@ -104,6 +151,19 @@ def health() -> None:
 
     if not ace_healthy:
         raise typer.Exit(code=1)
+
+
+@app.command()
+def models() -> None:
+    """List available ACE-Step model variants with VRAM and inference step requirements."""
+    table = Table(title="ACE-Step Model Variants", show_header=True)
+    table.add_column("Model", style="cyan", no_wrap=True)
+    table.add_column("Description")
+    table.add_column("VRAM", style="yellow", no_wrap=True)
+    table.add_column("Inference Steps", style="green", no_wrap=True)
+    for key, info in MODELS.items():
+        table.add_row(key, info["description"], info["vram"], info["steps"])
+    console.print(table)
 
 
 def _is_connection_error(exc: AceStepError) -> bool:
@@ -194,6 +254,11 @@ def generate(
         50, "--style-influence", help="Adherence to style descriptors (0-100). ACE-Step only."
     ),
     thinking: bool = typer.Option(False, "--thinking", help="Enable Chain-of-Thought mode. ACE-Step only."),
+    model: Optional[str] = typer.Option(
+        None,
+        "--model",
+        help=f"ACE-Step model variant ({', '.join(sorted(VALID_MODELS))}). ACE-Step only.",
+    ),
 ) -> None:
     """Generate music from a text prompt using the ACE-Step model or ElevenLabs cloud."""
     _VALID_FORMATS = {"wav", "flac", "mp3", "aac", "opus"}
@@ -251,6 +316,14 @@ def generate(
 
     config = load_config()
 
+    # Resolve model: --model flag > config.default_model > None (server default)
+    resolved_model = model or config.default_model or None
+    if resolved_model is not None and resolved_model not in VALID_MODELS:
+        console.print(
+            f"[red]Invalid --model: {resolved_model!r}. Valid options: {', '.join(sorted(VALID_MODELS))}[/red]"
+        )
+        raise typer.Exit(code=1)
+
     # Resolve output directory: --output > config output_dir > CWD
     if output is not None:
         output_path = output
@@ -303,6 +376,7 @@ def generate(
                 weirdness=weirdness,
                 style_influence=style_influence,
                 thinking=thinking,
+                model=resolved_model,
             )
             return
         except AceStepError as exc:
@@ -313,7 +387,7 @@ def generate(
             # Connection failure — attempt auto-fallback
             if not config.elevenlabs_api_key:
                 console.print(
-                    f"[red]ACE-Step unavailable ({exc}). " "Set ELEVENLABS_API_KEY to enable automatic fallback.[/red]"
+                    f"[red]ACE-Step unavailable ({exc}). Set ELEVENLABS_API_KEY to enable automatic fallback.[/red]"
                 )
                 raise typer.Exit(code=1)
             console.print("[yellow]ACE-Step unavailable — falling back to ElevenLabs[/yellow]")
@@ -322,7 +396,7 @@ def generate(
     if effective_backend == "elevenlabs":
         if not config.elevenlabs_api_key:
             console.print(
-                "[red]ELEVENLABS_API_KEY is not configured. " "Set it in .env to use the ElevenLabs backend.[/red]"
+                "[red]ELEVENLABS_API_KEY is not configured. Set it in .env to use the ElevenLabs backend.[/red]"
             )
             raise typer.Exit(code=1)
         if vocal_language is not None:
@@ -341,6 +415,8 @@ def generate(
             )
         if thinking:
             console.print("[yellow]Warning: --thinking is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]")
+        if resolved_model is not None:
+            console.print("[yellow]Warning: --model is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]")
 
         prompt_additions: list[str] = []
         if parsed_bpm is not None and parsed_bpm != "auto":
@@ -422,6 +498,7 @@ def _generate_via_ace_step(
     weirdness: int = 50,
     style_influence: int = 50,
     thinking: bool = False,
+    model: Optional[str] = None,
 ) -> None:
     """Submit, poll, and download audio via the ACE-Step backend."""
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
@@ -444,6 +521,7 @@ def _generate_via_ace_step(
         weirdness=weirdness,
         style_influence=style_influence,
         thinking=thinking,
+        model=model,
     )
     console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -21,45 +21,41 @@ from acemusic.utils import get_duration, make_filename, make_slug
 app = typer.Typer(help="acemusic — AI music generation CLI")
 console = Console()
 
-# ACE-Step model registry (US-3.4)
-MODELS: dict[str, dict] = {
+# ACE-Step model registry (US-3.4).
+# Keys map directly to the --model flag value and the API's model field.
+# All fields are rendered in `acemusic models` output.
+MODELS: dict[str, dict[str, str]] = {
     "turbo": {
-        "name": "ACE-Step Turbo (2B)",
         "description": "Fastest generation; best for quick drafts and iteration",
         "vram": "~2.4GB",
         "steps": "8",
         "dit_size": "2B",
     },
     "base": {
-        "name": "ACE-Step Base (2B)",
         "description": "Balanced quality/speed; general-purpose generation",
         "vram": "~2.4GB",
         "steps": "32-64",
         "dit_size": "2B",
     },
     "sft": {
-        "name": "ACE-Step SFT (2B)",
         "description": "Fine-tuned on supervised data; improved coherence",
         "vram": "~2.4GB",
         "steps": "32-64",
         "dit_size": "2B",
     },
     "xl-base": {
-        "name": "ACE-Step XL Base (4B)",
         "description": "Highest quality; best for professional-grade output",
         "vram": "~8GB",
         "steps": "32-64",
         "dit_size": "4B",
     },
     "xl-sft": {
-        "name": "ACE-Step XL SFT (4B)",
         "description": "XL fine-tuned; premium quality with improved coherence",
         "vram": "~8GB",
         "steps": "32-64",
         "dit_size": "4B",
     },
     "xl-turbo": {
-        "name": "ACE-Step XL Turbo (4B)",
         "description": "Fast XL generation; high quality with reduced steps",
         "vram": "~8GB",
         "steps": "8",
@@ -91,7 +87,7 @@ def main(
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())
         raise typer.Exit(0)
-    elif ctx.invoked_subcommand not in ("models",):
+    elif ctx.invoked_subcommand not in ("models",):  # offline-safe subcommands skip URL check
         config = load_config()
         if not config.api_url:
             typer.echo("ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml")
@@ -159,10 +155,11 @@ def models() -> None:
     table = Table(title="ACE-Step Model Variants", show_header=True)
     table.add_column("Model", style="cyan", no_wrap=True)
     table.add_column("Description")
-    table.add_column("VRAM", style="yellow", no_wrap=True)
+    table.add_column("VRAM (DIT size)", style="yellow", no_wrap=True)
     table.add_column("Inference Steps", style="green", no_wrap=True)
     for key, info in MODELS.items():
-        table.add_row(key, info["description"], info["vram"], info["steps"])
+        vram_dit = f"{info['vram']} ({info['dit_size']})"
+        table.add_row(key, info["description"], vram_dit, info["steps"])
     console.print(table)
 
 

--- a/src/acemusic/client.py
+++ b/src/acemusic/client.py
@@ -68,6 +68,7 @@ class AceStepClient:
         weirdness: int | None = None,
         style_influence: int | None = None,
         thinking: bool = False,
+        model: str | None = None,
     ) -> str:
         """Submit a generation task via POST /release_task and return the task_id.
 
@@ -88,6 +89,7 @@ class AceStepClient:
             weirdness: Deviation from conventional structures (0–100).
             style_influence: Adherence to style descriptors (0–100).
             thinking: If True, enables Chain-of-Thought mode.
+            model: ACE-Step model variant key (e.g. "turbo", "xl-base"). None uses server default.
 
         Raises:
             AceStepError: on HTTP error, connection failure, or missing task_id.
@@ -119,6 +121,8 @@ class AceStepClient:
             payload["style_influence"] = style_influence
         if thinking:
             payload["thinking"] = True
+        if model is not None:
+            payload["model"] = model
         try:
             response = httpx.post(
                 f"{self.base_url}/release_task",

--- a/src/acemusic/config.py
+++ b/src/acemusic/config.py
@@ -22,6 +22,7 @@ class AceConfig:
     output_dir: str | None = None
     elevenlabs_api_key: str | None = None
     elevenlabs_output_format: str = "mp3_44100_128"
+    default_model: str | None = None
 
 
 def load_config() -> AceConfig:
@@ -32,6 +33,7 @@ def load_config() -> AceConfig:
     api_url = os.environ.get("ACEMUSIC_BASE_URL") or None
     api_key = os.environ.get("ACEMUSIC_API_KEY") or None
     output_dir: str | None = None
+    yaml_default_model: str | None = None
 
     # Read ~/.acemusic/config.yaml — always load for output_dir; only fill
     # api_url/api_key from it when the env vars are absent.
@@ -46,11 +48,13 @@ def load_config() -> AceConfig:
             if not api_key:
                 api_key = data.get("api_key") or data.get("ACEMUSIC_API_KEY") or None
             output_dir = data.get("output_dir") or None
+            yaml_default_model = data.get("default_model") or None
         except Exception as exc:
             logger.warning("Failed to read config file %s: %s", yaml_path, exc)
 
     elevenlabs_api_key = os.environ.get("ELEVENLABS_API_KEY") or None
     elevenlabs_output_format = os.environ.get("ELEVENLABS_OUTPUT_FORMAT") or "mp3_44100_128"
+    default_model: str | None = os.environ.get("ACEMUSIC_DEFAULT_MODEL") or yaml_default_model or None
 
     return AceConfig(
         api_url=api_url,
@@ -58,4 +62,5 @@ def load_config() -> AceConfig:
         output_dir=output_dir,
         elevenlabs_api_key=elevenlabs_api_key,
         elevenlabs_output_format=elevenlabs_output_format,
+        default_model=default_model,
     )

--- a/src/acemusic/config.py
+++ b/src/acemusic/config.py
@@ -22,6 +22,8 @@ class AceConfig:
     output_dir: str | None = None
     elevenlabs_api_key: str | None = None
     elevenlabs_output_format: str = "mp3_44100_128"
+    # Loaded from ACEMUSIC_DEFAULT_MODEL env var or `default_model` in config.yaml.
+    # Not validated at load time; invalid values are caught by generate() at runtime.
     default_model: str | None = None
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,3 +50,42 @@ def test_missing_api_url_produces_friendly_error(monkeypatch):
     assert "ACEMUSIC_BASE_URL" in result.output
     assert "traceback" not in result.output.lower()
     assert "Traceback" not in result.output
+
+
+class TestModelsCommand:
+    """Tests for US-3.4: acemusic models command."""
+
+    def test_models_exits_zero(self):
+        """acemusic models exits with code 0."""
+        result = runner.invoke(app, ["models"])
+        assert result.exit_code == 0
+
+    def test_models_lists_all_variants(self):
+        """acemusic models output contains all six ACE-Step model names."""
+        result = runner.invoke(app, ["models"])
+        assert result.exit_code == 0
+        for name in ("turbo", "base", "sft", "xl-base", "xl-sft", "xl-turbo"):
+            assert name in result.output, f"Expected model '{name}' in output"
+
+    def test_models_shows_vram_info(self):
+        """acemusic models output includes VRAM information."""
+        result = runner.invoke(app, ["models"])
+        assert result.exit_code == 0
+        assert "GB" in result.output or "vram" in result.output.lower()
+
+    def test_models_shows_inference_steps(self):
+        """acemusic models output includes inference steps information."""
+        result = runner.invoke(app, ["models"])
+        assert result.exit_code == 0
+        # Should show step counts like "8" for turbo or "32" for standard models
+        assert any(s in result.output for s in ("8", "32", "64", "steps"))
+
+    def test_models_works_without_api_url(self, monkeypatch):
+        """acemusic models succeeds even when ACEMUSIC_BASE_URL is not configured."""
+        monkeypatch.delenv("ACEMUSIC_BASE_URL", raising=False)
+        from acemusic import config as cfg_mod
+
+        monkeypatch.setattr(cfg_mod, "load_config", lambda: cfg_mod.AceConfig(api_url=None, api_key=None))
+        result = runner.invoke(app, ["models"])
+        assert result.exit_code == 0
+        assert "turbo" in result.output

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1268,3 +1268,138 @@ class TestQualityCreativeParamsElevenLabs:
             )
         assert result.exit_code == 0, result.output
         assert "thinking" in result.output.lower()
+
+
+class TestModelSelection:
+    """Tests for US-3.4: --model flag and model selection."""
+
+    def test_model_flag_passes_to_submit_task(self, monkeypatch, tmp_path):
+        """--model turbo passes model='turbo' to AceStepClient.submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "jazz", "--model", "turbo", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args is not None
+        assert client_mock.submit_task.call_args.kwargs["model"] == "turbo"
+
+    def test_no_model_flag_passes_none(self, monkeypatch, tmp_path):
+        """Omitting --model with no config default passes model=None to submit_task."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url="http://localhost:8001", api_key=None, default_model=None),
+        )
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "jazz", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["model"] is None
+
+    def test_config_default_model_used_when_flag_omitted(self, monkeypatch, tmp_path):
+        """When --model is omitted, config.default_model is passed to submit_task."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url="http://localhost:8001", api_key=None, default_model="xl-turbo"),
+        )
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "jazz", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["model"] == "xl-turbo"
+
+    def test_explicit_model_flag_overrides_config_default(self, monkeypatch, tmp_path):
+        """--model flag takes precedence over config.default_model."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url="http://localhost:8001", api_key=None, default_model="xl-turbo"),
+        )
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "jazz", "--model", "base", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert client_mock.submit_task.call_args.kwargs["model"] == "base"
+
+    def test_invalid_model_exits_one(self, monkeypatch, tmp_path):
+        """--model with an invalid name exits 1 and lists valid options."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        result = runner.invoke(
+            app,
+            ["generate", "jazz", "--model", "invalid-name", "--output", str(tmp_path)],
+        )
+
+        assert result.exit_code == 1
+        assert "invalid-name" in result.output
+        assert "turbo" in result.output
+
+    def test_model_warns_on_elevenlabs(self, monkeypatch, tmp_path):
+        """--model with --backend elevenlabs prints a warning but continues."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="el-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "jazz", "--model", "turbo", "--backend", "elevenlabs", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "model" in result.output.lower()
+        assert "ignored" in result.output.lower() or "warning" in result.output.lower()


### PR DESCRIPTION
## Summary

Closes #22

- `acemusic models` lists all six ACE-Step model variants (turbo, base, sft, xl-base, xl-sft, xl-turbo) with description, VRAM requirement, and recommended inference steps — works without a server URL configured
- `--model <variant>` on `generate` selects a specific variant; resolves via flag → `ACEMUSIC_DEFAULT_MODEL` env var / `default_model` config key → server default (None)
- Invalid model name exits 1 with a clear error listing valid options
- `--model` with `--backend elevenlabs` prints a warning and continues (model selection is ignored by ElevenLabs)

## Changes

| File | What changed |
|------|-------------|
| `src/acemusic/cli.py` | Added `MODELS` registry, `VALID_MODELS` frozenset, `models()` command, `--model` flag on `generate`, model resolution + validation, ElevenLabs warning; exempted `models` subcommand from server-URL check |
| `src/acemusic/client.py` | Added `model: str | None = None` to `submit_task()`, conditionally included in payload |
| `src/acemusic/config.py` | Added `default_model` field to `AceConfig`; reads from `ACEMUSIC_DEFAULT_MODEL` env var and `default_model` key in config.yaml |
| `.env.example` | Documented `ACEMUSIC_DEFAULT_MODEL` |
| `tests/test_cli.py` | 5 new tests for `acemusic models` |
| `tests/test_generate.py` | 6 new tests for `--model` flag (pass-through, config fallback, validation, ElevenLabs warning) |

## Test plan

- [x] `acemusic models` exits 0 and shows all 6 variants with VRAM/steps
- [x] `acemusic models` works without `ACEMUSIC_BASE_URL` configured
- [x] `--model turbo` passes `model="turbo"` to `submit_task()`
- [x] Omitting `--model` with `config.default_model` set uses config value
- [x] Omitting `--model` with no config default passes `model=None`
- [x] `--model` flag takes precedence over config default
- [x] `--model invalid-name` exits 1 with error listing valid options
- [x] `--model` with `--backend elevenlabs` warns and continues
- [x] 159 tests pass, 88% coverage, ruff clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a models command to list available model variants (VRAM and inference step info).
  * Added a --model option for generate and a configurable default model via ACEMUSIC_DEFAULT_MODEL/config.
  * CLI now warns when --model is ignored for non-ACE-Step backends.

* **Tests**
  * Added tests covering the models command and model-selection behavior (including validation and backend-ignore cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->