### PR TITLE
docs: ACESTEP_INIT_LLM=false for <16GB GPUs + test/key cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ ACESTEP_LOCAL_URL=http://localhost:8001
 # API key securing the ACE-Step server process itself
 ACESTEP_API_KEY=
 
+# ACE-Step LLM (CoT) initialization. On GPUs with < ~16GB VRAM, auto-enabling the
+# LLM leaves no room for its KV cache and every generation fails with
+# "Insufficient KV cache to schedule sequence". Set to false to run DiT-only
+# (fast, reliable on 8GB; CoT caption/language features are auto-disabled).
+# Values: auto (default, GPU-detected) | true | false
+ACESTEP_INIT_LLM=
+
 # RunPod management API key (for starting/stopping remote GPU pods)
 RUNPOD_API_KEY=
 

--- a/model-deployment.md
+++ b/model-deployment.md
@@ -87,9 +87,31 @@ pip3 install torch torchvision torchaudio --index-url https://download.pytorch.o
 uv run acestep-api
 
 # Server listens on http://localhost:8001
-# Optional: set API key for security
-export ACESTEP_API_KEY=108030f6e31f4e8694b2d8d534854137
+# Optional: set API key for security (use your own; keep it out of version control)
+export ACESTEP_API_KEY=<your-api-key>
 ```
+
+#### 2.4.1 LLM (CoT) on low-VRAM GPUs — disable on < 16GB
+
+On GPUs below ~16GB VRAM (e.g. an RTX 4070 Laptop, 8GB), ACE-Step's GPU
+auto-detection still enables the LLM (chain-of-thought) path, but after loading
+the DiT + LLM models there is effectively **0 GB left for the LLM's KV cache**.
+Every generation then fails immediately with:
+
+```
+RuntimeError: Insufficient KV cache to schedule sequence. Free blocks: 1/1, blocks needed: 2 …
+[API Server] Job … FAILED: Music generation failed
+```
+
+**Fix:** force DiT-only generation by disabling the LLM. DiT-only on 8GB
+generates a 30s clip in ~5–7s; CoT caption/language features are auto-disabled.
+
+```bash
+ACESTEP_INIT_LLM=false uv run acestep-api   # or set ACESTEP_INIT_LLM=false in .env
+```
+
+This is also documented in the acemusic `.env.example`. Note that LLM-enabled
+generation (CoT) requires a larger GPU; on 8GB it is not viable.
 
 ### 2.5 Multi-Model Configuration
 
@@ -392,7 +414,7 @@ Request arrives at Platform API
 
 ```bash
 # .env additions for hybrid mode
-ACEMUSIC_API_KEY=108030f6e31f4e8694b2d8d534854137
+ACEMUSIC_API_KEY=<your-api-key>
 ACEMUSIC_BASE_URL=https://api.acemusic.ai
 
 # Local ACE-Step server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,11 @@ def ace_server():
     # (before main() runs), so the --api-key flag has no effect on _api_key.
     # Instead, set ACESTEP_API_KEY in the subprocess env directly.
     # If api_key is empty we strip it entirely so _api_key stays None (auth disabled).
+    #
+    # The server inherits the full environment (including ACESTEP_INIT_LLM) via the
+    # copy below. On < 16GB GPUs set ACESTEP_INIT_LLM=false in .env.local so the
+    # auto-started server runs DiT-only; otherwise the LLM auto-enables and every
+    # generation fails with "Insufficient KV cache" (see model-deployment.md 2.4.1).
     server_env = os.environ.copy()
     if api_key:
         server_env["ACESTEP_API_KEY"] = api_key

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -188,7 +188,7 @@ class TestGenerateCommand:
         """Integration: generate against a real ACE-Step server (prefers ACESTEP_LOCAL_URL)."""
         result = runner.invoke(
             app,
-            ["generate", "upbeat pop", "--output", str(tmp_path), "--num-clips", "1", "--duration", "15"],
+            ["generate", "upbeat pop", "--output", str(tmp_path), "--num-clips", "1", "--duration", "30"],
             env={"ACEMUSIC_BASE_URL": integration_url},
         )
         assert result.exit_code == 0, result.output
@@ -212,7 +212,7 @@ class TestGenerateCommand:
                 "--num-clips",
                 "1",
                 "--duration",
-                "15",
+                "30",
             ],
             env={"ACEMUSIC_BASE_URL": integration_url},
         )
@@ -227,7 +227,7 @@ class TestGenerateCommand:
         new_dir = tmp_path / "auto-created"
         result = runner.invoke(
             app,
-            ["generate", "upbeat pop", "--output", str(new_dir), "--num-clips", "1", "--duration", "15"],
+            ["generate", "upbeat pop", "--output", str(new_dir), "--num-clips", "1", "--duration", "30"],
             env={"ACEMUSIC_BASE_URL": integration_url},
         )
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary
Follow-up from the US-8.2 work and an ACE-Step server debugging session. Documents the real operational fix for low-VRAM GPUs and cleans up two test/doc nits.

Root cause we found: on < ~16GB GPUs (e.g. RTX 4070 Laptop 8GB), ACE-Step auto-enables the LLM (CoT) but has **no room left for the LLM KV cache**, so every generation fails with `Insufficient KV cache to schedule sequence`. Disabling the LLM (`ACESTEP_INIT_LLM=false`) makes DiT-only generation work in ~5–7s for a 30s clip (verified live).

## Changes
- **`.env.example`** — document `ACESTEP_INIT_LLM` (set `false` on <16GB GPUs).
- **`model-deployment.md` §2.4.1** — record the 8GB LLM/KV-cache failure + the DiT-only fix, with the exact error and command.
- **`tests/test_generate.py`** — integration generate tests use `--duration 30` instead of `15` (the CLI clamps 15→30 and explicitly warns to update; this removes the warning).
- **`tests/conftest.py`** — note that the auto-started ACE-Step server inherits `ACESTEP_INIT_LLM` from the environment (so `.env.local` controls it).
- **Security:** redact a real ACE-Step API key that was hardcoded in `model-deployment.md` (two spots) → `<your-api-key>`.

## Test Plan
- [x] Unit suite: 694 passed, 1 skipped, 15 integration deselected
- [x] `ruff` + `black` clean
- [x] No secret value remains in tracked files (verified)
- [x] Live verification: with `ACESTEP_INIT_LLM=false`, `generate_live_server` passes in ~7s (DiT-only)

## Known limitations
- Does not make the *heavy* integration suite pass on 8GB — running `cover` + multiple generations back-to-back still saturates an 8GB GPU (CPU-offload thrashing). That's an ACE-Step capacity ceiling on this hardware, not acemusic code.
- The redacted key still exists in `main`'s git history (committed long ago); fully purging it would require rewriting default-branch history (out of scope here).

## Notes
- The `--duration` change does not affect CI (integration tests are deselected there; they require a live ACE-Step server).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added `ACESTEP_INIT_LLM` environment variable to control LLM initialization behavior
  * Added guidance for low-VRAM GPUs to disable LLM mode to avoid KV-cache issues

* **Documentation**
  * Updated deployment documentation with API key setup instructions
  * Removed hardcoded API keys from examples

* **Tests**
  * Updated test duration parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->