### PR TITLE
feat: US-7.3 batch export (all clips in a workspace)

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1332,7 +1332,13 @@ def _batch_dest_name(clip: Clip, format: str, used: set[str]) -> str:
     suffix = "_Export.zip" if format == "daw" else f".{'wav' if format in ('wav', 'wav32') else format}"
     name = f"{base}{suffix}"
     if name in used:
+        # Disambiguate with the (unique) clip id, then with a counter if even
+        # that base already collides with another clip's primary name.
         name = f"{base}-{clip.id}{suffix}"
+        counter = 2
+        while name in used:
+            name = f"{base}-{clip.id}-{counter}{suffix}"
+            counter += 1
     used.add(name)
     return name
 
@@ -1401,7 +1407,7 @@ def _batch_export(workspace: str, format: str, output: Optional[Path]) -> None:
     """Export every clip in ``workspace`` to ``output`` (a directory) and print a summary."""
     try:
         ws = get_workspace_by_name(workspace)
-    except ValueError as exc:
+    except (ValueError, sqlite3.Error) as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1406,7 +1406,11 @@ def _batch_export(workspace: str, format: str, output: Optional[Path]) -> None:
         raise typer.Exit(code=1)
 
     out_dir = (output if output is not None else Path.cwd()).resolve()
-    out_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        console.print(f"[red]Error: cannot use output directory {out_dir}: {exc}[/red]")
+        raise typer.Exit(code=1)
 
     clips = list_clips(ws.id)
     used_names: set[str] = set()
@@ -1433,8 +1437,9 @@ def _batch_export(workspace: str, format: str, output: Optional[Path]) -> None:
             f"Exported {succeeded} of {succeeded + failed} clips "
             f"({failed} failed) → {out_dir} (total: {total_display})"
         )
