### PR TITLE
feat: US-5.5 basic local remaster (loudness normalization and EQ)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "soundfile>=0.12.0",
     "pydub>=0.25.1",
     "mido>=1.3.0",
+    "pyloudnorm>=0.1.0",
+    "scipy>=1.10.0",
 ]
 
 [project.scripts]

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -156,7 +156,7 @@ def normalize_loudness(audio: np.ndarray, sample_rate: int, target_lufs: float) 
 def apply_eq(audio: np.ndarray, sample_rate: int) -> np.ndarray:
     """Apply gentle EQ: presence boost (~3kHz) and low-end warmth (~100Hz).
 
-    Uses scipy second-order sections (SOS) for numerical stability.
+    Uses scipy IIR peak filters (second-order) for frequency-selective boosts.
     """
     from scipy.signal import iirpeak, lfilter
 

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -142,6 +142,10 @@ def normalize_loudness(audio: np.ndarray, sample_rate: int, target_lufs: float) 
 
     meter = pyln.Meter(sample_rate)
     current_lufs = meter.integrated_loudness(audio)
+
+    if not np.isfinite(current_lufs):
+        return audio.copy()
+
     normalized = pyln.normalize.loudness(audio, current_lufs, target_lufs)
 
     # True-peak limiting at -1 dBTP (~0.891)
@@ -188,8 +192,8 @@ def apply_eq(audio: np.ndarray, sample_rate: int) -> np.ndarray:
 def apply_compression(audio: np.ndarray, sample_rate: int) -> np.ndarray:
     """Apply soft-knee dynamic range compression.
 
-    Uses RMS-based envelope detection with moderate ratio (3:1),
-    ~10ms attack, ~100ms release, and automatic makeup gain.
+    Uses envelope-following with moderate ratio (3:1), ~10ms attack, ~100ms release.
+    Loudness recovery is handled by the pipeline's final normalization pass.
     """
     threshold_db = -20.0
     ratio = 3.0
@@ -206,25 +210,34 @@ def apply_compression(audio: np.ndarray, sample_rate: int) -> np.ndarray:
     else:
         envelope_signal = np.abs(result)
 
+    # Pre-compute sample dB levels as a vector (avoids per-sample np calls)
+    sample_db_all = 20.0 * np.log10(envelope_signal + 1e-10)
+
     n_samples = len(envelope_signal)
-    gain_db = np.zeros(n_samples)
+    env_db_arr = np.empty(n_samples)
     env_db = -120.0
 
+    # Envelope follower (sequential — state-dependent)
     for i in range(n_samples):
-        sample_db = 20.0 * np.log10(envelope_signal[i] + 1e-10)
-
-        if sample_db > env_db:
-            env_db = attack_coeff * env_db + (1.0 - attack_coeff) * sample_db
+        s = sample_db_all[i]
+        if s > env_db:
+            env_db = attack_coeff * env_db + (1.0 - attack_coeff) * s
         else:
-            env_db = release_coeff * env_db + (1.0 - release_coeff) * sample_db
+            env_db = release_coeff * env_db + (1.0 - release_coeff) * s
+        env_db_arr[i] = env_db
 
-        over_db = env_db - threshold_db
-        if over_db <= -knee_db / 2:
-            gain_db[i] = 0.0
-        elif over_db >= knee_db / 2:
-            gain_db[i] = -(1.0 - 1.0 / ratio) * over_db
-        else:
-            gain_db[i] = -(1.0 - 1.0 / ratio) * (over_db + knee_db / 2) ** 2 / (2.0 * knee_db)
+    # Vectorized gain computation (soft-knee)
+    over_db = env_db_arr - threshold_db
+    gain_reduction = 1.0 - 1.0 / ratio
+    gain_db = np.where(
+        over_db <= -knee_db / 2,
+        0.0,
+        np.where(
+            over_db >= knee_db / 2,
+            -gain_reduction * over_db,
+            -gain_reduction * (over_db + knee_db / 2) ** 2 / (2.0 * knee_db),
+        ),
+    )
 
     gain_linear = 10.0 ** (gain_db / 20.0)
 

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -1,8 +1,10 @@
-"""Audio analysis and manipulation utilities for acemusic (US-4.4, US-5.1)."""
+"""Audio analysis and manipulation utilities for acemusic (US-4.4, US-5.1, US-5.5)."""
 
 from __future__ import annotations
 
 from pathlib import Path
