### PR TITLE
feat: US-3.5 sounds mode — loops and one-shots via CLI

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -632,6 +632,166 @@ def _generate_via_elevenlabs(
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
 
 
+_VALID_SOUND_TYPES = {"one-shot", "loop"}
+
+
+@app.command()
+def sounds(
+    prompt: str = typer.Argument(..., help="Text description of the sound to generate."),
+    sound_type: str = typer.Option(..., "--type", help="Sound type: 'one-shot' or 'loop'."),
+    num_clips: int = typer.Option(1, "--num-clips", help="Number of audio clips to generate."),
+    duration: Optional[float] = typer.Option(None, "--duration", help="Target duration in seconds."),
+    format: str = typer.Option("wav", "--format", help="Output audio format."),
+    output: Optional[Path] = typer.Option(None, "--output", help="Directory to save generated files."),
+    name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix (e.g. 'kick' → kick-1.wav)."),
+    bpm: Optional[str] = typer.Option(
+        None,
+        "--bpm",
+        help=f"Tempo in BPM ({_BPM_MIN}–{_BPM_MAX}) or 'auto'. Applies to loops.",
+    ),
+    key: Optional[str] = typer.Option(
+        None,
+        "--key",
+        help="Tonal center (e.g. 'A minor'). Applies to loops.",
+    ),
+) -> None:
+    """Generate short audio samples (loops or one-shots) using the ACE-Step model."""
+    if sound_type not in _VALID_SOUND_TYPES:
+        console.print(
+            f"[red]Invalid --type: {sound_type!r}. Allowed values: {', '.join(sorted(_VALID_SOUND_TYPES))}[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    parsed_bpm: int | str | None = None
+    if bpm is not None:
+        try:
+            parsed_bpm = _parse_bpm(bpm)
+        except typer.BadParameter as exc:
+            console.print(f"[red]Invalid --bpm: {exc}[/red]")
+            raise typer.Exit(code=1)
+
+    try:
+        key = _validate_key(key)
+    except typer.BadParameter as exc:
+        console.print(f"[red]Invalid --key: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    config = load_config()
+
+    if output is not None:
+        output_path = output
+    elif config.output_dir:
+        output_path = Path(config.output_dir).expanduser()
+    else:
+        output_path = Path.cwd()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    slug = make_slug(prompt)
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    safe_name = make_slug(name) if name else None
+
+    ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
+    try:
+        _sounds_via_ace_step(
+            ace_client=ace_client,
+            prompt=prompt,
+            sound_type=sound_type,
+            num_clips=num_clips,
+            duration=duration,
+            format=format,
+            output_path=output_path,
+            slug=slug,
+            timestamp=timestamp,
+            safe_name=safe_name,
+            bpm=parsed_bpm,
+            key=key,
+        )
+    except AceStepError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+
+def _sounds_via_ace_step(
+    *,
+    ace_client: AceStepClient,
+    prompt: str,
+    sound_type: str,
+    num_clips: int,
+    duration: Optional[float],
+    format: str,
+    output_path: Path,
+    slug: str,
+    timestamp: str,
+    safe_name: Optional[str],
+    bpm: "int | str | None" = None,
+    key: Optional[str] = None,
+) -> None:
+    """Submit, poll, and download a short audio sample via the ACE-Step backend."""
+    poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
+    poll_interval = 2.0
+
+    task_id = ace_client.submit_task(
+        prompt=prompt,
+        num_clips=num_clips,
+        audio_duration=duration,
+        format=format,
+        bpm=bpm,
+        key=key,
+        mode="sound",
+        sound_type=sound_type,
+    )
+    console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
+
+    start = time.monotonic()
+    result: dict = {}
+    with console.status("[bold green]Generating…[/bold green]", spinner="dots") as status:
+        while True:
+            elapsed = time.monotonic() - start
+            if elapsed >= poll_timeout:
+                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
+                raise typer.Exit(code=1)
+
+            try:
+                result = ace_client.query_result(task_id)
+            except AceStepError as exc:
+                console.print(f"[red]Error polling status: {exc}[/red]")
+                raise typer.Exit(code=1)
+
+            job_status = result.get("status", "unknown")
+            status.update(f"[bold green]Generating… ({elapsed:.0f}s) — {job_status}[/bold green]")
+
+            if job_status == "completed":
+                break
+            if job_status == "failed":
+                error_msg = result.get("error", "unknown error")
+                console.print(f"[red]Generation failed: {error_msg}[/red]")
+                raise typer.Exit(code=1)
+
+            time.sleep(poll_interval)
+
+    audio_urls: list[str] = result.get("audio_urls", [])
+    for i, url in enumerate(audio_urls, start=1):
+        if safe_name:
+            filename = f"{safe_name}-{i}.{format}"
+        else:
+            filename = make_filename(slug, timestamp, i, ext=format)
+        dest = output_path / filename
+        try:
+            data = ace_client.download_audio(url)
+        except AceStepError as exc:
+            console.print(f"[red]Download failed for clip {i}: {exc}[/red]")
+            raise typer.Exit(code=1)
+
+        dest.write_bytes(data)
+        try:
+            dur = get_duration(dest)
+            dur_str = f"{dur:.1f}s"
+        except Exception:
+            dur_str = "unknown"
+
+        console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
+
+
 @app.command()
 def status() -> None:
     """Check the status of the ACE-Step server."""

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -656,6 +656,11 @@ def sounds(
     ),
 ) -> None:
     """Generate short audio samples (loops or one-shots) using the ACE-Step model."""
+    _VALID_FORMATS = {"wav", "flac", "mp3", "aac", "opus"}
+    if format not in _VALID_FORMATS:
+        console.print(f"[red]Invalid --format: {format!r}. Allowed values: {', '.join(sorted(_VALID_FORMATS))}[/red]")
+        raise typer.Exit(code=1)
+
     if sound_type not in _VALID_SOUND_TYPES:
         console.print(
             f"[red]Invalid --type: {sound_type!r}. Allowed values: {', '.join(sorted(_VALID_SOUND_TYPES))}[/red]"
@@ -674,6 +679,10 @@ def sounds(
         key = _validate_key(key)
     except typer.BadParameter as exc:
         console.print(f"[red]Invalid --key: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if sound_type == "one-shot" and (parsed_bpm is not None or key is not None):
+        console.print("[red]--bpm and --key are only valid with --type 'loop'.[/red]")
         raise typer.Exit(code=1)
 
     config = load_config()

--- a/src/acemusic/client.py
+++ b/src/acemusic/client.py
@@ -69,6 +69,8 @@ class AceStepClient:
         style_influence: int | None = None,
         thinking: bool = False,
         model: str | None = None,
+        mode: str | None = None,
+        sound_type: str | None = None,
     ) -> str:
         """Submit a generation task via POST /release_task and return the task_id.
 
@@ -90,6 +92,8 @@ class AceStepClient:
             style_influence: Adherence to style descriptors (0–100).
             thinking: If True, enables Chain-of-Thought mode.
             model: ACE-Step model variant key (e.g. "turbo", "xl-base"). None uses server default.
+            mode: Generation mode (e.g. "sound" for sounds mode). None uses server default.
+            sound_type: Sound type for sounds mode ("one-shot" or "loop"). None uses server default.
 
         Raises:
             AceStepError: on HTTP error, connection failure, or missing task_id.
@@ -123,6 +127,10 @@ class AceStepClient:
             payload["thinking"] = True
         if model is not None:
             payload["model"] = model
+        if mode is not None:
+            payload["mode"] = mode
+        if sound_type is not None:
+            payload["sound_type"] = sound_type
         try:
             response = httpx.post(
                 f"{self.base_url}/release_task",

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -1,10 +1,17 @@
 """Unit tests for acemusic sounds command (US-3.5)."""
 
+import re
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
 from acemusic.cli import app
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI escape codes from text (Rich emits these in CI environments)."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
 
 runner = CliRunner()
 
@@ -313,7 +320,7 @@ class TestSoundsCommand:
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
         result = runner.invoke(app, ["sounds", "--help"])
         assert result.exit_code == 0
-        assert "--type" in result.output
+        assert "--type" in _plain(result.output)
 
     def test_bpm_auto_accepted_for_loop(self, monkeypatch, tmp_path):
         """--bpm auto is accepted for loops."""

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -308,8 +308,9 @@ class TestSoundsCommand:
         assert result.exit_code == 0
         assert "sounds" in result.output
 
-    def test_sounds_help_shows_type_option(self):
+    def test_sounds_help_shows_type_option(self, monkeypatch):
         """acemusic sounds --help mentions the --type option."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
         result = runner.invoke(app, ["sounds", "--help"])
         assert result.exit_code == 0
         assert "--type" in result.output

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -15,10 +15,6 @@ def _plain(text: str) -> str:
 
 runner = CliRunner()
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 TASK_ID = "task-sounds-123"
 AUDIO_URL_1 = "http://localhost:8001/audio/oneshot1.wav"
 
@@ -42,11 +38,6 @@ def _make_client_mock(query_sequence=None, audio_bytes=FAKE_WAV):
     client.query_result.side_effect = query_sequence or [COMPLETED_RESULT]
     client.download_audio.return_value = audio_bytes
     return client
-
-
-# ---------------------------------------------------------------------------
-# Validation tests
-# ---------------------------------------------------------------------------
 
 
 class TestSoundsValidation:
@@ -78,6 +69,31 @@ class TestSoundsValidation:
         result = runner.invoke(app, ["sounds", "pad", "--type", "loop", "--key", "   ", "--output", str(tmp_path)])
         assert result.exit_code == 1
 
+    def test_invalid_format_exits_one(self, monkeypatch, tmp_path):
+        """--format with an unsupported value exits 1."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(
+            app, ["sounds", "kick", "--type", "one-shot", "--format", "ogg", "--output", str(tmp_path)]
+        )
+        assert result.exit_code == 1
+        assert "format" in result.output.lower() or "wav" in result.output.lower()
+
+    def test_bpm_with_oneshot_exits_one(self, monkeypatch, tmp_path):
+        """--bpm is rejected with --type one-shot."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["sounds", "kick", "--type", "one-shot", "--bpm", "120", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "loop" in result.output.lower() or "bpm" in result.output.lower()
+
+    def test_key_with_oneshot_exits_one(self, monkeypatch, tmp_path):
+        """--key is rejected with --type one-shot."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(
+            app, ["sounds", "kick", "--type", "one-shot", "--key", "C major", "--output", str(tmp_path)]
+        )
+        assert result.exit_code == 1
+        assert "loop" in result.output.lower() or "key" in result.output.lower()
+
     def test_missing_api_url_exits_one(self, monkeypatch, tmp_path):
         """Missing ACEMUSIC_BASE_URL exits 1 with a friendly error."""
         monkeypatch.delenv("ACEMUSIC_BASE_URL", raising=False)
@@ -86,11 +102,6 @@ class TestSoundsValidation:
         monkeypatch.setattr("acemusic.cli.load_config", lambda: AceConfig(api_url=None, api_key=None))
         result = runner.invoke(app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)])
         assert result.exit_code != 0
-
-
-# ---------------------------------------------------------------------------
-# Happy-path tests
-# ---------------------------------------------------------------------------
 
 
 class TestSoundsCommand:
@@ -158,9 +169,7 @@ class TestSoundsCommand:
 
         call_kwargs = client_mock.submit_task.call_args
         assert call_kwargs is not None
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
-        # mode="sound" must be passed
-        assert kwargs.get("mode") == "sound" or "sound" in str(call_kwargs)
+        assert call_kwargs.kwargs["mode"] == "sound"
 
     def test_sounds_passes_sound_type_to_client(self, monkeypatch, tmp_path):
         """sounds command passes sound_type to submit_task."""
@@ -176,8 +185,7 @@ class TestSoundsCommand:
 
         call_kwargs = client_mock.submit_task.call_args
         assert call_kwargs is not None
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
-        assert kwargs.get("sound_type") == "loop"
+        assert call_kwargs.kwargs["sound_type"] == "loop"
 
     def test_sounds_passes_bpm_to_client(self, monkeypatch, tmp_path):
         """--bpm is forwarded to submit_task."""
@@ -195,8 +203,7 @@ class TestSoundsCommand:
 
         call_kwargs = client_mock.submit_task.call_args
         assert call_kwargs is not None
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
-        assert kwargs.get("bpm") == 140
+        assert call_kwargs.kwargs["bpm"] == 140
 
     def test_sounds_passes_key_to_client(self, monkeypatch, tmp_path):
         """--key is forwarded to submit_task."""
@@ -214,8 +221,7 @@ class TestSoundsCommand:
 
         call_kwargs = client_mock.submit_task.call_args
         assert call_kwargs is not None
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
-        assert kwargs.get("key") == "A minor"
+        assert call_kwargs.kwargs["key"] == "A minor"
 
     def test_sounds_filenames_contain_slug(self, monkeypatch, tmp_path):
         """Generated filenames include a slug derived from the prompt."""
@@ -316,11 +322,14 @@ class TestSoundsCommand:
         assert "sounds" in result.output
 
     def test_sounds_help_shows_type_option(self, monkeypatch):
-        """acemusic sounds --help mentions the --type option."""
+        """acemusic sounds --help documents the --type option with its valid values."""
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
         result = runner.invoke(app, ["sounds", "--help"])
         assert result.exit_code == 0
-        assert "--type" in _plain(result.output)
+        plain = _plain(result.output).lower()
+        assert "type" in plain
+        assert "one-shot" in plain
+        assert "loop" in plain
 
     def test_bpm_auto_accepted_for_loop(self, monkeypatch, tmp_path):
         """--bpm auto is accepted for loops."""
@@ -352,5 +361,4 @@ class TestSoundsCommand:
 
         call_kwargs = client_mock.submit_task.call_args
         assert call_kwargs is not None
-        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
-        assert kwargs.get("num_clips", 1) == 1
+        assert call_kwargs.kwargs["num_clips"] == 1

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -1,0 +1,351 @@
+"""Unit tests for acemusic sounds command (US-3.5)."""
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TASK_ID = "task-sounds-123"
+AUDIO_URL_1 = "http://localhost:8001/audio/oneshot1.wav"
+
+COMPLETED_RESULT = {
+    "status": "completed",
+    "audio_urls": [AUDIO_URL_1],
+}
+FAILED_RESULT = {"status": "failed", "error": "model overloaded"}
+
+FAKE_WAV = (
+    b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00"
+    b"\x01\x00\x01\x00\x44\xac\x00\x00\x88X\x01\x00\x02\x00\x10\x00"
+    b"data\x00\x00\x00\x00"
+)
+
+
+def _make_client_mock(query_sequence=None, audio_bytes=FAKE_WAV):
+    """Return a patched AceStepClient instance."""
+    client = MagicMock()
+    client.submit_task.return_value = TASK_ID
+    client.query_result.side_effect = query_sequence or [COMPLETED_RESULT]
+    client.download_audio.return_value = audio_bytes
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSoundsValidation:
+    """Tests for sounds command parameter validation."""
+
+    def test_missing_type_exits_nonzero(self, monkeypatch):
+        """--type is required; omitting it exits non-zero."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(app, ["sounds", "deep kick drum"])
+        assert result.exit_code != 0
+
+    def test_invalid_type_exits_one(self, monkeypatch, tmp_path):
+        """--type must be 'one-shot' or 'loop'; any other value exits 1."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(
+            app, ["sounds", "deep kick drum", "--type", "full-song", "--output", str(tmp_path)]
+        )
+        assert result.exit_code == 1
+        assert "one-shot" in result.output or "loop" in result.output or "invalid" in result.output.lower()
+
+    def test_invalid_bpm_exits_one(self, monkeypatch, tmp_path):
+        """BPM outside 60-180 exits 1 with an error message."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(
+            app, ["sounds", "hi-hat", "--type", "loop", "--bpm", "999", "--output", str(tmp_path)]
+        )
+        assert result.exit_code == 1
+        assert "bpm" in result.output.lower() or "180" in result.output
+
+    def test_empty_key_exits_one(self, monkeypatch, tmp_path):
+        """--key with blank value exits 1."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        result = runner.invoke(
+            app, ["sounds", "pad", "--type", "loop", "--key", "   ", "--output", str(tmp_path)]
+        )
+        assert result.exit_code == 1
+
+    def test_missing_api_url_exits_one(self, monkeypatch, tmp_path):
+        """Missing ACEMUSIC_BASE_URL exits 1 with a friendly error."""
+        monkeypatch.delenv("ACEMUSIC_BASE_URL", raising=False)
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr("acemusic.cli.load_config", lambda: AceConfig(api_url=None, api_key=None))
+        result = runner.invoke(app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------------
+
+
+class TestSoundsCommand:
+    """Tests for the acemusic sounds CLI command (US-3.5)."""
+
+    def test_oneshot_creates_wav_file(self, monkeypatch, tmp_path):
+        """One-shot generation writes a WAV file to the output directory."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            result = runner.invoke(
+                app, ["sounds", "deep punchy kick drum", "--type", "one-shot", "--output", str(tmp_path)]
+            )
+
+        assert result.exit_code == 0, result.output
+        wav_files = list(tmp_path.glob("*.wav"))
+        assert len(wav_files) == 1
+
+    def test_loop_creates_wav_file(self, monkeypatch, tmp_path):
+        """Loop generation writes a WAV file to the output directory."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=8.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["sounds", "ambient pad", "--type", "loop", "--bpm", "120", "--key", "A minor", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        wav_files = list(tmp_path.glob("*.wav"))
+        assert len(wav_files) == 1
+
+    def test_sounds_passes_mode_to_client(self, monkeypatch, tmp_path):
+        """sounds command passes mode='sound' to submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=1.0),
+        ):
+            runner.invoke(app, ["sounds", "snare hit", "--type", "one-shot", "--output", str(tmp_path)])
+
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs is not None
+        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
+        # mode="sound" must be passed
+        assert kwargs.get("mode") == "sound" or "sound" in str(call_kwargs)
+
+    def test_sounds_passes_sound_type_to_client(self, monkeypatch, tmp_path):
+        """sounds command passes sound_type to submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+        ):
+            runner.invoke(app, ["sounds", "hi-hat pattern", "--type", "loop", "--output", str(tmp_path)])
+
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs is not None
+        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
+        assert kwargs.get("sound_type") == "loop"
+
+    def test_sounds_passes_bpm_to_client(self, monkeypatch, tmp_path):
+        """--bpm is forwarded to submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+        ):
+            runner.invoke(
+                app, ["sounds", "hi-hat pattern", "--type", "loop", "--bpm", "140", "--output", str(tmp_path)]
+            )
+
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs is not None
+        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
+        assert kwargs.get("bpm") == 140
+
+    def test_sounds_passes_key_to_client(self, monkeypatch, tmp_path):
+        """--key is forwarded to submit_task."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+        ):
+            runner.invoke(
+                app, ["sounds", "ambient pad", "--type", "loop", "--key", "A minor", "--output", str(tmp_path)]
+            )
+
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs is not None
+        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
+        assert kwargs.get("key") == "A minor"
+
+    def test_sounds_filenames_contain_slug(self, monkeypatch, tmp_path):
+        """Generated filenames include a slug derived from the prompt."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            runner.invoke(app, ["sounds", "deep kick", "--type", "one-shot", "--output", str(tmp_path)])
+
+        names = [f.name for f in tmp_path.glob("*.wav")]
+        assert len(names) == 1
+        assert "deep-kick" in names[0]
+
+    def test_sounds_name_flag_produces_prefixed_filename(self, monkeypatch, tmp_path):
+        """--name sets the filename prefix: kick-1.wav."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            runner.invoke(
+                app, ["sounds", "kick drum", "--type", "one-shot", "--name", "kick", "--output", str(tmp_path)]
+            )
+
+        names = [f.name for f in tmp_path.glob("*.wav")]
+        assert "kick-1.wav" in names
+
+    def test_sounds_prints_file_path(self, monkeypatch, tmp_path):
+        """Output includes the absolute path of the generated file."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            result = runner.invoke(
+                app, ["sounds", "snare", "--type", "one-shot", "--output", str(tmp_path)]
+            )
+
+        assert str(tmp_path) in result.output
+
+    def test_sounds_prints_duration(self, monkeypatch, tmp_path):
+        """Output includes the duration of the generated file."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=2.5),
+        ):
+            result = runner.invoke(
+                app, ["sounds", "snare", "--type", "one-shot", "--output", str(tmp_path)]
+            )
+
+        assert "2.5" in result.output
+
+    def test_sounds_api_failure_exits_one(self, monkeypatch, tmp_path):
+        """API failure prints a friendly message and exits 1."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock(query_sequence=[FAILED_RESULT])
+
+        with patch("acemusic.cli.AceStepClient", return_value=client_mock):
+            result = runner.invoke(
+                app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)]
+            )
+
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+
+    def test_sounds_connection_error_exits_one(self, monkeypatch, tmp_path):
+        """Connection error exits 1 with a friendly message (no ElevenLabs fallback)."""
+        from acemusic.client import AceStepError
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url="http://localhost:8001", api_key=None, elevenlabs_api_key=None),
+        )
+
+        client_mock = MagicMock()
+        client_mock.submit_task.side_effect = AceStepError("connection refused")
+
+        with patch("acemusic.cli.AceStepClient", return_value=client_mock):
+            result = runner.invoke(
+                app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)]
+            )
+
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+
+    def test_sounds_appears_in_help(self):
+        """'sounds' subcommand is listed in top-level --help output."""
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "sounds" in result.output
+
+    def test_sounds_help_shows_type_option(self):
+        """acemusic sounds --help mentions the --type option."""
+        result = runner.invoke(app, ["sounds", "--help"])
+        assert result.exit_code == 0
+        assert "--type" in result.output
+
+    def test_bpm_auto_accepted_for_loop(self, monkeypatch, tmp_path):
+        """--bpm auto is accepted for loops."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=4.0),
+        ):
+            result = runner.invoke(
+                app, ["sounds", "groove", "--type", "loop", "--bpm", "auto", "--output", str(tmp_path)]
+            )
+
+        assert result.exit_code == 0, result.output
+
+    def test_num_clips_default_is_one(self, monkeypatch, tmp_path):
+        """Default --num-clips for sounds is 1."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            runner.invoke(app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)])
+
+        call_kwargs = client_mock.submit_task.call_args
+        assert call_kwargs is not None
+        kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
+        assert kwargs.get("num_clips", 1) == 1

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -54,27 +54,21 @@ class TestSoundsValidation:
     def test_invalid_type_exits_one(self, monkeypatch, tmp_path):
         """--type must be 'one-shot' or 'loop'; any other value exits 1."""
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
-        result = runner.invoke(
-            app, ["sounds", "deep kick drum", "--type", "full-song", "--output", str(tmp_path)]
-        )
+        result = runner.invoke(app, ["sounds", "deep kick drum", "--type", "full-song", "--output", str(tmp_path)])
         assert result.exit_code == 1
         assert "one-shot" in result.output or "loop" in result.output or "invalid" in result.output.lower()
 
     def test_invalid_bpm_exits_one(self, monkeypatch, tmp_path):
         """BPM outside 60-180 exits 1 with an error message."""
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
-        result = runner.invoke(
-            app, ["sounds", "hi-hat", "--type", "loop", "--bpm", "999", "--output", str(tmp_path)]
-        )
+        result = runner.invoke(app, ["sounds", "hi-hat", "--type", "loop", "--bpm", "999", "--output", str(tmp_path)])
         assert result.exit_code == 1
         assert "bpm" in result.output.lower() or "180" in result.output
 
     def test_empty_key_exits_one(self, monkeypatch, tmp_path):
         """--key with blank value exits 1."""
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
-        result = runner.invoke(
-            app, ["sounds", "pad", "--type", "loop", "--key", "   ", "--output", str(tmp_path)]
-        )
+        result = runner.invoke(app, ["sounds", "pad", "--type", "loop", "--key", "   ", "--output", str(tmp_path)])
         assert result.exit_code == 1
 
     def test_missing_api_url_exits_one(self, monkeypatch, tmp_path):
