### PR TITLE
US-8.2: MongoDB connection and core collections (#70)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,10 @@ DATABASE_URL=
 # Allowed CORS origins for the FastAPI service (comma-separated).
 # Leave blank to use local dev defaults (http://localhost:3000, http://localhost:8000).
 ACEMUSIC_API_CORS_ALLOW_ORIGINS=
+
+# MongoDB connection (US-8.2).
+# Local dev default is mongodb://localhost:27017. For staging/production set this
+# to your Atlas cluster, e.g.
+#   mongodb+srv://<user>:<password>@<cluster>.mongodb.net/?retryWrites=true&w=majority
+ACEMUSIC_API_MONGODB_URL=
+ACEMUSIC_API_MONGODB_DB_NAME=acemusic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
 
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand(\"ping\")'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -36,5 +47,12 @@ jobs:
       - name: Lint (ruff)
         run: uv run ruff check .
 
-      - name: Test with coverage
+      - name: Test with coverage (unit)
         run: uv run pytest --cov
+
+      - name: Integration tests (MongoDB)
+        # Runs against the mongo service above. ACE-Step integration tests skip
+        # gracefully when their server is absent (see tests/conftest.py).
+        run: uv run pytest -m integration
+        env:
+          ACEMUSIC_TEST_MONGODB_URL: mongodb://localhost:27017

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,8 +101,10 @@ uv run acemusic export 42 --format flac --output /path/to/out.flac     # explici
 src/acemusic/
   __init__.py       # Package metadata (__version__)
   api/              # FastAPI platform API (Layer 2)
-    main.py         # create_app() factory + ASGI app (uvicorn target)
+    main.py         # create_app() factory + ASGI app (uvicorn target); DB lifespan
     settings.py     # ApiSettings (pydantic-settings, ACEMUSIC_API_ prefix)
+    database.py     # MongoDB connect/close (Beanie + pymongo async), fail-fast ping
+    models/         # Beanie ODM documents: User, Workspace, Clip, Job
     routers/        # Versioned routers mounted under /api/v1 (health, ...)
   cli.py            # Typer CLI app (health, generate, models, workspace commands)
   client.py         # AceStepClient — HTTP client for ACE-Step REST API

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Then visit `http://127.0.0.1:8000/docs` for the interactive Swagger UI, or
 `GET /api/v1/health` for a liveness check. Allowed CORS origins are configured
 via `ACEMUSIC_API_CORS_ALLOW_ORIGINS` (comma-separated).
 
+The API requires **MongoDB** and fails fast on startup if it is unreachable.
+Set `ACEMUSIC_API_MONGODB_URL` (defaults to `mongodb://localhost:27017`); use an
+Atlas `mongodb+srv://…` string for staging/production. Local integration tests
+run only against a local MongoDB (`uv run pytest -m integration`).
+
 ## Environment
 
 Copy `.env.example` to `.env` and fill in the required values before running.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,13 @@ dependencies = [
     # suite imports acemusic.api. Only the server runner (uvicorn) is optional.
     "fastapi>=0.110",
     "pydantic-settings>=2.7",
+    # Beanie 2.x is the ODM; it uses pymongo's native async client
+    # (AsyncMongoClient) directly — Motor is deprecated and no longer used.
+    # dnspython is required for Atlas mongodb+srv:// connection strings.
+    "beanie>=2.1",
+    "pymongo>=4.9",
+    "dnspython>=2.6",
+    "email-validator>=2.0",
 ]
 
 [project.scripts]
@@ -38,6 +45,7 @@ audio-ml = [
 dev = [
     "pytest",
     "pytest-bdd",
+    "pytest-asyncio",
     "pytest-cov",
     "ruff",
     "black",
@@ -72,6 +80,7 @@ target-version = ["py311"]
 testpaths = ["tests"]
 addopts = "--cov=src/acemusic --cov-report=term-missing -m 'not integration'"
 bdd_features_base_dir = "tests/features"
+asyncio_mode = "auto"
 markers = [
     "integration: requires a live external service (deselect with -m 'not integration')",
 ]

--- a/src/acemusic/api/database.py
+++ b/src/acemusic/api/database.py
@@ -1,0 +1,118 @@
+"""MongoDB connection lifecycle for the platform API (US-8.2).
+
+Uses pymongo's native async client (``AsyncMongoClient``) with Beanie as the ODM.
+``init_db`` verifies connectivity with a ping and fails fast (``ConnectionError``)
+if the server is unreachable, rather than letting requests hang later.
+
+Connection ownership: ``init_db`` returns the client so each caller owns its
+handle — the app lifespan stores it on ``app.state.mongo_client`` and closes that
+specific client on shutdown. The module-level accessors below track the most
+recent connection as a convenience for the single-app/test case. Note that
+running two app instances against different databases in one process is bounded
+by Beanie itself: ``init_beanie`` binds the Document classes to one database
+process-wide, so there is effectively one active ODM connection per process.
+"""
+
+import logging
+from urllib.parse import urlsplit, urlunsplit
+
+from beanie import init_beanie
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import PyMongoError
+
+from .models import ALL_MODELS
+from .settings import ApiSettings
+
+logger = logging.getLogger(__name__)
+
+_client: AsyncMongoClient | None = None
+_db_name: str | None = None
+
+
+def redact_mongodb_url(url: str) -> str:
+    """Return ``url`` with any credentials and query string removed.
+
+    Connection strings (e.g. Atlas ``mongodb+srv://user:password@host/?...``)
+    must never reach logs or error messages verbatim.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return "<mongodb-url>"
+    netloc = parts.netloc
+    if "@" in netloc:
+        netloc = "***@" + netloc.rsplit("@", 1)[1]
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
+async def init_db(settings: ApiSettings) -> AsyncMongoClient:
+    """Connect to MongoDB, verify with a ping, and initialize Beanie.
+
+    Returns the connected client. Raises ``ConnectionError`` with an actionable
+    message if the server cannot be reached (fail-fast).
+    """
+    global _client, _db_name
+
+    client: AsyncMongoClient = AsyncMongoClient(
+        settings.mongodb_url,
+        minPoolSize=settings.mongodb_min_pool_size,
+        maxPoolSize=settings.mongodb_max_pool_size,
+        serverSelectionTimeoutMS=settings.mongodb_server_selection_timeout_ms,
+    )
+
+    safe_url = redact_mongodb_url(settings.mongodb_url)
+    try:
+        await client.admin.command("ping")
+    except PyMongoError as exc:
+        await client.close()
+        raise ConnectionError(
+            f"Could not connect to MongoDB at {safe_url}: {exc}. "
+            "Verify the server is running and ACEMUSIC_API_MONGODB_URL is correct."
+        ) from exc
+
+    # If Beanie init fails after a good ping (e.g. invalid index/model, or the
+    # user lacks index-creation rights), close the client so a failed startup
+    # doesn't leak sockets/monitor tasks.
+    try:
+        await init_beanie(database=client[settings.mongodb_db_name], document_models=ALL_MODELS)
+    except Exception:
+        await client.close()
+        raise
+
+    _client = client
+    _db_name = settings.mongodb_db_name
+    logger.info("Connected to MongoDB database %r at %s", settings.mongodb_db_name, safe_url)
+    return client
+
+
+async def close_db(client: AsyncMongoClient | None = None) -> None:
+    """Close a MongoDB client.
+
+    Closes the given ``client`` (so a lifespan tears down exactly the connection
+    it opened); when called with no argument, closes the module-level client.
+    The module globals are cleared only when they refer to the closed client.
+    """
+    global _client, _db_name
+    target = client if client is not None else _client
+    if target is not None:
+        await target.close()
+        logger.info("Closed MongoDB connection")
+    if client is None or client is _client:
+        _client = None
+        _db_name = None
+
+
+def get_client() -> AsyncMongoClient:
+    """Return the active client. Raises if the database is not initialized."""
+    if _client is None:
+        raise RuntimeError("Database not initialized — call init_db() first.")
+    return _client
+
+
+def get_database() -> AsyncDatabase:
+    """Return the active database handle. Raises if not initialized."""
+    client = get_client()
+    if _db_name is None:
+        raise RuntimeError("Database not initialized — call init_db() first.")
+    return client[_db_name]

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -8,17 +8,36 @@ Routes are versioned under ``/api/v1``. OpenAPI docs are served at ``/docs``
 (Swagger UI) and ``/redoc``.
 """
 
+import logging
 import time
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from acemusic import __version__
 
+from . import database
 from .routers import health
 from .settings import ApiSettings
 
 API_V1_PREFIX = "/api/v1"
+
+
+def _ensure_app_logging() -> None:
+    """Make ``acemusic`` INFO logs visible when served (e.g. via uvicorn).
+
+    uvicorn configures only its own loggers, so application logs (the MongoDB
+    connection success/failure) would otherwise be silent. Attach a stream
+    handler to the ``acemusic`` logger once, without touching the root logger.
+    """
+    app_logger = logging.getLogger("acemusic")
+    if not app_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(levelname)s:     %(name)s - %(message)s"))
+        app_logger.addHandler(handler)
+        app_logger.setLevel(logging.INFO)
+        app_logger.propagate = False
 
 
 def create_app(settings: ApiSettings | None = None) -> FastAPI:
@@ -26,14 +45,31 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
 
     Accepts an optional ``settings`` instance for testing; defaults to
     environment-derived :class:`ApiSettings`.
+
+    The app connects to MongoDB on startup (and closes on shutdown) via the
+    lifespan handler. A failed connection aborts startup (fail-fast). Note that
+    Starlette only runs the lifespan when the app is actually served (uvicorn) or
+    when a test uses ``TestClient`` as a context manager — plain ``TestClient``
+    instantiation does not, so HTTP-surface unit tests need no live database.
     """
     settings = settings or ApiSettings()
+    _ensure_app_logging()
+
+    @asynccontextmanager
+    async def lifespan(app_: FastAPI):
+        client = await database.init_db(settings)
+        app_.state.mongo_client = client
+        try:
+            yield
+        finally:
+            await database.close_db(client)
 
     app = FastAPI(
         title="Auto Music Studio API",
         version=__version__,
         docs_url="/docs",
         redoc_url="/redoc",
+        lifespan=lifespan,
     )
     app.state.settings = settings
     app.state.start_time = time.monotonic()

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -1,0 +1,13 @@
+"""Beanie ODM document models for the platform's core collections (US-8.2).
+
+``ALL_MODELS`` is the registration list passed to ``init_beanie``.
+"""
+
+from .clip import Clip
+from .job import Job, JobStatus
+from .user import User
+from .workspace import Workspace
+
+ALL_MODELS = [User, Workspace, Clip, Job]
+
+__all__ = ["User", "Workspace", "Clip", "Job", "JobStatus", "ALL_MODELS"]

--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -1,0 +1,46 @@
+"""Clip document model (US-8.2).
+
+Fields mirror the CLI's :class:`acemusic.models.Clip` so the API and CLI share a
+consistent clip shape as the platform migrates from SQLite to MongoDB.
+"""
+
+from datetime import datetime
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, DESCENDING, IndexModel
+
+from .common import utcnow
+
+
+class Clip(Document):
+    """A generated or imported audio clip with its metadata and lineage."""
+
+    workspace_id: PydanticObjectId
+    user_id: PydanticObjectId
+    file_path: str
+    title: str | None = None
+    format: str | None = None
+    duration: float | None = None
+    bpm: int | None = None
+    key: str | None = None
+    style_tags: list[str] = Field(default_factory=list)
+    lyrics: str | None = None
+    vocal_language: str | None = None
+    model: str | None = None
+    seed: int | None = None
+    inference_steps: int | None = None
+    parent_clip_ids: list[PydanticObjectId] = Field(default_factory=list)
+    generation_mode: str | None = None
+    created_at: datetime = Field(default_factory=utcnow)
+
+    class Settings:
+        name = "clips"
+        indexes = [
+            # Compound index serves the common "clips in a workspace, newest
+            # first" query entirely from the index; its workspace_id prefix also
+            # covers plain workspace_id lookups (US-8.2 AC).
+            IndexModel([("workspace_id", ASCENDING), ("created_at", DESCENDING)]),
+            IndexModel([("user_id", ASCENDING)]),
+            IndexModel([("created_at", DESCENDING)]),
+        ]

--- a/src/acemusic/api/models/common.py
+++ b/src/acemusic/api/models/common.py
@@ -1,0 +1,8 @@
+"""Shared helpers for Beanie document models."""
+
+from datetime import datetime, timezone
+
+
+def utcnow() -> datetime:
+    """Timezone-aware current UTC time (used as a default_factory)."""
+    return datetime.now(timezone.utc)

--- a/src/acemusic/api/models/job.py
+++ b/src/acemusic/api/models/job.py
@@ -1,0 +1,44 @@
+"""Job document model (US-8.2).
+
+Tracks async generation/processing tasks. The status lifecycle matches the
+job-queue contract used by the Generation API (US-9.2):
+``queued -> processing -> completed | failed``.
+"""
+
+from datetime import datetime
+from enum import Enum
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+
+class JobStatus(str, Enum):
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class Job(Document):
+    """An async task record (generation, edit, export, …)."""
+
+    user_id: PydanticObjectId
+    workspace_id: PydanticObjectId
+    job_type: str
+    status: JobStatus = JobStatus.QUEUED
+    input_params: dict = Field(default_factory=dict)
+    result: dict | None = None
+    error: str | None = None
+    created_at: datetime = Field(default_factory=utcnow)
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    class Settings:
+        name = "jobs"
+        indexes = [
+            IndexModel([("user_id", ASCENDING)]),
+            IndexModel([("status", ASCENDING)]),
+        ]

--- a/src/acemusic/api/models/user.py
+++ b/src/acemusic/api/models/user.py
@@ -1,0 +1,24 @@
+"""User document model (US-8.2)."""
+
+from datetime import datetime
+
+from beanie import Document
+from pydantic import EmailStr, Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+
+class User(Document):
+    """A platform user. ``email`` is validated and uniquely indexed."""
+
+    email: EmailStr
+    name: str
+    oauth_provider: str | None = None
+    oauth_id: str | None = None
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime | None = None
+
+    class Settings:
+        name = "users"
+        indexes = [IndexModel([("email", ASCENDING)], unique=True)]

--- a/src/acemusic/api/models/workspace.py
+++ b/src/acemusic/api/models/workspace.py
@@ -1,0 +1,23 @@
+"""Workspace document model (US-8.2)."""
+
+from datetime import datetime
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+
+class Workspace(Document):
+    """A user-owned container for clips. ``is_default`` marks the auto-created one."""
+
+    name: str
+    user_id: PydanticObjectId
+    is_default: bool = False
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime | None = None
+
+    class Settings:
+        name = "workspaces"
+        indexes = [IndexModel([("user_id", ASCENDING)])]

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -7,7 +7,7 @@ not collide with CLI or ACE-Step server variables.
 
 from typing import Annotated
 
-from pydantic import field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 DEFAULT_CORS_ORIGINS = ["http://localhost:3000", "http://localhost:8000"]
@@ -30,6 +30,24 @@ class ApiSettings(BaseSettings):
     )
 
     cors_allow_origins: Annotated[list[str], NoDecode] = DEFAULT_CORS_ORIGINS
+
+    # MongoDB (US-8.2). Defaults target a local server; production/staging set
+    # mongodb_url to an Atlas mongodb+srv:// string via the environment.
+    mongodb_url: str = "mongodb://localhost:27017"
+    mongodb_db_name: str = "acemusic"
+    mongodb_min_pool_size: int = Field(default=10, ge=0)
+    mongodb_max_pool_size: int = Field(default=100, ge=1)
+    mongodb_server_selection_timeout_ms: int = Field(default=5000, ge=1)
+
+    @model_validator(mode="after")
+    def _check_pool_bounds(self) -> "ApiSettings":
+        """Catch misconfigured pool sizes at parse time, not during DB init."""
+        if self.mongodb_min_pool_size > self.mongodb_max_pool_size:
+            raise ValueError(
+                f"mongodb_min_pool_size ({self.mongodb_min_pool_size}) cannot exceed "
+                f"mongodb_max_pool_size ({self.mongodb_max_pool_size})"
+            )
+        return self
 
     @field_validator("cors_allow_origins", mode="before")
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,104 @@ def app_config():
 
 
 # ---------------------------------------------------------------------------
+# MongoDB fixtures (US-8.2) — local-only, isolated throwaway database
+# ---------------------------------------------------------------------------
+
+LOCAL_MONGO_HOSTS = ("localhost", "127.0.0.1", "::1", "mongo", "mongodb")
+
+
+def _mongo_test_url() -> str:
+    """Local MongoDB URL for tests. Overridable only with another LOCAL url."""
+    return os.environ.get("ACEMUSIC_TEST_MONGODB_URL", "mongodb://localhost:27017")
+
+
+def mongodb_uri_hosts(url: str) -> list[str]:
+    """Return every host listed in a MongoDB URI (handles replica-set lists)."""
+    from pymongo.uri_parser import parse_uri
+
+    try:
+        nodelist = parse_uri(url, warn=True)["nodelist"]
+        return [host for host, _port in nodelist]
+    except Exception:
+        from urllib.parse import urlparse
+
+        return [urlparse(url).hostname]
+
+
+def _assert_local(url: str) -> None:
+    """Hard guard: tests must never run against a remote/Atlas cluster.
+
+    Rejects ``mongodb+srv://`` (SRV resolves to a remote cluster) and requires
+    *every* host in a multi-host/replica-set URI to be local — checking only the
+    first host would let ``mongodb://localhost,prod.example.com/`` slip through
+    and have teardown drop a remote database.
+    """
+    if url.startswith("mongodb+srv://"):
+        raise RuntimeError(
+            "Refusing to run integration tests against a mongodb+srv:// (SRV/Atlas) URL. "
+            "Set ACEMUSIC_TEST_MONGODB_URL to a local mongodb:// URL."
+        )
+    remote = [h for h in mongodb_uri_hosts(url) if h not in LOCAL_MONGO_HOSTS]
+    if remote:
+        raise RuntimeError(
+            f"Refusing to run integration tests against non-local MongoDB host(s) {remote!r}. "
+            "Tests only run against a local MongoDB; set ACEMUSIC_TEST_MONGODB_URL to a local URL."
+        )
+
+
+async def _mongo_available(url: str) -> bool:
+    from pymongo import AsyncMongoClient
+
+    try:
+        client = AsyncMongoClient(url, serverSelectionTimeoutMS=2000)
+        await client.admin.command("ping")
+        await client.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture
+async def mongo_settings():
+    """ApiSettings pointed at an isolated local test database.
+
+    ``_env_file=None`` ensures a real ``.env`` (which may hold an Atlas URL) is
+    never read here, so tests cannot touch the production cluster.
+    """
+    import uuid
+
+    from acemusic.api.settings import ApiSettings
+
+    url = _mongo_test_url()
+    _assert_local(url)
+    db_name = f"acemusic_test_{uuid.uuid4().hex[:8]}"
+    return ApiSettings(_env_file=None, mongodb_url=url, mongodb_db_name=db_name)
+
+
+@pytest.fixture
+async def mongo_db(mongo_settings):
+    """Initialize the DB/Beanie against the isolated test database.
+
+    Yields the ``acemusic.api.database`` module. Drops the test database and
+    closes the client on teardown. Skips if no local MongoDB is reachable.
+    """
+    from acemusic.api import database
+
+    if not await _mongo_available(mongo_settings.mongodb_url):
+        pytest.skip(f"local MongoDB not available at {mongo_settings.mongodb_url}")
+
+    client = await database.init_db(mongo_settings)
+    try:
+        yield database
+    finally:
+        # Always close the client, even if dropping the test DB fails.
+        try:
+            await client.drop_database(mongo_settings.mongodb_db_name)
+        finally:
+            await database.close_db(client)
+
+
+# ---------------------------------------------------------------------------
 # Audio test helpers (shared across audio-related test modules)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -24,6 +24,18 @@ class TestAppFactory:
         """The OpenAPI/app version is sourced from the package version."""
         assert create_app().version == __version__
 
+    def test_app_logging_is_configured(self):
+        """create_app wires a handler on the 'acemusic' logger so connection
+        success/failure is visible under uvicorn (AC: 'logs success')."""
+        import logging
+
+        from acemusic.api.settings import ApiSettings
+
+        create_app(settings=ApiSettings(_env_file=None))
+        app_logger = logging.getLogger("acemusic")
+        assert app_logger.handlers
+        assert app_logger.getEffectiveLevel() <= logging.INFO
+
 
 class TestHealthEndpoint:
     def test_health_returns_ok(self, client):

--- a/tests/test_mongo_safety.py
+++ b/tests/test_mongo_safety.py
@@ -1,0 +1,44 @@
+"""Unit tests for MongoDB safety guards (US-8.2) — no live database required.
+
+Covers credential redaction in logs/errors and the test-only local-host guard
+that prevents the integration suite from ever touching a remote/Atlas cluster.
+"""
+
+import pytest
+
+from acemusic.api.database import redact_mongodb_url
+from tests.conftest import _assert_local, mongodb_uri_hosts
+
+
+class TestRedaction:
+    def test_credentials_are_removed(self):
+        # Assembled from parts (reserved .invalid host, no literal user:pass@host
+        # and no secret-ish keyword) so neither GitGuardian nor the local
+        # pre-commit secret hook false-positives, while still exercising redaction.
+        userinfo = "alice:" + "hunter7x9"
+        url = f"mongodb+srv://{userinfo}@cluster0.example.invalid/?retryWrites=true&w=majority"
+        safe = redact_mongodb_url(url)
+        assert "hunter7x9" not in safe
+        assert "alice" not in safe
+        assert "cluster0.example.invalid" in safe
+        assert "retryWrites" not in safe  # query string dropped too
+
+    def test_urls_without_credentials_are_unchanged_apart_from_query(self):
+        assert redact_mongodb_url("mongodb://localhost:27017") == "mongodb://localhost:27017"
+
+
+class TestLocalHostGuard:
+    def test_extracts_all_replica_set_hosts(self):
+        hosts = mongodb_uri_hosts("mongodb://localhost:27017,prod.example.com:27017/?replicaSet=rs0")
+        assert "localhost" in hosts and "prod.example.com" in hosts
+
+    def test_plain_localhost_is_allowed(self):
+        _assert_local("mongodb://localhost:27017")  # must not raise
+
+    def test_remote_member_in_replica_set_is_rejected(self):
+        with pytest.raises(RuntimeError, match="non-local"):
+            _assert_local("mongodb://localhost:27017,prod.example.com:27017/?replicaSet=rs0")
+
+    def test_srv_url_is_rejected(self):
+        with pytest.raises(RuntimeError, match="srv"):
+            _assert_local("mongodb+srv://cluster0.example.invalid/")

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -1,0 +1,147 @@
+"""Integration tests for the MongoDB data layer (US-8.2).
+
+These run against a real local MongoDB (no mocking). They are marked
+``integration`` so the default unit run deselects them; CI runs them with a
+mongo service container. Each test uses an isolated throwaway database.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestConnection:
+    async def test_init_db_connects_and_pings(self, mongo_db):
+        """init_db returns a live client that responds to ping."""
+        client = mongo_db.get_client()
+        result = await client.admin.command("ping")
+        assert result.get("ok") == 1.0
+
+    async def test_init_db_fails_fast_on_unreachable(self):
+        """An unreachable MongoDB raises ConnectionError quickly (no silent hang)."""
+        from acemusic.api import database
+        from acemusic.api.settings import ApiSettings
+
+        settings = ApiSettings(
+            _env_file=None,
+            mongodb_url="mongodb://127.0.0.1:1",  # nothing listens here
+            mongodb_db_name="acemusic_test_unreachable",
+            mongodb_server_selection_timeout_ms=1000,
+        )
+        with pytest.raises(ConnectionError) as exc:
+            await database.init_db(settings)
+        assert "mongo" in str(exc.value).lower()
+
+
+class TestIndexes:
+    async def test_required_indexes_created(self, mongo_db):
+        """Collections are created with the indexes required by the AC."""
+        db = mongo_db.get_database()
+
+        user_idx = await db["users"].index_information()
+        # email must be uniquely indexed
+        assert any(
+            keys[0][0] == "email" and meta.get("unique")
+            for meta in [user_idx[name] for name in user_idx]
+            for keys in [meta["key"]]
+        )
+
+        clip_idx = await db["clips"].index_information()
+        indexed_fields = {meta["key"][0][0] for meta in clip_idx.values()}
+        assert {"workspace_id", "user_id", "created_at"} <= indexed_fields
+
+
+class TestUserCrud:
+    async def test_create_query_update_delete(self, mongo_db):
+        from acemusic.api.models import User
+
+        user = await User(email="a@example.com", name="Ada").insert()
+        assert user.id is not None
+
+        found = await User.find_one(User.email == "a@example.com")
+        assert found is not None and found.name == "Ada"
+
+        found.name = "Ada L."
+        await found.save()
+        assert (await User.find_one(User.email == "a@example.com")).name == "Ada L."
+
+        await found.delete()
+        assert await User.find_one(User.email == "a@example.com") is None
+
+    async def test_duplicate_email_rejected(self, mongo_db):
+        """The unique email index prevents duplicate users."""
+        from pymongo.errors import DuplicateKeyError
+
+        from acemusic.api.models import User
+
+        await User(email="dup@example.com", name="One").insert()
+        with pytest.raises(DuplicateKeyError):
+            await User(email="dup@example.com", name="Two").insert()
+
+
+class TestWorkspaceCrud:
+    async def test_create_and_query_by_user(self, mongo_db):
+        from beanie import PydanticObjectId
+
+        from acemusic.api.models import Workspace
+
+        user_id = PydanticObjectId()
+        ws = await Workspace(name="My Album", user_id=user_id, is_default=True).insert()
+        assert ws.id is not None
+
+        results = await Workspace.find(Workspace.user_id == user_id).to_list()
+        assert len(results) == 1 and results[0].is_default is True
+
+
+class TestClipCrud:
+    async def test_create_and_created_at_ordering(self, mongo_db):
+        from datetime import datetime, timezone
+
+        from beanie import PydanticObjectId
+
+        from acemusic.api.models import Clip
+
+        ws = PydanticObjectId()
+        older = await Clip(
+            title="older",
+            workspace_id=ws,
+            user_id=PydanticObjectId(),
+            file_path="/x/older.wav",
+            created_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        ).insert()
+        newer = await Clip(
+            title="newer",
+            workspace_id=ws,
+            user_id=PydanticObjectId(),
+            file_path="/x/newer.wav",
+            created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        ).insert()
+
+        by_ws = await Clip.find(Clip.workspace_id == ws).sort("-created_at").to_list()
+        assert [c.title for c in by_ws] == ["newer", "older"]
+        assert {older.id, newer.id} == {c.id for c in by_ws}
+
+
+class TestJobCrud:
+    async def test_status_transitions(self, mongo_db):
+        from beanie import PydanticObjectId
+
+        from acemusic.api.models import Job, JobStatus
+
+        job = await Job(
+            user_id=PydanticObjectId(),
+            workspace_id=PydanticObjectId(),
+            job_type="generate",
+            input_params={"prompt": "lofi"},
+        ).insert()
+        assert job.status == JobStatus.QUEUED
+
+        job.status = JobStatus.PROCESSING
+        await job.save()
+        job.status = JobStatus.COMPLETED
+        job.result = {"clip_ids": ["1", "2"]}
+        await job.save()
+
+        reloaded = await Job.get(job.id)
+        assert reloaded.status == JobStatus.COMPLETED
+        assert reloaded.result == {"clip_ids": ["1", "2"]}

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,9 @@ name = "acemusic"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "beanie" },
+    { name = "dnspython" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "librosa" },
@@ -31,6 +34,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pydub" },
     { name = "pyloudnorm" },
+    { name = "pymongo" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "scipy" },
@@ -53,6 +57,7 @@ audio-ml-midi = [
 dev = [
     { name = "black" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-bdd" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -62,8 +67,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "basic-pitch", marker = "extra == 'audio-ml-midi'", specifier = ">=0.3.0" },
+    { name = "beanie", specifier = ">=2.1" },
     { name = "black", marker = "extra == 'dev'" },
     { name = "demucs", marker = "extra == 'audio-ml'", specifier = ">=4.0" },
+    { name = "dnspython", specifier = ">=2.6" },
+    { name = "email-validator", specifier = ">=2.0" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "librosa", specifier = ">=0.10.0" },
@@ -73,7 +81,9 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "pydub", specifier = ">=0.25.1" },
     { name = "pyloudnorm", specifier = ">=0.1.0" },
+    { name = "pymongo", specifier = ">=4.9" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-bdd", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=0.13.0" },
@@ -239,6 +249,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/68/384dcaa2493497581ef7a0f18c76ce35afa26ea8a8d703f4761bdae632e6/basic_pitch-0.4.0.tar.gz", hash = "sha256:6f48ac4b909c990fd59460622137a03b857c829bb1f3e65c71708da576ab68e5", size = 3715128, upload-time = "2024-08-16T17:17:10.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/0e/3a36d22562daeb0ae3c78ac78da3f8dba96543c5576ed57d4acb8ddbab5b/basic_pitch-0.4.0-py2.py3-none-any.whl", hash = "sha256:738adb503aae7fdfc7d1e1511aa0ce35052315f260a19531ef4c356708425db0", size = 758279, upload-time = "2024-08-16T17:17:08.41Z" },
+]
+
+[[package]]
+name = "beanie"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lazy-model" },
+    { name = "pydantic" },
+    { name = "pymongo" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/9c/f3037fff9ea059d7b0c72b6c6e4f3dcfeb28bf544fe0fc5420335d7c49d0/beanie-2.1.0.tar.gz", hash = "sha256:44f3c50710aa90daa9c9c40f9bf9c8954968fe16d7e5398c1f2fd462daf94fe1", size = 185979, upload-time = "2026-03-26T01:27:03.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b5/1c6c404bcce8fa53d3f422dce6e58bff99c3e3cb2a3c49d519e3e5822125/beanie-2.1.0-py3-none-any.whl", hash = "sha256:077381dad0e0129fd4dc38cdaa3d85cb517da7338e3d893a689314884df4379b", size = 92697, upload-time = "2026-03-26T01:27:02.191Z" },
 ]
 
 [[package]]
@@ -775,6 +801,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/38/55f835ebd9f443465087a6954ede19d4a41aebdf5e28567e89b99d6d2f57/demucs-4.0.1.tar.gz", hash = "sha256:e45a5a788bae79767c37bbf6e69aae03862ddcca05550fb79b926346a177d713", size = 1212924, upload-time = "2023-09-07T16:09:01.334Z" }
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "dora-search"
 version = "0.1.12"
 source = { registry = "https://pypi.org/simple" }
@@ -794,6 +829,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1229,6 +1277,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "lazy-model"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/85/e25dc36dee49cf0726c03a1558b5c311a17095bc9361bcbf47226cb3075a/lazy-model-0.4.0.tar.gz", hash = "sha256:a851d85d0b518b0b9c8e626bbee0feb0494c0e0cb5636550637f032dbbf9c55f", size = 8256, upload-time = "2025-08-07T20:05:34.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/54/653ea0d7c578741e9867ccf0cbf47b7eac09ff22e4238f311ac20671a911/lazy_model-0.4.0-py3-none-any.whl", hash = "sha256:95ea59551c1ac557a2c299f75803c56cc973923ef78c67ea4839a238142f7927", size = 13749, upload-time = "2025-08-07T20:05:36.303Z" },
 ]
 
 [[package]]
@@ -2150,6 +2210,67 @@ wheels = [
 ]
 
 [[package]]
+name = "pymongo"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/64/50be6fbac9c79fe2e4c17401a467da2d8764d82833d83cec325afe5cab32/pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0", size = 2523370, upload-time = "2026-04-20T16:39:53.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/e2/336d86f221cf1b56b2ed9330d4a3b98f9f38f0b37829ae9a9184617d5419/pymongo-4.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4141e6c6a339789b2974efa00ecd9409101672d77a0e3ee2cc3839eedf8ec4df", size = 874668, upload-time = "2026-04-20T16:37:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8e/75d3c6c935d187ab59c61e9c15d9aab3f274b563eaf1706e8cae5f508dec/pymongo-4.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e68c76b84e0c132d9dbf9307f12ff8185702328187a87b9aca8c941303873433", size = 875294, upload-time = "2026-04-20T16:37:43.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ec/62e855744489dbcd54fd778aae4d80fa4c4819e8fb228ca0cf6f21a03997/pymongo-4.17.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba2195d4f386f839a52a23ea1cfd60ffaaba78a3d7841db51b7e433001139918", size = 1496233, upload-time = "2026-04-20T16:37:45.518Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e8/93e4e5e5ce8fdf8929dabeefe24aafa5ce046028eed0dfa8eeb936e72c49/pymongo-4.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446ff4bfcb6ec2a2e50998c860986a1e992136f998b7f53e7a717fb8aa5a0b9", size = 1522927, upload-time = "2026-04-20T16:37:47.492Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/425dc1d21e0f17bdea0072fc463f662f7fa06d2852af52975c9eced3c07c/pymongo-4.17.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2a0d5ac205728c86e0a02192f1aa5f865b0d7d51f8df6101c01a69a7fc620d72", size = 1583468, upload-time = "2026-04-20T16:37:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9d/f08b07eeffda1a43c1759f0fa625e88ae12360996eb56d42aad832fa7dff/pymongo-4.17.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:485c8a8eaa4c739f00a331fc73757898ee7c092c214a79e63866ff76aaf282ff", size = 1572787, upload-time = "2026-04-20T16:37:51.061Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c2/6855a07aafa7b894929af23675b6fb9634800ce43122b76a62f6eeb8da2a/pymongo-4.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2dfcc795f5b9fedbe179a11fdf6051581479d196582a3fe819a92a00e9b9969", size = 1526184, upload-time = "2026-04-20T16:37:53.358Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/05/c952bac7db71c1942ea3559fcd308b49754cc5004b455935fb4000d1f37b/pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510", size = 852621, upload-time = "2026-04-20T16:37:55.28Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c0/c04da9f4c0c6252404598f4e394b862a58a9e866822a70ae261c8a018fdf/pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9", size = 867852, upload-time = "2026-04-20T16:37:57.233Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b2/c7b4870fbeef471e947d3e014676f5910d02e0197074d692ebcf24ec049a/pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae", size = 855019, upload-time = "2026-04-20T16:37:58.983Z" },
+    { url = "https://files.pythonhosted.org/packages/98/90/60bcb508840135d5ee46b51b1a950f548338aa8145a8366dbe6639ae51ac/pymongo-4.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53ffa94b2340dbf6b055e09a0090618c60482c158ecfc9565642fc996bf0944", size = 930529, upload-time = "2026-04-20T16:38:00.936Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e9/313840f1e52c6dfac47f704428cbfbce59956ebe7633bffc92b03f74f0ad/pymongo-4.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fe0de9d0f6791abce3471230b32b4817bf89d27b1182b6a550e1ec0fa72aa9a", size = 930665, upload-time = "2026-04-20T16:38:02.915Z" },
+    { url = "https://files.pythonhosted.org/packages/78/35/9d3565ea45b1606f635c1e2cd2563c28d66caafdc50f7ad7d979fcd1b363/pymongo-4.17.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e537e95514dae1aaa718f481ec03151a0f0394bcd05f1322896d8fc1330cb729", size = 1762369, upload-time = "2026-04-20T16:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ee/149b0d4b1a11c38bff6f14c23d5814c9b0843fd6dc38ad40596bdb1a62d2/pymongo-4.17.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37a8385c29881b43eab31f584100fa0eaddedd5607adf010147ba1810118be90", size = 1798044, upload-time = "2026-04-20T16:38:07.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d4/4cee4a7b8d8f6f0550ef6cd2fea42455c5ed619a220cb6ba4fb40d6a5bc8/pymongo-4.17.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f3ee3d241ed77a4fc99ce3cff3b289c3ebce37f61fdd7349d3592c23b82c8784", size = 1878567, upload-time = "2026-04-20T16:38:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ef/7fe366c84952619ee2f69973566c214775e083dd4df465751912153e4b72/pymongo-4.17.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9eb5d63a3c518cb0804ed678f5e2b875af032d89a7cf57a57360322cf6a4d222", size = 1864881, upload-time = "2026-04-20T16:38:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/b577d82c6d1be7aee7ac7e249bc86f7847998345042e5f8360de238e177b/pymongo-4.17.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e97e03fa13327c87e3fdc5656acd01e71817f0c1dc3221cd8f30de136bf4ec3", size = 1800349, upload-time = "2026-04-20T16:38:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/69/dafcf04f66e130ddd91aeb92e7a692480eda46dcd04ec1dbe82c06619e10/pymongo-4.17.0-cp312-cp312-win32.whl", hash = "sha256:6877214bff5f06f6884a9fc8d9016a4a7a5f51f537f5c51ac3a576f93e7dfb32", size = 900518, upload-time = "2026-04-20T16:38:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/11/35/5c9262a459f988b4eb2605f70815240b77a0d4131136c4326d18f1822b89/pymongo-4.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:9828485f72f63c7d802e0ec41f71906f633c2692621ab3af55ca990186b091b1", size = 920335, upload-time = "2026-04-20T16:38:17.665Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/e9c7265ee176faccf4e52c4797837e794d93569a1046f6b19a4acc36e5ad/pymongo-4.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:1195370a77baf003b59b10e91ecc4706297197f0dd9d29c840cc556dc08f7cee", size = 903289, upload-time = "2026-04-20T16:38:19.33Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/c1206879708b94e82fcd8b9653440ec271f79a3674d122192df383047f5a/pymongo-4.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:809ec74de3b9148ae43fa8df9faf53470f511c8d384f13b99d6f671f2a379f15", size = 985829, upload-time = "2026-04-20T16:38:21.031Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/bb044ed85160e5c40f568c7c4f4e8ea16f40764ff5d302e5befbe8f6f814/pymongo-4.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a431b737816bf4cddd4fa0fcef04e424ad36b7692734a64150f872fb8f3208be", size = 985899, upload-time = "2026-04-20T16:38:23.409Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0a/f6dfd5ea3901e5d6888da8de8ba728971a1d447debab681cfc56f90d1208/pymongo-4.17.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4fab10f8403169ce92f3cea921609d9ee81107306caae06c08f592d4b8ad2b5", size = 2028569, upload-time = "2026-04-20T16:38:25.343Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c5/081f59a1c02ae8c0dc73ae58e563838c44eec81aeafa7d0b93a637841c9b/pymongo-4.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20323b0b1c1d33770ad1fc68d429c757734ce9ad3594421c3d6618f10572b1b9", size = 2072916, upload-time = "2026-04-20T16:38:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/31/42/6e41d434297ffe8b30d9c3717916591a4a7be9075a0dcc2fafdfaaaa62ed/pymongo-4.17.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5a5de048e6da5c18e27cc2437e8c15b3b0cdc8385c15b41178b0caa3322a09c2", size = 2173234, upload-time = "2026-04-20T16:38:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cf/1e4a7db352ef9485831c7268dfe8402f0117b32a9ad54b16e810699e3617/pymongo-4.17.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dff3de1294fbbc1db0ba6b511f77b8e540601d092538a31312e99c8a91a78b1e", size = 2156784, upload-time = "2026-04-20T16:38:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/12/10/6195be29962a61ebb5f4bd9e4c7519890b172f7968a0a0d880398c6ddb02/pymongo-4.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faf03e4c2aafd6de626dbd30ba246d369ae33f47f10629d1bbe40f72115027a6", size = 2074446, upload-time = "2026-04-20T16:38:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/33410b8819837ed370c738587306bdf060b59cef11823be212f4a07703c5/pymongo-4.17.0-cp313-cp313-win32.whl", hash = "sha256:c9786665926a09630c5d420c79762cfadbff35a9438bcbc4c81a9fb5ab9228b7", size = 948435, upload-time = "2026-04-20T16:38:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/77/c0ed522f798a286b99acaa7914ed8d9c80ab091f97f57c59ffed72906e5e/pymongo-4.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:5960519b4d7168f1ecdd3ea10c81b2aedeb9423651aca953cfbc8e76705d3b38", size = 972847, upload-time = "2026-04-20T16:38:37.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f0/c39480a2db385fde23861d0c8acda41cdaf1d43e46579db72c5c013a2e81/pymongo-4.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:0ff6bd2f735ab5356541e3e57d5b7dbfbc3f2ee1ccb10b6b0f82d58af69d1d8e", size = 951575, upload-time = "2026-04-20T16:38:40.544Z" },
+    { url = "https://files.pythonhosted.org/packages/da/49/2b0250762a89737ed6f9cea238331baca061b89a8ddd10dd17fee52c3970/pymongo-4.17.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff5aa3f1c7e3f08eb0e7a016c91ba468b1850ccfd63d9b1f12f56350f4974cef", size = 1040945, upload-time = "2026-04-20T16:38:42.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1c/7a9b5447a08be20e84b6e5b17330917e8d6d9507daa3cd099a9309f11ad7/pymongo-4.17.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e816db649ba5d7de0568cf3a9f287a9dc9aad21cf0ca667ab156a7ef47fca0b0", size = 1041187, upload-time = "2026-04-20T16:38:45.358Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a1/71704f61632dfc90407a5834fe5f6132854937c4a3648f6c05c351d85a45/pymongo-4.17.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c4fded3a9f1d6a687e36ebd384ac6d00b9b00de1969aa74048e7051ec2a713", size = 2294806, upload-time = "2026-04-20T16:38:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b9/aff42be75108b96c2469b1d9329b912c15108f3e7ef32fdc86da8423c330/pymongo-4.17.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2db66aa8dd253a0fc1fad3b0d23d5b3993f7ebde02fbbd7727128debf2853675", size = 2348231, upload-time = "2026-04-20T16:38:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/30/44c115b8ba1479942c15fd9480eb29a7da0ba68acd56983423ba0deb4a94/pymongo-4.17.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3987e96e7c7be4083d42e8ac2cc6c0d5b78db9973c90fce42ae800b616ca6b20", size = 2467614, upload-time = "2026-04-20T16:38:52.665Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/84/21ee95c8bf0ca7acae7ec7eb365d740bf8fc0156c194baf2c3bdfcb85ec0/pymongo-4.17.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cee36b3c0d0354f880fa7a7fdcdaf2bb5e542c2281e25c1bfadf8cfe21eba7d2", size = 2445970, upload-time = "2026-04-20T16:38:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/06/89/081d7f1809d5ca09d1e47e49f2111b245f5694de3a7af32cd3a353a6f43f/pymongo-4.17.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:320b34457b20bbcc79997801f95d25ce00472915ca5241167242b42c4359e027", size = 2348605, upload-time = "2026-04-20T16:38:57.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c3/0d949f9d3f2a341c1f635c398c16615e96f89f51ff424ed81e914cf1a4de/pymongo-4.17.0-cp314-cp314-win32.whl", hash = "sha256:df4a644af9ae132d4bfdb2e9516ea51a615fd881caddfbfbd071cf1354844479", size = 1004119, upload-time = "2026-04-20T16:39:00.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/55/5c3a3db1048054c695c75c5964cc8bedc2247fdb5a75ef6fab4ec8bb013e/pymongo-4.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:c797f8a80957134f6dd9690367a0f8f5906d672119af2c6aa55f0c527b656bed", size = 1032314, upload-time = "2026-04-20T16:39:02.665Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/19/e235f39906134cb0ffd5574c5a59c355ef5380f0499644ab94994afbb109/pymongo-4.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:68fca71e05ee5da23a8d73cee8379dfb3d26e609a377cae731d742771ed96946", size = 1007627, upload-time = "2026-04-20T16:39:04.678Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/c4c1a86791415b14c684fa0908f9da96de91594a3fd1fa1b8dc689fbb800/pymongo-4.17.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b4384700cffc3f1dd98e088bc0072dedf6d7d68a230bb4b972665cf69c071c1e", size = 1099151, upload-time = "2026-04-20T16:39:06.969Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4b/69c67f3e23fd9b23b9bedc7ebd23754881cc9d5c5d5b2a9811e96b07f475/pymongo-4.17.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:93641192644fa1ee0f34030e774fd31022a27ad11ba22cb1716142231524f8bd", size = 1099346, upload-time = "2026-04-20T16:39:08.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/19/a5208f62f9508a26d73acc69bd3821b8c8adae253679a3c26d2f9652f0d5/pymongo-4.17.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:75bc3aa5b94fdb7138d357ec6ca61cd97e0c79f4f7f0bd3efe9639b15cc50942", size = 2619034, upload-time = "2026-04-20T16:39:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/77/27/426cba1ec5973082a56d4150798529bfdf4151c31391ed1fbbecb23ef2ac/pymongo-4.17.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e8f8e23c6df7c6d6929f5e734980b227706e73ee847517c9ba5af90f7fc466", size = 2689939, upload-time = "2026-04-20T16:39:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2e/f70993d1255e33f6ee59a4ec4371cc65bff7a7e3fda7d55c3386f25287e8/pymongo-4.17.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:15d3f3d732aecac1f8d481bde4029755615639bd3076f258a2147210aec8515a", size = 2824994, upload-time = "2026-04-20T16:39:16.057Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/eb/87b0e988ba889e1fcc3430c2cfc166b251872c813e92b43174298bee17ff/pymongo-4.17.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5f62862d0f87be481fa1fe8cb811994486773c94a2b61e509285e3f2890763", size = 2801745, upload-time = "2026-04-20T16:39:18.476Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4c/3f83412d086f682d4d468761d66ddc49cf161e786ea74073045eb4491c60/pymongo-4.17.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64837adbbd72073301af51bb0fc80e3d7707fe5527cea1033ba0320f0b2f881b", size = 2684636, upload-time = "2026-04-20T16:39:20.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/b75f6f4ab6c8beb50b0270a4f1e2530b5774f5e116563440e1677ca1820f/pymongo-4.17.0-cp314-cp314t-win32.whl", hash = "sha256:b93b22eedc62598cf5ee9d8c8007a8e9121c50fd88137012d8985500e9dc3151", size = 1056356, upload-time = "2026-04-20T16:39:22.996Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5e/648c8a238eef18a25ed8a169ea6542d4a860bbec3e95b3d9badac2935c71/pymongo-4.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3689ea34f6b647c7d1e7bdc60fcfb214b2789ed1359a7fb96569c69f50e5f18f", size = 1090964, upload-time = "2026-04-20T16:39:24.989Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cb/d9780b66939c4fc1f024bcc7be23a2abcfe06a9745ca8fa76dc73395482e/pymongo-4.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9543d8f84c2e5608565c08ac679774811e6730770d8a645439b073422a4276fb", size = 1058526, upload-time = "2026-04-20T16:39:27.924Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2163,6 +2284,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Implements #70 — the platform's MongoDB data layer (Beanie ODM), wired into the US-8.1 FastAPI app.

- **`ApiSettings`**: `mongodb_url`, `mongodb_db_name`, pool sizes, server-selection timeout (`ACEMUSIC_API_` prefix). Defaults to local; **Atlas `mongodb+srv://` for staging/prod via env**.
- **Beanie 2.x Document models**: `User` (unique `email`), `Workspace` (`user_id` idx, `is_default`), `Clip` (`workspace_id`/`user_id`/`created_at` idx, fields aligned with the CLI `Clip`), `Job` + `JobStatus` enum (`user_id`/`status` idx). `ALL_MODELS` registration.
- **`database.py`**: `init_db` connects via pymongo's native `AsyncMongoClient` with pooling, **pings to verify, raises `ConnectionError` fail-fast**, then `init_beanie`. `close_db`. Credentials redacted from all logs/errors.
- **`main.py`**: FastAPI **lifespan** connects on startup / closes on shutdown; each app owns its client (`app.state.mongo_client`).
- **CI**: `mongo:7` service + a dedicated `pytest -m integration` step.
- **Tests**: real-local-Mongo integration tests (no mocking) with an **isolated throwaway DB** and a **localhost-only guard** (rejects `mongodb+srv://` and any remote replica-set member); plus unit tests for the guard + credential redaction. `pytest-asyncio` (auto mode).

## Acceptance Criteria
- [x] Connects to MongoDB on startup and logs success
- [x] If MongoDB is down, exits with a clear error (fail-fast `ConnectionError`, not a silent hang)
- [x] Collections created with defined indexes on first run
- [x] CRUD operations on each collection work from test fixtures

## Test Plan
- [x] TDD: integration tests written first (`test_mongodb.py`), then unit safety tests (`test_mongo_safety.py`)
- [x] 693 passing locally (8 Mongo integration + 6 safety unit + existing); lint + format clean
- [x] Mutation sanity check: unique-email, clip index, fail-fast, and host-guard mutations each fail the right test
- [x] Cross-family review: **codex** — 5 findings across 3 passes, all fixed except one rebutted (below)

### codex findings resolved
- Lifespan owns/closes its own client (not a process-global) [P2 → fixed]
- Credentials redacted in logs + errors [P2 → fixed]
- Local-only test guard checks **every** host + rejects SRV [P1 → fixed]
- Close client if `init_beanie` fails after a good ping [P2 → fixed]

## Known Limitations / Intentionally Deferred
- **Fail-fast on startup when Mongo is unreachable is intentional** (codex flagged the app being "unstartable" without Mongo). This is the explicit US-8.2 contract: FR *"Startup verifies connectivity; fails fast if MongoDB is unreachable"* and AC *"If MongoDB is down, the app exits with a clear error."* From Stage 8.2 on, MongoDB is a hard dependency; serving `/health` while the DB is down would misreport health. **Rebuttal: required behavior, not a regression.**
- **"Seed default workspace on user creation"** → deferred to **US-8.4** (no user-creation flow yet); `Workspace.is_default` is modeled.
- **Motor not used**: Beanie 2.x uses pymongo's native async client; Motor is deprecated. Same async-driver-with-pooling outcome as the spec's "Motor" wording.
- No repository/service abstraction — Beanie Document CRUD used directly (YAGNI).

## Implementation Notes
- Extends the existing `ApiSettings` rather than adding a parallel config module (the issue's CodeRabbit coding plan predated US-8.1).
- Beanie's `init_beanie` binds Document classes to one database per process; the module-level connection handle reflects this (documented in `database.py`).

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MongoDB-backed data layer with persistent models for users, workspaces, clips, and jobs
  * App startup/shutdown now initializes and tears down the database connection

* **Tests**
  * Integration tests for DB init, indexes, CRUD, and job lifecycle
  * Safety tests enforcing local-only test DB usage and URL redaction
  * App factory logging behavior covered by unit test

* **Chores**
  * CI updated to run MongoDB-backed integration tests; env/config and deps added
* **Documentation**
  * README and architecture notes updated with DB requirements and startup behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->