+
+import numpy as np
 
 SUPPORTED_FORMATS: set[str] = {".wav", ".flac", ".mp3", ".ogg", ".aac", ".aiff"}
 
@@ -119,3 +121,181 @@ def time_stretch_audio(
 
     # Export to file
     sf.write(output_path, y_stretched.T if y_stretched.ndim > 1 else y_stretched, sr, subtype="PCM_16")
+
+
+# ---------------------------------------------------------------------------
+# Remaster pipeline (US-5.5)
+# ---------------------------------------------------------------------------
+
+
+def measure_lufs(audio: np.ndarray, sample_rate: int) -> float:
+    """Measure integrated loudness (LUFS) using ITU-R BS.1770-4."""
+    import pyloudnorm as pyln
+
+    meter = pyln.Meter(sample_rate)
+    return meter.integrated_loudness(audio)
+
+
+def normalize_loudness(audio: np.ndarray, sample_rate: int, target_lufs: float) -> np.ndarray:
+    """Normalize audio to target LUFS with true-peak limiting at -1 dBTP."""
+    import pyloudnorm as pyln
+
+    meter = pyln.Meter(sample_rate)
+    current_lufs = meter.integrated_loudness(audio)
+    normalized = pyln.normalize.loudness(audio, current_lufs, target_lufs)
+
+    # True-peak limiting at -1 dBTP (~0.891)
+    peak_limit = 10 ** (-1.0 / 20.0)
+    peak = np.max(np.abs(normalized))
+    if peak > peak_limit:
+        normalized = normalized * (peak_limit / peak)
+
+    return normalized
+
+
+def apply_eq(audio: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Apply gentle EQ: presence boost (~3kHz) and low-end warmth (~100Hz).
+
+    Uses scipy second-order sections (SOS) for numerical stability.
+    """
+    from scipy.signal import iirpeak, lfilter
+
+    result = audio.copy()
+
+    # Presence boost: +3dB peak at 3kHz, Q=1.0
+    b_pres, a_pres = iirpeak(3000 / (sample_rate / 2), 1.0)
+    gain_presence = 10 ** (3.0 / 20.0)
+
+    # Low-end warmth: +2dB peak at 100Hz, Q=0.7
+    b_low, a_low = iirpeak(100 / (sample_rate / 2), 0.7)
+    gain_low = 10 ** (2.0 / 20.0)
+
+    for ch in range(result.shape[1] if result.ndim > 1 else 1):
+        channel = result[:, ch] if result.ndim > 1 else result
+        # Apply as parallel EQ: original + boosted bands
+        presence_band = lfilter(b_pres, a_pres, channel)
+        low_band = lfilter(b_low, a_low, channel)
+        # Mix: original + gain * filtered bands (shelf-style additive EQ)
+        filtered = channel + (gain_presence - 1.0) * presence_band + (gain_low - 1.0) * low_band
+        if result.ndim > 1:
+            result[:, ch] = filtered
+        else:
+            result = filtered
+
+    return result
+
+
+def apply_compression(audio: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Apply soft-knee dynamic range compression.
+
+    Uses RMS-based envelope detection with moderate ratio (3:1),
+    ~10ms attack, ~100ms release, and automatic makeup gain.
+    """
+    threshold_db = -20.0
+    ratio = 3.0
+    attack_s = 0.01
+    release_s = 0.1
+    knee_db = 6.0
+
+    attack_coeff = np.exp(-1.0 / (sample_rate * attack_s))
+    release_coeff = np.exp(-1.0 / (sample_rate * release_s))
+
+    result = audio.copy()
+    if result.ndim > 1:
+        envelope_signal = np.mean(np.abs(result), axis=1)
+    else:
+        envelope_signal = np.abs(result)
+
+    n_samples = len(envelope_signal)
+    gain_db = np.zeros(n_samples)
+    env_db = -120.0
+
+    for i in range(n_samples):
+        sample_db = 20.0 * np.log10(envelope_signal[i] + 1e-10)
+
+        if sample_db > env_db:
+            env_db = attack_coeff * env_db + (1.0 - attack_coeff) * sample_db
+        else:
+            env_db = release_coeff * env_db + (1.0 - release_coeff) * sample_db
+
+        over_db = env_db - threshold_db
+        if over_db <= -knee_db / 2:
+            gain_db[i] = 0.0
+        elif over_db >= knee_db / 2:
+            gain_db[i] = -(1.0 - 1.0 / ratio) * over_db
+        else:
+            gain_db[i] = -(1.0 - 1.0 / ratio) * (over_db + knee_db / 2) ** 2 / (2.0 * knee_db)
+
+    gain_linear = 10.0 ** (gain_db / 20.0)
+
+    if result.ndim > 1:
+        for ch in range(result.shape[1]):
+            result[:, ch] *= gain_linear
+    else:
+        result *= gain_linear
+
+    return result
+
+
+def apply_stereo_widening(audio: np.ndarray, amount: float = 1.2) -> np.ndarray:
+    """Apply stereo widening via mid/side processing.
+
+    amount=1.0 is neutral, >1.0 widens, <1.0 narrows, 0.0 collapses to mono.
+    Includes mono-compatibility safeguard.
+    """
+    if audio.ndim < 2 or audio.shape[1] < 2:
+        return audio
+
+    left = audio[:, 0]
+    right = audio[:, 1]
+
+    mid = (left + right) / 2.0
+    side = (left - right) / 2.0
+
+    side_scaled = side * amount
+
+    new_left = mid + side_scaled
+    new_right = mid - side_scaled
+
+    result = np.column_stack([new_left, new_right])
+
+    # Mono-compatibility safeguard: prevent clipping
+    peak = np.max(np.abs(result))
+    if peak > 1.0:
+        result /= peak
+
+    return result
+
+
+def remaster_audio(input_path: Path, output_path: Path, target_lufs: float = -14.0) -> dict:
+    """Orchestrate the full remaster pipeline: normalize → EQ → compress → widen → peak-limit → write.
+
+    Returns a dict with before/after LUFS measurements.
+    """
+    import soundfile as sf
+
+    audio, sample_rate = sf.read(str(input_path))
+
+    # Ensure stereo
+    if audio.ndim == 1:
+        audio = np.column_stack([audio, audio])
+
+    before_lufs = measure_lufs(audio, sample_rate)
+
+    # Pipeline: normalize → EQ → compress → widen
+    audio = normalize_loudness(audio, sample_rate, target_lufs)
+    audio = apply_eq(audio, sample_rate)
+    audio = apply_compression(audio, sample_rate)
+    audio = apply_stereo_widening(audio, amount=1.2)
+
+    # Final loudness pass to hit target after processing
+    audio = normalize_loudness(audio, sample_rate, target_lufs)
+
+    after_lufs = measure_lufs(audio, sample_rate)
+
+    sf.write(str(output_path), audio, sample_rate, subtype="PCM_16")
+
+    return {
+        "before_lufs": before_lufs,
+        "after_lufs": after_lufs,
+    }

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1,4 +1,4 @@
-"""CLI entry point for acemusic (US-2.1, US-2.2, US-2.3, US-4.2, US-5.1, US-5.3, US-5.4)."""
+"""CLI entry point for acemusic (US-2.1, US-2.2, US-2.3, US-4.2, US-5.1, US-5.3, US-5.4, US-5.5)."""
 
 from __future__ import annotations
 
@@ -23,6 +23,7 @@ from acemusic.audio import (
     crop_audio,
     detect_bpm,
     detect_key,
+    remaster_audio,
     time_stretch_audio,
 )
 from acemusic.client import AceStepClient, AceStepError
@@ -43,7 +44,14 @@ from acemusic.elevenlabs_client import ElevenLabsClient, ElevenLabsError
 from acemusic.midi_client import MidiClient, MidiError
 from acemusic.models import Clip, Preset
 from acemusic.stems_client import StemsClient, StemsError
-from acemusic.utils import get_duration, make_filename, make_slug, parse_time_string, snap_to_beat
+from acemusic.utils import (
+    generate_remaster_filename,
+    get_duration,
+    make_filename,
+    make_slug,
+    parse_time_string,
+    snap_to_beat,
+)
 from acemusic.workspace import (
     create_workspace,
     delete_workspace,
@@ -143,6 +151,7 @@ def main(
         "speed",
         "stems",
         "midi",
+        "remaster",
     ):
         config = load_config()
         if not config.api_url:
@@ -1671,6 +1680,76 @@ def midi(
     console.print(f"\n  [green]✓[/green] Extracted MIDI from clip {clip_id} ({elapsed:.1f}s)")
     for label, nid, mpath in new_ids:
         console.print(f"    {label:<8} → clip {nid}  {mpath}")
+
+
+# ---------------------------------------------------------------------------
+# Remaster command (US-5.5)
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def remaster(
+    clip_id: int = typer.Argument(..., help="ID of the source clip to remaster."),
+    target_lufs: float = typer.Option(-14.0, "--target-lufs", help="Target loudness in LUFS (default: -14)."),
+    output: Optional[Path] = typer.Option(None, "--output", help="Custom output file path."),
+) -> None:
+    """Apply audio enhancement: loudness normalization, EQ, compression, and stereo widening. Original is preserved."""
+    source = get_clip(clip_id)
+    if source is None:
+        console.print(f"[red]Error: clip {clip_id} not found.[/red]")
+        raise typer.Exit(code=1)
+
+    src_path = Path(source.file_path)
+    if not src_path.exists():
+        console.print(f"[red]Error: source file not found: {src_path}[/red]")
+        raise typer.Exit(code=1)
+
+    src_ext = src_path.suffix.lower()
+    if src_ext not in {".wav"}:
+        console.print(
+            f"[red]Error: unsupported format '{src_ext}' for remastering. Currently only .wav is supported.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if output is not None:
+        dest_path = output
+    else:
+        dest_path = generate_remaster_filename(src_path)
+
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with console.status("[bold green]Remastering..."):
+            result = remaster_audio(src_path, dest_path, target_lufs=target_lufs)
+    except Exception as exc:
+        console.print(f"[red]Error during remastering: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    # Register new clip in DB
+    dur = get_duration(dest_path)
+    new_clip = Clip(
+        workspace_id=source.workspace_id,
+        file_path=str(dest_path.resolve()),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        format=source.format,
+        duration=dur,
+        bpm=source.bpm,
+        key=source.key,
+        parent_clip_id=source.id,
+        generation_mode="remaster",
+    )
+    try:
+        new_id = create_clip(new_clip)
+    except Exception as exc:
+        dest_path.unlink(missing_ok=True)
+        console.print(f"[red]Error saving clip record: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    before_lufs = result["before_lufs"]
+    after_lufs = result["after_lufs"]
+    console.print(f"  [green]\u2713[/green] Remastered clip {clip_id} \u2192 clip {new_id}")
+    console.print(f"    Path:   {dest_path}")
+    console.print(f"    LUFS:   {before_lufs:.1f} \u2192 {after_lufs:.1f}")
 
 
 # Preset commands (US-4.3)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1722,6 +1722,7 @@ def remaster(
         with console.status("[bold green]Remastering..."):
             result = remaster_audio(src_path, dest_path, target_lufs=target_lufs)
     except Exception as exc:
+        dest_path.unlink(missing_ok=True)
         console.print(f"[red]Error during remastering: {exc}[/red]")
         raise typer.Exit(code=1)
 

--- a/src/acemusic/utils.py
+++ b/src/acemusic/utils.py
@@ -65,6 +65,17 @@ def parse_time_string(time_str: str) -> int:
     return int(round(seconds * 1000))
 
 
+def generate_remaster_filename(original_path: Path) -> Path:
+    """Generate a remaster output filename in the same directory as the original.
+
+    Produces: {stem}-remaster-{timestamp}.{ext}
+    """
+    from datetime import datetime
+
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    return original_path.parent / f"{original_path.stem}-remaster-{timestamp}{original_path.suffix}"
+
+
 def snap_to_beat(time_ms: int | float, bpm: int | float) -> int:
     """Round time_ms to the nearest beat boundary for the given BPM.
 

--- a/tests/test_remaster.py
+++ b/tests/test_remaster.py
@@ -1,0 +1,153 @@
+"""Tests for the remaster CLI command (US-5.5)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import numpy as np
+import pytest
+import soundfile as sf
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+from acemusic.models import Clip
+
+runner = CliRunner()
+
+
+def _make_test_wav(path, amplitude=0.3, duration_s=1.0, sample_rate=44100):
+    """Create a minimal valid WAV file for testing."""
+    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
+    mono = (amplitude * np.sin(2 * np.pi * 440.0 * t)).astype(np.float64)
+    stereo = np.column_stack([mono, mono])
+    sf.write(str(path), stereo, sample_rate)
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    import acemusic.db as _db
+
+    monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+    return tmp_path
+
+
+@pytest.fixture
+def workspace_with_clip(isolated_db):
+    """Set up a workspace with a single clip for remaster testing."""
+    from acemusic.db import create_clip
+    from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+    ensure_default_workspace()
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    src_wav = clips_dir / "source.wav"
+    _make_test_wav(src_wav, amplitude=0.3, duration_s=1.0)
+
+    clip = Clip(
+        workspace_id=ws.id,
+        file_path=str(src_wav),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        format="wav",
+        duration=1.0,
+        generation_mode="generate",
+    )
+    clip_id = create_clip(clip)
+    return ws, clip_id, src_wav
+
+
+class TestRemasterCommand:
+    def test_successful_remaster(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        result = runner.invoke(app, ["remaster", str(clip_id)])
+        assert result.exit_code == 0, result.output
+        assert "remaster" in result.output.lower() or "LUFS" in result.output
+
+    def test_creates_child_clip_in_db(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        result = runner.invoke(app, ["remaster", str(clip_id)])
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        clips = list_clips(ws.id)
+        remastered = [c for c in clips if c.generation_mode == "remaster"]
+        assert len(remastered) == 1
+        assert remastered[0].parent_clip_id == clip_id
+
+    def test_target_lufs_option(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        result = runner.invoke(app, ["remaster", str(clip_id), "--target-lufs", "-12"])
+        assert result.exit_code == 0, result.output
+
+    def test_output_option(self, workspace_with_clip, tmp_path):
+        ws, clip_id, src_wav = workspace_with_clip
+        output_path = tmp_path / "custom_output.wav"
+        result = runner.invoke(app, ["remaster", str(clip_id), "--output", str(output_path)])
+        assert result.exit_code == 0, result.output
+        assert output_path.exists()
+
+    def test_original_file_unchanged(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        original_bytes = src_wav.read_bytes()
+        result = runner.invoke(app, ["remaster", str(clip_id)])
+        assert result.exit_code == 0, result.output
+        assert src_wav.read_bytes() == original_bytes
+
+
+class TestRemasterValidation:
+    def test_nonexistent_clip_returns_error(self, isolated_db):
+        from acemusic.workspace import ensure_default_workspace
+
+        ensure_default_workspace()
+        result = runner.invoke(app, ["remaster", "99999"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_unsupported_format_returns_error(self, isolated_db):
+        from acemusic.db import create_clip
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+
+        txt_file = clips_dir / "not_audio.txt"
+        txt_file.write_text("this is not audio")
+
+        clip = Clip(
+            workspace_id=ws.id,
+            file_path=str(txt_file),
+            created_at=datetime.now(timezone.utc).isoformat(),
+            format="txt",
+            duration=10.0,
+            generation_mode="upload",
+        )
+        clip_id = create_clip(clip)
+
+        result = runner.invoke(app, ["remaster", str(clip_id)])
+        assert result.exit_code == 1
+        assert "unsupported" in result.output.lower() or "format" in result.output.lower()
+
+    def test_missing_file_returns_error(self, isolated_db):
+        from acemusic.db import create_clip
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+
+        clip = Clip(
+            workspace_id=ws.id,
+            file_path="/nonexistent/path/audio.wav",
+            created_at=datetime.now(timezone.utc).isoformat(),
+            format="wav",
+            duration=10.0,
+            generation_mode="generate",
+        )
+        clip_id = create_clip(clip)
+
+        result = runner.invoke(app, ["remaster", str(clip_id)])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower() or "exist" in result.output.lower()

--- a/tests/test_remaster_audio.py
+++ b/tests/test_remaster_audio.py
@@ -1,0 +1,226 @@
+"""Unit tests for remaster audio processing functions (US-5.5)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _make_stereo_sine(
+    frequency: float = 440.0,
+    duration_s: float = 2.0,
+    sample_rate: int = 44100,
+    amplitude: float = 0.5,
+) -> tuple[np.ndarray, int]:
+    """Create a stereo sine wave for testing."""
+    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
+    mono = (amplitude * np.sin(2 * np.pi * frequency * t)).astype(np.float64)
+    stereo = np.column_stack([mono, mono])
+    return stereo, sample_rate
+
+
+def _make_dynamic_stereo(
+    sample_rate: int = 44100,
+    duration_s: float = 2.0,
+) -> tuple[np.ndarray, int]:
+    """Create a stereo signal with high dynamic range (loud + quiet sections)."""
+    n_samples = int(sample_rate * duration_s)
+    t = np.linspace(0, duration_s, n_samples, endpoint=False)
+    half = n_samples // 2
+    signal = np.zeros(n_samples, dtype=np.float64)
+    signal[:half] = 0.8 * np.sin(2 * np.pi * 440.0 * t[:half])
+    signal[half:] = 0.05 * np.sin(2 * np.pi * 440.0 * t[half:])
+    stereo = np.column_stack([signal, signal])
+    return stereo, sample_rate
+
+
+class TestMeasureLufs:
+    def test_returns_float(self):
+        from acemusic.audio import measure_lufs
+
+        audio, sr = _make_stereo_sine(amplitude=0.5)
+        result = measure_lufs(audio, sr)
+        assert isinstance(result, float)
+
+    def test_louder_signal_has_higher_lufs(self):
+        from acemusic.audio import measure_lufs
+
+        loud, sr = _make_stereo_sine(amplitude=0.8)
+        quiet, _ = _make_stereo_sine(amplitude=0.1)
+        loud_lufs = measure_lufs(loud, sr)
+        quiet_lufs = measure_lufs(quiet, sr)
+        assert loud_lufs > quiet_lufs
+
+    def test_result_is_negative(self):
+        from acemusic.audio import measure_lufs
+
+        audio, sr = _make_stereo_sine(amplitude=0.5)
+        result = measure_lufs(audio, sr)
+        assert result < 0
+
+
+class TestNormalizeLoudness:
+    def test_output_near_target_lufs(self):
+        from acemusic.audio import measure_lufs, normalize_loudness
+
+        audio, sr = _make_stereo_sine(amplitude=0.3)
+        target = -14.0
+        normalized = normalize_loudness(audio, sr, target)
+        result_lufs = measure_lufs(normalized, sr)
+        assert abs(result_lufs - target) < 1.5
+
+    def test_preserves_shape(self):
+        from acemusic.audio import normalize_loudness
+
+        audio, sr = _make_stereo_sine(amplitude=0.3)
+        normalized = normalize_loudness(audio, sr, -14.0)
+        assert normalized.shape == audio.shape
+
+    def test_no_clipping(self):
+        from acemusic.audio import normalize_loudness
+
+        audio, sr = _make_stereo_sine(amplitude=0.3)
+        normalized = normalize_loudness(audio, sr, -14.0)
+        assert np.max(np.abs(normalized)) <= 1.0
+
+
+class TestApplyEq:
+    def test_preserves_audio_length(self):
+        from acemusic.audio import apply_eq
+
+        audio, sr = _make_stereo_sine()
+        result = apply_eq(audio, sr)
+        assert result.shape == audio.shape
+
+    def test_no_clipping(self):
+        from acemusic.audio import apply_eq
+
+        audio, sr = _make_stereo_sine(amplitude=0.5)
+        result = apply_eq(audio, sr)
+        assert np.max(np.abs(result)) <= 1.01  # small tolerance for filter ringing
+
+
+class TestApplyCompression:
+    def test_reduces_dynamic_range(self):
+        from acemusic.audio import apply_compression
+
+        audio, sr = _make_dynamic_stereo()
+        compressed = apply_compression(audio, sr)
+
+        half = len(audio) // 2
+        # Measure RMS of loud and quiet sections
+        rms_loud_orig = np.sqrt(np.mean(audio[:half] ** 2))
+        rms_quiet_orig = np.sqrt(np.mean(audio[half:] ** 2))
+        ratio_orig = rms_loud_orig / rms_quiet_orig
+
+        rms_loud_comp = np.sqrt(np.mean(compressed[:half] ** 2))
+        rms_quiet_comp = np.sqrt(np.mean(compressed[half:] ** 2))
+        ratio_comp = rms_loud_comp / rms_quiet_comp
+
+        # After compression, the ratio between loud and quiet should decrease
+        assert ratio_comp < ratio_orig
+
+    def test_preserves_shape(self):
+        from acemusic.audio import apply_compression
+
+        audio, sr = _make_dynamic_stereo()
+        result = apply_compression(audio, sr)
+        assert result.shape == audio.shape
+
+
+class TestApplyStereoWidening:
+    def test_preserves_shape(self):
+        from acemusic.audio import apply_stereo_widening
+
+        audio, sr = _make_stereo_sine()
+        result = apply_stereo_widening(audio, amount=1.2)
+        assert result.shape == audio.shape
+
+    def test_mono_compatibility(self):
+        """Sum of L+R should not be significantly reduced."""
+        from acemusic.audio import apply_stereo_widening
+
+        audio, sr = _make_stereo_sine()
+        result = apply_stereo_widening(audio, amount=1.2)
+
+        mono_orig = audio[:, 0] + audio[:, 1]
+        mono_widened = result[:, 0] + result[:, 1]
+
+        energy_orig = np.sum(mono_orig**2)
+        energy_widened = np.sum(mono_widened**2)
+
+        # Mono energy should not drop by more than 3dB
+        assert energy_widened >= energy_orig * 0.5
+
+    def test_amount_zero_returns_mono_collapse(self):
+        """Amount 0 should collapse to mono (L=R)."""
+        from acemusic.audio import apply_stereo_widening
+
+        # Create a signal with L/R difference
+        left = np.sin(2 * np.pi * 440 * np.linspace(0, 1, 44100))
+        right = np.sin(2 * np.pi * 880 * np.linspace(0, 1, 44100))
+        audio = np.column_stack([left, right])
+
+        result = apply_stereo_widening(audio, amount=0.0)
+        # At amount=0, L and R should be identical (pure mid)
+        np.testing.assert_allclose(result[:, 0], result[:, 1], atol=1e-10)
+
+
+class TestRemasterAudio:
+    def test_end_to_end_creates_output_file(self, tmp_path):
+        from acemusic.audio import remaster_audio
+
+        audio, sr = _make_stereo_sine(amplitude=0.3, duration_s=2.0)
+        input_path = tmp_path / "input.wav"
+        output_path = tmp_path / "output.wav"
+
+        import soundfile as sf
+
+        sf.write(str(input_path), audio, sr)
+
+        result = remaster_audio(input_path, output_path, target_lufs=-14.0)
+        assert output_path.exists()
+        assert "before_lufs" in result
+        assert "after_lufs" in result
+
+    def test_output_lufs_near_target(self, tmp_path):
+        from acemusic.audio import remaster_audio
+
+        audio, sr = _make_stereo_sine(amplitude=0.1, duration_s=2.0)
+        input_path = tmp_path / "quiet_input.wav"
+        output_path = tmp_path / "remastered.wav"
+
+        import soundfile as sf
+
+        sf.write(str(input_path), audio, sr)
+
+        result = remaster_audio(input_path, output_path, target_lufs=-14.0)
+        assert abs(result["after_lufs"] - (-14.0)) < 2.0
+
+    def test_original_file_unchanged(self, tmp_path):
+        from acemusic.audio import remaster_audio
+
+        audio, sr = _make_stereo_sine(amplitude=0.3, duration_s=2.0)
+        input_path = tmp_path / "original.wav"
+        output_path = tmp_path / "remastered.wav"
+
+        import soundfile as sf
+
+        sf.write(str(input_path), audio, sr)
+
+        original_bytes = input_path.read_bytes()
+        remaster_audio(input_path, output_path, target_lufs=-14.0)
+        assert input_path.read_bytes() == original_bytes
+
+    def test_custom_target_lufs(self, tmp_path):
+        from acemusic.audio import remaster_audio
+
+        audio, sr = _make_stereo_sine(amplitude=0.3, duration_s=2.0)
+        input_path = tmp_path / "input.wav"
+        output_path = tmp_path / "output.wav"
+
+        import soundfile as sf
+
+        sf.write(str(input_path), audio, sr)
+
+        result = remaster_audio(input_path, output_path, target_lufs=-12.0)
+        assert abs(result["after_lufs"] - (-12.0)) < 2.0

--- a/uv.lock
+++ b/uv.lock
@@ -26,8 +26,10 @@ dependencies = [
     { name = "mido" },
     { name = "mutagen" },
     { name = "pydub" },
+    { name = "pyloudnorm" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "scipy" },
     { name = "soundfile" },
     { name = "typer" },
 ]
@@ -59,12 +61,14 @@ requires-dist = [
     { name = "mido", specifier = ">=1.3.0" },
     { name = "mutagen", specifier = ">=1.47" },
     { name = "pydub", specifier = ">=0.25.1" },
+    { name = "pyloudnorm", specifier = ">=0.1.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-bdd", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=0.13.0" },
     { name = "pyyaml", specifier = ">=5.4" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "scipy", specifier = ">=1.10.0" },
     { name = "soundfile", specifier = ">=0.12.0" },
     { name = "torch", marker = "extra == 'audio-ml'", specifier = ">=2.0" },
     { name = "torchaudio", marker = "extra == 'audio-ml'", specifier = ">=2.0" },
@@ -1917,6 +1921,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyloudnorm"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and sys_platform == 'darwin'" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/00/f915eaa75326f4209941179c2b93ac477f2040e4aeff5bb21d16eb8058f9/pyloudnorm-0.2.0.tar.gz", hash = "sha256:8bf597658ea4e1975c275adf490f6deb5369ea409f2901f939915efa4b681b16", size = 14037, upload-time = "2026-01-04T11:43:35.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/b6/65a49a05614b2548edbba3aab118f2ebe7441dfd778accdcdce9f6567f20/pyloudnorm-0.2.0-py3-none-any.whl", hash = "sha256:9bb69afb904f59d007a7f9ba3d75d16fb8aeef35c44d6df822a9f192d69cf13f", size = 10879, upload-time = "2026-01-04T11:43:34.534Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `acemusic remaster <clip_id>` command with full DSP pipeline: loudness normalization (LUFS targeting via pyloudnorm), presence/low-end EQ (scipy), soft-knee compression, and stereo widening (mid/side processing)
- Supports `--target-lufs` (default -14) and `--output` options; original clip is always preserved
- Registers remastered clip in DB with `generation_mode="remaster"` and `parent_clip_id` linking

## Implementation Details

- **DSP functions** in `src/acemusic/audio.py`: `measure_lufs`, `normalize_loudness`, `apply_eq`, `apply_compression`, `apply_stereo_widening`, `remaster_audio`
- **CLI command** in `src/acemusic/cli.py`: follows existing patterns (Typer, Rich status spinner, clip DB registration)
- **Utility** `generate_remaster_filename()` in `src/acemusic/utils.py`
- **Dependencies**: `pyloudnorm>=0.1.0`, `scipy>=1.10.0`

## Test plan

- [x] 17 DSP unit tests covering all audio processing functions (LUFS measurement, normalization, EQ, compression, stereo widening, end-to-end remaster)
- [x] 8 CLI integration tests (happy path, --target-lufs, --output, original unchanged, error cases for nonexistent clip/unsupported format/missing file)
- [x] Full suite: 415 passed, 0 failed, 85% coverage
- [x] Ruff + Black clean

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced audio remastering: loudness measurement, normalization, EQ, compression, and stereo widening.
  * Added a top-level remaster CLI command for processing WAV files with configurable target loudness and automatic output naming.

* **Chores**
  * Added runtime audio-processing dependencies to support the remastering pipeline.

* **Tests**
  * Added comprehensive unit and CLI tests covering remastering behavior, outputs, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->