### PR TITLE
feat: US-4.2 clip metadata storage — SQLite, CRUD, and search

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1068,8 +1068,12 @@ def clips_search(
     bpm_range: Optional[str] = typer.Option(None, "--bpm-range", help="BPM range as MIN-MAX (e.g. 100-140)."),
     key: Optional[str] = typer.Option(None, "--key", help="Filter by key (exact match, e.g. 'C major')."),
     model: Optional[str] = typer.Option(None, "--model", help="Filter by model name."),
-    date_from: Optional[str] = typer.Option(None, "--date-from", help="Include clips created on or after this date (YYYY-MM-DD)."),
-    date_to: Optional[str] = typer.Option(None, "--date-to", help="Include clips created on or before this date (YYYY-MM-DD)."),
+    date_from: Optional[str] = typer.Option(
+        None, "--date-from", help="Include clips created on or after this date (YYYY-MM-DD)."
+    ),
+    date_to: Optional[str] = typer.Option(
+        None, "--date-to", help="Include clips created on or before this date (YYYY-MM-DD)."
+    ),
 ) -> None:
     """Search clips with optional filters."""
     bpm_min: Optional[int] = None

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -19,13 +19,11 @@ from acemusic.client import AceStepClient, AceStepError
 from acemusic.config import load_config
 from acemusic.db import (
     create_clip,
+    delete_clip,
     get_clip,
     list_clips,
     search_clips,
     update_clip_title,
-)
-from acemusic.db import (
-    delete_clip as _db_delete_clip,
 )
 from acemusic.elevenlabs_client import ElevenLabsClient, ElevenLabsError
 from acemusic.models import Clip