@@ -125,7 +119,18 @@ class TestSoundsCommand:
         ):
             result = runner.invoke(
                 app,
-                ["sounds", "ambient pad", "--type", "loop", "--bpm", "120", "--key", "A minor", "--output", str(tmp_path)],
+                [
+                    "sounds",
+                    "ambient pad",
+                    "--type",
+                    "loop",
+                    "--bpm",
+                    "120",
+                    "--key",
+                    "A minor",
+                    "--output",
+                    str(tmp_path),
+                ],
             )
 
         assert result.exit_code == 0, result.output
@@ -248,9 +253,7 @@ class TestSoundsCommand:
             patch("acemusic.cli.AceStepClient", return_value=client_mock),
             patch("acemusic.cli.get_duration", return_value=1.5),
         ):
-            result = runner.invoke(
-                app, ["sounds", "snare", "--type", "one-shot", "--output", str(tmp_path)]
-            )
+            result = runner.invoke(app, ["sounds", "snare", "--type", "one-shot", "--output", str(tmp_path)])
 
         assert str(tmp_path) in result.output
 
@@ -264,9 +267,7 @@ class TestSoundsCommand:
             patch("acemusic.cli.AceStepClient", return_value=client_mock),
             patch("acemusic.cli.get_duration", return_value=2.5),
         ):
