### PR TITLE
feat: US-4.1 workspace management — create, list, switch, rename, delete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AI-powered music generation platform built on **ACE-Step-1.5** (fork: `github.co
 3. **Layer 3 — Web UI** (Stages 15–21): Next.js frontend
 4. **Layer 4 — Advanced Integrations** (Stages 22–28): VST3 plugin, music video, voice models, credits, moderation
 
-**Current progress:** Stages 1–2 complete. CLI entry point, health check, basic generation, output naming all implemented.
+**Current progress:** Stages 1–4 complete. CLI entry point, health check, basic generation, musical parameters, quality/speed tradeoffs, model selection, sound modes, and workspace management all implemented.
 
 ## Commands
 
@@ -45,6 +45,14 @@ uv run acemusic health
 uv run acemusic generate "upbeat pop" --output ./output --name demo
 uv run acemusic generate "dark electro" --bpm 128 --key "C minor" --time-signature "4/4" --seed 42 --duration 60
 uv run acemusic generate "ambient pad" --backend elevenlabs --instrumental
+
+# Workspace management (US-4.1)
+uv run acemusic workspace list                        # list all workspaces (auto-creates Default)
+uv run acemusic workspace create "My Album"           # create a new workspace
+uv run acemusic workspace switch "My Album"           # set active workspace
+uv run acemusic workspace rename "My Album" "Debut"   # rename a workspace
+uv run acemusic workspace delete "Debut"              # delete (prompts if clips exist)
+uv run acemusic workspace delete "Debut" --force      # delete without confirmation
 ```
 
 ## Architecture
@@ -54,10 +62,12 @@ uv run acemusic generate "ambient pad" --backend elevenlabs --instrumental
 ```
 src/acemusic/
   __init__.py       # Package metadata (__version__)
-  cli.py            # Typer CLI app (health, generate, status commands)
+  cli.py            # Typer CLI app (health, generate, models, workspace commands)
   client.py         # AceStepClient — HTTP client for ACE-Step REST API
   config.py         # Config loading: env > .env > ~/.acemusic/config.yaml
+  db.py             # SQLite connection and schema init (~/.acemusic/metadata.db)
   utils.py          # Filename helpers (make_slug, make_filename, get_duration)
+  workspace.py      # Workspace CRUD — create, list, switch, rename, delete
 
 tests/
   conftest.py       # Fixtures: ace_server (session-scoped lifecycle), integration_url
@@ -68,6 +78,7 @@ tests/
   test_utils.py     # Utility function tests
   test_package.py   # Package import/version tests
   test_smoke.py     # Test runner smoke test
+  test_workspace.py # Workspace command tests
   features/         # pytest-bdd feature files (not yet populated)
 
 web/                # Next.js frontend (placeholder, Layer 3)
@@ -78,8 +89,10 @@ docs/               # Additional documentation (placeholder)
 ### Key Modules
 
 - **`client.py`** — The core integration with ACE-Step-1.5. Understands the API envelope (`{"data": ..., "code": 200}`), integer status codes (0=pending, 1=completed, 2=failed), and the `/release_task` → `/query_result` → `/v1/audio` workflow.
-- **`cli.py`** — Typer-based CLI. Commands: `health`, `generate`, `status` (stub). Uses `AceStepClient` for all API communication.
+- **`cli.py`** — Typer-based CLI. Commands: `health`, `generate`, `models`, and the `workspace` subcommand group (`create`, `list`, `switch`, `rename`, `delete`). Uses `AceStepClient` for generation and `workspace.py` for workspace ops.
 - **`config.py`** — Returns `AceConfig(api_url, api_key, output_dir)`. Priority: env vars > `.env` > `~/.acemusic/config.yaml`.
+- **`db.py`** — Opens (and schema-inits on first use) the SQLite metadata database at `~/.acemusic/metadata.db`. All workspace state is persisted here.
+- **`workspace.py`** — CRUD operations on workspaces. Audio clips are stored under `~/.acemusic/workspaces/{id}/clips/`. A "Default" workspace is auto-created on first access. `generate` falls back to the active workspace's clips directory when `--output` and `config.output_dir` are both unset.
 
 ### ACE-Step API Contract
 

--- a/demo-us-4.1.md
+++ b/demo-us-4.1.md
@@ -95,7 +95,7 @@ Confirmation prompt shown when clips exist. ✓ The --force flag skips the promp
 
 ## Criterion 4: New generations are saved to the active workspace
 
-The generate command output priority is: --output > config.output_dir > active workspace clips dir > cwd.
+The generate command output priority is: --output > config.output_dir > active workspace clips dir.
 Test evidence from the pytest suite (test_output_falls_back_to_active_workspace_when_no_config):
 
 ```bash

--- a/demo-us-4.1.md
+++ b/demo-us-4.1.md
@@ -1,0 +1,131 @@
+# US-4.1: Workspace Management
+
+*2026-04-12T21:57:32Z*
+
+US-4.1 introduces named workspace containers for organizing clips. A Default workspace is auto-created on first run. This demo verifies all four acceptance criteria.
+
+## Criterion 1: Default workspace exists on first run
+
+The first time any workspace command runs, a "Default" workspace is auto-created.
+
+```bash
+/home/frankbria/.local/bin/uv run acemusic workspace list
+```
+
+```output
+               Workspaces                
+┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name    ┃ Clips ┃ Active ┃ Created    ┃
+┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━┩
+│ Default │     2 │   ✓    │ 2026-04-12 │
+└─────────┴───────┴────────┴────────────┘
+```
+
+VERIFIED ✓ Default workspace exists with 2 clips from previous use.
+
+## Criterion 2: Create, list, switch, rename, and delete all work
+
+```bash
+/home/frankbria/.local/bin/uv run acemusic workspace create "Demo Album"
+```
+
+```output
+Created workspace: Demo Album
+```
+
+```bash
+/home/frankbria/.local/bin/uv run acemusic workspace list
+```
+
+```output
+                 Workspaces                 
+┏━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name       ┃ Clips ┃ Active ┃ Created    ┃
+┡━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━┩
+│ Default    │     2 │   ✓    │ 2026-04-12 │
+│ Demo Album │     0 │        │ 2026-04-12 │
+└────────────┴───────┴────────┴────────────┘
+```
+
+```bash
+/home/frankbria/.local/bin/uv run acemusic workspace switch "Demo Album"
+```
+
+```output
+Switched to workspace: Demo Album
+```
+
+```bash
+/home/frankbria/.local/bin/uv run acemusic workspace rename "Demo Album" "Debut LP"
+```
+
+```output
+Renamed workspace: 'Demo Album' → 'Debut LP'
+```
+
+```bash
+/home/frankbria/.local/bin/uv run acemusic workspace list
+```
+
+```output
+                Workspaces                
+┏━━━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name     ┃ Clips ┃ Active ┃ Created    ┃
+┡━━━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━┩
+│ Default  │     2 │        │ 2026-04-12 │
+│ Debut LP │     0 │   ✓    │ 2026-04-12 │
+└──────────┴───────┴────────┴────────────┘
+```
+
+Create, list, switch, and rename all working. ✓
+
+## Criterion 3: Deleting non-empty workspace requires confirmation
+
+First switch back to Default so we can delete the demo workspace after adding a clip to it.
+
+```bash
+echo "y" | /home/frankbria/.local/bin/uv run acemusic workspace delete "Debut LP"
+```
+
+```output
+Workspace 'Debut LP' contains 1 clip(s). Delete anyway? [y/N]: Deleted workspace: Debut LP
+```
+
+Confirmation prompt shown when clips exist. ✓ The --force flag skips the prompt for scripted use.
+
+## Criterion 4: New generations are saved to the active workspace
+
+The generate command output priority is: --output > config.output_dir > active workspace clips dir > cwd.
+Test evidence from the pytest suite (test_output_falls_back_to_active_workspace_when_no_config):
+
+```bash
+/home/frankbria/.local/bin/uv run pytest tests/test_generate.py -k "workspace" -v --no-header --tb=short 2>&1 | tail -15
+```
+
+```output
+_______________ coverage: platform linux, python 3.13.3-final-0 ________________
+
+Name                                Stmts   Miss  Cover   Missing
+-----------------------------------------------------------------
+src/acemusic/__init__.py                5      2    60%   5-6
+src/acemusic/cli.py                   443    321    28%   85-86, 102-103, 107-108, 114-163, 169-177, 182-183, 197-205, 212-215, 277-278, 281-284, 287-288, 291-292, 296-300, 304-306, 309-313, 316-326, 333-336, 340, 342, 350-357, 394-487, 546-547, 551-553, 560-565, 570, 576-578, 584-585, 592-600, 619-647, 674-735, 754-816, 822-827, 833-843, 849-854, 863-868, 877-890, 896
+src/acemusic/client.py                 94     84    11%   29-30, 42-47, 101-151, 165-202, 210-217
+src/acemusic/config.py                 37     22    41%   33-61
+src/acemusic/db.py                     14      0   100%
+src/acemusic/elevenlabs_client.py      34     26    24%   19-21, 43-66, 70-79
+src/acemusic/utils.py                  15      3    80%   29-32
+src/acemusic/workspace.py             107     48    55%   29, 59, 74-79, 84-91, 102-107, 124, 134-144, 149-165, 175-178
+-----------------------------------------------------------------
+TOTAL                                 749    506    32%
+======================= 2 passed, 79 deselected in 0.18s =======================
+```
+
+Both workspace generate tests pass: default fallback to active workspace, and switched workspace. ✓
+
+## Summary
+
+All acceptance criteria verified:
+- ✓ Default workspace auto-created on first run  
+- ✓ Create, list, switch, rename, delete all work
+- ✓ Non-empty workspace delete prompts for confirmation
+- ✓ New generations use active workspace as output directory

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -877,9 +877,7 @@ def workspace_delete(
     try:
         clips = get_clip_count(get_workspace_by_name(name).id)
         if clips > 0 and not force:
-            confirmed = typer.confirm(
-                f"Workspace {name!r} contains {clips} clip(s). Delete anyway?"
-            )
+            confirmed = typer.confirm(f"Workspace {name!r} contains {clips} clip(s). Delete anyway?")
             if not confirmed:
                 console.print("Aborted.")
                 return

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -17,8 +17,20 @@ from acemusic.client import AceStepClient, AceStepError
 from acemusic.config import load_config
 from acemusic.elevenlabs_client import ElevenLabsClient, ElevenLabsError
 from acemusic.utils import get_duration, make_filename, make_slug
+from acemusic.workspace import (
+    create_workspace,
+    delete_workspace,
+    get_active_workspace,
+    get_clip_count,
+    get_workspace_path,
+    list_workspaces,
+    rename_workspace,
+    switch_workspace,
+)
 
 app = typer.Typer(help="acemusic — AI music generation CLI")
+workspace_app = typer.Typer(help="Manage workspaces")
+app.add_typer(workspace_app, name="workspace")
 console = Console()
 
 # ACE-Step model registry (US-3.4).
@@ -87,7 +99,7 @@ def main(
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())
         raise typer.Exit(0)
-    elif ctx.invoked_subcommand not in ("models",):  # offline-safe subcommands skip URL check
+    elif ctx.invoked_subcommand not in ("models", "workspace"):  # offline-safe subcommands skip URL check
         config = load_config()
         if not config.api_url:
             typer.echo("ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml")
@@ -321,13 +333,14 @@ def generate(
         )
         raise typer.Exit(code=1)
 
-    # Resolve output directory: --output > config output_dir > CWD
+    # Resolve output directory: --output > config output_dir > active workspace > CWD
     if output is not None:
         output_path = output
     elif config.output_dir:
         output_path = Path(config.output_dir).expanduser()
     else:
-        output_path = Path.cwd()
+        active_ws = get_active_workspace()
+        output_path = get_workspace_path(active_ws.id)
     output_path.mkdir(parents=True, exist_ok=True)
 
     resolved_lyrics = lyrics
@@ -799,6 +812,90 @@ def _sounds_via_ace_step(
             dur_str = "unknown"
 
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
+
+
+@workspace_app.command("create")
+def workspace_create(name: str = typer.Argument(..., help="Workspace name.")) -> None:
+    """Create a new workspace."""
+    try:
+        ws = create_workspace(name)
+        console.print(f"[green]Created workspace:[/green] {ws.name}")
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+
+@workspace_app.command("list")
+def workspace_list() -> None:
+    """List all workspaces."""
+    from acemusic.workspace import ensure_default_workspace
+
+    ensure_default_workspace()
+    workspaces = list_workspaces()
+    table = Table(title="Workspaces", show_header=True)
+    table.add_column("Name", style="cyan")
+    table.add_column("Clips", justify="right")
+    table.add_column("Active", justify="center")
+    table.add_column("Created")
+    for ws in workspaces:
+        active_mark = "[green]\u2713[/green]" if ws.is_active else ""
+        table.add_row(ws.name, str(get_clip_count(ws.id)), active_mark, ws.created_at[:10])
+    console.print(table)
+
+
+@workspace_app.command("switch")
+def workspace_switch(name: str = typer.Argument(..., help="Workspace name to activate.")) -> None:
+    """Switch the active workspace."""
+    try:
+        switch_workspace(name)
+        console.print(f"[green]Switched to workspace:[/green] {name}")
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+
+@workspace_app.command("rename")
+def workspace_rename(
+    old_name: str = typer.Argument(..., help="Current workspace name."),
+    new_name: str = typer.Argument(..., help="New workspace name."),
+) -> None:
+    """Rename a workspace."""
+    try:
+        rename_workspace(old_name, new_name)
+        console.print(f"[green]Renamed workspace:[/green] {old_name!r} → {new_name!r}")
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+
+@workspace_app.command("delete")
+def workspace_delete(
+    name: str = typer.Argument(..., help="Workspace name to delete."),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt."),
+) -> None:
+    """Delete a workspace (prompts if non-empty, unless --force)."""
+    try:
+        clips = get_clip_count(_get_workspace_id(name))
+        if clips > 0 and not force:
+            confirmed = typer.confirm(
+                f"Workspace {name!r} contains {clips} clip(s). Delete anyway?"
+            )
+            if not confirmed:
+                console.print("Aborted.")
+                return
+        delete_workspace(name)
+        console.print(f"[green]Deleted workspace:[/green] {name}")
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+
+def _get_workspace_id(name: str) -> str:
+    """Return the workspace id for the given name, or raise ValueError."""
+    for ws in list_workspaces():
+        if ws.name == name:
+            return ws.id
+    raise ValueError(f"Workspace {name!r} not found")
 
 
 @app.command()

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import time
 from datetime import datetime
 from pathlib import Path
@@ -821,7 +822,7 @@ def workspace_create(name: str = typer.Argument(..., help="Workspace name.")) ->
     try:
         ws = create_workspace(name)
         console.print(f"[green]Created workspace:[/green] {ws.name}")
-    except ValueError as exc:
+    except (ValueError, sqlite3.Error, OSError) as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
 
@@ -829,8 +830,12 @@ def workspace_create(name: str = typer.Argument(..., help="Workspace name.")) ->
 @workspace_app.command("list")
 def workspace_list() -> None:
     """List all workspaces."""
-    ensure_default_workspace()
-    workspaces = list_workspaces()
+    try:
+        ensure_default_workspace()
+        workspaces = list_workspaces()
+    except (ValueError, sqlite3.Error, OSError) as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
     table = Table(title="Workspaces", show_header=True)
     table.add_column("Name", style="cyan")
     table.add_column("Clips", justify="right")
@@ -848,7 +853,7 @@ def workspace_switch(name: str = typer.Argument(..., help="Workspace name to act
     try:
         switch_workspace(name)
         console.print(f"[green]Switched to workspace:[/green] {name}")
-    except ValueError as exc:
+    except (ValueError, sqlite3.Error, OSError) as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
 
@@ -862,7 +867,7 @@ def workspace_rename(
     try:
         rename_workspace(old_name, new_name)
         console.print(f"[green]Renamed workspace:[/green] {old_name!r} → {new_name!r}")
-    except ValueError as exc:
+    except (ValueError, sqlite3.Error, OSError) as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
 
@@ -882,7 +887,7 @@ def workspace_delete(
                 return
         delete_workspace(name)
         console.print(f"[green]Deleted workspace:[/green] {name}")
-    except ValueError as exc:
+    except (ValueError, sqlite3.Error, OSError) as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -20,8 +20,10 @@ from acemusic.utils import get_duration, make_filename, make_slug
 from acemusic.workspace import (
     create_workspace,
     delete_workspace,
+    ensure_default_workspace,
     get_active_workspace,
     get_clip_count,
+    get_workspace_by_name,
     get_workspace_path,
     list_workspaces,
     rename_workspace,
@@ -828,8 +830,6 @@ def workspace_create(name: str = typer.Argument(..., help="Workspace name.")) ->
 @workspace_app.command("list")
 def workspace_list() -> None:
     """List all workspaces."""
-    from acemusic.workspace import ensure_default_workspace
-
     ensure_default_workspace()
     workspaces = list_workspaces()
     table = Table(title="Workspaces", show_header=True)
@@ -875,7 +875,7 @@ def workspace_delete(
 ) -> None:
     """Delete a workspace (prompts if non-empty, unless --force)."""
     try:
-        clips = get_clip_count(_get_workspace_id(name))
+        clips = get_clip_count(get_workspace_by_name(name).id)
         if clips > 0 and not force:
             confirmed = typer.confirm(
                 f"Workspace {name!r} contains {clips} clip(s). Delete anyway?"
@@ -888,14 +888,6 @@ def workspace_delete(
     except ValueError as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
-
-
-def _get_workspace_id(name: str) -> str:
-    """Return the workspace id for the given name, or raise ValueError."""
-    for ws in list_workspaces():
-        if ws.name == name:
-            return ws.id
-    raise ValueError(f"Workspace {name!r} not found")
 
 
 @app.command()

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -101,7 +101,7 @@ def main(
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())
         raise typer.Exit(0)
-    elif ctx.invoked_subcommand not in ("models", "workspace"):  # offline-safe subcommands skip URL check
+    elif ctx.invoked_subcommand not in ("models", "workspace"):
         config = load_config()
         if not config.api_url:
             typer.echo("ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml")
@@ -335,7 +335,6 @@ def generate(
         )
         raise typer.Exit(code=1)
 
-    # Resolve output directory: --output > config output_dir > active workspace > CWD
     if output is not None:
         output_path = output
     elif config.output_dir:

--- a/src/acemusic/db.py
+++ b/src/acemusic/db.py
@@ -23,14 +23,12 @@ def get_db() -> sqlite3.Connection:
 
 
 def _init_schema(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        """
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS workspaces (
             id         TEXT PRIMARY KEY,
             name       TEXT UNIQUE NOT NULL,
             is_active  INTEGER DEFAULT 0,
             created_at TEXT NOT NULL
         )
-        """
-    )
+        """)
     conn.commit()

--- a/src/acemusic/db.py
+++ b/src/acemusic/db.py
@@ -1,0 +1,36 @@
+"""SQLite database management for acemusic metadata (US-4.1)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+DB_DIR: Path = Path.home() / ".acemusic"
+
+
+def get_db() -> sqlite3.Connection:
+    """Return an open SQLite connection to the acemusic metadata database.
+
+    Creates the database file and schema on first call. The caller is
+    responsible for closing the connection.
+    """
+    db_path = DB_DIR / "metadata.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    _init_schema(conn)
+    return conn
+
+
+def _init_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS workspaces (
+            id         TEXT PRIMARY KEY,
+            name       TEXT UNIQUE NOT NULL,
+            is_active  INTEGER DEFAULT 0,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()

--- a/src/acemusic/workspace.py
+++ b/src/acemusic/workspace.py
@@ -64,8 +64,7 @@ def create_workspace(name: str) -> Workspace:
             (ws_id, name, created_at),
         )
         conn.commit()
-        row = conn.execute("SELECT * FROM workspaces WHERE id = ?", (ws_id,)).fetchone()
-        return _row_to_workspace(row)
+        return Workspace(id=ws_id, name=name, is_active=False, created_at=created_at)
     finally:
         conn.close()
 
@@ -76,6 +75,18 @@ def list_workspaces() -> list[Workspace]:
     try:
         rows = conn.execute("SELECT * FROM workspaces ORDER BY created_at").fetchall()
         return [_row_to_workspace(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_workspace_by_name(name: str) -> Workspace:
+    """Return the workspace with the given name, or raise ValueError if not found."""
+    conn = _db.get_db()
+    try:
+        row = conn.execute("SELECT * FROM workspaces WHERE name = ?", (name,)).fetchone()
+        if row is None:
+            raise ValueError(f"Workspace {name!r} not found")
+        return _row_to_workspace(row)
     finally:
         conn.close()
 
@@ -93,8 +104,13 @@ def get_active_workspace() -> Workspace:
             ).fetchone()
             conn.execute("UPDATE workspaces SET is_active = 1 WHERE id = ?", (first["id"],))
             conn.commit()
-            row = conn.execute("SELECT * FROM workspaces WHERE id = ?", (first["id"],)).fetchone()
-        return _row_to_workspace(row)
+            row = first
+        return Workspace(
+            id=row["id"],
+            name=row["name"],
+            is_active=True,
+            created_at=row["created_at"],
+        )
     finally:
         conn.close()
 

--- a/src/acemusic/workspace.py
+++ b/src/acemusic/workspace.py
@@ -99,9 +99,7 @@ def get_active_workspace() -> Workspace:
         row = conn.execute("SELECT * FROM workspaces WHERE is_active = 1").fetchone()
         if row is None:
             # Edge case: workspaces exist but none is active — activate the oldest.
-            first = conn.execute(
-                "SELECT * FROM workspaces ORDER BY created_at LIMIT 1"
-            ).fetchone()
+            first = conn.execute("SELECT * FROM workspaces ORDER BY created_at LIMIT 1").fetchone()
             conn.execute("UPDATE workspaces SET is_active = 1 WHERE id = ?", (first["id"],))
             conn.commit()
             row = first

--- a/src/acemusic/workspace.py
+++ b/src/acemusic/workspace.py
@@ -1,0 +1,162 @@
+"""Workspace repository for acemusic (US-4.1).
+
+Workspaces are named containers for audio clips. Audio files are stored under
+~/.acemusic/workspaces/{workspace_id}/clips/. A "Default" workspace is
+auto-created on first access.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import acemusic.db as _db
+
+
+@dataclass
+class Workspace:
+    id: str
+    name: str
+    is_active: bool
+    created_at: str
+
+
+def _row_to_workspace(row: sqlite3.Row) -> Workspace:
+    return Workspace(
+        id=row["id"],
+        name=row["name"],
+        is_active=bool(row["is_active"]),
+        created_at=row["created_at"],
+    )
+
+
+def ensure_default_workspace() -> None:
+    """Create the Default workspace if no workspaces exist."""
+    conn = _db.get_db()
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM workspaces").fetchone()[0]
+        if count == 0:
+            ws_id = str(uuid.uuid4())
+            created_at = datetime.now(timezone.utc).isoformat()
+            conn.execute(
+                "INSERT INTO workspaces (id, name, is_active, created_at) VALUES (?, ?, 1, ?)",
+                (ws_id, "Default", created_at),
+            )
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def create_workspace(name: str) -> Workspace:
+    """Create a new workspace with the given name and return it."""
+    conn = _db.get_db()
+    try:
+        if conn.execute("SELECT id FROM workspaces WHERE name = ?", (name,)).fetchone():
+            raise ValueError(f"Workspace {name!r} already exists")
+        ws_id = str(uuid.uuid4())
+        created_at = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            "INSERT INTO workspaces (id, name, is_active, created_at) VALUES (?, ?, 0, ?)",
+            (ws_id, name, created_at),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM workspaces WHERE id = ?", (ws_id,)).fetchone()
+        return _row_to_workspace(row)
+    finally:
+        conn.close()
+
+
+def list_workspaces() -> list[Workspace]:
+    """Return all workspaces sorted by creation time."""
+    conn = _db.get_db()
+    try:
+        rows = conn.execute("SELECT * FROM workspaces ORDER BY created_at").fetchall()
+        return [_row_to_workspace(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_active_workspace() -> Workspace:
+    """Return the active workspace, auto-creating Default if no workspaces exist."""
+    ensure_default_workspace()
+    conn = _db.get_db()
+    try:
+        row = conn.execute("SELECT * FROM workspaces WHERE is_active = 1").fetchone()
+        if row is None:
+            # Edge case: workspaces exist but none is active — activate the oldest.
+            first = conn.execute(
+                "SELECT * FROM workspaces ORDER BY created_at LIMIT 1"
+            ).fetchone()
+            conn.execute("UPDATE workspaces SET is_active = 1 WHERE id = ?", (first["id"],))
+            conn.commit()
+            row = conn.execute("SELECT * FROM workspaces WHERE id = ?", (first["id"],)).fetchone()
+        return _row_to_workspace(row)
+    finally:
+        conn.close()
+
+
+def switch_workspace(name: str) -> None:
+    """Set the named workspace as active."""
+    conn = _db.get_db()
+    try:
+        row = conn.execute("SELECT id FROM workspaces WHERE name = ?", (name,)).fetchone()
+        if row is None:
+            raise ValueError(f"Workspace {name!r} not found")
+        conn.execute("UPDATE workspaces SET is_active = 0")
+        conn.execute("UPDATE workspaces SET is_active = 1 WHERE id = ?", (row["id"],))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def rename_workspace(old_name: str, new_name: str) -> None:
+    """Rename a workspace from old_name to new_name."""
+    conn = _db.get_db()
+    try:
+        row = conn.execute("SELECT id FROM workspaces WHERE name = ?", (old_name,)).fetchone()
+        if row is None:
+            raise ValueError(f"Workspace {old_name!r} not found")
+        if conn.execute("SELECT id FROM workspaces WHERE name = ?", (new_name,)).fetchone():
+            raise ValueError(f"Workspace {new_name!r} already exists")
+        conn.execute("UPDATE workspaces SET name = ? WHERE id = ?", (new_name, row["id"]))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def delete_workspace(name: str) -> None:
+    """Delete a workspace by name and remove its clips directory."""
+    conn = _db.get_db()
+    try:
+        row = conn.execute("SELECT id FROM workspaces WHERE name = ?", (name,)).fetchone()
+        if row is None:
+            raise ValueError(f"Workspace {name!r} not found")
+        count = conn.execute("SELECT COUNT(*) FROM workspaces").fetchone()[0]
+        if count <= 1:
+            raise ValueError("Cannot delete the last remaining workspace")
+        ws_id = row["id"]
+        conn.execute("DELETE FROM workspaces WHERE id = ?", (ws_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    ws_dir = get_workspace_path(ws_id).parent  # parent of clips/
+    if ws_dir.exists():
+        shutil.rmtree(ws_dir)
+
+
+def get_workspace_path(workspace_id: str) -> Path:
+    """Return the clips directory for the given workspace."""
+    return _db.DB_DIR / "workspaces" / workspace_id / "clips"
+
+
+def get_clip_count(workspace_id: str) -> int:
+    """Count audio files in the workspace's clips directory."""
+    clips_dir = get_workspace_path(workspace_id)
+    if not clips_dir.exists():
+        return 0
+    return sum(1 for f in clips_dir.iterdir() if f.is_file())

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -340,12 +340,15 @@ class TestGenerateOutputNaming:
         assert len(list(cli_out.glob("*.wav"))) == 2
         assert len(list(config_dir.glob("*.wav"))) == 0
 
-    def test_output_falls_back_to_cwd_when_no_config(self, monkeypatch, tmp_path):
-        """When --output omitted and no config output_dir, files go to CWD."""
+    def test_output_falls_back_to_active_workspace_when_no_config(self, monkeypatch, tmp_path):
+        """When --output omitted and no config output_dir, files go to the active workspace."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
-        monkeypatch.chdir(tmp_path)
 
         from acemusic.config import AceConfig
+        from acemusic.workspace import get_active_workspace, get_workspace_path
 
         monkeypatch.setattr(
             "acemusic.cli.load_config",
@@ -361,7 +364,39 @@ class TestGenerateOutputNaming:
             result = runner.invoke(app, ["generate", "test"])
 
         assert result.exit_code == 0, result.output
-        assert len(list(tmp_path.glob("*.wav"))) == 2
+        active_ws = get_active_workspace()
+        clips_dir = get_workspace_path(active_ws.id)
+        assert len(list(clips_dir.glob("*.wav"))) == 2
+
+    def test_output_uses_switched_workspace(self, monkeypatch, tmp_path):
+        """Files go to the switched active workspace when no --output or config output_dir."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        from acemusic.config import AceConfig
+        from acemusic.workspace import create_workspace, get_workspace_path, switch_workspace
+
+        ws = create_workspace("MyProject")
+        switch_workspace("MyProject")
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url="http://localhost:8001", api_key=None, output_dir=None),
+        )
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "test"])
+
+        assert result.exit_code == 0, result.output
+        clips_dir = get_workspace_path(ws.id)
+        assert len(list(clips_dir.glob("*.wav"))) == 2
 
 
 class TestStyleLyricsFlags:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,365 @@
+"""Tests for workspace repository and CLI commands (US-4.1)."""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_workspace(tmp_path, monkeypatch):
+    """Redirect DB and workspace dirs to tmp_path for full isolation."""
+    import acemusic.db as _db
+
+    monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# ensure_default_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureDefaultWorkspace:
+    def test_creates_default_on_first_access(self, isolated_workspace):
+        from acemusic.workspace import ensure_default_workspace, list_workspaces
+
+        ensure_default_workspace()
+        workspaces = list_workspaces()
+        assert len(workspaces) == 1
+        assert workspaces[0].name == "Default"
+        assert workspaces[0].is_active
+
+    def test_is_idempotent(self, isolated_workspace):
+        from acemusic.workspace import ensure_default_workspace, list_workspaces
+
+        ensure_default_workspace()
+        ensure_default_workspace()
+        assert len(list_workspaces()) == 1
+
+
+# ---------------------------------------------------------------------------
+# create_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkspace:
+    def test_creates_workspace(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, list_workspaces
+
+        ws = create_workspace("My Album")
+        assert ws.name == "My Album"
+        assert any(w.name == "My Album" for w in list_workspaces())
+
+    def test_raises_on_duplicate_name(self, isolated_workspace):
+        from acemusic.workspace import create_workspace
+
+        create_workspace("My Album")
+        with pytest.raises(ValueError, match="already exists"):
+            create_workspace("My Album")
+
+
+# ---------------------------------------------------------------------------
+# list_workspaces
+# ---------------------------------------------------------------------------
+
+
+class TestListWorkspaces:
+    def test_returns_all_workspaces(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, list_workspaces
+
+        create_workspace("Alpha")
+        create_workspace("Beta")
+        names = [w.name for w in list_workspaces()]
+        assert "Alpha" in names
+        assert "Beta" in names
+
+    def test_sorted_by_created_at(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, list_workspaces
+
+        create_workspace("First")
+        create_workspace("Second")
+        names = [w.name for w in list_workspaces()]
+        assert names.index("First") < names.index("Second")
+
+
+# ---------------------------------------------------------------------------
+# get_active_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestGetActiveWorkspace:
+    def test_returns_default_on_first_access(self, isolated_workspace):
+        from acemusic.workspace import get_active_workspace
+
+        ws = get_active_workspace()
+        assert ws.name == "Default"
+        assert ws.is_active
+
+    def test_returns_switched_workspace(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, get_active_workspace, switch_workspace
+
+        create_workspace("Custom")
+        switch_workspace("Custom")
+        assert get_active_workspace().name == "Custom"
+
+
+# ---------------------------------------------------------------------------
+# switch_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestSwitchWorkspace:
+    def test_switches_active_workspace(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, get_active_workspace, switch_workspace
+
+        create_workspace("New")
+        switch_workspace("New")
+        assert get_active_workspace().name == "New"
+
+    def test_only_one_active_at_a_time(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, list_workspaces, switch_workspace
+
+        create_workspace("A")
+        create_workspace("B")
+        switch_workspace("A")
+        switch_workspace("B")
+        active = [w for w in list_workspaces() if w.is_active]
+        assert len(active) == 1
+        assert active[0].name == "B"
+
+    def test_raises_on_not_found(self, isolated_workspace):
+        from acemusic.workspace import switch_workspace
+
+        with pytest.raises(ValueError, match="not found"):
+            switch_workspace("NonExistent")
+
+
+# ---------------------------------------------------------------------------
+# rename_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestRenameWorkspace:
+    def test_renames_workspace(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, list_workspaces, rename_workspace
+
+        create_workspace("Old Name")
+        rename_workspace("Old Name", "New Name")
+        names = [w.name for w in list_workspaces()]
+        assert "New Name" in names
+        assert "Old Name" not in names
+
+    def test_raises_on_not_found(self, isolated_workspace):
+        from acemusic.workspace import rename_workspace
+
+        with pytest.raises(ValueError, match="not found"):
+            rename_workspace("NonExistent", "New")
+
+    def test_raises_on_duplicate_target(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, rename_workspace
+
+        create_workspace("Alpha")
+        create_workspace("Beta")
+        with pytest.raises(ValueError, match="already exists"):
+            rename_workspace("Alpha", "Beta")
+
+
+# ---------------------------------------------------------------------------
+# delete_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteWorkspace:
+    def test_deletes_workspace(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, delete_workspace, list_workspaces
+
+        create_workspace("Extra")  # ensure not last
+        create_workspace("Temp")
+        delete_workspace("Temp")
+        names = [w.name for w in list_workspaces()]
+        assert "Temp" not in names
+
+    def test_raises_on_not_found(self, isolated_workspace):
+        from acemusic.workspace import delete_workspace
+
+        with pytest.raises(ValueError, match="not found"):
+            delete_workspace("NonExistent")
+
+    def test_raises_on_last_workspace(self, isolated_workspace):
+        from acemusic.workspace import delete_workspace, ensure_default_workspace
+
+        ensure_default_workspace()
+        with pytest.raises(ValueError, match="[Ll]ast"):
+            delete_workspace("Default")
+
+    def test_removes_clips_directory(self, isolated_workspace):
+        from acemusic.workspace import (
+            create_workspace,
+            delete_workspace,
+            get_workspace_path,
+        )
+
+        create_workspace("Extra")
+        ws = create_workspace("WithFiles")
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        (clips_dir / "clip.wav").write_bytes(b"FAKE")
+        delete_workspace("WithFiles")
+        assert not clips_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# get_workspace_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkspacePath:
+    def test_returns_correct_path(self, isolated_workspace, tmp_path):
+        from acemusic.workspace import create_workspace, get_workspace_path
+
+        ws = create_workspace("PathTest")
+        path = get_workspace_path(ws.id)
+        assert path == tmp_path / ".acemusic" / "workspaces" / ws.id / "clips"
+
+
+# ---------------------------------------------------------------------------
+# get_clip_count
+# ---------------------------------------------------------------------------
+
+
+class TestGetClipCount:
+    def test_returns_zero_when_empty(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, get_clip_count
+
+        ws = create_workspace("Empty")
+        assert get_clip_count(ws.id) == 0
+
+    def test_counts_files(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, get_clip_count, get_workspace_path
+
+        ws = create_workspace("Full")
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        (clips_dir / "clip1.wav").write_bytes(b"FAKE")
+        (clips_dir / "clip2.wav").write_bytes(b"FAKE")
+        assert get_clip_count(ws.id) == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI: workspace create
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceCreateCLI:
+    def test_create_workspace(self, isolated_workspace):
+        result = runner.invoke(app, ["workspace", "create", "My Album"])
+        assert result.exit_code == 0, result.output
+        assert "My Album" in result.output
+
+    def test_create_duplicate_name_shows_error(self, isolated_workspace):
+        runner.invoke(app, ["workspace", "create", "My Album"])
+        result = runner.invoke(app, ["workspace", "create", "My Album"])
+        assert result.exit_code != 0 or "already exists" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI: workspace list
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceListCLI:
+    def test_list_shows_default_workspace(self, isolated_workspace):
+        result = runner.invoke(app, ["workspace", "list"])
+        assert result.exit_code == 0, result.output
+        assert "Default" in result.output
+
+    def test_list_shows_created_workspaces(self, isolated_workspace):
+        runner.invoke(app, ["workspace", "create", "My Album"])
+        result = runner.invoke(app, ["workspace", "list"])
+        assert result.exit_code == 0, result.output
+        assert "My Album" in result.output
+
+    def test_list_marks_active_workspace(self, isolated_workspace):
+        result = runner.invoke(app, ["workspace", "list"])
+        assert result.exit_code == 0, result.output
+        assert "\u2713" in result.output  # ✓
+
+
+# ---------------------------------------------------------------------------
+# CLI: workspace switch
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceSwitchCLI:
+    def test_switch_workspace(self, isolated_workspace):
+        runner.invoke(app, ["workspace", "create", "New"])
+        result = runner.invoke(app, ["workspace", "switch", "New"])
+        assert result.exit_code == 0, result.output
+        assert "New" in result.output
+
+    def test_switch_not_found_shows_error(self, isolated_workspace):
+        result = runner.invoke(app, ["workspace", "switch", "NonExistent"])
+        assert result.exit_code != 0 or "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI: workspace rename
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceRenameCLI:
+    def test_rename_workspace(self, isolated_workspace):
+        runner.invoke(app, ["workspace", "create", "Old"])
+        result = runner.invoke(app, ["workspace", "rename", "Old", "New"])
+        assert result.exit_code == 0, result.output
+        assert "New" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: workspace delete
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceDeleteCLI:
+    def test_delete_with_force_flag(self, isolated_workspace):
+        runner.invoke(app, ["workspace", "create", "Temp"])
+        runner.invoke(app, ["workspace", "create", "Another"])
+        result = runner.invoke(app, ["workspace", "delete", "Temp", "--force"])
+        assert result.exit_code == 0, result.output
+
+    def test_delete_prompts_when_clips_exist(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, get_workspace_path
+
+        ws = create_workspace("FilledWS")
+        create_workspace("Extra")
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        (clips_dir / "clip.wav").write_bytes(b"FAKE")
+        result = runner.invoke(app, ["workspace", "delete", "FilledWS"], input="y\n")
+        assert result.exit_code == 0, result.output
+
+    def test_delete_aborts_on_no(self, isolated_workspace):
+        from acemusic.workspace import create_workspace, get_workspace_path, list_workspaces
+
+        ws = create_workspace("FilledWS2")
+        create_workspace("Extra2")
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        (clips_dir / "clip.wav").write_bytes(b"FAKE")
+        runner.invoke(app, ["workspace", "delete", "FilledWS2"], input="n\n")
+        names = [w.name for w in list_workspaces()]
+        assert "FilledWS2" in names
+
+    def test_delete_last_workspace_shows_error(self, isolated_workspace):
+        result = runner.invoke(app, ["workspace", "delete", "Default", "--force"])
+        assert result.exit_code != 0 or "last" in result.output.lower()


### PR DESCRIPTION
## Summary

Implements #24: US-4.1 Workspace Management

- Introduces named workspace containers for organizing generated clips
- `acemusic workspace create/list/switch/rename/delete` sub-commands
- Default workspace auto-created on first run; active workspace determines generate output directory
- SQLite metadata database at `~/.acemusic/metadata.db` (lazy-init, stdlib `sqlite3` only)

## Acceptance Criteria

- [x] Creating, listing, switching, renaming, and deleting workspaces all work
- [x] New generations are saved to the active workspace
- [x] Deleting a non-empty workspace requires confirmation
- [x] Default workspace exists on first run

## Test Plan

- [x] 33 new tests in `tests/test_workspace.py` (repository unit tests + CLI command tests, TDD)
- [x] 2 new generate integration tests verifying workspace output routing
- [x] 218 total tests passing, 0 failures
- [x] `ruff check` clean
- [x] Demo document `demo-us-4.1.md` with live command captures

## Implementation Notes

- `src/acemusic/db.py`: SQLite layer with `DB_DIR` module constant (monkeypatchable for test isolation)
- `src/acemusic/workspace.py`: Full CRUD repository; `get_workspace_by_name` added for CLI use
- `src/acemusic/cli.py`: `workspace_app = typer.Typer(...)` registered with `app.add_typer()`; "workspace" added to offline-safe subcommands in `main()` so no API URL is required
- Generate output resolution updated: `--output` > `config.output_dir` > active workspace clips dir (CWD fallback removed)

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace management: create, list, switch, rename, delete; a "Default" workspace is auto-created.
  * Workspace metadata is persisted locally; generation output now defaults to the active workspace when no output is specified.

* **Bug Fixes / UX**
  * Deleting non-empty workspaces prompts for confirmation; --force skips the prompt.

* **Documentation**
  * Added a demo documenting workspace flows and acceptance evidence.

* **Tests**
  * Added tests covering workspace repository, CLI flows, and generation output fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->