@@ -1063,7 +1061,7 @@ def clips_delete(
         raise typer.Exit(code=1)
     if not yes:
         typer.confirm(f"Delete clip {clip_id} and file {clip.file_path}?", abort=True)
-    _db_delete_clip(clip_id)
+    delete_clip(clip_id)
     Path(clip.file_path).unlink(missing_ok=True)
     console.print(f"[green]Deleted clip {clip_id}[/green] and file {clip.file_path}")
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -600,7 +600,7 @@ def _generate_via_ace_step(
 
         try:
             ws = get_active_workspace()
-            bpm_int = bpm if isinstance(bpm, int) else None
+            bpm_int = int(bpm) if isinstance(bpm, (int, float)) else None
             clip = Clip(
                 title=f"{slug}-{i}",
                 workspace_id=ws.id,
@@ -616,7 +616,7 @@ def _generate_via_ace_step(
                 seed=seed,
                 inference_steps=inference_steps,
                 generation_mode="generate",
-                created_at=datetime.now().isoformat(),
+                created_at=datetime.now(timezone.utc).isoformat(),
             )
             create_clip(clip)
         except Exception:
@@ -695,7 +695,7 @@ def _generate_via_elevenlabs(
                 lyrics=lyrics,
                 model="elevenlabs",
                 generation_mode="generate",
-                created_at=datetime.now().isoformat(),
+                created_at=datetime.now(timezone.utc).isoformat(),
             )
             create_clip(clip)
         except Exception:
@@ -964,8 +964,7 @@ def _fmt_duration(seconds: Optional[float]) -> str:
     """Format a duration in seconds as MM:SS, or '-' if None."""
     if seconds is None:
         return "-"
-    mins = int(seconds) // 60
-    secs = int(seconds) % 60
+    mins, secs = divmod(int(seconds), 60)
     return f"{mins:02d}:{secs:02d}"
 
 
@@ -1052,14 +1051,20 @@ def clips_rename(
 
 
 @clips_app.command("delete")
-def clips_delete(clip_id: int = typer.Argument(..., help="Clip ID.")) -> None:
-    """Delete a clip and its audio file."""
-    file_path = _db_delete_clip(clip_id)
-    if file_path is None:
+def clips_delete(
+    clip_id: int = typer.Argument(..., help="Clip ID."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+) -> None:
+    """Delete a clip and its audio file (permanent — also removes the audio from disk)."""
+    clip = get_clip(clip_id)
+    if clip is None:
         console.print(f"[red]Clip {clip_id} not found.[/red]")
         raise typer.Exit(code=1)
-    Path(file_path).unlink(missing_ok=True)
-    console.print(f"[green]Deleted clip {clip_id}[/green] and file {file_path}")
+    if not yes:
+        typer.confirm(f"Delete clip {clip_id} and file {clip.file_path}?", abort=True)
+    _db_delete_clip(clip_id)
+    Path(clip.file_path).unlink(missing_ok=True)
+    console.print(f"[green]Deleted clip {clip_id}[/green] and file {clip.file_path}")
 
 
 @clips_app.command("search")
@@ -1084,6 +1089,9 @@ def clips_search(
             console.print(f"[red]Invalid --bpm-range: {bpm_range!r}. Expected format: MIN-MAX (e.g. 100-140).[/red]")
             raise typer.Exit(code=1)
         bpm_min, bpm_max = int(parts[0]), int(parts[1])
+        if bpm_min > bpm_max:
+            console.print(f"[red]Invalid --bpm-range: min ({bpm_min}) must be ≤ max ({bpm_max}).[/red]")
+            raise typer.Exit(code=1)
 
     try:
         ensure_default_workspace()

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1,4 +1,4 @@
-"""CLI entry point for acemusic (US-2.1, US-2.2, US-2.3)."""
+"""CLI entry point for acemusic (US-2.1, US-2.2, US-2.3, US-4.2)."""
 
 from __future__ import annotations
 
@@ -16,7 +16,18 @@ from rich.table import Table
 from acemusic import __version__
 from acemusic.client import AceStepClient, AceStepError
 from acemusic.config import load_config
+from acemusic.db import (
+    create_clip,
+    get_clip,
+    list_clips,
+    search_clips,
+    update_clip_title,
+)
+from acemusic.db import (
+    delete_clip as _db_delete_clip,
+)
 from acemusic.elevenlabs_client import ElevenLabsClient, ElevenLabsError
+from acemusic.models import Clip
 from acemusic.utils import get_duration, make_filename, make_slug
 from acemusic.workspace import (
     create_workspace,
@@ -33,7 +44,9 @@ from acemusic.workspace import (
 
 app = typer.Typer(help="acemusic — AI music generation CLI")
 workspace_app = typer.Typer(help="Manage workspaces")
+clips_app = typer.Typer(help="Manage audio clips")
 app.add_typer(workspace_app, name="workspace")
+app.add_typer(clips_app, name="clips")
 console = Console()
 
 # ACE-Step model registry (US-3.4).
@@ -102,7 +115,7 @@ def main(
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())
         raise typer.Exit(0)
-    elif ctx.invoked_subcommand not in ("models", "workspace"):
+    elif ctx.invoked_subcommand not in ("models", "workspace", "clips"):
         config = load_config()
         if not config.api_url:
             typer.echo("ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml")
@@ -578,11 +591,36 @@ def _generate_via_ace_step(
             raise typer.Exit(code=1)
 
         dest.write_bytes(data)
+        dur: Optional[float] = None
         try:
             dur = get_duration(dest)
             dur_str = f"{dur:.1f}s"
         except Exception:
             dur_str = "unknown"
+
+        try:
+            ws = get_active_workspace()
+            bpm_int = bpm if isinstance(bpm, int) else None
+            clip = Clip(
+                title=f"{slug}-{i}",
+                workspace_id=ws.id,
+                file_path=str(dest.resolve()),
+                format=format,
+                duration=dur,
+                bpm=bpm_int,
+                key=key,
+                style_tags=style,
+                lyrics=lyrics,
+                vocal_language=vocal_language,
+                model=model,
+                seed=seed,
+                inference_steps=inference_steps,
+                generation_mode="generate",
+                created_at=datetime.now().isoformat(),
+            )
+            create_clip(clip)
+        except Exception:
+            pass  # metadata recording is best-effort; never block generation output
 
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
 
@@ -638,11 +676,30 @@ def _generate_via_elevenlabs(
             filename = make_filename(slug, timestamp, i, ext=ext)
         dest = output_path / filename
         dest.write_bytes(data)
+        el_dur: Optional[float] = None
         try:
-            dur = get_duration(dest)
-            dur_str = f"{dur:.1f}s"
+            el_dur = get_duration(dest)
+            dur_str = f"{el_dur:.1f}s"
         except Exception:
             dur_str = "unknown"
+
+        try:
+            ws = get_active_workspace()
+            clip = Clip(
+                title=f"{slug}-{i}",
+                workspace_id=ws.id,
+                file_path=str(dest.resolve()),
+                format=ext,
+                duration=el_dur,
+                style_tags=style,
+                lyrics=lyrics,
+                model="elevenlabs",
+                generation_mode="generate",
+                created_at=datetime.now().isoformat(),
+            )
+            create_clip(clip)
+        except Exception:
+            pass  # metadata recording is best-effort; never block generation output
 
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
 
@@ -896,3 +953,169 @@ def workspace_delete(
 def status() -> None:
     """Check the status of the ACE-Step server."""
     typer.echo("Not yet implemented")
+
+
+# ---------------------------------------------------------------------------
+# clips sub-application (US-4.2)
+# ---------------------------------------------------------------------------
+
+
+def _fmt_duration(seconds: Optional[float]) -> str:
+    """Format a duration in seconds as MM:SS, or '-' if None."""
+    if seconds is None:
+        return "-"
+    mins = int(seconds) // 60
+    secs = int(seconds) % 60
+    return f"{mins:02d}:{secs:02d}"
+
+
+@clips_app.command("list")
+def clips_list() -> None:
+    """List all clips in the active workspace."""
+    try:
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        clips = list_clips(ws.id)
+    except (ValueError, sqlite3.Error, OSError) as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if not clips:
+        console.print("No clips found.")
+        return
+
+    table = Table(title=f"Clips — {ws.name}", show_header=True)
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Title")
+    table.add_column("Duration", justify="right")
+    table.add_column("BPM", justify="right")
+    table.add_column("Model")
+    table.add_column("Created")
+    for clip in clips:
+        table.add_row(
+            str(clip.id),
+            clip.title or "-",
+            _fmt_duration(clip.duration),
+            str(clip.bpm) if clip.bpm is not None else "-",
+            clip.model or "-",
+            (clip.created_at or "")[:10],
+        )
+    console.print(table)
+
+
+@clips_app.command("info")
+def clips_info(clip_id: int = typer.Argument(..., help="Clip ID.")) -> None:
+    """Show full metadata for a clip."""
+    clip = get_clip(clip_id)
+    if clip is None:
+        console.print(f"[red]Clip {clip_id} not found.[/red]")
+        raise typer.Exit(code=1)
+
+    table = Table(show_header=False, box=None, padding=(0, 1))
+    table.add_column("Field", style="bold")
+    table.add_column("Value")
+    fields = [
+        ("ID", str(clip.id)),
+        ("Title", clip.title or "-"),
+        ("Workspace", clip.workspace_id),
+        ("File", clip.file_path),
+        ("Format", clip.format or "-"),
+        ("Duration", _fmt_duration(clip.duration)),
+        ("BPM", str(clip.bpm) if clip.bpm is not None else "-"),
+        ("Key", clip.key or "-"),
+        ("Style Tags", clip.style_tags or "-"),
+        ("Lyrics", clip.lyrics or "-"),
+        ("Vocal Language", clip.vocal_language or "-"),
+        ("Model", clip.model or "-"),
+        ("Seed", str(clip.seed) if clip.seed is not None else "-"),
+        ("Inference Steps", str(clip.inference_steps) if clip.inference_steps is not None else "-"),
+        ("Parent Clip ID", str(clip.parent_clip_id) if clip.parent_clip_id is not None else "-"),
+        ("Generation Mode", clip.generation_mode or "-"),
+        ("Created", clip.created_at),
+    ]
+    for field_name, value in fields:
+        table.add_row(field_name, value)
+    console.print(table)
+
+
+@clips_app.command("rename")
+def clips_rename(
+    clip_id: int = typer.Argument(..., help="Clip ID."),
+    new_title: str = typer.Argument(..., help="New title for the clip."),
+) -> None:
+    """Rename a clip."""
+    success = update_clip_title(clip_id, new_title)
+    if not success:
+        console.print(f"[red]Clip {clip_id} not found.[/red]")
+        raise typer.Exit(code=1)
+    console.print(f"[green]Renamed clip {clip_id}:[/green] {new_title!r}")
+
+
+@clips_app.command("delete")
+def clips_delete(clip_id: int = typer.Argument(..., help="Clip ID.")) -> None:
+    """Delete a clip and its audio file."""
+    file_path = _db_delete_clip(clip_id)
+    if file_path is None:
+        console.print(f"[red]Clip {clip_id} not found.[/red]")
+        raise typer.Exit(code=1)
+    Path(file_path).unlink(missing_ok=True)
+    console.print(f"[green]Deleted clip {clip_id}[/green] and file {file_path}")
+
+
+@clips_app.command("search")
+def clips_search(
+    style: Optional[str] = typer.Option(None, "--style", help="Filter by style tag (substring match)."),
+    bpm_range: Optional[str] = typer.Option(None, "--bpm-range", help="BPM range as MIN-MAX (e.g. 100-140)."),
+    key: Optional[str] = typer.Option(None, "--key", help="Filter by key (exact match, e.g. 'C major')."),
+    model: Optional[str] = typer.Option(None, "--model", help="Filter by model name."),
+    date_from: Optional[str] = typer.Option(None, "--date-from", help="Include clips created on or after this date (YYYY-MM-DD)."),
+    date_to: Optional[str] = typer.Option(None, "--date-to", help="Include clips created on or before this date (YYYY-MM-DD)."),
+) -> None:
+    """Search clips with optional filters."""
+    bpm_min: Optional[int] = None
+    bpm_max: Optional[int] = None
+    if bpm_range is not None:
+        parts = bpm_range.split("-")
+        if len(parts) != 2 or not parts[0].isdigit() or not parts[1].isdigit():
+            console.print(f"[red]Invalid --bpm-range: {bpm_range!r}. Expected format: MIN-MAX (e.g. 100-140).[/red]")
+            raise typer.Exit(code=1)
+        bpm_min, bpm_max = int(parts[0]), int(parts[1])
+
+    try:
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        clips = search_clips(
+            workspace_id=ws.id,
+            style=style,
+            bpm_min=bpm_min,
+            bpm_max=bpm_max,
+            key=key,
+            model=model,
+            date_from=date_from,
+            date_to=date_to,
+        )
+    except (ValueError, sqlite3.Error, OSError) as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if not clips:
+        console.print("No clips found matching the given filters.")
+        return
+
+    table = Table(title="Search Results", show_header=True)
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Title")
+    table.add_column("Duration", justify="right")
+    table.add_column("BPM", justify="right")
+    table.add_column("Model")
+    table.add_column("Created")
+    for clip in clips:
+        table.add_row(
+            str(clip.id),
+            clip.title or "-",
+            _fmt_duration(clip.duration),
+            str(clip.bpm) if clip.bpm is not None else "-",
+            clip.model or "-",
+            (clip.created_at or "")[:10],
+        )
+    console.print(table)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import time
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -619,8 +620,8 @@ def _generate_via_ace_step(
                 created_at=datetime.now(timezone.utc).isoformat(),
             )
             create_clip(clip)
-        except Exception:
-            pass  # metadata recording is best-effort; never block generation output
+        except Exception as exc:
+            warnings.warn(f"clip metadata not saved: {exc}", stacklevel=2)
 
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
 
@@ -698,8 +699,8 @@ def _generate_via_elevenlabs(
                 created_at=datetime.now(timezone.utc).isoformat(),
             )
             create_clip(clip)
-        except Exception:
-            pass  # metadata recording is best-effort; never block generation output
+        except Exception as exc:
+            warnings.warn(f"clip metadata not saved: {exc}", stacklevel=2)
 
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
 

--- a/src/acemusic/db.py
+++ b/src/acemusic/db.py
@@ -1,9 +1,13 @@
-"""SQLite database management for acemusic metadata (US-4.1)."""
+"""SQLite database management for acemusic metadata (US-4.1, US-4.2)."""
 
 from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from acemusic.models import Clip
 
 DB_DIR: Path = Path.home() / ".acemusic"
 
@@ -31,4 +35,186 @@ def _init_schema(conn: sqlite3.Connection) -> None:
             created_at TEXT NOT NULL
         )
         """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS clips (
+            id               INTEGER PRIMARY KEY,
+            title            TEXT,
+            workspace_id     TEXT NOT NULL,
+            file_path        TEXT NOT NULL,
+            format           TEXT,
+            duration         REAL,
+            bpm              INTEGER,
+            key              TEXT,
+            style_tags       TEXT,
+            lyrics           TEXT,
+            vocal_language   TEXT,
+            model            TEXT,
+            seed             INTEGER,
+            inference_steps  INTEGER,
+            parent_clip_id   INTEGER REFERENCES clips(id),
+            generation_mode  TEXT,
+            created_at       TEXT NOT NULL
+        )
+        """)
     conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Clip CRUD
+# ---------------------------------------------------------------------------
+
+
+def _row_to_clip(row: sqlite3.Row) -> "Clip":
+    from acemusic.models import Clip
+
+    return Clip(
+        id=row["id"],
+        title=row["title"],
+        workspace_id=row["workspace_id"],
+        file_path=row["file_path"],
+        format=row["format"],
+        duration=row["duration"],
+        bpm=row["bpm"],
+        key=row["key"],
+        style_tags=row["style_tags"],
+        lyrics=row["lyrics"],
+        vocal_language=row["vocal_language"],
+        model=row["model"],
+        seed=row["seed"],
+        inference_steps=row["inference_steps"],
+        parent_clip_id=row["parent_clip_id"],
+        generation_mode=row["generation_mode"],
+        created_at=row["created_at"],
+    )
+
+
+def create_clip(clip: "Clip") -> int:
+    """Insert a clip record and return the new row id."""
+    conn = get_db()
+    try:
+        cur = conn.execute(
+            """INSERT INTO clips
+               (title, workspace_id, file_path, format, duration, bpm, key,
+                style_tags, lyrics, vocal_language, model, seed, inference_steps,
+                parent_clip_id, generation_mode, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                clip.title,
+                clip.workspace_id,
+                clip.file_path,
+                clip.format,
+                clip.duration,
+                clip.bpm,
+                clip.key,
+                clip.style_tags,
+                clip.lyrics,
+                clip.vocal_language,
+                clip.model,
+                clip.seed,
+                clip.inference_steps,
+                clip.parent_clip_id,
+                clip.generation_mode,
+                clip.created_at,
+            ),
+        )
+        conn.commit()
+        return cur.lastrowid
+    finally:
+        conn.close()
+
+
+def get_clip(clip_id: int) -> Optional["Clip"]:
+    """Return the clip with the given id, or None if not found."""
+    conn = get_db()
+    try:
+        row = conn.execute("SELECT * FROM clips WHERE id = ?", (clip_id,)).fetchone()
+        return _row_to_clip(row) if row else None
+    finally:
+        conn.close()
+
+
+def list_clips(workspace_id: str) -> list["Clip"]:
+    """Return all clips for a workspace, newest first."""
+    conn = get_db()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM clips WHERE workspace_id = ? ORDER BY created_at DESC",
+            (workspace_id,),
+        ).fetchall()
+        return [_row_to_clip(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def update_clip_title(clip_id: int, title: str) -> bool:
+    """Rename a clip. Returns True if the record existed, False otherwise."""
+    conn = get_db()
+    try:
+        cur = conn.execute("UPDATE clips SET title = ? WHERE id = ?", (title, clip_id))
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def delete_clip(clip_id: int) -> Optional[str]:
+    """Delete a clip record and return its file_path, or None if not found."""
+    conn = get_db()
+    try:
+        row = conn.execute("SELECT file_path FROM clips WHERE id = ?", (clip_id,)).fetchone()
+        if row is None:
+            return None
+        file_path = row["file_path"]
+        conn.execute("DELETE FROM clips WHERE id = ?", (clip_id,))
+        conn.commit()
+        return file_path
+    finally:
+        conn.close()
+
+
+def search_clips(
+    workspace_id: str,
+    style: Optional[str] = None,
+    bpm_min: Optional[int] = None,
+    bpm_max: Optional[int] = None,
+    key: Optional[str] = None,
+    model: Optional[str] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+) -> list["Clip"]:
+    """Return clips matching the given filters, newest first."""
+    conditions = ["workspace_id = ?"]
+    params: list = [workspace_id]
+
+    if style is not None:
+        conditions.append("style_tags LIKE ?")
+        params.append(f"%{style}%")
+    if bpm_min is not None:
+        conditions.append("bpm >= ?")
+        params.append(bpm_min)
+    if bpm_max is not None:
+        conditions.append("bpm <= ?")
+        params.append(bpm_max)
+    if key is not None:
+        conditions.append("key = ?")
+        params.append(key)
+    if model is not None:
+        conditions.append("model = ?")
+        params.append(model)
+    if date_from is not None:
+        conditions.append("DATE(created_at) >= ?")
+        params.append(date_from)
+    if date_to is not None:
+        conditions.append("DATE(created_at) <= ?")
+        params.append(date_to)
+
+    where = " AND ".join(conditions)
+    conn = get_db()
+    try:
+        rows = conn.execute(
+            f"SELECT * FROM clips WHERE {where} ORDER BY created_at DESC",
+            params,
+        ).fetchall()
+        return [_row_to_clip(r) for r in rows]
+    finally:
+        conn.close()

--- a/src/acemusic/db.py
+++ b/src/acemusic/db.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
-if TYPE_CHECKING:
-    from acemusic.models import Clip
+from acemusic.models import Clip
 
 DB_DIR: Path = Path.home() / ".acemusic"
 
@@ -64,9 +63,7 @@ def _init_schema(conn: sqlite3.Connection) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _row_to_clip(row: sqlite3.Row) -> "Clip":
-    from acemusic.models import Clip
-
+def _row_to_clip(row: sqlite3.Row) -> Clip:
     return Clip(
         id=row["id"],
         title=row["title"],
@@ -88,7 +85,7 @@ def _row_to_clip(row: sqlite3.Row) -> "Clip":
     )
 
 
-def create_clip(clip: "Clip") -> int:
+def create_clip(clip: Clip) -> int:
     """Insert a clip record and return the new row id."""
     conn = get_db()
     try:
@@ -123,7 +120,7 @@ def create_clip(clip: "Clip") -> int:
         conn.close()
 
 
-def get_clip(clip_id: int) -> Optional["Clip"]:
+def get_clip(clip_id: int) -> Optional[Clip]:
     """Return the clip with the given id, or None if not found."""
     conn = get_db()
     try:
@@ -133,7 +130,7 @@ def get_clip(clip_id: int) -> Optional["Clip"]:
         conn.close()
 
 
-def list_clips(workspace_id: str) -> list["Clip"]:
+def list_clips(workspace_id: str) -> list[Clip]:
     """Return all clips for a workspace, newest first."""
     conn = get_db()
     try:
@@ -181,7 +178,7 @@ def search_clips(
     model: Optional[str] = None,
     date_from: Optional[str] = None,
     date_to: Optional[str] = None,
-) -> list["Clip"]:
+) -> list[Clip]:
     """Return clips matching the given filters, newest first."""
     conditions = ["workspace_id = ?"]
     params: list = [workspace_id]

--- a/src/acemusic/models.py
+++ b/src/acemusic/models.py
@@ -1,0 +1,29 @@
+"""Data models for acemusic (US-4.2)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Clip:
+    """Represents a generated audio clip with its full metadata."""
+
+    workspace_id: str
+    file_path: str
+    created_at: str
+    id: Optional[int] = field(default=None)
+    title: Optional[str] = field(default=None)
+    format: Optional[str] = field(default=None)
+    duration: Optional[float] = field(default=None)
+    bpm: Optional[int] = field(default=None)
+    key: Optional[str] = field(default=None)
+    style_tags: Optional[str] = field(default=None)
+    lyrics: Optional[str] = field(default=None)
+    vocal_language: Optional[str] = field(default=None)
+    model: Optional[str] = field(default=None)
+    seed: Optional[int] = field(default=None)
+    inference_steps: Optional[int] = field(default=None)
+    parent_clip_id: Optional[int] = field(default=None)
+    generation_mode: Optional[str] = field(default=None)

--- a/src/acemusic/models.py
+++ b/src/acemusic/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 
@@ -13,17 +13,17 @@ class Clip:
     workspace_id: str
     file_path: str
     created_at: str
-    id: Optional[int] = field(default=None)
-    title: Optional[str] = field(default=None)
-    format: Optional[str] = field(default=None)
-    duration: Optional[float] = field(default=None)
-    bpm: Optional[int] = field(default=None)
-    key: Optional[str] = field(default=None)
-    style_tags: Optional[str] = field(default=None)
-    lyrics: Optional[str] = field(default=None)
-    vocal_language: Optional[str] = field(default=None)
-    model: Optional[str] = field(default=None)
-    seed: Optional[int] = field(default=None)
-    inference_steps: Optional[int] = field(default=None)
-    parent_clip_id: Optional[int] = field(default=None)
-    generation_mode: Optional[str] = field(default=None)
+    id: Optional[int] = None
+    title: Optional[str] = None
+    format: Optional[str] = None
+    duration: Optional[float] = None
+    bpm: Optional[int] = None
+    key: Optional[str] = None
+    style_tags: Optional[str] = None
+    lyrics: Optional[str] = None
+    vocal_language: Optional[str] = None
+    model: Optional[str] = None
+    seed: Optional[int] = None
+    inference_steps: Optional[int] = None
+    parent_clip_id: Optional[int] = None
+    generation_mode: Optional[str] = None

--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -484,7 +484,7 @@ class TestClipsDeleteCommand:
         audio_file.write_bytes(b"fake audio data")
         clip_id = _insert_test_clip(db_path, title="Delete Me", workspace_id=ws.id, file_path=str(audio_file))
 
-        result = runner.invoke(app, ["clips", "delete", str(clip_id)])
+        result = runner.invoke(app, ["clips", "delete", str(clip_id), "--yes"])
         assert result.exit_code == 0
         assert not audio_file.exists()
 
@@ -499,7 +499,7 @@ class TestClipsDeleteCommand:
         from acemusic.workspace import ensure_default_workspace
 
         ensure_default_workspace()
-        result = runner.invoke(app, ["clips", "delete", "9999"])
+        result = runner.invoke(app, ["clips", "delete", "9999", "--yes"])
         assert result.exit_code != 0 or "not found" in result.output.lower()
 
 
@@ -553,6 +553,16 @@ class TestClipsSearchCommand:
 
         ensure_default_workspace()
         result = runner.invoke(app, ["clips", "search", "--bpm-range", "abc"])
+        assert result.exit_code != 0 or "invalid" in result.output.lower()
+
+    def test_search_bpm_range_min_gt_max(self, isolated_db):
+        import acemusic.db as _db
+
+        _db.get_db().close()
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+        result = runner.invoke(app, ["clips", "search", "--bpm-range", "140-100"])
         assert result.exit_code != 0 or "invalid" in result.output.lower()
 
     def test_search_no_results(self, isolated_db):

--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -81,10 +81,7 @@ class TestSchemaInit:
         import acemusic.db as _db
 
         conn = _db.get_db()
-        tables = [
-            r[0]
-            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
-        ]
+        tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
         conn.close()
         assert "clips" in tables
 
@@ -92,10 +89,7 @@ class TestSchemaInit:
         import acemusic.db as _db
 
         conn = _db.get_db()
-        tables = [
-            r[0]
-            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
-        ]
+        tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
         conn.close()
         assert "workspaces" in tables
 
@@ -146,6 +140,7 @@ class TestClipsCRUD:
 
     def test_list_clips_empty(self, isolated_db):
         import acemusic.db as _db
+
         _db.get_db().close()  # ensure schema is initialized
         from acemusic.db import list_clips
 
@@ -154,6 +149,7 @@ class TestClipsCRUD:
 
     def test_list_clips_returns_workspace_clips(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         from acemusic.db import create_clip, list_clips
@@ -181,6 +177,7 @@ class TestClipsCRUD:
 
     def test_list_clips_ordered_newest_first(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         from acemusic.db import create_clip, list_clips
@@ -196,6 +193,7 @@ class TestClipsCRUD:
 
     def test_update_clip_title(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
@@ -211,6 +209,7 @@ class TestClipsCRUD:
 
     def test_update_clip_title_not_found(self, isolated_db):
         import acemusic.db as _db
+
         _db.get_db().close()
         from acemusic.db import update_clip_title
 
@@ -219,6 +218,7 @@ class TestClipsCRUD:
 
     def test_delete_clip_returns_file_path(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
@@ -232,6 +232,7 @@ class TestClipsCRUD:
 
     def test_delete_clip_not_found(self, isolated_db):
         import acemusic.db as _db
+
         _db.get_db().close()
         from acemusic.db import delete_clip
 
@@ -246,13 +247,50 @@ class TestClipsCRUD:
 class TestClipsSearch:
     def _seed_clips(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
-        _insert_test_clip(db_path, title="Rock Track", workspace_id="ws-1", style_tags="rock, hard", bpm=140, key="E minor", model="ace-step-base", created_at="2026-01-01T10:00:00")
-        _insert_test_clip(db_path, title="Pop Track", workspace_id="ws-1", style_tags="pop, bright", bpm=100, key="C major", model="elevenlabs", created_at="2026-01-02T10:00:00")
-        _insert_test_clip(db_path, title="Jazz Track", workspace_id="ws-1", style_tags="jazz, smooth", bpm=90, key="Bb major", model="ace-step-xl", created_at="2026-01-03T10:00:00")
-        _insert_test_clip(db_path, title="Other WS", workspace_id="ws-2", style_tags="rock", bpm=120, key="G major", model="ace-step-base", created_at="2026-01-01T12:00:00")
+        _insert_test_clip(
+            db_path,
+            title="Rock Track",
+            workspace_id="ws-1",
+            style_tags="rock, hard",
+            bpm=140,
+            key="E minor",
+            model="ace-step-base",
+            created_at="2026-01-01T10:00:00",
+        )
+        _insert_test_clip(
+            db_path,
+            title="Pop Track",
+            workspace_id="ws-1",
+            style_tags="pop, bright",
+            bpm=100,
+            key="C major",
+            model="elevenlabs",
+            created_at="2026-01-02T10:00:00",
+        )
+        _insert_test_clip(
+            db_path,
+            title="Jazz Track",
+            workspace_id="ws-1",
+            style_tags="jazz, smooth",
+            bpm=90,
+            key="Bb major",
+            model="ace-step-xl",
+            created_at="2026-01-03T10:00:00",
+        )
+        _insert_test_clip(
+            db_path,
+            title="Other WS",
+            workspace_id="ws-2",
+            style_tags="rock",
+            bpm=120,
+            key="G major",
+            model="ace-step-base",
+            created_at="2026-01-01T12:00:00",
+        )
 
     def test_search_no_filters_returns_all_workspace_clips(self, isolated_db):
         self._seed_clips(isolated_db)
@@ -338,6 +376,7 @@ class TestClipsListCommand:
 
     def test_list_shows_clips(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
@@ -360,6 +399,7 @@ class TestClipsListCommand:
 class TestClipsInfoCommand:
     def test_info_valid_id(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
@@ -376,6 +416,7 @@ class TestClipsInfoCommand:
 
     def test_info_not_found(self, isolated_db):
         import acemusic.db as _db
+
         _db.get_db().close()
         from acemusic.workspace import ensure_default_workspace
 
@@ -392,6 +433,7 @@ class TestClipsInfoCommand:
 class TestClipsRenameCommand:
     def test_rename_success(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
@@ -412,6 +454,7 @@ class TestClipsRenameCommand:
 
     def test_rename_not_found(self, isolated_db):
         import acemusic.db as _db
+
         _db.get_db().close()
         from acemusic.workspace import ensure_default_workspace
 
@@ -428,6 +471,7 @@ class TestClipsRenameCommand:
 class TestClipsDeleteCommand:
     def test_delete_removes_record_and_file(self, isolated_db, tmp_path):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
@@ -450,6 +494,7 @@ class TestClipsDeleteCommand:
 
     def test_delete_not_found(self, isolated_db):
         import acemusic.db as _db
+
         _db.get_db().close()
         from acemusic.workspace import ensure_default_workspace
 
@@ -466,6 +511,7 @@ class TestClipsDeleteCommand:
 class TestClipsSearchCommand:
     def test_search_by_style_option(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
@@ -483,6 +529,7 @@ class TestClipsSearchCommand:
 
     def test_search_by_bpm_range(self, isolated_db):
         import acemusic.db as _db
+
         conn = _db.get_db()
         conn.close()
         db_path = _get_db_path(isolated_db)
@@ -500,6 +547,7 @@ class TestClipsSearchCommand:
 
     def test_search_bpm_range_invalid(self, isolated_db):
         import acemusic.db as _db
+
         _db.get_db().close()
         from acemusic.workspace import ensure_default_workspace
 
@@ -509,6 +557,7 @@ class TestClipsSearchCommand:
 
     def test_search_no_results(self, isolated_db):
         import acemusic.db as _db
+
         _db.get_db().close()
         from acemusic.workspace import ensure_default_workspace
 

--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -47,7 +47,7 @@ def _insert_test_clip(db_path: Path, **overrides) -> int:
         "inference_steps": 32,
         "parent_clip_id": None,
         "generation_mode": "generate",
-        "created_at": datetime.now().isoformat(),
+        "created_at": datetime.now(timezone.utc).isoformat(),
     }
     defaults.update(overrides)
     conn = sqlite3.connect(str(db_path))
@@ -120,7 +120,7 @@ class TestClipsCRUD:
             inference_steps=32,
             parent_clip_id=None,
             generation_mode="generate",
-            created_at=datetime.now().isoformat(),
+            created_at=datetime.now(timezone.utc).isoformat(),
         )
         clip_id = create_clip(clip)
         assert isinstance(clip_id, int)
@@ -162,7 +162,7 @@ class TestClipsCRUD:
                 file_path=f"/tmp/{title}.wav",
                 format="wav",
                 duration=30.0,
-                created_at=datetime.now().isoformat(),
+                created_at=datetime.now(timezone.utc).isoformat(),
             )
 
         create_clip(_make("Alpha", "ws-a"))

--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -1,0 +1,611 @@
+"""Tests for clip metadata storage and CLI commands (US-4.2)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    """Redirect DB_DIR to tmp_path for full isolation."""
+    import acemusic.db as _db
+
+    monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+    return tmp_path
+
+
+def _insert_test_clip(db_path: Path, **overrides) -> int:
+    """Insert a clip record directly via sqlite3 and return its id."""
+    defaults = {
+        "title": "Test Clip",
+        "workspace_id": "ws-test",
+        "file_path": "/tmp/test.wav",
+        "format": "wav",
+        "duration": 30.0,
+        "bpm": 120,
+        "key": "C major",
+        "style_tags": "pop, upbeat",
+        "lyrics": None,
+        "vocal_language": None,
+        "model": "ace-step-base",
+        "seed": 42,
+        "inference_steps": 32,
+        "parent_clip_id": None,
+        "generation_mode": "generate",
+        "created_at": datetime.now().isoformat(),
+    }
+    defaults.update(overrides)
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.execute(
+        """INSERT INTO clips
+           (title, workspace_id, file_path, format, duration, bpm, key,
+            style_tags, lyrics, vocal_language, model, seed, inference_steps,
+            parent_clip_id, generation_mode, created_at)
+           VALUES (:title, :workspace_id, :file_path, :format, :duration, :bpm, :key,
+                   :style_tags, :lyrics, :vocal_language, :model, :seed, :inference_steps,
+                   :parent_clip_id, :generation_mode, :created_at)""",
+        defaults,
+    )
+    conn.commit()
+    row_id = cur.lastrowid
+    conn.close()
+    return row_id
+
+
+def _get_db_path(isolated_db: Path) -> Path:
+    return isolated_db / ".acemusic" / "metadata.db"
+
+
+# ---------------------------------------------------------------------------
+# DB layer: schema init
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaInit:
+    def test_clips_table_created(self, isolated_db):
+        import acemusic.db as _db
+
+        conn = _db.get_db()
+        tables = [
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        ]
+        conn.close()
+        assert "clips" in tables
+
+    def test_workspaces_table_still_present(self, isolated_db):
+        import acemusic.db as _db
+
+        conn = _db.get_db()
+        tables = [
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        ]
+        conn.close()
+        assert "workspaces" in tables
+
+
+# ---------------------------------------------------------------------------
+# DB layer: CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestClipsCRUD:
+    def test_create_and_get_clip(self, isolated_db):
+        from acemusic.db import create_clip, get_clip
+        from acemusic.models import Clip
+
+        clip = Clip(
+            title="My Track",
+            workspace_id="ws-1",
+            file_path="/tmp/my-track.wav",
+            format="wav",
+            duration=45.0,
+            bpm=130,
+            key="A minor",
+            style_tags="rock",
+            lyrics=None,
+            vocal_language="en",
+            model="ace-step-base",
+            seed=7,
+            inference_steps=32,
+            parent_clip_id=None,
+            generation_mode="generate",
+            created_at=datetime.now().isoformat(),
+        )
+        clip_id = create_clip(clip)
+        assert isinstance(clip_id, int)
+        assert clip_id > 0
+
+        retrieved = get_clip(clip_id)
+        assert retrieved is not None
+        assert retrieved.title == "My Track"
+        assert retrieved.bpm == 130
+        assert retrieved.key == "A minor"
+        assert retrieved.seed == 7
+
+    def test_get_clip_not_found(self, isolated_db):
+        from acemusic.db import get_clip
+
+        assert get_clip(9999) is None
+
+    def test_list_clips_empty(self, isolated_db):
+        import acemusic.db as _db
+        _db.get_db().close()  # ensure schema is initialized
+        from acemusic.db import list_clips
+
+        clips = list_clips("ws-empty")
+        assert clips == []
+
+    def test_list_clips_returns_workspace_clips(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        from acemusic.db import create_clip, list_clips
+        from acemusic.models import Clip
+
+        def _make(title: str, ws: str) -> Clip:
+            return Clip(
+                title=title,
+                workspace_id=ws,
+                file_path=f"/tmp/{title}.wav",
+                format="wav",
+                duration=30.0,
+                created_at=datetime.now().isoformat(),
+            )
+
+        create_clip(_make("Alpha", "ws-a"))
+        create_clip(_make("Beta", "ws-a"))
+        create_clip(_make("Gamma", "ws-b"))
+
+        clips_a = list_clips("ws-a")
+        clips_b = list_clips("ws-b")
+        assert len(clips_a) == 2
+        assert len(clips_b) == 1
+        assert {c.title for c in clips_a} == {"Alpha", "Beta"}
+
+    def test_list_clips_ordered_newest_first(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        from acemusic.db import create_clip, list_clips
+        from acemusic.models import Clip
+
+        ts1 = "2026-01-01T10:00:00"
+        ts2 = "2026-01-01T11:00:00"
+        create_clip(Clip(title="Older", workspace_id="ws-x", file_path="/tmp/older.wav", format="wav", created_at=ts1))
+        create_clip(Clip(title="Newer", workspace_id="ws-x", file_path="/tmp/newer.wav", format="wav", created_at=ts2))
+
+        clips = list_clips("ws-x")
+        assert clips[0].title == "Newer"
+
+    def test_update_clip_title(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        clip_id = _insert_test_clip(db_path, workspace_id="ws-1")
+
+        from acemusic.db import get_clip, update_clip_title
+
+        result = update_clip_title(clip_id, "Renamed Track")
+        assert result is True
+
+        updated = get_clip(clip_id)
+        assert updated.title == "Renamed Track"
+
+    def test_update_clip_title_not_found(self, isolated_db):
+        import acemusic.db as _db
+        _db.get_db().close()
+        from acemusic.db import update_clip_title
+
+        result = update_clip_title(9999, "Ghost Track")
+        assert result is False
+
+    def test_delete_clip_returns_file_path(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        clip_id = _insert_test_clip(db_path, file_path="/tmp/track.wav")
+
+        from acemusic.db import delete_clip, get_clip
+
+        returned_path = delete_clip(clip_id)
+        assert returned_path == "/tmp/track.wav"
+        assert get_clip(clip_id) is None
+
+    def test_delete_clip_not_found(self, isolated_db):
+        import acemusic.db as _db
+        _db.get_db().close()
+        from acemusic.db import delete_clip
+
+        assert delete_clip(9999) is None
+
+
+# ---------------------------------------------------------------------------
+# DB layer: search
+# ---------------------------------------------------------------------------
+
+
+class TestClipsSearch:
+    def _seed_clips(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        _insert_test_clip(db_path, title="Rock Track", workspace_id="ws-1", style_tags="rock, hard", bpm=140, key="E minor", model="ace-step-base", created_at="2026-01-01T10:00:00")
+        _insert_test_clip(db_path, title="Pop Track", workspace_id="ws-1", style_tags="pop, bright", bpm=100, key="C major", model="elevenlabs", created_at="2026-01-02T10:00:00")
+        _insert_test_clip(db_path, title="Jazz Track", workspace_id="ws-1", style_tags="jazz, smooth", bpm=90, key="Bb major", model="ace-step-xl", created_at="2026-01-03T10:00:00")
+        _insert_test_clip(db_path, title="Other WS", workspace_id="ws-2", style_tags="rock", bpm=120, key="G major", model="ace-step-base", created_at="2026-01-01T12:00:00")
+
+    def test_search_no_filters_returns_all_workspace_clips(self, isolated_db):
+        self._seed_clips(isolated_db)
+        from acemusic.db import search_clips
+
+        clips = search_clips("ws-1")
+        assert len(clips) == 3
+
+    def test_search_by_style(self, isolated_db):
+        self._seed_clips(isolated_db)
+        from acemusic.db import search_clips
+
+        clips = search_clips("ws-1", style="rock")
+        assert len(clips) == 1
+        assert clips[0].title == "Rock Track"
+
+    def test_search_by_bpm_range(self, isolated_db):
+        self._seed_clips(isolated_db)
+        from acemusic.db import search_clips
+
+        clips = search_clips("ws-1", bpm_min=95, bpm_max=145)
+        assert len(clips) == 2
+        titles = {c.title for c in clips}
+        assert "Rock Track" in titles
+        assert "Pop Track" in titles
+
+    def test_search_by_key(self, isolated_db):
+        self._seed_clips(isolated_db)
+        from acemusic.db import search_clips
+
+        clips = search_clips("ws-1", key="C major")
+        assert len(clips) == 1
+        assert clips[0].title == "Pop Track"
+
+    def test_search_by_model(self, isolated_db):
+        self._seed_clips(isolated_db)
+        from acemusic.db import search_clips
+
+        clips = search_clips("ws-1", model="elevenlabs")
+        assert len(clips) == 1
+        assert clips[0].title == "Pop Track"
+
+    def test_search_by_date_from(self, isolated_db):
+        self._seed_clips(isolated_db)
+        from acemusic.db import search_clips
+
+        clips = search_clips("ws-1", date_from="2026-01-02")
+        assert len(clips) == 2
+        titles = {c.title for c in clips}
+        assert "Pop Track" in titles
+        assert "Jazz Track" in titles
+
+    def test_search_by_date_to(self, isolated_db):
+        self._seed_clips(isolated_db)
+        from acemusic.db import search_clips
+
+        clips = search_clips("ws-1", date_to="2026-01-01")
+        assert len(clips) == 1
+        assert clips[0].title == "Rock Track"
+
+    def test_search_isolates_to_workspace(self, isolated_db):
+        self._seed_clips(isolated_db)
+        from acemusic.db import search_clips
+
+        clips = search_clips("ws-2")
+        assert len(clips) == 1
+        assert clips[0].title == "Other WS"
+
+
+# ---------------------------------------------------------------------------
+# CLI: clips list
+# ---------------------------------------------------------------------------
+
+
+class TestClipsListCommand:
+    def test_list_empty(self, isolated_db):
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+        result = runner.invoke(app, ["clips", "list"])
+        assert result.exit_code == 0
+        assert "No clips" in result.output
+
+    def test_list_shows_clips(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        _insert_test_clip(db_path, title="My Song", workspace_id=ws.id, bpm=120, duration=65.0, model="ace-step-base")
+
+        result = runner.invoke(app, ["clips", "list"])
+        assert result.exit_code == 0
+        assert "My Song" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: clips info
+# ---------------------------------------------------------------------------
+
+
+class TestClipsInfoCommand:
+    def test_info_valid_id(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        clip_id = _insert_test_clip(db_path, title="Info Track", workspace_id=ws.id, seed=99)
+
+        result = runner.invoke(app, ["clips", "info", str(clip_id)])
+        assert result.exit_code == 0
+        assert "Info Track" in result.output
+        assert "99" in result.output
+
+    def test_info_not_found(self, isolated_db):
+        import acemusic.db as _db
+        _db.get_db().close()
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+        result = runner.invoke(app, ["clips", "info", "9999"])
+        assert result.exit_code != 0 or "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI: clips rename
+# ---------------------------------------------------------------------------
+
+
+class TestClipsRenameCommand:
+    def test_rename_success(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        clip_id = _insert_test_clip(db_path, title="Old Title", workspace_id=ws.id)
+
+        result = runner.invoke(app, ["clips", "rename", str(clip_id), "New Title"])
+        assert result.exit_code == 0
+        assert "New Title" in result.output or "renamed" in result.output.lower() or "success" in result.output.lower()
+
+        from acemusic.db import get_clip
+
+        updated = get_clip(clip_id)
+        assert updated.title == "New Title"
+
+    def test_rename_not_found(self, isolated_db):
+        import acemusic.db as _db
+        _db.get_db().close()
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+        result = runner.invoke(app, ["clips", "rename", "9999", "Ghost"])
+        assert result.exit_code != 0 or "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI: clips delete
+# ---------------------------------------------------------------------------
+
+
+class TestClipsDeleteCommand:
+    def test_delete_removes_record_and_file(self, isolated_db, tmp_path):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+
+        audio_file = tmp_path / "track.wav"
+        audio_file.write_bytes(b"fake audio data")
+        clip_id = _insert_test_clip(db_path, title="Delete Me", workspace_id=ws.id, file_path=str(audio_file))
+
+        result = runner.invoke(app, ["clips", "delete", str(clip_id)])
+        assert result.exit_code == 0
+        assert not audio_file.exists()
+
+        from acemusic.db import get_clip
+
+        assert get_clip(clip_id) is None
+
+    def test_delete_not_found(self, isolated_db):
+        import acemusic.db as _db
+        _db.get_db().close()
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+        result = runner.invoke(app, ["clips", "delete", "9999"])
+        assert result.exit_code != 0 or "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI: clips search
+# ---------------------------------------------------------------------------
+
+
+class TestClipsSearchCommand:
+    def test_search_by_style_option(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        _insert_test_clip(db_path, title="Rock Hit", workspace_id=ws.id, style_tags="rock, electric")
+        _insert_test_clip(db_path, title="Pop Song", workspace_id=ws.id, style_tags="pop, bright")
+
+        result = runner.invoke(app, ["clips", "search", "--style", "rock"])
+        assert result.exit_code == 0
+        assert "Rock Hit" in result.output
+        assert "Pop Song" not in result.output
+
+    def test_search_by_bpm_range(self, isolated_db):
+        import acemusic.db as _db
+        conn = _db.get_db()
+        conn.close()
+        db_path = _get_db_path(isolated_db)
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        _insert_test_clip(db_path, title="Fast Track", workspace_id=ws.id, bpm=160)
+        _insert_test_clip(db_path, title="Slow Track", workspace_id=ws.id, bpm=80)
+
+        result = runner.invoke(app, ["clips", "search", "--bpm-range", "100-180"])
+        assert result.exit_code == 0
+        assert "Fast Track" in result.output
+        assert "Slow Track" not in result.output
+
+    def test_search_bpm_range_invalid(self, isolated_db):
+        import acemusic.db as _db
+        _db.get_db().close()
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+        result = runner.invoke(app, ["clips", "search", "--bpm-range", "abc"])
+        assert result.exit_code != 0 or "invalid" in result.output.lower()
+
+    def test_search_no_results(self, isolated_db):
+        import acemusic.db as _db
+        _db.get_db().close()
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+        result = runner.invoke(app, ["clips", "search", "--style", "noresults"])
+        assert result.exit_code == 0
+        assert "no clips" in result.output.lower() or "0" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Generation integration: metadata recorded after generate
+# ---------------------------------------------------------------------------
+
+TASK_ID = "task-clips-123"
+AUDIO_URL_1 = "http://localhost:8001/audio/clip1.wav"
+AUDIO_URL_2 = "http://localhost:8001/audio/clip2.wav"
+COMPLETED_RESULT = {"status": "completed", "audio_urls": [AUDIO_URL_1, AUDIO_URL_2]}
+FAKE_WAV = b"RIFF\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\x44\xac\x00\x00\x88X\x01\x00\x02\x00\x10\x00data\x00\x00\x00\x00"
+
+
+class TestGenerationCreatesClipMetadata:
+    def test_generate_creates_clip_records(self, isolated_db, monkeypatch, tmp_path):
+        """After a successful generate, clips appear in the database."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+
+        client_mock = MagicMock()
+        client_mock.submit_task.return_value = TASK_ID
+        client_mock.query_result.return_value = COMPLETED_RESULT
+        client_mock.download_audio.return_value = FAKE_WAV
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=30.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "upbeat pop", "--output", str(tmp_path), "--num-clips", "2"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+        from acemusic.workspace import get_active_workspace
+
+        ws = get_active_workspace()
+        clips = list_clips(ws.id)
+        assert len(clips) == 2
+        for clip in clips:
+            assert clip.generation_mode == "generate"
+            assert clip.file_path.endswith(".wav")
+
+    def test_generate_records_style_and_model(self, isolated_db, monkeypatch, tmp_path):
+        """Clip metadata includes style_tags and model from generate args."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+
+        client_mock = MagicMock()
+        client_mock.submit_task.return_value = TASK_ID
+        client_mock.query_result.return_value = {"status": "completed", "audio_urls": [AUDIO_URL_1]}
+        client_mock.download_audio.return_value = FAKE_WAV
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=45.0),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "generate",
+                    "dark electro",
+                    "--output",
+                    str(tmp_path),
+                    "--num-clips",
+                    "1",
+                    "--style",
+                    "dark, synth",
+                    "--model",
+                    "base",
+                    "--seed",
+                    "123",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+        from acemusic.workspace import get_active_workspace
+
+        ws = get_active_workspace()
+        clips = list_clips(ws.id)
+        assert len(clips) == 1
+        assert clips[0].style_tags == "dark, synth"
+        assert clips[0].model == "base"
+        assert clips[0].seed == 123
+        assert clips[0].duration == 45.0


### PR DESCRIPTION
## Summary

- Adds `Clip` dataclass (`models.py`) with all schema fields (id, title, workspace_id, file_path, format, duration, bpm, key, style_tags, lyrics, vocal_language, model, seed, inference_steps, parent_clip_id, generation_mode, created_at)
- Extends `db.py` with a `clips` table (auto-created alongside `workspaces`) and full CRUD: `create_clip`, `get_clip`, `list_clips`, `update_clip_title`, `delete_clip`, `search_clips`
- Adds `acemusic clips` sub-app with `list / info / rename / delete / search` commands; `search` supports `--style`, `--bpm-range`, `--key`, `--model`, `--date-from`, `--date-to`
- Hooks `create_clip()` into both `_generate_via_ace_step` and `_generate_via_elevenlabs` (best-effort: recording failures never block generation)
- Uses `get_active_workspace()` for real workspace_id (US-4.1 is already merged)

## Test plan

- [x] 33 new tests in `tests/test_clips.py` covering DB CRUD, search filters, all CLI commands, and generation integration
- [x] 239 total passing at 89% coverage; `db.py` and `models.py` at 100%
- [x] No regressions in existing test suite
- [x] `acemusic clips list / info / rename / search` verified against live dev DB
- [x] `uv run ruff check` passes on all changed files

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level "clips" CLI for managing generated audio: list, info, rename, delete (supports --yes/-y), and search.
  * Generation now best-effort records clip metadata (including duration, BPM, key, model, style) and records creation time in UTC.
  * Durations displayed consistently as MM:SS or "-".

* **Search**
  * Filter clips by style, BPM range, key, model, and creation date range.

* **Tests**
  * Added tests covering clip storage, CLI commands, search, and generation integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->