-            result = runner.invoke(
-                app, ["sounds", "snare", "--type", "one-shot", "--output", str(tmp_path)]
-            )
+            result = runner.invoke(app, ["sounds", "snare", "--type", "one-shot", "--output", str(tmp_path)])
 
         assert "2.5" in result.output
 
@@ -277,9 +278,7 @@ class TestSoundsCommand:
         client_mock = _make_client_mock(query_sequence=[FAILED_RESULT])
 
         with patch("acemusic.cli.AceStepClient", return_value=client_mock):
-            result = runner.invoke(
-                app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)]
-            )
+            result = runner.invoke(app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)])
 
         assert result.exit_code == 1
         assert "Traceback" not in result.output
@@ -298,9 +297,7 @@ class TestSoundsCommand:
         client_mock.submit_task.side_effect = AceStepError("connection refused")
 
         with patch("acemusic.cli.AceStepClient", return_value=client_mock):
-            result = runner.invoke(
-                app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)]
-            )
+            result = runner.invoke(app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)])
 
         assert result.exit_code == 1
         assert "Traceback" not in result.output


### PR DESCRIPTION
## Summary

- Adds `acemusic sounds` subcommand for generating short audio samples (loops and one-shots)
- Required `--type one-shot|loop` flag; optional `--bpm`, `--key`, `--duration`, `--output`, `--format`, `--num-clips`, `--name`
- ACE-Step backend only (ElevenLabs doesn't support sounds mode per design choice)
- Extends `AceStepClient.submit_task()` with `mode` and `sound_type` parameters
- 21 new unit tests covering validation, happy paths, and error handling

Closes #23

## Test plan

- [x] `acemusic sounds "deep punchy kick drum" --type one-shot` — one-shot generation
- [x] `acemusic sounds "ambient pad" --type loop --bpm 120 --key "A minor"` — loop with constraints
- [x] Invalid `--type` exits 1 with clear error
- [x] BPM out of range (60–180) exits 1
- [x] Empty `--key` exits 1
- [x] API failure exits 1 cleanly (no traceback)
- [x] Connection error exits 1 (no ElevenLabs fallback)
- [x] `acemusic sounds --help` shows all options
- [x] `acemusic --help` lists `sounds` subcommand
- [x] Full test suite: 181 tests, 0 regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `sounds` command to generate short audio samples (one-shot or loop) with options for clip count, duration, format, BPM, key, and output naming; command saves files and reports per-clip duration.

* **Bug Fixes / Improvements**
  * Validates sound type, BPM, and key; enforces allowed option combinations; resolves and creates output directory; prints friendly errors without stack traces.

* **Tests**
  * New test suite covering help text, validations, success and failure flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->