-    else:
-        console.print(f"Exported {succeeded} clips → {out_dir} (total: {total_display})")
+        # Surface partial failure to callers (CI/scripts) via a non-zero exit code.
+        raise typer.Exit(code=1)
+    console.print(f"Exported {succeeded} clips → {out_dir} (total: {total_display})")
 
 
 # ---------------------------------------------------------------------------

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -57,6 +57,7 @@ from acemusic.stems_client import StemsClient, StemsError
 from acemusic.utils import (
     generate_remaster_filename,
     get_duration,
+    human_readable_size,
     make_filename,
     make_slug,
     parse_time_string,
@@ -1289,23 +1290,84 @@ def import_clip(
 # ---------------------------------------------------------------------------
 
 
+def _clip_default_basename(clip: Clip) -> str:
+    """Filename-safe base name for a clip (slug of its title, else ``clip-<id>``)."""
+    if clip.title:
+        slug = make_slug(clip.title)
+        if slug:
+            return slug
+    return f"clip-{clip.id}"
+
+
+def _export_one_clip(clip: Clip, format: str, dest: Path) -> int:
+    """Export a single clip to ``dest`` and return the number of bytes written.
+
+    Handles both audio formats (via ``export_audio``) and the ``daw`` bundle
+    (via ``build_daw_bundle``). Raises on failure; callers decide whether a
+    failure aborts (single export) or is tracked and skipped (batch export).
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if format == "daw":
+        build_daw_bundle(
+            clip,
+            output_path=dest,
+            stems_client_factory=StemsClient,
+            midi_client_factory=MidiClient,
+        )
+    else:
+        source = Path(clip.file_path)
+        if not source.exists():
+            raise FileNotFoundError(f"source file not found: {source}")
+        export_audio(source, dest, format)
+    return dest.stat().st_size
+
+
+def _batch_dest_name(clip: Clip, format: str, used: set[str]) -> str:
+    """Pick a distinct, descriptive output filename for ``clip`` within a batch.
+
+    Names derive from the clip title (or ``clip-<id>``). When two clips would
+    collide (shared/empty titles), the clip id is appended to keep names unique.
+    """
+    base = _clip_default_basename(clip)
+    suffix = "_Export.zip" if format == "daw" else f".{'wav' if format in ('wav', 'wav32') else format}"
+    name = f"{base}{suffix}"
+    if name in used:
+        name = f"{base}-{clip.id}{suffix}"
+    used.add(name)
+    return name
+
+
 @app.command(name="export")
 def export_cmd(
-    clip_id: int = typer.Argument(..., help="ID of the clip to export."),
+    clip_id: Optional[int] = typer.Argument(None, help="ID of the clip to export (single-clip mode)."),
+    workspace: Optional[str] = typer.Option(
+        None, "--workspace", help="Export every clip in the named workspace (batch mode)."
+    ),
     format: str = typer.Option(
         "wav",
         "--format",
         help=f"Output format: {', '.join(EXPORT_FORMATS)}, daw.",
     ),
     output: Optional[Path] = typer.Option(
-        None, "--output", help="Output file path. Defaults to ./<slug>.<ext> in the current directory."
+        None,
+        "--output",
+        help="Single mode: output file path (default ./<slug>.<ext>). "
+        "Batch mode: output directory (default current directory).",
     ),
 ) -> None:
-    """Export a clip to a file (WAV/WAV32/FLAC/MP3) or a DAW bundle ZIP (daw)."""
+    """Export a clip, or every clip in a workspace, to files (WAV/WAV32/FLAC/MP3) or DAW bundles."""
     allowed = (*EXPORT_FORMATS, "daw")
     if format not in allowed:
         console.print(f"[red]Error: invalid --format {format!r}. Allowed values: {', '.join(allowed)}[/red]")
         raise typer.Exit(code=1)
+
+    if (clip_id is None) == (workspace is None):
+        console.print("[red]Error: provide exactly one of CLIP_ID or --workspace.[/red]")
+        raise typer.Exit(code=1)
+
+    if workspace is not None:
+        _batch_export(workspace, format, output)
+        return
 
     clip = get_clip(clip_id)
     if clip is None:
@@ -1313,43 +1375,66 @@ def export_cmd(
         raise typer.Exit(code=1)
 
     source = Path(clip.file_path)
-    if not source.exists():
+    if format != "daw" and not source.exists():
         console.print(f"[red]Error: source file not found: {source}[/red]")
         raise typer.Exit(code=1)
 
-    if format == "daw":
-        dest = output if output is not None else Path.cwd() / f"{project_slug(clip)}_Export.zip"
-        try:
-            build_daw_bundle(
-                clip,
-                output_path=dest,
-                stems_client_factory=StemsClient,
-                midi_client_factory=MidiClient,
-            )
-        except Exception as exc:
-            console.print(f"[red]Error: {exc}[/red]")
-            raise typer.Exit(code=1)
-        size = dest.stat().st_size
-        console.print(f"  [green]✓[/green] Exported DAW bundle: {dest} ({size} bytes)")
-        return
-
     if output is not None:
         dest = output
+    elif format == "daw":
+        dest = Path.cwd() / f"{project_slug(clip)}_Export.zip"
     else:
         ext = "wav" if format in ("wav", "wav32") else format
-        slug = make_slug(clip.title) if clip.title else f"clip-{clip_id}"
-        dest = Path.cwd() / f"{slug}.{ext}"
-
-    dest.parent.mkdir(parents=True, exist_ok=True)
+        dest = Path.cwd() / f"{_clip_default_basename(clip)}.{ext}"
 
     try:
-        export_audio(source, dest, format)
+        size = _export_one_clip(clip, format, dest)
     except Exception as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
 
-    size = dest.stat().st_size
-    console.print(f"  [green]✓[/green] Exported: {dest}  ({size} bytes)")
+    label = "DAW bundle" if format == "daw" else "clip"
+    console.print(f"  [green]✓[/green] Exported {label}: {dest}  ({size} bytes)")
+
+
+def _batch_export(workspace: str, format: str, output: Optional[Path]) -> None:
+    """Export every clip in ``workspace`` to ``output`` (a directory) and print a summary."""
+    try:
+        ws = get_workspace_by_name(workspace)
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    out_dir = (output if output is not None else Path.cwd()).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    clips = list_clips(ws.id)
+    used_names: set[str] = set()
+    total_bytes = 0
+    succeeded = 0
+    failed = 0
+
+    for clip in clips:
+        dest = out_dir / _batch_dest_name(clip, format, used_names)
+        label = clip.title or f"clip-{clip.id}"
+        try:
+            size = _export_one_clip(clip, format, dest)
+        except Exception as exc:
+            failed += 1
+            console.print(f"  [yellow]![/yellow] Failed: {label} — {exc}")
+            continue
+        succeeded += 1
+        total_bytes += size
+        console.print(f"  [green]✓[/green] {label} → {dest.name}")
+
+    total_display = human_readable_size(total_bytes)
+    if failed:
+        console.print(
+            f"Exported {succeeded} of {succeeded + failed} clips "
+            f"({failed} failed) → {out_dir} (total: {total_display})"
+        )
+    else:
+        console.print(f"Exported {succeeded} clips → {out_dir} (total: {total_display})")
 
 
 # ---------------------------------------------------------------------------

--- a/src/acemusic/utils.py
+++ b/src/acemusic/utils.py
@@ -26,6 +26,22 @@ def make_filename(slug: str, timestamp: str, index: int, ext: str = "wav") -> st
     return f"{slug}-{timestamp}-{index}.{ext}"
 
 
+def human_readable_size(num_bytes: int) -> str:
+    """Format a byte count as a human-readable string (bytes/KB/MB/GB).
+
+    Uses binary (1024) units. Sub-kilobyte values are shown as whole "bytes";
+    larger values use one decimal place, e.g. "1.5 KB", "23.7 MB", "1.2 GB".
+    """
+    if num_bytes < 1024:
+        return f"{num_bytes} bytes"
+    for unit in ("KB", "MB", "GB"):
+        num_bytes /= 1024
+        if num_bytes < 1024 or unit == "GB":
+            return f"{num_bytes:.1f} {unit}"
+    # Unreachable: the GB branch above always returns.
+    return f"{num_bytes:.1f} GB"
+
+
 def get_duration(path: Path | str) -> float | None:
     """Return the duration in seconds of an audio file using mutagen, or None on failure."""
     import mutagen

--- a/tests/test_batch_export.py
+++ b/tests/test_batch_export.py
@@ -1,0 +1,198 @@
+"""Tests for batch export (`acemusic export --workspace ...`) — US-7.3."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    import acemusic.db as _db
+
+    monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+    return tmp_path
+
+
+def _make_clip(ws_id, source, title):
+    from acemusic.db import create_clip
+    from acemusic.models import Clip
+
+    return create_clip(
+        Clip(
+            workspace_id=ws_id,
+            file_path=str(source),
+            created_at=datetime.now(timezone.utc).isoformat(),
+            title=title,
+            format="wav",
+            duration=0.5,
+        )
+    )
+
+
+@pytest.fixture
+def workspace_with_clips(isolated_db, write_tone):
+    """An active workspace named 'My Album' holding three distinct WAV clips."""
+    from acemusic.workspace import (
+        create_workspace,
+        get_workspace_path,
+        switch_workspace,
+    )
+
+    ws = create_workspace("My Album")
+    switch_workspace("My Album")
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    titles = ["First Song", "Second Song", "Third Song"]
+    clip_ids = []
+    for i, title in enumerate(titles):
+        source = clips_dir / f"clip{i}.wav"
+        write_tone(source, duration_s=0.5)
+        clip_ids.append(_make_clip(ws.id, source, title))
+    return ws, clip_ids, clips_dir
+
+
+def _fake_export(s, d, f):
+    Path(d).write_bytes(b"x" * 1024)
+
+
+class TestBatchExportRouting:
+    def test_neither_clip_id_nor_workspace_errors(self, isolated_db):
+        result = runner.invoke(app, ["export"])
+        assert result.exit_code == 1
+        assert "workspace" in result.output.lower() or "clip" in result.output.lower()
+
+    def test_both_clip_id_and_workspace_errors(self, workspace_with_clips):
+        _, clip_ids, _ = workspace_with_clips
+        result = runner.invoke(app, ["export", str(clip_ids[0]), "--workspace", "My Album"])
+        assert result.exit_code == 1
+        assert "exactly one" in result.output.lower() or "both" in result.output.lower()
+
+    def test_unknown_workspace_errors(self, isolated_db):
+        result = runner.invoke(app, ["export", "--workspace", "Nope"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+
+class TestBatchExportAllClips:
+    def test_exports_every_clip(self, workspace_with_clips, tmp_path, monkeypatch):
+        _, clip_ids, _ = workspace_with_clips
+        out = tmp_path / "out"
+        with patch("acemusic.cli.export_audio", side_effect=_fake_export) as mock_exp:
+            result = runner.invoke(app, ["export", "--workspace", "My Album", "--output", str(out)])
+        assert result.exit_code == 0, result.output
+        assert mock_exp.call_count == len(clip_ids)
+        produced = sorted(p.name for p in out.glob("*.wav"))
+        assert produced == ["first-song.wav", "second-song.wav", "third-song.wav"]
+
+    def test_default_output_is_cwd(self, workspace_with_clips, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with patch("acemusic.cli.export_audio", side_effect=_fake_export):
+            result = runner.invoke(app, ["export", "--workspace", "My Album"])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "first-song.wav").exists()
+
+    def test_daw_format_routes_through_bundle(self, workspace_with_clips, tmp_path):
+        _, clip_ids, _ = workspace_with_clips
+        out = tmp_path / "daw"
+
+        def fake_bundle(clip, *, output_path, **kwargs):
+            Path(output_path).write_bytes(b"PK\x03\x04zipdata")
+            return Path(output_path)
+
+        with patch("acemusic.cli.build_daw_bundle", side_effect=fake_bundle) as mock_b:
+            result = runner.invoke(app, ["export", "--workspace", "My Album", "--format", "daw", "--output", str(out)])
+        assert result.exit_code == 0, result.output
+        assert mock_b.call_count == len(clip_ids)
+        zips = sorted(p.name for p in out.glob("*.zip"))
+        assert zips == ["first-song_Export.zip", "second-song_Export.zip", "third-song_Export.zip"]
+
+
+class TestDistinctFilenames:
+    def test_duplicate_titles_get_distinct_names(self, isolated_db, write_tone, tmp_path):
+        from acemusic.workspace import create_workspace, get_workspace_path, switch_workspace
+
+        ws = create_workspace("Dupes")
+        switch_workspace("Dupes")
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        ids = []
+        for i in range(2):
+            src = clips_dir / f"d{i}.wav"
+            write_tone(src, duration_s=0.5)
+            ids.append(_make_clip(ws.id, src, "Same Title"))
+
+        out = tmp_path / "out"
+        with patch("acemusic.cli.export_audio", side_effect=_fake_export):
+            result = runner.invoke(app, ["export", "--workspace", "Dupes", "--output", str(out)])
+        assert result.exit_code == 0, result.output
+        names = sorted(p.name for p in out.glob("*.wav"))
+        assert len(names) == 2
+        assert len(set(names)) == 2  # distinct
+
+    def test_untitled_clips_use_clip_id(self, isolated_db, write_tone, tmp_path):
+        from acemusic.workspace import create_workspace, get_workspace_path, switch_workspace
+
+        ws = create_workspace("Untitled")
+        switch_workspace("Untitled")
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        src = clips_dir / "u.wav"
+        write_tone(src, duration_s=0.5)
+        cid = _make_clip(ws.id, src, None)
+
+        out = tmp_path / "out"
+        with patch("acemusic.cli.export_audio", side_effect=_fake_export):
+            result = runner.invoke(app, ["export", "--workspace", "Untitled", "--output", str(out)])
+        assert result.exit_code == 0, result.output
+        assert (out / f"clip-{cid}.wav").exists()
+
+
+class TestSummaryAndFailures:
+    def test_summary_shows_count_and_size(self, workspace_with_clips, tmp_path):
+        out = tmp_path / "out"
+        with patch("acemusic.cli.export_audio", side_effect=_fake_export):
+            result = runner.invoke(app, ["export", "--workspace", "My Album", "--output", str(out)])
+        assert result.exit_code == 0, result.output
+        flat = result.output.replace("\n", "")
+        assert "3 clips" in flat
+        assert "total" in flat.lower()
+        assert "KB" in flat or "bytes" in flat or "MB" in flat
+
+    def test_partial_failure_continues_and_reports(self, workspace_with_clips, tmp_path):
+        _, clip_ids, _ = workspace_with_clips
+        out = tmp_path / "out"
+        calls = {"n": 0}
+
+        def flaky(s, d, f):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("ffmpeg blew up")
+            Path(d).write_bytes(b"x" * 1024)
+
+        with patch("acemusic.cli.export_audio", side_effect=flaky):
+            result = runner.invoke(app, ["export", "--workspace", "My Album", "--output", str(out)])
+        # Individual failure must not abort the whole batch.
+        assert result.exit_code == 0, result.output
+        flat = result.output.replace("\n", "")
+        assert "2 of 3" in flat
+        assert "1 failed" in flat
+        assert len(list(out.glob("*.wav"))) == 2
+
+    def test_empty_workspace_reports_zero(self, isolated_db):
+        from acemusic.workspace import create_workspace, switch_workspace
+
+        create_workspace("Empty")
+        switch_workspace("Empty")
+        result = runner.invoke(app, ["export", "--workspace", "Empty"])
+        assert result.exit_code == 0, result.output
+        assert "0 clips" in result.output.replace("\n", "")

--- a/tests/test_batch_export.py
+++ b/tests/test_batch_export.py
@@ -181,12 +181,20 @@ class TestSummaryAndFailures:
 
         with patch("acemusic.cli.export_audio", side_effect=flaky):
             result = runner.invoke(app, ["export", "--workspace", "My Album", "--output", str(out)])
-        # Individual failure must not abort the whole batch.
-        assert result.exit_code == 0, result.output
+        # Individual failures must not abort the batch — the other clips still export —
+        # but a partial failure surfaces as a non-zero exit code for scripts/CI.
+        assert result.exit_code == 1, result.output
         flat = result.output.replace("\n", "")
         assert "2 of 3" in flat
         assert "1 failed" in flat
         assert len(list(out.glob("*.wav"))) == 2
+
+    def test_output_pointing_at_existing_file_errors(self, workspace_with_clips, tmp_path):
+        existing_file = tmp_path / "not-a-dir"
+        existing_file.write_text("i am a file")
+        result = runner.invoke(app, ["export", "--workspace", "My Album", "--output", str(existing_file)])
+        assert result.exit_code == 1
+        assert "error" in result.output.lower()
 
     def test_empty_workspace_reports_zero(self, isolated_db):
         from acemusic.workspace import create_workspace, switch_workspace

--- a/tests/test_batch_export.py
+++ b/tests/test_batch_export.py
@@ -139,6 +139,40 @@ class TestDistinctFilenames:
         assert len(names) == 2
         assert len(set(names)) == 2  # distinct
 
+    def test_fallback_name_does_not_overwrite_another_clips_primary_name(self, isolated_db, write_tone, tmp_path):
+        """A disambiguated fallback must not collide with another clip's primary name.
+
+        Clip "Song" (taken) falls back to "song-<id>"; a sibling literally titled
+        "Song <id>" produces primary "song-<id>" — both must remain distinct.
+        """
+        from acemusic.workspace import create_workspace, get_workspace_path, switch_workspace
+
+        ws = create_workspace("Collide")
+        switch_workspace("Collide")
+        clips_dir = get_workspace_path(ws.id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+
+        # First "Song" claims song.wav.
+        s0 = clips_dir / "s0.wav"
+        write_tone(s0, duration_s=0.5)
+        _make_clip(ws.id, s0, "Song")
+        # Second "Song" must fall back to song-<id1>.wav.
+        s1 = clips_dir / "s1.wav"
+        write_tone(s1, duration_s=0.5)
+        id1 = _make_clip(ws.id, s1, "Song")
+        # A clip literally titled "Song <id1>" would also slug to song-<id1>.
+        s2 = clips_dir / "s2.wav"
+        write_tone(s2, duration_s=0.5)
+        _make_clip(ws.id, s2, f"Song {id1}")
+
+        out = tmp_path / "out"
+        with patch("acemusic.cli.export_audio", side_effect=_fake_export):
+            result = runner.invoke(app, ["export", "--workspace", "Collide", "--output", str(out)])
+        assert result.exit_code == 0, result.output
+        names = [p.name for p in out.glob("*.wav")]
+        assert len(names) == 3
+        assert len(set(names)) == 3  # all distinct, no overwrites
+
     def test_untitled_clips_use_clip_id(self, isolated_db, write_tone, tmp_path):
         from acemusic.workspace import create_workspace, get_workspace_path, switch_workspace
 

--- a/tests/test_stems.py
+++ b/tests/test_stems.py
@@ -151,7 +151,8 @@ class TestStemsCommand:
                 result = runner.invoke(app, ["stems", str(clip_id), "--output-format", "flac"])
 
         assert result.exit_code == 0, result.output
-        assert ".flac" in result.output
+        # Rich may soft-wrap the path on narrow terminals — flatten before the substring check.
+        assert ".flac" in result.output.replace("\n", "")
 
     def test_stems_custom_output_dir(self, workspace_with_clips_dir, tmp_path):
         """--output overrides the default stems/ directory."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,12 +5,36 @@ import soundfile as sf
 
 from acemusic.utils import (
     concatenate_audio,
+    human_readable_size,
     make_filename,
     make_slug,
     parse_time_string,
     slice_audio,
     snap_to_beat,
 )
+
+
+class TestHumanReadableSize:
+    """Tests for the human_readable_size() byte-count formatter (US-7.3)."""
+
+    def test_zero_bytes(self):
+        assert human_readable_size(0) == "0 bytes"
+
+    def test_bytes_below_one_kib(self):
+        assert human_readable_size(512) == "512 bytes"
+
+    def test_one_kib_boundary(self):
+        assert human_readable_size(1024) == "1.0 KB"
+
+    def test_kilobytes(self):
+        assert human_readable_size(1536) == "1.5 KB"
+
+    def test_megabytes(self):
+        # 2.5 MiB
+        assert human_readable_size(int(2.5 * 1024 * 1024)) == "2.5 MB"
+
+    def test_gigabytes(self):
+        assert human_readable_size(3 * 1024**3) == "3.0 GB"
 
 
 class TestMakeSlug:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,6 @@ class TestHumanReadableSize:
         assert human_readable_size(1536) == "1.5 KB"
 
     def test_megabytes(self):
-        # 2.5 MiB
         assert human_readable_size(int(2.5 * 1024 * 1024)) == "2.5 MB"
 
     def test_gigabytes(self):

--- a/user-stories/01-layer-1-cli-foundation.md
+++ b/user-stories/01-layer-1-cli-foundation.md
@@ -848,9 +848,9 @@ Export multiple clips in one command, with consistent naming and optional format
 - Summary output: number of clips exported, total size, output location
 
 **Acceptance Criteria:**
-- [ ] All clips in the workspace are exported
-- [ ] Each clip has a distinct, descriptively-named file
-- [ ] Summary shows count and total size
+- [x] All clips in the workspace are exported
+- [x] Each clip has a distinct, descriptively-named file
+- [x] Summary shows count and total size
 
 ---
 


### PR DESCRIPTION
## Summary

Implements **US-7.3: Batch export** (#42) — export every clip in a workspace at once.

Extends the existing `export` command with a `--workspace` batch mode that reuses the single-clip (US-7.1) and DAW bundle (US-7.2) export paths plus the workspace/clip data layer (US-5.x). No new parallel module — the dependencies the original CodeRabbit plan assumed missing are now all implemented.

```
acemusic export --workspace "My Album" --format flac --output ./album
  ✓ Outro → outro.flac
  ✓ Main Groove → main-groove.flac
  ✓ Intro Theme → intro-theme.flac
Exported 3 clips → /abs/path/album (total: 80.1 KB)
```

## What changed
- `export` command: `clip_id` is now an optional positional; `--workspace` selects batch mode (the two are mutually exclusive). Single-clip usage is unchanged/backward compatible.
- Batch mode writes one **distinctly-named** file/ZIP per clip (title slug, `clip-<id>` fallback, `-<id>` suffix on collisions), continues past individual clip failures, and prints a **count + total-size** summary.
- `--output` is a directory in batch mode (default cwd), a file path in single mode.
- Added `human_readable_size()` helper in `utils.py`.
- Fixed a pre-existing terminal-width-brittle assertion in `test_stems.py` (Rich soft-wrapped `.flac` across a newline).

## Acceptance criteria
- [x] All clips in the workspace are exported — *demo: 3/3 exported, wav & flac*
- [x] Each clip has a distinct, descriptively-named file — *intro-theme / main-groove / outro; collision + untitled fallbacks tested*
- [x] Summary shows count and total size — *"Exported 3 clips → … (total: 1.2 MB)"*

## Testing
- New `tests/test_batch_export.py` (14 tests): routing/mutual-exclusivity, exports-every-clip, daw routing, distinct names, partial failure, empty workspace, invalid output dir.
- New `human_readable_size` unit tests in `test_utils.py`.
- Full suite: **653 passed, 1 skipped**. Lint (ruff) + format (black) clean.
- Demonstrated end-to-end with real audio (not mocked).

## Review fixes (codex, cross-family)
- **[P2]** Partial batch failure now exits non-zero so CI/scripts can detect it (per-clip continue preserved).
- **[P3]** `--output` pointing at an existing file now yields a clean `Error: …` + exit 1 instead of an uncaught `FileExistsError`.

## Known limitations
- `time_signature` is not persisted on clips (deferred to US-4.2), so DAW bundles use the default 4/4 map — inherited from US-7.2, unchanged here.

Closes #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch export mode: export all clips from a workspace into distinct files with a summary showing clip count and human-readable total size
  * Improved single-clip export: clearer output handling, deterministic filenames, and stricter argument validation

* **Bug Fixes**
  * More robust test output checks to handle terminal wrapping

* **Tests**
  * Added comprehensive batch export tests and unit tests for human-readable size formatting

* **Documentation**
  * Updated acceptance criteria to mark batch-export items as complete

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankbria/auto-music-studio/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->