### PR TITLE
feat: US-7.1 single clip export (WAV/FLAC/MP3/WAV32)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,13 @@ uv run acemusic workspace switch "My Album"           # set active workspace
 uv run acemusic workspace rename "My Album" "Debut"   # rename a workspace
 uv run acemusic workspace delete "Debut"              # delete (prompts if clips exist)
 uv run acemusic workspace delete "Debut" --force      # delete without confirmation
+
+# Export (US-7.1) — export a clip to disk in the chosen audio format
+uv run acemusic export 42                                              # default: WAV 48kHz/24-bit → ./<slug>.wav
+uv run acemusic export 42 --format wav32                               # 48kHz / 32-bit float WAV
+uv run acemusic export 42 --format flac                                # lossless FLAC
+uv run acemusic export 42 --format mp3                                 # 320 kbps MP3
+uv run acemusic export 42 --format flac --output /path/to/out.flac     # explicit destination path
 ```
 
 ## Architecture

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -476,7 +476,6 @@ def export_audio(source_path: str | Path, dest_path: str | Path, fmt: str) -> Pa
     elif fmt == "mp3":
         audio.export(str(dest_path), format="mp3", bitrate="320k")
     else:
-        # Guard against EXPORT_FORMATS being extended without a matching branch.
         raise AssertionError(f"Unhandled export format: {fmt!r}")
 
     return dest_path

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
 
 SUPPORTED_FORMATS: set[str] = {".wav", ".flac", ".mp3", ".ogg", ".aac", ".aiff"}
 
+# Output formats accepted by export_audio() (US-7.1). Distinct from SUPPORTED_FORMATS
+# above, which lists *input* file extensions accepted by `import`.
+EXPORT_FORMATS: tuple[str, ...] = ("wav", "wav32", "flac", "mp3")
+
 _PITCH_CLASSES: list[str] = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
 
 
@@ -427,3 +431,49 @@ def combine_sample(
 
     combined.export(str(output_path), format=_path_format(output_path))
     return output_path
+
+
+# ---------------------------------------------------------------------------
+# Single-clip export (US-7.1)
+# ---------------------------------------------------------------------------
+
+
+def export_audio(source_path: str | Path, dest_path: str | Path, fmt: str) -> Path:
+    """Export a source audio file to ``dest_path`` in the requested format.
+
+    Format specs:
+        wav    48 kHz, 24-bit PCM (pcm_s24le)
+        wav32  48 kHz, 32-bit float PCM (pcm_f32le)
+        flac   Lossless FLAC at source sample rate
+        mp3    320 kbps CBR
+
+    Returns the destination path. Raises ValueError for unknown ``fmt``.
+    """
+    if fmt not in EXPORT_FORMATS:
+        raise ValueError(f"Unsupported export format: {fmt!r}. Expected one of {EXPORT_FORMATS}.")
+
+    from pydub import AudioSegment
+
+    source_path = Path(source_path)
+    dest_path = Path(dest_path)
+
+    audio = AudioSegment.from_file(str(source_path), format=_path_format(source_path))
+
+    if fmt == "wav":
+        audio.export(
+            str(dest_path),
+            format="wav",
+            parameters=["-acodec", "pcm_s24le", "-ar", "48000"],
+        )
+    elif fmt == "wav32":
+        audio.export(
+            str(dest_path),
+            format="wav",
+            parameters=["-acodec", "pcm_f32le", "-ar", "48000"],
+        )
+    elif fmt == "flac":
+        audio.export(str(dest_path), format="flac")
+    elif fmt == "mp3":
+        audio.export(str(dest_path), format="mp3", bitrate="320k")
+
+    return dest_path

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -12,8 +12,7 @@ if TYPE_CHECKING:
 
 SUPPORTED_FORMATS: set[str] = {".wav", ".flac", ".mp3", ".ogg", ".aac", ".aiff"}
 
-# Output formats accepted by export_audio() (US-7.1). Distinct from SUPPORTED_FORMATS
-# above, which lists *input* file extensions accepted by `import`.
+# US-7.1 export targets; distinct from input-side SUPPORTED_FORMATS above.
 EXPORT_FORMATS: tuple[str, ...] = ("wav", "wav32", "flac", "mp3")
 
 _PITCH_CLASSES: list[str] = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
@@ -476,6 +475,6 @@ def export_audio(source_path: str | Path, dest_path: str | Path, fmt: str) -> Pa
     elif fmt == "mp3":
         audio.export(str(dest_path), format="mp3", bitrate="320k")
     else:
-        raise AssertionError(f"Unhandled export format: {fmt!r}")
+        raise NotImplementedError(f"Unhandled export format: {fmt!r}")
 
     return dest_path

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 SUPPORTED_FORMATS: set[str] = {".wav", ".flac", ".mp3", ".ogg", ".aac", ".aiff"}
 
-# US-7.1 export targets; distinct from input-side SUPPORTED_FORMATS above.
+# Export-side formats; distinct from input-side SUPPORTED_FORMATS above.
 EXPORT_FORMATS: tuple[str, ...] = ("wav", "wav32", "flac", "mp3")
 
 _PITCH_CLASSES: list[str] = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]

--- a/src/acemusic/audio.py
+++ b/src/acemusic/audio.py
@@ -475,5 +475,8 @@ def export_audio(source_path: str | Path, dest_path: str | Path, fmt: str) -> Pa
         audio.export(str(dest_path), format="flac")
     elif fmt == "mp3":
         audio.export(str(dest_path), format="mp3", bitrate="320k")
+    else:
+        # Guard against EXPORT_FORMATS being extended without a matching branch.
+        raise AssertionError(f"Unhandled export format: {fmt!r}")
 
     return dest_path

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1331,7 +1331,7 @@ def export_cmd(
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
 
-    size = dest.stat().st_size if dest.exists() else 0
+    size = dest.stat().st_size
     console.print(f"  [green]✓[/green] Exported: {dest}  ({size} bytes)")
 
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1322,7 +1322,6 @@ def export_cmd(
         slug = make_slug(clip.title) if clip.title else f"clip-{clip_id}"
         dest = Path.cwd() / f"{slug}.{ext}"
 
-    # Ensure the destination directory exists so pydub doesn't error opaquely.
     dest.parent.mkdir(parents=True, exist_ok=True)
 
     try:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1322,6 +1322,9 @@ def export_cmd(
         slug = make_slug(clip.title) if clip.title else f"clip-{clip_id}"
         dest = Path.cwd() / f"{slug}.{ext}"
 
+    # Ensure the destination directory exists so pydub doesn't error opaquely.
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
     try:
         export_audio(source, dest, format)
     except Exception as exc:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -21,6 +21,7 @@ from rich.table import Table
 
 from acemusic import __version__
 from acemusic.audio import (
+    EXPORT_FORMATS,
     SAMPLE_ROLES,
     SUPPORTED_FORMATS,
     calculate_speed_multiplier,
@@ -29,6 +30,7 @@ from acemusic.audio import (
     crossfade_stitch,
     detect_bpm,
     detect_key,
+    export_audio,
     remaster_audio,
     time_stretch_audio,
 )
@@ -159,6 +161,7 @@ def main(
         "clips",
         "preset",
         "import",
+        "export",
         "crop",
         "speed",
         "stems",
@@ -1278,6 +1281,55 @@ def import_clip(
     console.print(f"    Duration: {duration_display}")
     console.print(f"    BPM:      {bpm_display}")
     console.print(f"    Key:      {key_display}")
+
+
+# ---------------------------------------------------------------------------
+# Export command (US-7.1)
+# ---------------------------------------------------------------------------
+
+
+@app.command(name="export")
+def export_cmd(
+    clip_id: int = typer.Argument(..., help="ID of the clip to export."),
+    format: str = typer.Option(
+        "wav",
+        "--format",
+        help=f"Output format: {', '.join(EXPORT_FORMATS)}.",
+    ),
+    output: Optional[Path] = typer.Option(
+        None, "--output", help="Output file path. Defaults to ./<slug>.<ext> in the current directory."
+    ),
+) -> None:
+    """Export a clip to a file in the chosen format (WAV/WAV32/FLAC/MP3)."""
+    if format not in EXPORT_FORMATS:
+        console.print(f"[red]Error: invalid --format {format!r}. Allowed values: {', '.join(EXPORT_FORMATS)}[/red]")
+        raise typer.Exit(code=1)
+
+    clip = get_clip(clip_id)
+    if clip is None:
+        console.print(f"[red]Error: clip {clip_id} not found.[/red]")
+        raise typer.Exit(code=1)
+
+    source = Path(clip.file_path)
+    if not source.exists():
+        console.print(f"[red]Error: source file not found: {source}[/red]")
+        raise typer.Exit(code=1)
+
+    if output is not None:
+        dest = output
+    else:
+        ext = "wav" if format in ("wav", "wav32") else format
+        slug = make_slug(clip.title) if clip.title else f"clip-{clip_id}"
+        dest = Path.cwd() / f"{slug}.{ext}"
+
+    try:
+        export_audio(source, dest, format)
+    except Exception as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    size = dest.stat().st_size if dest.exists() else 0
+    console.print(f"  [green]✓[/green] Exported: {dest}  ({size} bytes)")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -701,5 +701,5 @@ class TestExportAudio:
         mock_pydub.AudioSegment.from_file.return_value = mock_seg
 
         with patch.dict("sys.modules", {"pydub": mock_pydub}):
-            with pytest.raises(AssertionError, match="Unhandled export format"):
+            with pytest.raises(NotImplementedError, match="Unhandled export format"):
                 _audio.export_audio(src, dest, "opus")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -684,3 +684,23 @@ class TestExportAudio:
         from acemusic.audio import EXPORT_FORMATS
 
         assert set(EXPORT_FORMATS) == {"wav", "wav32", "flac", "mp3"}
+
+    def test_export_unhandled_branch_raises_assertion(self, tmp_path, monkeypatch):
+        """If EXPORT_FORMATS is extended without a matching if/elif branch, the function
+        should fail loudly instead of silently returning the dest path."""
+        from acemusic import audio as _audio
+
+        src = tmp_path / "in.wav"
+        src.write_bytes(b"fake")
+        dest = tmp_path / "out.xyz"
+
+        # Inject a phantom format that the if/elif chain doesn't handle.
+        monkeypatch.setattr(_audio, "EXPORT_FORMATS", _audio.EXPORT_FORMATS + ("opus",))
+
+        mock_seg = MagicMock()
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
+
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            with pytest.raises(AssertionError, match="Unhandled export format"):
+                _audio.export_audio(src, dest, "opus")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -650,7 +650,6 @@ class TestExportAudio:
         dest = tmp_path / "out.wav"
 
         mock_seg = MagicMock()
-        mock_seg.set_frame_rate.return_value = mock_seg
         mock_pydub = MagicMock()
         mock_pydub.AudioSegment.from_file.return_value = mock_seg
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -566,3 +566,121 @@ class TestWriteSampleMetadata:
         )
         data = json.loads(sidecar.read_text())
         assert data["source_clip_id"] is None
+
+
+class TestExportAudio:
+    """Tests for export_audio() — single-clip export with per-format quality specs (US-7.1)."""
+
+    def test_export_rejects_unknown_format(self, tmp_path):
+        from acemusic.audio import export_audio
+
+        src = tmp_path / "in.wav"
+        src.write_bytes(b"fake")
+        dest = tmp_path / "out.xyz"
+        with pytest.raises(ValueError, match="Unsupported export format"):
+            export_audio(src, dest, "xyz")
+
+    def test_export_wav_real_roundtrip_is_48k_24bit(self, tmp_path, write_tone):
+        """Real pydub WAV export: source tone → exported WAV is 48kHz, 24-bit PCM.
+
+        Uses ffmpeg parameters for codec/rate control, so skip when ffmpeg is not
+        on PATH (CI runners without the system package).
+        """
+        import shutil
+        import wave
+
+        if shutil.which("ffmpeg") is None:
+            pytest.skip("ffmpeg not installed; required for codec parameter override")
+
+        from acemusic.audio import export_audio
+
+        src = tmp_path / "tone.wav"
+        dest = tmp_path / "exported.wav"
+        write_tone(src, duration_s=0.5, sample_rate=44100)
+
+        export_audio(src, dest, "wav")
+
+        assert dest.exists()
+        with wave.open(str(dest), "rb") as wf:
+            assert wf.getframerate() == 48000
+            assert wf.getsampwidth() == 3  # 24-bit = 3 bytes
+
+    def test_export_flac_invokes_pydub_with_flac_format(self, tmp_path):
+        from acemusic.audio import export_audio
+
+        src = tmp_path / "in.wav"
+        src.write_bytes(b"fake")
+        dest = tmp_path / "out.flac"
+
+        mock_seg = MagicMock()
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
+
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            export_audio(src, dest, "flac")
+
+        mock_pydub.AudioSegment.from_file.assert_called_once_with(str(src), format="wav")
+        mock_seg.export.assert_called_once()
+        _, kwargs = mock_seg.export.call_args
+        assert kwargs["format"] == "flac"
+
+    def test_export_mp3_invokes_pydub_with_320k_bitrate(self, tmp_path):
+        from acemusic.audio import export_audio
+
+        src = tmp_path / "in.wav"
+        src.write_bytes(b"fake")
+        dest = tmp_path / "out.mp3"
+
+        mock_seg = MagicMock()
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
+
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            export_audio(src, dest, "mp3")
+
+        _, kwargs = mock_seg.export.call_args
+        assert kwargs["format"] == "mp3"
+        assert kwargs["bitrate"] == "320k"
+
+    def test_export_wav32_uses_float_codec_parameters(self, tmp_path):
+        from acemusic.audio import export_audio
+
+        src = tmp_path / "in.wav"
+        src.write_bytes(b"fake")
+        dest = tmp_path / "out.wav"
+
+        mock_seg = MagicMock()
+        mock_seg.set_frame_rate.return_value = mock_seg
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
+
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            export_audio(src, dest, "wav32")
+
+        _, kwargs = mock_seg.export.call_args
+        assert kwargs["format"] == "wav"
+        params = kwargs.get("parameters", [])
+        assert "pcm_f32le" in params
+        assert "48000" in params
+
+    def test_export_uses_source_extension_as_format_hint(self, tmp_path):
+        """The from_file format= hint is derived from the source file extension."""
+        from acemusic.audio import export_audio
+
+        src = tmp_path / "in.mp3"
+        src.write_bytes(b"fake")
+        dest = tmp_path / "out.flac"
+
+        mock_seg = MagicMock()
+        mock_pydub = MagicMock()
+        mock_pydub.AudioSegment.from_file.return_value = mock_seg
+
+        with patch.dict("sys.modules", {"pydub": mock_pydub}):
+            export_audio(src, dest, "flac")
+
+        mock_pydub.AudioSegment.from_file.assert_called_once_with(str(src), format="mp3")
+
+    def test_export_formats_constant_lists_all_four_formats(self):
+        from acemusic.audio import EXPORT_FORMATS
+
+        assert set(EXPORT_FORMATS) == {"wav", "wav32", "flac", "mp3"}

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -80,6 +80,39 @@ class TestExportCommand:
         assert result.exit_code == 0, result.output
         assert captured["fmt"] == "wav"
 
+    def test_default_filename_falls_back_to_clip_id_when_title_is_none(
+        self, isolated_db, write_tone, tmp_path, monkeypatch
+    ):
+        """When the clip has no title, the default output filename uses `clip-<id>` instead."""
+        from acemusic.db import create_clip
+        from acemusic.models import Clip
+        from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+        ensure_default_workspace()
+        ws = get_active_workspace()
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        source = clips_dir / "untitled.wav"
+        write_tone(source, duration_s=0.5)
+
+        clip_id = create_clip(
+            Clip(
+                workspace_id=ws.id,
+                file_path=str(source),
+                created_at=datetime.now(timezone.utc).isoformat(),
+                title=None,
+                format="wav",
+                duration=0.5,
+            )
+        )
+
+        monkeypatch.chdir(tmp_path)
+        with patch("acemusic.cli.export_audio", side_effect=lambda s, d, f: Path(d).write_bytes(b"x")):
+            result = runner.invoke(app, ["export", str(clip_id)])
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / f"clip-{clip_id}.wav").exists()
+
     def test_default_output_path_uses_slugified_clip_title(self, workspace_with_clip, tmp_path, monkeypatch):
         _, clip_id, _ = workspace_with_clip
         monkeypatch.chdir(tmp_path)

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -154,6 +154,17 @@ class TestExportCommand:
         assert "my-cool-track.wav" in flattened
         assert "Exported" in flattened
 
+    def test_output_creates_missing_parent_directories(self, workspace_with_clip, tmp_path):
+        """When --output points into a non-existent directory, the parent is created."""
+        _, clip_id, _ = workspace_with_clip
+        dest = tmp_path / "new" / "nested" / "out.flac"
+
+        with patch("acemusic.cli.export_audio", side_effect=lambda s, d, f: Path(d).write_bytes(b"x")):
+            result = runner.invoke(app, ["export", str(clip_id), "--format", "flac", "--output", str(dest)])
+
+        assert result.exit_code == 0, result.output
+        assert dest.parent.is_dir()
+
     def test_export_audio_failure_exits_one(self, workspace_with_clip, tmp_path, monkeypatch):
         _, clip_id, _ = workspace_with_clip
         monkeypatch.chdir(tmp_path)

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -1,0 +1,165 @@
+"""Tests for the `acemusic export` CLI command (US-7.1)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    import acemusic.db as _db
+
+    monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+    return tmp_path
+
+
+@pytest.fixture
+def workspace_with_clip(isolated_db, write_tone):
+    """Create an active workspace containing one real WAV clip on disk."""
+    from acemusic.db import create_clip
+    from acemusic.models import Clip
+    from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+    ensure_default_workspace()
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    source = clips_dir / "source.wav"
+    write_tone(source, duration_s=0.5)
+
+    clip = Clip(
+        workspace_id=ws.id,
+        file_path=str(source),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        title="My Cool Track",
+        format="wav",
+        duration=0.5,
+    )
+    clip_id = create_clip(clip)
+    return ws, clip_id, source
+
+
+class TestExportCommand:
+    def test_unknown_clip_id_errors(self, isolated_db):
+        result = runner.invoke(app, ["export", "999"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_missing_source_file_errors(self, workspace_with_clip):
+        _, clip_id, source = workspace_with_clip
+        source.unlink()
+        result = runner.invoke(app, ["export", str(clip_id)])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_default_format_is_wav(self, workspace_with_clip, tmp_path, monkeypatch):
+        _, clip_id, _ = workspace_with_clip
+        monkeypatch.chdir(tmp_path)
+
+        captured: dict = {}
+
+        def fake_export(source, dest, fmt):
+            captured["source"] = source
+            captured["dest"] = dest
+            captured["fmt"] = fmt
+            Path(dest).write_bytes(b"fake")
+
+        with patch("acemusic.cli.export_audio", side_effect=fake_export):
+            result = runner.invoke(app, ["export", str(clip_id)])
+
+        assert result.exit_code == 0, result.output
+        assert captured["fmt"] == "wav"
+
+    def test_default_output_path_uses_slugified_clip_title(self, workspace_with_clip, tmp_path, monkeypatch):
+        _, clip_id, _ = workspace_with_clip
+        monkeypatch.chdir(tmp_path)
+
+        with patch("acemusic.cli.export_audio", side_effect=lambda s, d, f: Path(d).write_bytes(b"x")):
+            result = runner.invoke(app, ["export", str(clip_id)])
+
+        assert result.exit_code == 0, result.output
+        expected = tmp_path / "my-cool-track.wav"
+        assert expected.exists()
+
+    def test_output_flag_uses_given_path(self, workspace_with_clip, tmp_path):
+        _, clip_id, _ = workspace_with_clip
+        dest = tmp_path / "subdir" / "custom-name.flac"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        with patch("acemusic.cli.export_audio", side_effect=lambda s, d, f: Path(d).write_bytes(b"x")) as mock_exp:
+            result = runner.invoke(app, ["export", str(clip_id), "--format", "flac", "--output", str(dest)])
+
+        assert result.exit_code == 0, result.output
+        called_dest = mock_exp.call_args[0][1]
+        assert Path(called_dest) == dest
+
+    @pytest.mark.parametrize("fmt", ["wav", "wav32", "flac", "mp3"])
+    def test_all_formats_passed_through(self, workspace_with_clip, tmp_path, monkeypatch, fmt):
+        _, clip_id, _ = workspace_with_clip
+        monkeypatch.chdir(tmp_path)
+
+        captured: dict = {}
+
+        def fake_export(source, dest, f):
+            captured["fmt"] = f
+            Path(dest).write_bytes(b"fake")
+
+        with patch("acemusic.cli.export_audio", side_effect=fake_export):
+            result = runner.invoke(app, ["export", str(clip_id), "--format", fmt])
+
+        assert result.exit_code == 0, result.output
+        assert captured["fmt"] == fmt
+
+    def test_invalid_format_errors(self, workspace_with_clip):
+        _, clip_id, _ = workspace_with_clip
+        result = runner.invoke(app, ["export", str(clip_id), "--format", "ogg"])
+        assert result.exit_code == 1
+        assert "format" in result.output.lower()
+
+    def test_default_output_extension_matches_format(self, workspace_with_clip, tmp_path, monkeypatch):
+        """wav32 → .wav extension; other formats → matching extension."""
+        _, clip_id, _ = workspace_with_clip
+        monkeypatch.chdir(tmp_path)
+
+        with patch("acemusic.cli.export_audio", side_effect=lambda s, d, f: Path(d).write_bytes(b"x")):
+            result = runner.invoke(app, ["export", str(clip_id), "--format", "wav32"])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "my-cool-track.wav").exists()
+
+        with patch("acemusic.cli.export_audio", side_effect=lambda s, d, f: Path(d).write_bytes(b"x")):
+            result = runner.invoke(app, ["export", str(clip_id), "--format", "mp3"])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "my-cool-track.mp3").exists()
+
+    def test_success_message_includes_path(self, workspace_with_clip, tmp_path, monkeypatch):
+        _, clip_id, _ = workspace_with_clip
+        monkeypatch.chdir(tmp_path)
+
+        with patch("acemusic.cli.export_audio", side_effect=lambda s, d, f: Path(d).write_bytes(b"hello-bytes")):
+            result = runner.invoke(app, ["export", str(clip_id)])
+
+        assert result.exit_code == 0, result.output
+        # Rich may soft-wrap the path on narrow terminals — strip newlines before substring check.
+        flattened = result.output.replace("\n", "")
+        assert "my-cool-track.wav" in flattened
+        assert "Exported" in flattened
+
+    def test_export_audio_failure_exits_one(self, workspace_with_clip, tmp_path, monkeypatch):
+        _, clip_id, _ = workspace_with_clip
+        monkeypatch.chdir(tmp_path)
+
+        with patch("acemusic.cli.export_audio", side_effect=RuntimeError("ffmpeg blew up")):
+            result = runner.invoke(app, ["export", str(clip_id)])
+
+        assert result.exit_code == 1
+        assert "ffmpeg blew up" in result.output or "error" in result.output.lower()


### PR DESCRIPTION
## Summary

Adds `acemusic export <clip_id> --format wav|wav32|flac|mp3 [--output PATH]` to export a stored clip into the chosen audio format. Default output is `./<clip-title-slug>.<ext>`.

| Format | Spec |
|--------|------|
| `wav`  | 48 kHz / 24-bit PCM (pcm_s24le) |
| `wav32`| 48 kHz / 32-bit float PCM (pcm_f32le) |
| `flac` | Lossless FLAC at source sample rate |
| `mp3`  | 320 kbps CBR |

## Acceptance Criteria — Demo Mapping

- [x] Each format produces a valid, playable file → `test_export_*_invokes_pydub_with_*` (mocked encode) + real WAV roundtrip + manual demo (Phase 11)
- [x] WAV output is 48 kHz / 24-bit → `test_export_wav_real_roundtrip_is_48k_24bit` asserts via stdlib `wave` module (`getframerate()==48000`, `getsampwidth()==3`)
- [x] File is named after the clip title by default → `test_default_output_path_uses_slugified_clip_title`

## Adapted from CodeRabbit Plan

The CodeRabbit-generated plan (issue body) assumed pydub was not installed and the clip DB didn't yet exist. Reality after Stage 4–6 merged:
- `pydub>=0.25.1` already a dep — skipped that task
- `db.get_clip(clip_id: int)` already exists; `clip_id` is **int**, not string
- `get_duration()` already handles MP3/FLAC via generic `mutagen.File()` — no extension needed
- Used `EXPORT_FORMATS` (distinct constant) to avoid clashing with existing input-side `SUPPORTED_FORMATS`
- Pydub `from_file(..., format=...)` hint passed explicitly (project convention to avoid ffprobe)
- Export does **not** create a new Clip DB record (issue is export-to-disk only)

## Known Limitations

- The real-pydub WAV roundtrip test (`test_export_wav_real_roundtrip_is_48k_24bit`) is skipped when ffmpeg is not on PATH. CI ubuntu-latest does not install ffmpeg, so it'll be skipped there. FLAC/MP3/WAV32 codec verification is covered by mock-based tests that don't need ffmpeg.
- The `export` command does not insert a new Clip record into the DB (intentional — issue asks only for file output). If we later want to track exports as derived clips, a follow-up issue can add that.
- Pydub's `--output` path is taken verbatim; no extension normalization (e.g., `--format mp3 --output foo.wav` will produce an MP3 file named `foo.wav`).

## Test plan

- [x] `uv run pytest tests/test_audio.py::TestExportAudio tests/test_export_cli.py` — 20 tests pass
- [x] `uv run pytest --no-cov` — full suite 611 passed, 1 skipped (was skipped before this change)
- [x] `uv run ruff check .` — passes
- [x] `uv run black --check .` — passes
- [ ] Demo (Phase 11): run `acemusic export` against a real clip, play each output format
- [ ] CI green on push

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export audio clips to WAV (48 kHz/24-bit), WAV32 (32-bit float), FLAC, and MP3 (320 kbps); format validation and clear error reporting. New CLI export command with sensible default naming, extension mapping, and automatic parent-directory creation; prints success and file size.

* **Tests**
  * Added unit and CLI tests covering format validation, export behaviors, filename/output handling, and error cases.

* **Documentation**
  * Added CLI export usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankbria/auto-music-studio/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->