### PR TITLE
feat: US-6.6 add vocal layering and section replacement (#38)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AI-powered music generation platform built on **ACE-Step-1.5** (fork: `github.co
 3. **Layer 3 — Web UI** (Stages 15–21): Next.js frontend
 4. **Layer 4 — Advanced Integrations** (Stages 22–28): VST3 plugin, music video, voice models, credits, moderation
 
-**Current progress:** Stages 1–4 complete; Stage 6 in progress (US-6.1 extend, US-6.2 cover, US-6.3 repaint, and US-6.4 mashup implemented). CLI entry point, health check, basic generation, musical parameters, quality/speed tradeoffs, model selection, sound modes, workspace management, clip extension, cover-mode restyle, section repaint with crossfade blending, and two-clip mashup with BPM alignment all implemented.
+**Current progress:** Stages 1–4 complete; Stage 6 in progress (US-6.1 extend, US-6.2 cover, US-6.3 repaint, US-6.4 mashup, US-6.5 sample, and US-6.6 add-vocal/replace implemented). CLI entry point, health check, basic generation, musical parameters, quality/speed tradeoffs, model selection, sound modes, workspace management, clip extension, cover-mode restyle, section repaint with crossfade blending, two-clip mashup with BPM alignment, loop sampling, vocal layering, and section replacement all implemented.
 
 ## Commands
 
@@ -64,6 +64,14 @@ uv run acemusic mashup 42 43                                                    
 uv run acemusic mashup 42 43 --blend sequential                                 # section-by-section blend
 uv run acemusic mashup 42 43 --blend ai-guided --style "lo-fi hip hop"          # model chooses; unifying style applied
 
+# Add vocal (US-6.6) — layer vocals onto an instrumental clip
+uv run acemusic add-vocal 42 --lyrics "[Verse]\nSing this line"                                    # default voice
+uv run acemusic add-vocal 42 --lyrics "[Chorus]\nLouder now" --voice soulful --style "breathy"     # styled vocal
+
+# Replace section (US-6.6) — regenerate a specific time range with new instructions
+uv run acemusic replace 42 --start 30s --end 45s --prompt "make this section more energetic"      # locks context (default)
+uv run acemusic replace 42 --start 1m --end 1m30s --prompt "soft strings" --no-lock-context        # use model output as-is
+
 # Workspace management (US-4.1)
 uv run acemusic workspace list                        # list all workspaces (auto-creates Default)
 uv run acemusic workspace create "My Album"           # create a new workspace
@@ -107,7 +115,7 @@ docs/               # Additional documentation (placeholder)
 ### Key Modules
 
 - **`client.py`** — The core integration with ACE-Step-1.5. Understands the API envelope (`{"data": ..., "code": 200}`), integer status codes (0=pending, 1=completed, 2=failed), and the `/release_task` → `/query_result` → `/v1/audio` workflow.
-- **`cli.py`** — Typer-based CLI. Commands: `health`, `generate`, `models`, `extend`, `cover`, `repaint`, and the `workspace` subcommand group (`create`, `list`, `switch`, `rename`, `delete`). Uses `AceStepClient` for generation and `workspace.py` for workspace ops.
+- **`cli.py`** — Typer-based CLI. Commands: `health`, `generate`, `models`, `extend`, `cover`, `repaint`, `mashup`, `sample`, `add-vocal`, `replace`, and the `workspace` subcommand group (`create`, `list`, `switch`, `rename`, `delete`). Uses `AceStepClient` for generation and `workspace.py` for workspace ops.
 - **`config.py`** — Returns `AceConfig(api_url, api_key, output_dir)`. Priority: env vars > `.env` > `~/.acemusic/config.yaml`.
 - **`db.py`** — Opens (and schema-inits on first use) the SQLite metadata database at `~/.acemusic/metadata.db`. All workspace state is persisted here.
 - **`workspace.py`** — CRUD operations on workspaces. Audio clips are stored under `~/.acemusic/workspaces/{id}/clips/`. A "Default" workspace is auto-created on first access. `generate` falls back to the active workspace's clips directory when `--output` and `config.output_dir` are both unset.

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+from pydub import AudioSegment
 from rich.console import Console
 from rich.table import Table
 
@@ -2289,8 +2290,6 @@ def repaint(
     # Splice the regenerated section into the original with crossfade at the seams.
     # Passing format= explicitly so pydub uses Python's wave module for WAVs and
     # avoids invoking ffprobe (which is not always available, e.g. in CI runners).
-    from pydub import AudioSegment
-
     try:
         original = AudioSegment.from_file(str(src_path), format=ext)
         repaint_full = AudioSegment.from_file(io.BytesIO(repaint_bytes), format=ext)
@@ -2701,8 +2700,6 @@ def replace(
         raise typer.Exit(code=1)
 
     if lock_context:
-        from pydub import AudioSegment
-
         try:
             original = AudioSegment.from_file(str(src_path), format=ext)
             replace_full = AudioSegment.from_file(io.BytesIO(replace_bytes), format=ext)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2710,7 +2710,10 @@ def replace(
             console.print(f"[red]Error decoding audio for stitching: {exc}[/red]")
             raise typer.Exit(code=1)
 
-        if len(replace_full) < end_ms - 10:
+        # Use a 1ms tolerance for both checks so the pre-slice and post-slice
+        # guards agree \u2014 anything that passes the first check produces a
+        # `middle` that won't trip the second.
+        if len(replace_full) < end_ms - 1:
             console.print(
                 f"[red]Error: ACE-Step output is {len(replace_full)}ms but the replace "
                 f"window ends at {end_ms}ms \u2014 the model returned a truncated clip.[/red]"

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2368,7 +2368,11 @@ def repaint(
 def add_vocal(
     clip_id: int = typer.Argument(..., help="ID of the source instrumental clip."),
     lyrics: str = typer.Option(..., "--lyrics", help="Lyrics to layer onto the instrumental."),
-    voice: str = typer.Option("default", "--voice", help="Voice identifier (Stage 25 feature)."),
+    voice: str = typer.Option(
+        "default",
+        "--voice",
+        help="Voice identifier (Stage 25 stub — value is currently accepted but not forwarded to the model).",
+    ),
     style: Optional[str] = typer.Option(None, "--style", help="Optional vocal style (e.g. 'breathy, soulful')."),
     output: Optional[Path] = typer.Option(None, "--output", help="Directory to save the resulting clip."),
     name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix for the resulting clip."),
@@ -2426,9 +2430,13 @@ def add_vocal(
     dest_name = f"{title_slug}-vocal-{uuid.uuid4().hex[:8]}.{ext}"
     dest_path = clips_dir / dest_name
 
+    # Prompt describes the instrumental backdrop (so the model knows what it's
+    # singing over); --style separately controls the vocal performance style.
+    vocal_prompt = source.style_tags or source.title or "layer vocals over the instrumental"
+
     try:
         task_id = ace_client.submit_task(
-            prompt=style or "add vocals",
+            prompt=vocal_prompt,
             num_clips=1,
             audio_duration=source_duration,
             format=ext,
@@ -2713,6 +2721,19 @@ def replace(
             before = original[: int(start_ms)]
             middle = replace_full[int(start_ms) : int(end_ms)]
             after = original[int(end_ms) :]
+        except Exception as exc:
+            console.print(f"[red]Error slicing audio for stitching: {exc}[/red]")
+            raise typer.Exit(code=1)
+
+        expected_middle_ms = end_ms - start_ms
+        if len(middle) < expected_middle_ms - 1:
+            console.print(
+                f"[red]Error: replacement section is {len(middle)}ms but the window "
+                f"expects {expected_middle_ms}ms \u2014 model output was shorter than the window.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        try:
             stitched = crossfade_stitch(before, middle, after, fade_ms=crossfade_ms)
             stitched.export(str(dest_path), format=ext)
         except Exception as exc:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1,4 +1,4 @@
-"""CLI entry point for acemusic (US-2.1, US-2.2, US-2.3, US-4.2, US-5.1, US-5.3, US-5.4, US-5.5, US-6.2, US-6.4, US-6.5)."""
+"""CLI entry point for acemusic (US-2.1, US-2.2, US-2.3, US-4.2, US-5.1, US-5.3, US-5.4, US-5.5, US-6.2, US-6.4, US-6.5, US-6.6)."""
 
 from __future__ import annotations
 
@@ -2355,6 +2355,416 @@ def repaint(
 
     dur_str = f"{new_duration:.1f}s" if new_duration is not None else "unknown"
     console.print(f"  [green]\u2713[/green] Repainted clip {clip_id} ({start}\u2013{end}) \u2192 clip {new_id}")
+    console.print(f"    Path:     {dest_path}")
+    console.print(f"    Duration: {dur_str}")
+
+
+# ---------------------------------------------------------------------------
+# Add-vocal command (US-6.6)
+# ---------------------------------------------------------------------------
+
+
+@app.command("add-vocal")
+def add_vocal(
+    clip_id: int = typer.Argument(..., help="ID of the source instrumental clip."),
+    lyrics: str = typer.Option(..., "--lyrics", help="Lyrics to layer onto the instrumental."),
+    voice: str = typer.Option("default", "--voice", help="Voice identifier (Stage 25 feature)."),
+    style: Optional[str] = typer.Option(None, "--style", help="Optional vocal style (e.g. 'breathy, soulful')."),
+    output: Optional[Path] = typer.Option(None, "--output", help="Directory to save the resulting clip."),
+    name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix for the resulting clip."),
+) -> None:
+    """Layer vocals onto an instrumental clip.
+
+    Submits a ``task_type=complete`` request to ACE-Step with the source clip as
+    src_audio. The model generates a vocal layered over the instrumental, and
+    the result is saved as a new clip with ``parent_clip_id`` set to the source
+    and ``generation_mode='add_vocal'``.
+
+    Note: Requires ACE-Step to run on the same host (or with shared filesystem
+    access), since the source audio is passed via an absolute server-side path.
+    """
+    source = get_clip(clip_id)
+    if source is None:
+        console.print(f"[red]Error: clip {clip_id} not found.[/red]")
+        raise typer.Exit(code=1)
+
+    src_path = Path(source.file_path)
+    if not src_path.exists():
+        console.print(f"[red]Error: source file not found: {src_path}[/red]")
+        raise typer.Exit(code=1)
+
+    if src_path.suffix.lower() not in SUPPORTED_FORMATS:
+        console.print(
+            f"[red]Error: source clip {clip_id} is not a supported audio file "
+            f"({src_path.suffix or 'no extension'}). add-vocal requires one of: "
+            f"{', '.join(sorted(SUPPORTED_FORMATS))}.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    source_duration = source.duration
+    if source_duration is None or source_duration <= 0:
+        try:
+            source_duration = get_duration(src_path)
+        except Exception as exc:
+            console.print(f"[red]Error: unable to determine source duration for clip {clip_id}: {exc}[/red]")
+            raise typer.Exit(code=1)
+        if source_duration is None or source_duration <= 0:
+            console.print(f"[red]Error: source clip {clip_id} has no valid duration metadata.[/red]")
+            raise typer.Exit(code=1)
+
+    if voice != "default":
+        console.print("[yellow]Voice selection available in Stage 25.[/yellow]")
+
+    config = load_config()
+    ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
+
+    clips_dir = output if output is not None else get_workspace_path(source.workspace_id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    ext = source.format or "wav"
+    title_slug = make_slug(name or source.title or "clip")
+    dest_name = f"{title_slug}-vocal-{uuid.uuid4().hex[:8]}.{ext}"
+    dest_path = clips_dir / dest_name
+
+    try:
+        task_id = ace_client.submit_task(
+            prompt=style or "add vocals",
+            num_clips=1,
+            audio_duration=source_duration,
+            format=ext,
+            style=style,
+            lyrics=lyrics,
+            vocal_language=source.vocal_language,
+            bpm=source.bpm,
+            key=source.key,
+            seed=source.seed,
+            task_type="complete",
+            src_audio_path=str(src_path.resolve()),
+        )
+    except AceStepError as exc:
+        console.print(f"[red]Error submitting add-vocal task: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
+
+    poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
+    poll_interval = 2.0
+    poll_start = time.monotonic()
+    result: dict = {}
+    with console.status("[bold green]Adding vocal\u2026[/bold green]", spinner="dots") as status_bar:
+        while True:
+            elapsed = time.monotonic() - poll_start
+            if elapsed >= poll_timeout:
+                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
+                raise typer.Exit(code=1)
+            try:
+                result = ace_client.query_result(task_id)
+            except AceStepError as exc:
+                console.print(f"[red]Error polling status: {exc}[/red]")
+                raise typer.Exit(code=1)
+            job_status = result.get("status", "unknown")
+            status_bar.update(f"[bold green]Adding vocal\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]")
+            if job_status == "completed":
+                break
+            if job_status == "failed":
+                error_msg = result.get("error", "unknown error")
+                console.print(f"[red]Add-vocal failed: {error_msg}[/red]")
+                raise typer.Exit(code=1)
+            time.sleep(poll_interval)
+
+    audio_urls: list[str] = result.get("audio_urls", [])
+    if not audio_urls:
+        console.print("[red]Error: ACE-Step returned no audio URLs.[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        data = ace_client.download_audio(audio_urls[0])
+    except AceStepError as exc:
+        console.print(f"[red]Error downloading add-vocal clip: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        dest_path.write_bytes(data)
+    except OSError as exc:
+        console.print(f"[red]Error writing add-vocal clip to {dest_path}: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        new_duration = get_duration(dest_path)
+    except Exception as exc:
+        warnings.warn(f"add-vocal clip duration probe failed: {exc}", stacklevel=2)
+        new_duration = None
+
+    if name:
+        new_title = name
+    elif source.title:
+        new_title = f"{source.title} (vocal)"
+    else:
+        new_title = None
+
+    new_clip = Clip(
+        workspace_id=source.workspace_id,
+        file_path=str(dest_path.resolve()),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        title=new_title,
+        format=ext,
+        duration=new_duration,
+        bpm=source.bpm,
+        key=source.key,
+        style_tags=style or source.style_tags,
+        lyrics=lyrics,
+        vocal_language=source.vocal_language,
+        model=source.model,
+        seed=source.seed,
+        inference_steps=source.inference_steps,
+        parent_clip_id=source.id,
+        generation_mode="add_vocal",
+    )
+    try:
+        new_id = create_clip(new_clip)
+    except Exception as exc:
+        dest_path.unlink(missing_ok=True)
+        console.print(f"[red]Error saving clip record: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    dur_str = f"{new_duration:.1f}s" if new_duration is not None else "unknown"
+    console.print(f"  [green]\u2713[/green] Added vocal to clip {clip_id} \u2192 clip {new_id}")
+    console.print(f"    Path:     {dest_path}")
+    console.print(f"    Duration: {dur_str}")
+
+
+# ---------------------------------------------------------------------------
+# Replace command (US-6.6)
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def replace(
+    clip_id: int = typer.Argument(..., help="ID of the source clip whose section will be replaced."),
+    start: str = typer.Option(..., "--start", help="Start of the region to regenerate (e.g. '30s', '1m30s')."),
+    end: str = typer.Option(..., "--end", help="End of the region to regenerate (e.g. '45s', '2m')."),
+    prompt: str = typer.Option(..., "--prompt", help="Prompt describing what should fill the region."),
+    lock_context: bool = typer.Option(
+        True,
+        "--lock-context/--no-lock-context",
+        help="Blend replacement with surrounding audio via crossfade stitch (default: on).",
+    ),
+    style: Optional[str] = typer.Option(None, "--style", help="Optional style override for the regenerated section."),
+    output: Optional[Path] = typer.Option(None, "--output", help="Directory to save the resulting clip."),
+    name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix for the resulting clip."),
+    crossfade_ms: int = typer.Option(
+        50,
+        "--crossfade-ms",
+        help="Crossfade length at the splice boundaries (milliseconds). Only used with --lock-context.",
+    ),
+) -> None:
+    """Regenerate a specific time range of a clip with new instructions.
+
+    Submits a ``task_type=repaint`` request to ACE-Step with the source clip as
+    src_audio and the [start, end] region marked for regeneration. With
+    ``--lock-context`` (default on), the regenerated section is stitched back
+    into the original with a short crossfade at each boundary so surrounding
+    audio is preserved. With ``--no-lock-context``, the model's full output is
+    saved directly without stitching. The result is saved as a new clip with
+    ``parent_clip_id`` set to the source and ``generation_mode='replace'``.
+
+    Note: Requires ACE-Step to run on the same host (or with shared filesystem
+    access), since the source audio is passed via an absolute server-side path.
+    """
+    try:
+        start_ms = parse_time_string(start)
+        end_ms = parse_time_string(end)
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    start_s = start_ms / 1000.0
+    end_s = end_ms / 1000.0
+
+    if start_s >= end_s:
+        console.print(f"[red]Error: --start ({start!r}) must be less than --end ({end!r}).[/red]")
+        raise typer.Exit(code=1)
+
+    source = get_clip(clip_id)
+    if source is None:
+        console.print(f"[red]Error: clip {clip_id} not found.[/red]")
+        raise typer.Exit(code=1)
+
+    src_path = Path(source.file_path)
+    if not src_path.exists():
+        console.print(f"[red]Error: source file not found: {src_path}[/red]")
+        raise typer.Exit(code=1)
+
+    if src_path.suffix.lower() not in SUPPORTED_FORMATS:
+        console.print(
+            f"[red]Error: source clip {clip_id} is not a supported audio file "
+            f"({src_path.suffix or 'no extension'}). replace requires one of: "
+            f"{', '.join(sorted(SUPPORTED_FORMATS))}.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    source_duration = source.duration
+    if source_duration is None or source_duration <= 0:
+        try:
+            source_duration = get_duration(src_path)
+        except Exception as exc:
+            console.print(f"[red]Error: unable to determine source duration for clip {clip_id}: {exc}[/red]")
+            raise typer.Exit(code=1)
+        if source_duration is None or source_duration <= 0:
+            console.print(f"[red]Error: source clip {clip_id} has no valid duration metadata.[/red]")
+            raise typer.Exit(code=1)
+
+    if end_s > source_duration + 0.01:
+        console.print(
+            f"[red]Error: --end ({end!r}={end_s:.2f}s) exceeds source duration ({source_duration:.2f}s).[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if crossfade_ms < 0:
+        console.print(f"[red]Error: --crossfade-ms must be non-negative, got {crossfade_ms}.[/red]")
+        raise typer.Exit(code=1)
+
+    config = load_config()
+    ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
+
+    clips_dir = output if output is not None else get_workspace_path(source.workspace_id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    ext = source.format or "wav"
+    title_slug = make_slug(name or source.title or "clip")
+    dest_name = f"{title_slug}-replace-{uuid.uuid4().hex[:8]}.{ext}"
+    dest_path = clips_dir / dest_name
+
+    try:
+        task_id = ace_client.submit_task(
+            prompt=prompt,
+            num_clips=1,
+            audio_duration=source_duration,
+            format=ext,
+            style=style,
+            bpm=source.bpm,
+            key=source.key,
+            seed=source.seed,
+            task_type="repaint",
+            src_audio_path=str(src_path.resolve()),
+            repainting_start=start_s,
+            repainting_end=end_s,
+        )
+    except AceStepError as exc:
+        console.print(f"[red]Error submitting replace task: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
+
+    poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
+    poll_interval = 2.0
+    poll_start = time.monotonic()
+    result: dict = {}
+    with console.status("[bold green]Replacing section\u2026[/bold green]", spinner="dots") as status_bar:
+        while True:
+            elapsed = time.monotonic() - poll_start
+            if elapsed >= poll_timeout:
+                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
+                raise typer.Exit(code=1)
+            try:
+                result = ace_client.query_result(task_id)
+            except AceStepError as exc:
+                console.print(f"[red]Error polling status: {exc}[/red]")
+                raise typer.Exit(code=1)
+            job_status = result.get("status", "unknown")
+            status_bar.update(f"[bold green]Replacing section\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]")
+            if job_status == "completed":
+                break
+            if job_status == "failed":
+                error_msg = result.get("error", "unknown error")
+                console.print(f"[red]Replace failed: {error_msg}[/red]")
+                raise typer.Exit(code=1)
+            time.sleep(poll_interval)
+
+    audio_urls: list[str] = result.get("audio_urls", [])
+    if not audio_urls:
+        console.print("[red]Error: ACE-Step returned no audio URLs.[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        replace_bytes = ace_client.download_audio(audio_urls[0])
+    except AceStepError as exc:
+        console.print(f"[red]Error downloading replaced clip: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if lock_context:
+        from pydub import AudioSegment
+
+        try:
+            original = AudioSegment.from_file(str(src_path), format=ext)
+            replace_full = AudioSegment.from_file(io.BytesIO(replace_bytes), format=ext)
+        except Exception as exc:
+            console.print(f"[red]Error decoding audio for stitching: {exc}[/red]")
+            raise typer.Exit(code=1)
+
+        if len(replace_full) < end_ms - 10:
+            console.print(
+                f"[red]Error: ACE-Step output is {len(replace_full)}ms but the replace "
+                f"window ends at {end_ms}ms \u2014 the model returned a truncated clip.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        try:
+            before = original[: int(start_ms)]
+            middle = replace_full[int(start_ms) : int(end_ms)]
+            after = original[int(end_ms) :]
+            stitched = crossfade_stitch(before, middle, after, fade_ms=crossfade_ms)
+            stitched.export(str(dest_path), format=ext)
+        except Exception as exc:
+            console.print(f"[red]Error stitching replaced section: {exc}[/red]")
+            raise typer.Exit(code=1)
+    else:
+        try:
+            dest_path.write_bytes(replace_bytes)
+        except OSError as exc:
+            console.print(f"[red]Error writing replaced clip to {dest_path}: {exc}[/red]")
+            raise typer.Exit(code=1)
+
+    try:
+        new_duration = get_duration(dest_path)
+    except Exception as exc:
+        warnings.warn(f"replace clip duration probe failed: {exc}", stacklevel=2)
+        new_duration = None
+
+    if name:
+        new_title = name
+    elif source.title:
+        new_title = f"{source.title} (replace)"
+    else:
+        new_title = None
+
+    new_clip = Clip(
+        workspace_id=source.workspace_id,
+        file_path=str(dest_path.resolve()),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        title=new_title,
+        format=ext,
+        duration=new_duration,
+        bpm=source.bpm,
+        key=source.key,
+        style_tags=style or source.style_tags,
+        lyrics=source.lyrics,
+        vocal_language=source.vocal_language,
+        model=source.model,
+        seed=source.seed,
+        inference_steps=source.inference_steps,
+        parent_clip_id=source.id,
+        generation_mode="replace",
+    )
+    try:
+        new_id = create_clip(new_clip)
+    except Exception as exc:
+        dest_path.unlink(missing_ok=True)
+        console.print(f"[red]Error saving clip record: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    dur_str = f"{new_duration:.1f}s" if new_duration is not None else "unknown"
+    console.print(f"  [green]\u2713[/green] Replaced clip {clip_id} ({start}\u2013{end}) \u2192 clip {new_id}")
     console.print(f"    Path:     {dest_path}")
     console.print(f"    Duration: {dur_str}")
 

--- a/tests/test_add_vocal.py
+++ b/tests/test_add_vocal.py
@@ -134,6 +134,10 @@ class TestAddVocalCommand:
         assert kwargs["src_audio_path"] == str(src_wav.resolve())
         assert kwargs["lyrics"] == "[Verse]\nHello world"
         assert kwargs["style"] == "breathy, soulful"
+        # The prompt describes the instrumental backdrop (from source.style_tags),
+        # not the vocal style — those are separate concepts.
+        assert kwargs["prompt"] == "ambient"
+        assert kwargs["prompt"] != kwargs["style"]
 
     def test_lyrics_required(self, workspace_with_clip):
         ws, clip_id, src_wav = workspace_with_clip
@@ -152,7 +156,8 @@ class TestAddVocalCommand:
         assert result.exit_code != 0
         assert "not found" in result.output.lower()
 
-    def test_default_voice_is_default(self, workspace_with_clip):
+    def test_default_voice_suppresses_stage_25_warning(self, workspace_with_clip):
+        """When --voice is left at its default, the Stage 25 stub warning should not fire."""
         ws, clip_id, src_wav = workspace_with_clip
         client = _make_client_mock()
         with patch("acemusic.cli.AceStepClient", return_value=client):
@@ -161,7 +166,19 @@ class TestAddVocalCommand:
                 ["add-vocal", str(clip_id), "--lyrics", "[Verse]\nHi"],
             )
         assert result.exit_code == 0, result.output
-        # The voice flag should not crash when defaulted.
+        assert "Stage 25" not in result.output
+
+    def test_non_default_voice_emits_stage_25_warning(self, workspace_with_clip):
+        """When --voice is set to something other than default, the user should see the stub warning."""
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", str(clip_id), "--lyrics", "[Verse]\nHi", "--voice", "soulful"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Stage 25" in result.output
 
     def test_failed_task_exits(self, workspace_with_clip):
         ws, clip_id, src_wav = workspace_with_clip
@@ -228,6 +245,44 @@ class TestAddVocalCommand:
         children = [c for c in list_clips(ws.id) if c.generation_mode == "add_vocal"]
         assert len(children) == 1
         assert "my-song" in children[0].file_path
+
+    def test_falls_back_to_probing_when_duration_missing(self, isolated_db, write_tone):
+        """When source.duration is None, add-vocal should probe the file via get_duration()."""
+        from acemusic.db import create_clip, list_clips
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+
+        src_wav = clips_dir / "no-duration.wav"
+        write_tone(src_wav, duration_s=2.0, frequency=440.0)
+
+        clip = Clip(
+            workspace_id=ws.id,
+            file_path=str(src_wav),
+            created_at=datetime.now(timezone.utc).isoformat(),
+            format="wav",
+            duration=None,
+            generation_mode="generate",
+        )
+        clip_id = create_clip(clip)
+
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", str(clip_id), "--lyrics", "hi"],
+            )
+        assert result.exit_code == 0, result.output
+
+        # The audio_duration kwarg should be ~2.0s — derived from the probed file.
+        kwargs = client.submit_task.call_args.kwargs
+        assert kwargs["audio_duration"] == pytest.approx(2.0, abs=0.1)
+
+        children = [c for c in list_clips(ws.id) if c.generation_mode == "add_vocal"]
+        assert len(children) == 1
 
     def test_records_lyrics_on_new_clip(self, workspace_with_clip):
         ws, clip_id, src_wav = workspace_with_clip

--- a/tests/test_add_vocal.py
+++ b/tests/test_add_vocal.py
@@ -1,0 +1,245 @@
+"""Tests for the add-vocal CLI command (US-6.6)."""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import soundfile as sf
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+from acemusic.client import AceStepError
+from acemusic.models import Clip
+
+runner = CliRunner()
+
+TASK_ID = "task-add-vocal-123"
+AUDIO_URL = "http://localhost:8001/v1/audio?path=add-vocal.wav"
+COMPLETED_RESULT = {"status": "completed", "audio_urls": [AUDIO_URL]}
+PENDING_RESULT = {"status": "pending", "audio_urls": []}
+FAILED_RESULT = {"status": "failed", "audio_urls": [], "error": "model overloaded"}
+
+
+def _wav_bytes(duration_s: float, sample_rate: int = 44100) -> bytes:
+    buf = io.BytesIO()
+    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * 440.0 * t)).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    sf.write(buf, stereo, sample_rate, format="WAV")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    import acemusic.db as _db
+
+    monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+    monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+    return tmp_path
+
+
+@pytest.fixture
+def workspace_with_clip(isolated_db, write_tone):
+    """Workspace + 2-second instrumental source WAV clip registered in the DB."""
+    from acemusic.db import create_clip
+    from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+    ensure_default_workspace()
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    src_wav = clips_dir / "instrumental.wav"
+    write_tone(src_wav, duration_s=2.0, frequency=440.0)
+
+    clip = Clip(
+        workspace_id=ws.id,
+        file_path=str(src_wav),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        format="wav",
+        duration=2.0,
+        bpm=120,
+        key="C major",
+        style_tags="ambient",
+        generation_mode="generate",
+    )
+    clip_id = create_clip(clip)
+    return ws, clip_id, src_wav
+
+
+def _make_client_mock(audio_bytes: bytes | None = None, query_sequence=None):
+    if audio_bytes is None:
+        audio_bytes = _wav_bytes(2.0)
+    client = MagicMock()
+    client.submit_task.return_value = TASK_ID
+    client.query_result.side_effect = query_sequence or [COMPLETED_RESULT]
+    client.download_audio.return_value = audio_bytes
+    return client
+
+
+class TestAddVocalCommand:
+    """Tests for the `acemusic add-vocal` CLI command (US-6.6)."""
+
+    def test_default_succeeds(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", str(clip_id), "--lyrics", "[Verse]\nHello world"],
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_creates_child_clip_with_lineage(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", str(clip_id), "--lyrics", "[Verse]\nHello world"],
+            )
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        children = [c for c in list_clips(ws.id) if c.generation_mode == "add_vocal"]
+        assert len(children) == 1
+        assert children[0].parent_clip_id == clip_id
+
+    def test_submits_complete_task_with_correct_params(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "add-vocal",
+                    str(clip_id),
+                    "--lyrics",
+                    "[Verse]\nHello world",
+                    "--voice",
+                    "soulful",
+                    "--style",
+                    "breathy, soulful",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        client.submit_task.assert_called_once()
+        kwargs = client.submit_task.call_args.kwargs
+        assert kwargs["task_type"] == "complete"
+        assert kwargs["src_audio_path"] == str(src_wav.resolve())
+        assert kwargs["lyrics"] == "[Verse]\nHello world"
+        assert kwargs["style"] == "breathy, soulful"
+
+    def test_lyrics_required(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(app, ["add-vocal", str(clip_id)])
+        assert result.exit_code != 0
+
+    def test_missing_clip_exits(self, isolated_db):
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", "9999", "--lyrics", "hi"],
+            )
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_default_voice_is_default(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", str(clip_id), "--lyrics", "[Verse]\nHi"],
+            )
+        assert result.exit_code == 0, result.output
+        # The voice flag should not crash when defaulted.
+
+    def test_failed_task_exits(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock(query_sequence=[FAILED_RESULT])
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", str(clip_id), "--lyrics", "hi"],
+            )
+        assert result.exit_code != 0
+        assert "failed" in result.output.lower()
+
+    def test_submit_error_exits(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = MagicMock()
+        client.submit_task.side_effect = AceStepError("network down")
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", str(clip_id), "--lyrics", "hi"],
+            )
+        assert result.exit_code != 0
+        assert "error" in result.output.lower()
+
+    def test_output_directory_overrides_default(self, workspace_with_clip, tmp_path):
+        ws, clip_id, src_wav = workspace_with_clip
+        custom_dir = tmp_path / "custom-out"
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "add-vocal",
+                    str(clip_id),
+                    "--lyrics",
+                    "hi",
+                    "--output",
+                    str(custom_dir),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert custom_dir.exists()
+        produced = list(custom_dir.glob("*.wav"))
+        assert len(produced) == 1
+
+    def test_name_overrides_filename_prefix(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "add-vocal",
+                    str(clip_id),
+                    "--lyrics",
+                    "hi",
+                    "--name",
+                    "my-song",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        from acemusic.db import list_clips
+
+        children = [c for c in list_clips(ws.id) if c.generation_mode == "add_vocal"]
+        assert len(children) == 1
+        assert "my-song" in children[0].file_path
+
+    def test_records_lyrics_on_new_clip(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["add-vocal", str(clip_id), "--lyrics", "[Verse]\nHello world"],
+            )
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        children = [c for c in list_clips(ws.id) if c.generation_mode == "add_vocal"]
+        assert children[0].lyrics == "[Verse]\nHello world"

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -1,0 +1,384 @@
+"""Tests for the replace CLI command (US-6.6)."""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import soundfile as sf
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+from acemusic.client import AceStepError
+from acemusic.models import Clip
+
+runner = CliRunner()
+
+TASK_ID = "task-replace-123"
+AUDIO_URL = "http://localhost:8001/v1/audio?path=replaced.wav"
+COMPLETED_RESULT = {"status": "completed", "audio_urls": [AUDIO_URL]}
+FAILED_RESULT = {"status": "failed", "audio_urls": [], "error": "model overloaded"}
+
+
+def _wav_bytes(duration_s: float, sample_rate: int = 44100, frequency: float = 880.0) -> bytes:
+    buf = io.BytesIO()
+    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * frequency * t)).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    sf.write(buf, stereo, sample_rate, format="WAV")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    import acemusic.db as _db
+
+    monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+    monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+    return tmp_path
+
+
+@pytest.fixture
+def workspace_with_clip(isolated_db, write_tone):
+    """Workspace + 4-second source WAV clip registered in the DB."""
+    from acemusic.db import create_clip
+    from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+    ensure_default_workspace()
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    src_wav = clips_dir / "source.wav"
+    write_tone(src_wav, duration_s=4.0, frequency=440.0)
+
+    clip = Clip(
+        workspace_id=ws.id,
+        file_path=str(src_wav),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        format="wav",
+        duration=4.0,
+        bpm=120,
+        key="C major",
+        style_tags="ambient",
+        generation_mode="generate",
+    )
+    clip_id = create_clip(clip)
+    return ws, clip_id, src_wav
+
+
+def _make_client_mock(audio_bytes: bytes | None = None, query_sequence=None):
+    if audio_bytes is None:
+        audio_bytes = _wav_bytes(4.0, frequency=880.0)
+    client = MagicMock()
+    client.submit_task.return_value = TASK_ID
+    client.query_result.side_effect = query_sequence or [COMPLETED_RESULT]
+    client.download_audio.return_value = audio_bytes
+    return client
+
+
+class TestReplaceCommand:
+    """Tests for the `acemusic replace` CLI command (US-6.6)."""
+
+    def test_default_succeeds(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "make this section more energetic",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_creates_child_clip_with_lineage(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "energetic",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        children = [c for c in list_clips(ws.id) if c.generation_mode == "replace"]
+        assert len(children) == 1
+        assert children[0].parent_clip_id == clip_id
+
+    def test_submits_repaint_task_with_correct_params(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "energetic",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        client.submit_task.assert_called_once()
+        kwargs = client.submit_task.call_args.kwargs
+        assert kwargs["task_type"] == "repaint"
+        assert kwargs["src_audio_path"] == str(src_wav.resolve())
+        assert kwargs["repainting_start"] == pytest.approx(1.0, abs=0.01)
+        assert kwargs["repainting_end"] == pytest.approx(2.0, abs=0.01)
+        assert kwargs["prompt"] == "energetic"
+
+    def test_lock_context_default_is_on(self, workspace_with_clip):
+        """When --lock-context is on (default), output preserves total duration via crossfade stitch."""
+        from acemusic.db import list_clips
+        from acemusic.utils import get_duration
+
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock(audio_bytes=_wav_bytes(4.0, frequency=880.0))
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "x",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+        children = [c for c in list_clips(ws.id) if c.generation_mode == "replace"]
+        assert len(children) == 1
+        new_dur = get_duration(children[0].file_path)
+        # With lock_context (default), the output preserves the source duration (~4.0s).
+        assert new_dur == pytest.approx(4.0, abs=0.2)
+
+    def test_no_lock_context_writes_model_output_as_is(self, workspace_with_clip):
+        """--no-lock-context bypasses stitching and uses the model output directly."""
+        from acemusic.db import list_clips
+        from acemusic.utils import get_duration
+
+        ws, clip_id, src_wav = workspace_with_clip
+        # Model returns a 3.0s clip; with --no-lock-context, this is the final duration.
+        client = _make_client_mock(audio_bytes=_wav_bytes(3.0, frequency=880.0))
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "x",
+                    "--no-lock-context",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+        children = [c for c in list_clips(ws.id) if c.generation_mode == "replace"]
+        assert len(children) == 1
+        new_dur = get_duration(children[0].file_path)
+        # No stitching: duration matches the model's output, not the source's 4.0s.
+        assert new_dur == pytest.approx(3.0, abs=0.2)
+
+    def test_outside_region_preserved_when_locked(self, workspace_with_clip):
+        """With --lock-context on, samples outside [start, end] should match the source."""
+        from acemusic.db import list_clips
+
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock(audio_bytes=_wav_bytes(4.0, frequency=880.0))
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "x",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+        children = [c for c in list_clips(ws.id) if c.generation_mode == "replace"]
+        data, sr = sf.read(children[0].file_path)
+        # Clearly-before-crossfade window: 0.0–0.5s
+        head = data[: int(0.5 * sr)]
+        src_data, src_sr = sf.read(str(src_wav))
+        src_head = src_data[: int(0.5 * src_sr)]
+
+        head_rms = np.sqrt(np.mean((head - src_head) ** 2))
+        assert head_rms < 0.01, f"Head RMS drift {head_rms} too high — outside region not preserved"
+
+    def test_invalid_time_range_exits(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "2s",
+                    "--end",
+                    "1s",
+                    "--prompt",
+                    "x",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "start" in result.output.lower()
+
+    def test_end_exceeds_duration_exits(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "10s",
+                    "--prompt",
+                    "x",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "duration" in result.output.lower()
+
+    def test_missing_clip_exits(self, isolated_db):
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["replace", "9999", "--start", "1s", "--end", "2s", "--prompt", "x"],
+            )
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_passes_style_when_provided(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "solo",
+                    "--style",
+                    "jazz piano",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert client.submit_task.call_args.kwargs["style"] == "jazz piano"
+
+    def test_failed_task_exits(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock(query_sequence=[FAILED_RESULT])
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "x",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "failed" in result.output.lower()
+
+    def test_submit_error_exits(self, workspace_with_clip):
+        ws, clip_id, src_wav = workspace_with_clip
+        client = MagicMock()
+        client.submit_task.side_effect = AceStepError("network down")
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "x",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "error" in result.output.lower()
+
+    def test_output_directory_overrides_default(self, workspace_with_clip, tmp_path):
+        ws, clip_id, src_wav = workspace_with_clip
+        custom_dir = tmp_path / "custom-out"
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "x",
+                    "--output",
+                    str(custom_dir),
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert custom_dir.exists()
+        produced = list(custom_dir.glob("*.wav"))
+        assert len(produced) == 1

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -245,6 +245,28 @@ class TestReplaceCommand:
         head_rms = np.sqrt(np.mean((head - src_head) ** 2))
         assert head_rms < 0.01, f"Head RMS drift {head_rms} too high — outside region not preserved"
 
+    def test_truncated_model_output_exits_when_locked(self, workspace_with_clip):
+        """If ACE-Step returns audio shorter than the replace window, exit cleanly with --lock-context."""
+        ws, clip_id, src_wav = workspace_with_clip
+        # Window is 1s–2s but model returns only 1.5s
+        client = _make_client_mock(audio_bytes=_wav_bytes(1.5, frequency=880.0))
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                [
+                    "replace",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "2s",
+                    "--prompt",
+                    "x",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "truncated" in result.output.lower() or "shorter" in result.output.lower()
+
     def test_invalid_time_range_exits(self, workspace_with_clip):
         ws, clip_id, src_wav = workspace_with_clip
         client = _make_client_mock()

--- a/user-stories/01-layer-1-cli-foundation.md
+++ b/user-stories/01-layer-1-cli-foundation.md
@@ -725,9 +725,9 @@ Add Vocal layers a vocal performance onto an instrumental. Replace Section regen
 - Both create new clips with lineage
 
 **Acceptance Criteria:**
-- [ ] Add-vocal produces a clip with vocals layered on the instrumental
-- [ ] Replace section changes only the target time range
-- [ ] Surrounding audio is preserved with smooth transitions
+- [x] Add-vocal produces a clip with vocals layered on the instrumental
+- [x] Replace section changes only the target time range
+- [x] Surrounding audio is preserved with smooth transitions
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #38 — implements two new CLI commands for refining specific parts of a composition:

- **`acemusic add-vocal <clip_id> --lyrics ...`** — Layers vocals onto an instrumental clip via ACE-Step's `complete` mode. Supports `--voice`, `--style`, `--output`, `--name`.
- **`acemusic replace <clip_id> --start 30s --end 45s --prompt ...`** — Regenerates a specific time range via ACE-Step's `repaint` mode. `--lock-context` (default on) crossfade-stitches the new section into the original so surrounding audio is preserved. `--no-lock-context` writes the model output directly without stitching.

Both commands create child clips with `parent_clip_id` set and the appropriate `generation_mode` (`add_vocal` / `replace`).

## Design notes

- **No client.py changes** — `AceStepClient.submit_task()` already supports `task_type="complete"` and `"repaint"` (added by US-6.1 / US-6.3). The new commands reuse those code paths.
- **Reuses US-6.3 stitching logic** — `replace` with `--lock-context` shares the same `crossfade_stitch` helper as `repaint`, only differing at the CLI/UX layer.
- **Time parsing** — uses the existing `parse_time_string()` utility from US-5.1 / US-6.3 (supports `30s`, `1m30s`, `1:30`).

## Acceptance criteria

- [x] Add-vocal produces a clip with vocals layered on the instrumental
- [x] Replace section changes only the target time range
- [x] Surrounding audio is preserved with smooth transitions (verified by `test_outside_region_preserved_when_locked`)

## Test plan

- [x] 24 new tests added (`tests/test_add_vocal.py` × 11, `tests/test_replace.py` × 13)
- [x] All 562 pre-existing tests still pass
- [x] `ruff check` and `black --check` clean
- [ ] Manual demo with a live ACE-Step server (will follow once integration env is available)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * add-vocal: layer vocals onto instrumental clips with required lyrics; supports style, voice warning for non-default, output/name overrides and duration-probing fallback
  * replace: regenerate a specified time range with optional context-locked stitching, crossfade control, and validation of time bounds; truncated model output surfaces as an error

* **Tests**
  * Comprehensive suites for both commands covering success paths, validations/failures, duration probing, output/name overrides, lineage, locking, and stitching

* **Documentation**
  * Project status, acceptance criteria, and CLI docs updated to include the new commands and examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankbria/auto-music-studio/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->