### PR TITLE
feat: US-5.1 crop and trim audio clips

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "mutagen>=1.47",
     "librosa>=0.10.0",
     "soundfile>=0.12.0",
+    "pydub>=0.25.1",
 ]
 
 [project.scripts]

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -56,5 +56,5 @@ def crop_audio(
         segment = segment.fade_in(fade_in_ms)
     if fade_out_ms > 0:
         segment = segment.fade_out(fade_out_ms)
-    fmt = output_path.rsplit(".", 1)[-1] if "." in output_path else "wav"
+    fmt = output_path.rsplit(".", 1)[-1].lower() if "." in output_path else "wav"
     segment.export(output_path, format=fmt)

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -1,4 +1,4 @@
-"""Audio analysis utilities for acemusic (US-4.4)."""
+"""Audio analysis and manipulation utilities for acemusic (US-4.4, US-5.1)."""
 
 from __future__ import annotations
 
@@ -32,3 +32,29 @@ def detect_key(path: Path) -> str | None:
         return f"{_PITCH_CLASSES[dominant]} major"
     except Exception:
         return None
+
+
+def crop_audio(
+    input_path: str,
+    output_path: str,
+    start_ms: int,
+    end_ms: int,
+    fade_in_ms: int = 0,
+    fade_out_ms: int = 0,
+) -> None:
+    """Trim an audio file to [start_ms, end_ms] and optionally apply fades.
+
+    Loads input_path, slices to the given range, applies fade-in/fade-out if
+    requested, and exports to output_path preserving the original format.
+    The original file is never modified.
+    """
+    from pydub import AudioSegment
+
+    audio = AudioSegment.from_file(input_path)
+    segment = audio[start_ms:end_ms]
+    if fade_in_ms > 0:
+        segment = segment.fade_in(fade_in_ms)
+    if fade_out_ms > 0:
+        segment = segment.fade_out(fade_out_ms)
+    fmt = output_path.rsplit(".", 1)[-1] if "." in output_path else "wav"
+    segment.export(output_path, format=fmt)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1277,7 +1277,13 @@ def crop(
         end_ms = snap_to_beat(end_ms, source.bpm)
 
     if start_ms >= end_ms:
-        console.print(f"[red]Error: --start ({start}) must be less than --end ({end}).[/red]")
+        if snap_to_beat_flag:
+            console.print(
+                f"[red]Error: after beat-snapping, start ({start_ms / 1000:.3f}s) "
+                f"is not less than end ({end_ms / 1000:.3f}s).[/red]"
+            )
+        else:
+            console.print(f"[red]Error: --start ({start}) must be less than --end ({end}).[/red]")
         raise typer.Exit(code=1)
 
     if source.duration is not None:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1,4 +1,4 @@
-"""CLI entry point for acemusic (US-2.1, US-2.2, US-2.3, US-4.2)."""
+"""CLI entry point for acemusic (US-2.1, US-2.2, US-2.3, US-4.2, US-5.1)."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.table import Table
 
 from acemusic import __version__
-from acemusic.audio import SUPPORTED_FORMATS, detect_bpm, detect_key
+from acemusic.audio import SUPPORTED_FORMATS, crop_audio, detect_bpm, detect_key
 from acemusic.client import AceStepClient, AceStepError
 from acemusic.config import load_config
 from acemusic.db import (
@@ -34,7 +34,7 @@ from acemusic.db import (
 )
 from acemusic.elevenlabs_client import ElevenLabsClient, ElevenLabsError
 from acemusic.models import Clip, Preset
-from acemusic.utils import get_duration, make_filename, make_slug
+from acemusic.utils import get_duration, make_filename, make_slug, parse_time_string, snap_to_beat
 from acemusic.workspace import (
     create_workspace,
     delete_workspace,
@@ -124,7 +124,7 @@ def main(
     if ctx.invoked_subcommand is None:
         typer.echo(ctx.get_help())
         raise typer.Exit(0)
-    elif ctx.invoked_subcommand not in ("models", "workspace", "clips", "preset", "import"):
+    elif ctx.invoked_subcommand not in ("models", "workspace", "clips", "preset", "import", "crop"):
         config = load_config()
         if not config.api_url:
             typer.echo("ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml")
@@ -1238,6 +1238,102 @@ def import_clip(
     console.print(f"    Duration: {duration_display}")
     console.print(f"    BPM:      {bpm_display}")
     console.print(f"    Key:      {key_display}")
+
+
+# ---------------------------------------------------------------------------
+# Crop command (US-5.1)
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def crop(
+    clip_id: int = typer.Argument(..., help="ID of the source clip to crop."),
+    start: str = typer.Option(..., "--start", help="Start time (e.g. '10s', '1m30s')."),
+    end: str = typer.Option(..., "--end", help="End time (e.g. '45s', '2m')."),
+    fade_in: str = typer.Option("0s", "--fade-in", help="Fade-in duration (e.g. '0.5s')."),
+    fade_out: str = typer.Option("0s", "--fade-out", help="Fade-out duration (e.g. '1s')."),
+    snap_to_beat_flag: bool = typer.Option(False, "--snap-to-beat", help="Round start/end to nearest beat boundary."),
+) -> None:
+    """Crop an existing clip to a time range, creating a new clip. Original is preserved."""
+    try:
+        start_ms = parse_time_string(start)
+        end_ms = parse_time_string(end)
+        fade_in_ms = parse_time_string(fade_in)
+        fade_out_ms = parse_time_string(fade_out)
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    source = get_clip(clip_id)
+    if source is None:
+        console.print(f"[red]Error: clip {clip_id} not found.[/red]")
+        raise typer.Exit(code=1)
+
+    if snap_to_beat_flag:
+        if source.bpm is None:
+            console.print(f"[red]Error: --snap-to-beat requires BPM metadata on clip {clip_id}, but none is set.[/red]")
+            raise typer.Exit(code=1)
+        start_ms = snap_to_beat(start_ms, source.bpm)
+        end_ms = snap_to_beat(end_ms, source.bpm)
+
+    if start_ms >= end_ms:
+        console.print(f"[red]Error: --start ({start}) must be less than --end ({end}).[/red]")
+        raise typer.Exit(code=1)
+
+    if source.duration is not None:
+        source_duration_ms = int(round(source.duration * 1000))
+        if end_ms > source_duration_ms:
+            console.print(f"[red]Error: --end ({end}) exceeds clip duration " f"({source.duration:.1f}s).[/red]")
+            raise typer.Exit(code=1)
+
+    try:
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+    except (ValueError, sqlite3.Error, OSError) as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    src_ext = Path(source.file_path).suffix.lower() or ".wav"
+    dest_name = f"{uuid.uuid4().hex}{src_ext}"
+    dest_path = clips_dir / dest_name
+
+    try:
+        crop_audio(
+            input_path=source.file_path,
+            output_path=str(dest_path),
+            start_ms=start_ms,
+            end_ms=end_ms,
+            fade_in_ms=fade_in_ms,
+            fade_out_ms=fade_out_ms,
+        )
+    except Exception as exc:
+        console.print(f"[red]Error during crop: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    duration_s = (end_ms - start_ms) / 1000.0
+    new_clip = Clip(
+        workspace_id=source.workspace_id,
+        file_path=str(dest_path.resolve()),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        format=source.format,
+        duration=duration_s,
+        bpm=source.bpm,
+        key=source.key,
+        parent_clip_id=source.id,
+        generation_mode="crop",
+    )
+    try:
+        new_id = create_clip(new_clip)
+    except Exception as exc:
+        dest_path.unlink(missing_ok=True)
+        console.print(f"[red]Error saving clip record: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    console.print(f"  [green]\u2713[/green] Cropped clip {clip_id} → clip {new_id}")
+    console.print(f"    Path:     {dest_path}")
+    console.print(f"    Duration: {_fmt_duration(duration_s)}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/acemusic/utils.py
+++ b/src/acemusic/utils.py
@@ -1,4 +1,4 @@
-"""Filename and audio duration utilities for acemusic (US-2.3)."""
+"""Filename and audio duration utilities for acemusic (US-2.3, US-5.1)."""
 
 from __future__ import annotations
 
@@ -32,3 +32,46 @@ def get_duration(path: Path | str) -> float | None:
     if audio is None:
         return None
     return audio.info.length
+
+
+# ---------------------------------------------------------------------------
+# Time parsing utilities (US-5.1)
+# ---------------------------------------------------------------------------
+
+_TIME_PATTERN = re.compile(r"^(?:(?P<minutes>\d+)m)?(?P<seconds>\d+(?:\.\d+)?)s$|^(?P<plain>\d+(?:\.\d+)?)$")
+
+
+def parse_time_string(time_str: str) -> int:
+    """Parse a human-readable time string into milliseconds.
+
+    Supported formats: "10s", "1m30s", "1.5s", "90s", "5" (plain seconds).
+    Returns milliseconds as an integer.
+    Raises ValueError for invalid or negative input.
+    """
+    if not time_str:
+        raise ValueError(f"Cannot parse time string: {time_str!r}")
+
+    m = _TIME_PATTERN.match(time_str.strip())
+    if not m:
+        raise ValueError(f"Cannot parse time string: {time_str!r}")
+
+    if m.group("plain") is not None:
+        seconds = float(m.group("plain"))
+    else:
+        minutes = int(m.group("minutes") or 0)
+        seconds = float(m.group("seconds"))
+        seconds += minutes * 60
+
+    if seconds < 0:
+        raise ValueError(f"Time value must be non-negative, got: {time_str!r}")
+
+    return int(round(seconds * 1000))
+
+
+def snap_to_beat(time_ms: int | float, bpm: int | float) -> int:
+    """Round time_ms to the nearest beat boundary for the given BPM.
+
+    Returns the snapped time in milliseconds.
+    """
+    beat_ms = 60_000 / bpm
+    return round(round(time_ms / beat_ms) * beat_ms)

--- a/src/acemusic/utils.py
+++ b/src/acemusic/utils.py
@@ -62,9 +62,6 @@ def parse_time_string(time_str: str) -> int:
         seconds = float(m.group("seconds"))
         seconds += minutes * 60
 
-    if seconds < 0:
-        raise ValueError(f"Time value must be non-negative, got: {time_str!r}")
-
     return int(round(seconds * 1000))
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -134,3 +134,123 @@ class TestDetectKey:
             result = detect_key(fake_path)
 
         assert result == "A major"
+
+
+class TestCropAudio:
+    """Tests for crop_audio() — the pure audio trim/fade function."""
+
+    def test_crop_audio_correct_duration(self, tmp_path):
+        """Output duration equals end_ms - start_ms."""
+        from unittest.mock import MagicMock, patch
+
+        input_path = tmp_path / "input.wav"
+        output_path = tmp_path / "output.wav"
+        input_path.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_sliced = MagicMock()
+        mock_segment.__getitem__.return_value = mock_sliced
+        mock_sliced.fade_in.return_value = mock_sliced
+        mock_sliced.fade_out.return_value = mock_sliced
+
+        mock_audio_segment = MagicMock()
+        mock_audio_segment.from_file.return_value = mock_segment
+
+        with patch.dict("sys.modules", {"pydub": MagicMock(), "pydub.AudioSegment": mock_audio_segment}):
+
+            import acemusic.audio as audio_mod
+
+            with patch.object(audio_mod, "crop_audio") as mock_crop_audio:
+                mock_crop_audio(
+                    input_path=str(input_path),
+                    output_path=str(output_path),
+                    start_ms=10_000,
+                    end_ms=45_000,
+                )
+                mock_crop_audio.assert_called_once()
+
+    def test_crop_audio_applies_fade_in(self, tmp_path):
+        """crop_audio applies fade_in when fade_in_ms > 0."""
+
+        input_path = tmp_path / "in.wav"
+        output_path = tmp_path / "out.wav"
+        input_path.write_bytes(b"fake")
+
+        mock_seg = MagicMock()
+        mock_sliced = MagicMock()
+        mock_seg.__getitem__ = MagicMock(return_value=mock_sliced)
+        mock_sliced.fade_in.return_value = mock_sliced
+        mock_sliced.fade_out.return_value = mock_sliced
+
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
+
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            from acemusic.audio import crop_audio as _crop
+
+            _crop(
+                input_path=str(input_path),
+                output_path=str(output_path),
+                start_ms=0,
+                end_ms=5000,
+                fade_in_ms=500,
+            )
+
+        mock_sliced.fade_in.assert_called_once_with(500)
+
+    def test_crop_audio_applies_fade_out(self, tmp_path):
+        """crop_audio applies fade_out when fade_out_ms > 0."""
+
+        input_path = tmp_path / "in2.wav"
+        output_path = tmp_path / "out2.wav"
+        input_path.write_bytes(b"fake")
+
+        mock_seg = MagicMock()
+        mock_sliced = MagicMock()
+        mock_seg.__getitem__ = MagicMock(return_value=mock_sliced)
+        mock_sliced.fade_in.return_value = mock_sliced
+        mock_sliced.fade_out.return_value = mock_sliced
+
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
+
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            from acemusic.audio import crop_audio as _crop
+
+            _crop(
+                input_path=str(input_path),
+                output_path=str(output_path),
+                start_ms=0,
+                end_ms=5000,
+                fade_out_ms=1000,
+            )
+
+        mock_sliced.fade_out.assert_called_once_with(1000)
+
+    def test_crop_audio_no_fade_by_default(self, tmp_path):
+        """crop_audio does not apply fades when fade params are 0."""
+        input_path = tmp_path / "in3.wav"
+        output_path = tmp_path / "out3.wav"
+        input_path.write_bytes(b"fake")
+
+        mock_seg = MagicMock()
+        mock_sliced = MagicMock()
+        mock_seg.__getitem__ = MagicMock(return_value=mock_sliced)
+        mock_sliced.fade_in.return_value = mock_sliced
+        mock_sliced.fade_out.return_value = mock_sliced
+
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
+
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            from acemusic.audio import crop_audio as _crop
+
+            _crop(
+                input_path=str(input_path),
+                output_path=str(output_path),
+                start_ms=0,
+                end_ms=5000,
+            )
+
+        mock_sliced.fade_in.assert_not_called()
+        mock_sliced.fade_out.assert_not_called()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -139,35 +139,33 @@ class TestDetectKey:
 class TestCropAudio:
     """Tests for crop_audio() — the pure audio trim/fade function."""
 
-    def test_crop_audio_correct_duration(self, tmp_path):
-        """Output duration equals end_ms - start_ms."""
-        from unittest.mock import MagicMock, patch
-
+    def test_crop_audio_slices_correct_range(self, tmp_path):
+        """crop_audio slices the audio segment to [start_ms:end_ms]."""
         input_path = tmp_path / "input.wav"
         output_path = tmp_path / "output.wav"
         input_path.write_bytes(b"fake")
 
-        mock_segment = MagicMock()
+        mock_seg = MagicMock()
         mock_sliced = MagicMock()
-        mock_segment.__getitem__.return_value = mock_sliced
+        mock_seg.__getitem__ = MagicMock(return_value=mock_sliced)
         mock_sliced.fade_in.return_value = mock_sliced
         mock_sliced.fade_out.return_value = mock_sliced
 
-        mock_audio_segment = MagicMock()
-        mock_audio_segment.from_file.return_value = mock_segment
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
 
-        with patch.dict("sys.modules", {"pydub": MagicMock(), "pydub.AudioSegment": mock_audio_segment}):
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            from acemusic.audio import crop_audio as _crop
 
-            import acemusic.audio as audio_mod
+            _crop(
+                input_path=str(input_path),
+                output_path=str(output_path),
+                start_ms=10_000,
+                end_ms=45_000,
+            )
 
-            with patch.object(audio_mod, "crop_audio") as mock_crop_audio:
-                mock_crop_audio(
-                    input_path=str(input_path),
-                    output_path=str(output_path),
-                    start_ms=10_000,
-                    end_ms=45_000,
-                )
-                mock_crop_audio.assert_called_once()
+        mock_seg.__getitem__.assert_called_once_with(slice(10_000, 45_000))
+        mock_sliced.export.assert_called_once()
 
     def test_crop_audio_applies_fade_in(self, tmp_path):
         """crop_audio applies fade_in when fade_in_ms > 0."""

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -1,0 +1,259 @@
+"""Tests for the crop command (US-5.1)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+from acemusic.models import Clip
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    import acemusic.db as _db
+
+    monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+    return tmp_path
+
+
+@pytest.fixture
+def workspace_with_clips_dir(isolated_db, monkeypatch):
+    """Ensure an active workspace exists and the clips dir is ready."""
+    from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+    ensure_default_workspace()
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+def _make_clip(workspace_id: str, file_path: str, **kwargs) -> Clip:
+    return Clip(
+        workspace_id=workspace_id,
+        file_path=file_path,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        format=kwargs.get("format", "wav"),
+        duration=kwargs.get("duration", 60.0),
+        bpm=kwargs.get("bpm", None),
+        generation_mode=kwargs.get("generation_mode", "generate"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestCropCommand:
+    def test_crop_creates_new_clip_with_correct_metadata(self, workspace_with_clips_dir, tmp_path):
+        """Crop registers a new clip with parent_clip_id and generation_mode='crop'."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+
+        # Create a source clip on disk and in DB
+        src_wav = clips_dir / "source.wav"
+        src_wav.write_bytes(b"fake audio data")
+
+        from acemusic.db import create_clip
+
+        src_clip = _make_clip(ws.id, str(src_wav), duration=60.0)
+        clip_id = create_clip(src_clip)
+
+        with patch("acemusic.cli.crop_audio") as mock_crop:
+            mock_crop.return_value = None
+            result = runner.invoke(app, ["crop", str(clip_id), "--start", "10s", "--end", "45s"])
+
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        clips = list_clips(ws.id)
+        cropped = [c for c in clips if c.generation_mode == "crop"]
+        assert len(cropped) == 1
+        assert cropped[0].parent_clip_id == clip_id
+        assert cropped[0].duration == pytest.approx(35.0)
+
+    def test_crop_preserves_original_clip(self, workspace_with_clips_dir, tmp_path):
+        """Original clip is unchanged after a crop."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+
+        src_wav = clips_dir / "original.wav"
+        src_wav.write_bytes(b"original audio")
+
+        from acemusic.db import create_clip, get_clip
+
+        src_clip = _make_clip(ws.id, str(src_wav), duration=60.0)
+        clip_id = create_clip(src_clip)
+
+        with patch("acemusic.cli.crop_audio"):
+            runner.invoke(app, ["crop", str(clip_id), "--start", "5s", "--end", "20s"])
+
+        original = get_clip(clip_id)
+        assert original is not None
+        assert original.generation_mode != "crop"
+        assert original.parent_clip_id is None
+
+    def test_crop_passes_fade_options_to_crop_audio(self, workspace_with_clips_dir):
+        """Fade-in/out options are forwarded to crop_audio()."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        src_wav = clips_dir / "fadey.wav"
+        src_wav.write_bytes(b"audio")
+
+        from acemusic.db import create_clip
+
+        clip_id = create_clip(_make_clip(ws.id, str(src_wav), duration=60.0))
+
+        with patch("acemusic.cli.crop_audio") as mock_crop:
+            result = runner.invoke(
+                app,
+                ["crop", str(clip_id), "--start", "0s", "--end", "30s", "--fade-in", "0.5s", "--fade-out", "1s"],
+            )
+
+        assert result.exit_code == 0, result.output
+        _args, kwargs = mock_crop.call_args
+        assert kwargs["fade_in_ms"] == 500
+        assert kwargs["fade_out_ms"] == 1000
+
+    def test_crop_snap_to_beat_adjusts_times(self, workspace_with_clips_dir):
+        """--snap-to-beat rounds start/end to nearest beat boundary using clip BPM."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        src_wav = clips_dir / "beat.wav"
+        src_wav.write_bytes(b"audio")
+
+        from acemusic.db import create_clip
+
+        # 120 BPM → beat_ms = 500ms
+        clip_id = create_clip(_make_clip(ws.id, str(src_wav), duration=60.0, bpm=120))
+
+        with patch("acemusic.cli.crop_audio") as mock_crop:
+            result = runner.invoke(
+                app,
+                # start=10100ms → snap to 10000ms; end=45300ms → snap to 45500ms
+                ["crop", str(clip_id), "--start", "10.1s", "--end", "45.3s", "--snap-to-beat"],
+            )
+
+        assert result.exit_code == 0, result.output
+        _args, kwargs = mock_crop.call_args
+        assert kwargs["start_ms"] == 10000
+        assert kwargs["end_ms"] == 45500
+
+    def test_crop_output_message_contains_new_clip_id(self, workspace_with_clips_dir):
+        """Success output shows the new clip ID and file path."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        src_wav = clips_dir / "src.wav"
+        src_wav.write_bytes(b"audio")
+
+        from acemusic.db import create_clip
+
+        clip_id = create_clip(_make_clip(ws.id, str(src_wav), duration=60.0))
+
+        with patch("acemusic.cli.crop_audio"):
+            result = runner.invoke(app, ["crop", str(clip_id), "--start", "5s", "--end", "25s"])
+
+        assert result.exit_code == 0, result.output
+        assert "Cropped" in result.output or "clip" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Validation / error scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestCropValidation:
+    def test_invalid_clip_id_returns_error(self, workspace_with_clips_dir):
+        """Non-existent clip ID produces a friendly error."""
+        result = runner.invoke(app, ["crop", "99999", "--start", "0s", "--end", "10s"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_start_greater_than_end_returns_error(self, workspace_with_clips_dir):
+        """start >= end must be rejected."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        src_wav = clips_dir / "src2.wav"
+        src_wav.write_bytes(b"audio")
+
+        from acemusic.db import create_clip
+
+        clip_id = create_clip(_make_clip(ws.id, str(src_wav), duration=60.0))
+
+        result = runner.invoke(app, ["crop", str(clip_id), "--start", "30s", "--end", "10s"])
+        assert result.exit_code == 1
+        assert "start" in result.output.lower() or "end" in result.output.lower()
+
+    def test_end_exceeds_clip_duration_returns_error(self, workspace_with_clips_dir):
+        """end > clip duration must be rejected."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        src_wav = clips_dir / "src3.wav"
+        src_wav.write_bytes(b"audio")
+
+        from acemusic.db import create_clip
+
+        clip_id = create_clip(_make_clip(ws.id, str(src_wav), duration=30.0))
+
+        result = runner.invoke(app, ["crop", str(clip_id), "--start", "0s", "--end", "60s"])
+        assert result.exit_code == 1
+        assert "duration" in result.output.lower() or "exceed" in result.output.lower()
+
+    def test_snap_to_beat_without_bpm_returns_error(self, workspace_with_clips_dir):
+        """--snap-to-beat with no BPM in metadata produces a clear error."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        src_wav = clips_dir / "src4.wav"
+        src_wav.write_bytes(b"audio")
+
+        from acemusic.db import create_clip
+
+        clip_id = create_clip(_make_clip(ws.id, str(src_wav), duration=60.0, bpm=None))
+
+        result = runner.invoke(app, ["crop", str(clip_id), "--start", "5s", "--end", "20s", "--snap-to-beat"])
+        assert result.exit_code == 1
+        assert "bpm" in result.output.lower()
+
+    def test_start_equal_to_end_returns_error(self, workspace_with_clips_dir):
+        """start == end should be rejected (zero-length segment)."""
+        from acemusic.workspace import get_active_workspace, get_workspace_path
+
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        src_wav = clips_dir / "src5.wav"
+        src_wav.write_bytes(b"audio")
+
+        from acemusic.db import create_clip
+
+        clip_id = create_clip(_make_clip(ws.id, str(src_wav), duration=60.0))
+
+        result = runner.invoke(app, ["crop", str(clip_id), "--start", "10s", "--end", "10s"])
+        assert result.exit_code == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
-"""Unit tests for acemusic utility helpers (US-2.3)."""
+"""Unit tests for acemusic utility helpers (US-2.3, US-5.1)."""
 
-from acemusic.utils import make_filename, make_slug
+import pytest
+
+from acemusic.utils import make_filename, make_slug, parse_time_string, snap_to_beat
 
 
 class TestMakeSlug:
@@ -49,3 +51,71 @@ class TestMakeFilename:
     def test_index_in_name(self):
         """Clip index appears as the last numeric component before the extension."""
         assert make_filename("test", "ts", 3).endswith("-3.wav")
+
+
+class TestParseTimeString:
+    """Tests for parse_time_string() — time string to milliseconds."""
+
+    def test_seconds_integer(self):
+        assert parse_time_string("10s") == 10_000
+
+    def test_seconds_float(self):
+        assert parse_time_string("1.5s") == 1_500
+
+    def test_zero_seconds(self):
+        assert parse_time_string("0s") == 0
+
+    def test_minutes_and_seconds(self):
+        assert parse_time_string("1m30s") == 90_000
+
+    def test_large_seconds(self):
+        assert parse_time_string("90s") == 90_000
+
+    def test_plain_int_as_string(self):
+        assert parse_time_string("5") == 5_000
+
+    def test_plain_float_as_string(self):
+        assert parse_time_string("2.5") == 2_500
+
+    def test_invalid_raises_value_error(self):
+        with pytest.raises(ValueError, match="Cannot parse time"):
+            parse_time_string("abc")
+
+    def test_empty_string_raises_value_error(self):
+        with pytest.raises(ValueError, match="Cannot parse time"):
+            parse_time_string("")
+
+    def test_negative_seconds_raises_value_error(self):
+        with pytest.raises(ValueError):
+            parse_time_string("-5s")
+
+
+class TestSnapToBeat:
+    """Tests for snap_to_beat() — round time to nearest beat boundary."""
+
+    def test_snap_at_120bpm_on_beat(self):
+        # 120 BPM → beat_ms = 500ms; 1000ms is exactly on beat 2
+        assert snap_to_beat(1000, 120) == 1000
+
+    def test_snap_at_120bpm_rounds_down(self):
+        # 120 BPM → beat_ms = 500ms; 749ms rounds to 500ms
+        assert snap_to_beat(749, 120) == 500
+
+    def test_snap_at_120bpm_rounds_up(self):
+        # 120 BPM → beat_ms = 500ms; 750ms rounds up to 1000ms
+        assert snap_to_beat(750, 120) == 1000
+
+    def test_snap_at_60bpm(self):
+        # 60 BPM → beat_ms = 1000ms
+        assert snap_to_beat(1400, 60) == 1000
+
+    def test_snap_at_60bpm_rounds_up(self):
+        assert snap_to_beat(1500, 60) == 2000
+
+    def test_snap_at_90bpm(self):
+        # 90 BPM → beat_ms ≈ 666.67ms; 700ms closer to 666.67 than 1333.33 → 667
+        result = snap_to_beat(700, 90)
+        assert result == round(666.67)
+
+    def test_snap_zero_stays_zero(self):
+        assert snap_to_beat(0, 120) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ dependencies = [
     { name = "httpx" },
     { name = "librosa" },
     { name = "mutagen" },
+    { name = "pydub" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "soundfile" },
@@ -35,6 +36,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "librosa", specifier = ">=0.10.0" },
     { name = "mutagen", specifier = ">=1.47" },
+    { name = "pydub", specifier = ">=0.25.1" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-bdd", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
@@ -983,6 +985,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydub"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `acemusic crop <clip_id> --start <time> --end <time>` CLI command that creates a new clip from a time range of an existing clip
- Supports `--fade-in`/`--fade-out` durations and `--snap-to-beat` (rounds to nearest beat boundary using BPM metadata)
- Original clip is preserved; new clip records `parent_clip_id` and `generation_mode="crop"`

### Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Add `pydub>=0.25.1` dependency |
| `src/acemusic/audio.py` | Add `crop_audio()` — pure file-in/file-out trim+fade |
| `src/acemusic/utils.py` | Add `parse_time_string()` and `snap_to_beat()` |
| `src/acemusic/cli.py` | Add `crop` command with validation |
| `tests/test_crop.py` | 10 tests for crop CLI (happy path + validation) |
| `tests/test_audio.py` | 4 tests for `crop_audio()` |
| `tests/test_utils.py` | 16 tests for `parse_time_string()` and `snap_to_beat()` |

## Test plan

- [x] `acemusic crop <id> --start 10s --end 45s` creates a new clip with correct duration (35s)
- [x] `--fade-in 0.5s --fade-out 1s` passes fade params to `crop_audio()`
- [x] `--snap-to-beat` adjusts times using BPM from metadata (120 BPM verified)
- [x] Original clip remains unchanged after crop
- [x] Metadata records `parent_clip_id` and `generation_mode="crop"`
- [x] Invalid clip ID returns friendly error
- [x] `start >= end` rejected
- [x] `end > clip duration` rejected
- [x] `--snap-to-beat` without BPM metadata returns clear error
- [x] 329 tests passing, 89% coverage, ruff + black clean

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio cropping: trim clips to precise time ranges with optional fade-in/out and export to new files.
  * CLI: new crop command accepting flexible time formats and optional beat-snapping; creates cropped clips linked to their source.

* **Bug Fixes / Validation**
  * CLI validates time parsing, ordering, duration bounds, and BPM requirements when snapping; returns clear error codes/messages.

* **Chores**
  * Added required runtime audio library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->