### PR TITLE
fix: retry transient errors while polling generation status

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -249,8 +249,75 @@ def _is_connection_error(exc: AceStepError) -> bool:
     """Return True if the AceStepError is a connection/timeout failure (not an API error)."""
     msg = str(exc).lower()
     return any(
-        keyword in msg for keyword in ("connection refused", "connect", "timeout", "unreachable", "name or service")
+        keyword in msg
+        # "timed out" and "timeout" are distinct substrings: httpx renders read/
+        # connect timeouts as "timed out", so both must be matched.
+        for keyword in ("connection refused", "connect", "timeout", "timed out", "unreachable", "name or service")
     )
+
+
+_MAX_CONSECUTIVE_POLL_ERRORS = 5
+
+
+def _poll_until_complete(
+    ace_client: AceStepClient,
+    task_id: str,
+    status_bar,
+    label: str,
+    poll_timeout: float,
+    poll_interval: float = 2.0,
+) -> dict:
+    """Poll ``query_result`` until the task completes; return the result dict.
+
+    Transient connection/timeout errors (e.g. the server briefly blocking while it
+    loads models on a cold start) are tolerated and retried within the overall
+    ``poll_timeout`` budget, rather than aborting the whole job on a single blip.
+    A genuine API error aborts immediately, and a run of consecutive connection
+    failures (``_MAX_CONSECUTIVE_POLL_ERRORS``) aborts so a truly-down server fails
+    fast instead of waiting out the full budget.
+
+    Raises ``typer.Exit(code=1)`` on timeout, reported failure, or abort.
+    """
+    start = time.monotonic()
+    consecutive_errors = 0
+    while True:
+        elapsed = time.monotonic() - start
+        if elapsed >= poll_timeout:
+            console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
+            raise typer.Exit(code=1)
+
+        try:
+            result = ace_client.query_result(task_id)
+            consecutive_errors = 0
+        except AceStepError as exc:
+            if _is_connection_error(exc):
+                consecutive_errors += 1
+                if consecutive_errors >= _MAX_CONSECUTIVE_POLL_ERRORS:
+                    console.print(
+                        f"[red]Error polling status after {consecutive_errors} consecutive "
+                        f"connection failures: {exc}[/red]"
+                    )
+                    raise typer.Exit(code=1)
+                status_bar.update(
+                    f"[bold green]{label}… ({elapsed:.0f}s) — waiting for server "
+                    f"(retry {consecutive_errors}/{_MAX_CONSECUTIVE_POLL_ERRORS})[/bold green]"
+                )
+                time.sleep(poll_interval)
+                continue
+            console.print(f"[red]Error polling status: {exc}[/red]")
+            raise typer.Exit(code=1)
+
+        job_status = result.get("status", "unknown")
+        status_bar.update(f"[bold green]{label}… ({elapsed:.0f}s) — {job_status}[/bold green]")
+
+        if job_status == "completed":
+            return result
+        if job_status == "failed":
+            error_msg = result.get("error", "unknown error")
+            console.print(f"[red]Generation failed: {error_msg}[/red]")
+            raise typer.Exit(code=1)
+
+        time.sleep(poll_interval)
 
 
 _VALID_TIME_SIGNATURES = {"4/4", "3/4", "6/8", "5/4", "7/8"}
@@ -631,32 +698,8 @@ def _generate_via_ace_step(
     )
     console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
 
-    start = time.monotonic()
-    result: dict = {}
     with console.status("[bold green]Generating…[/bold green]", spinner="dots") as status:
-        while True:
-            elapsed = time.monotonic() - start
-            if elapsed >= poll_timeout:
-                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                raise typer.Exit(code=1)
-
-            try:
-                result = ace_client.query_result(task_id)
-            except AceStepError as exc:
-                console.print(f"[red]Error polling status: {exc}[/red]")
-                raise typer.Exit(code=1)
-
-            job_status = result.get("status", "unknown")
-            status.update(f"[bold green]Generating… ({elapsed:.0f}s) — {job_status}[/bold green]")
-
-            if job_status == "completed":
-                break
-            if job_status == "failed":
-                error_msg = result.get("error", "unknown error")
-                console.print(f"[red]Generation failed: {error_msg}[/red]")
-                raise typer.Exit(code=1)
-
-            time.sleep(poll_interval)
+        result = _poll_until_complete(ace_client, task_id, status, "Generating", poll_timeout, poll_interval)
 
     audio_urls: list[str] = result.get("audio_urls", [])
     for i, url in enumerate(audio_urls, start=1):
@@ -904,32 +947,8 @@ def _sounds_via_ace_step(
     )
     console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
 
-    start = time.monotonic()
-    result: dict = {}
     with console.status("[bold green]Generating…[/bold green]", spinner="dots") as status:
-        while True:
-            elapsed = time.monotonic() - start
-            if elapsed >= poll_timeout:
-                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                raise typer.Exit(code=1)
-
-            try:
-                result = ace_client.query_result(task_id)
-            except AceStepError as exc:
-                console.print(f"[red]Error polling status: {exc}[/red]")
-                raise typer.Exit(code=1)
-
-            job_status = result.get("status", "unknown")
-            status.update(f"[bold green]Generating… ({elapsed:.0f}s) — {job_status}[/bold green]")
-
-            if job_status == "completed":
-                break
-            if job_status == "failed":
-                error_msg = result.get("error", "unknown error")
-                console.print(f"[red]Generation failed: {error_msg}[/red]")
-                raise typer.Exit(code=1)
-
-            time.sleep(poll_interval)
+        result = _poll_until_complete(ace_client, task_id, status, "Generating", poll_timeout, poll_interval)
 
     audio_urls: list[str] = result.get("audio_urls", [])
     for i, url in enumerate(audio_urls, start=1):
@@ -2080,28 +2099,8 @@ def extend(
 
         poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
         poll_interval = 2.0
-        start = time.monotonic()
-        result: dict = {}
         with console.status("[bold green]Extending\u2026[/bold green]", spinner="dots") as status_bar:
-            while True:
-                elapsed = time.monotonic() - start
-                if elapsed >= poll_timeout:
-                    console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                    raise typer.Exit(code=1)
-                try:
-                    result = ace_client.query_result(task_id)
-                except AceStepError as exc:
-                    console.print(f"[red]Error polling status: {exc}[/red]")
-                    raise typer.Exit(code=1)
-                job_status = result.get("status", "unknown")
-                status_bar.update(f"[bold green]Extending\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]")
-                if job_status == "completed":
-                    break
-                if job_status == "failed":
-                    error_msg = result.get("error", "unknown error")
-                    console.print(f"[red]Generation failed: {error_msg}[/red]")
-                    raise typer.Exit(code=1)
-                time.sleep(poll_interval)
+            result = _poll_until_complete(ace_client, task_id, status_bar, "Extending", poll_timeout, poll_interval)
 
         audio_urls: list[str] = result.get("audio_urls", [])
         if not audio_urls:
@@ -2251,30 +2250,10 @@ def _generate_section(
 
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
     poll_interval = 2.0
-    start = time.monotonic()
-    result: dict = {}
     with console.status(f"[bold green]Generating {section.name}\u2026[/bold green]", spinner="dots") as status_bar:
-        while True:
-            elapsed = time.monotonic() - start
-            if elapsed >= poll_timeout:
-                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds on {section.name!r}.[/red]")
-                raise typer.Exit(code=1)
-            try:
-                result = ace_client.query_result(task_id)
-            except AceStepError as exc:
-                console.print(f"[red]Error polling status for {section.name!r}: {exc}[/red]")
-                raise typer.Exit(code=1)
-            job_status = result.get("status", "unknown")
-            status_bar.update(
-                f"[bold green]Generating {section.name}\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]"
-            )
-            if job_status == "completed":
-                break
-            if job_status == "failed":
-                error_msg = result.get("error", "unknown error")
-                console.print(f"[red]Generation failed on section {section.name!r}: {error_msg}[/red]")
-                raise typer.Exit(code=1)
-            time.sleep(poll_interval)
+        result = _poll_until_complete(
+            ace_client, task_id, status_bar, f"Generating {section.name}", poll_timeout, poll_interval
+        )
 
     audio_urls: list[str] = result.get("audio_urls", [])
     if not audio_urls:
@@ -2513,28 +2492,8 @@ def cover(
 
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
     poll_interval = 2.0
-    start = time.monotonic()
-    result: dict = {}  # set below by the polling loop; initialized to satisfy mypy/lint on the post-loop read
     with console.status("[bold green]Covering\u2026[/bold green]", spinner="dots") as status_bar:
-        while True:
-            elapsed = time.monotonic() - start
-            if elapsed >= poll_timeout:
-                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                raise typer.Exit(code=1)
-            try:
-                result = ace_client.query_result(task_id)
-            except AceStepError as exc:
-                console.print(f"[red]Error polling status: {exc}[/red]")
-                raise typer.Exit(code=1)
-            job_status = result.get("status", "unknown")
-            status_bar.update(f"[bold green]Covering\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]")
-            if job_status == "completed":
-                break
-            if job_status == "failed":
-                error_msg = result.get("error", "unknown error")
-                console.print(f"[red]Cover failed: {error_msg}[/red]")
-                raise typer.Exit(code=1)
-            time.sleep(poll_interval)
+        result = _poll_until_complete(ace_client, task_id, status_bar, "Covering", poll_timeout, poll_interval)
 
     audio_urls: list[str] = result.get("audio_urls", [])
     if not audio_urls:
@@ -2714,28 +2673,8 @@ def repaint(
 
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
     poll_interval = 2.0
-    poll_start = time.monotonic()
-    result: dict = {}
     with console.status("[bold green]Repainting\u2026[/bold green]", spinner="dots") as status_bar:
-        while True:
-            elapsed = time.monotonic() - poll_start
-            if elapsed >= poll_timeout:
-                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                raise typer.Exit(code=1)
-            try:
-                result = ace_client.query_result(task_id)
-            except AceStepError as exc:
-                console.print(f"[red]Error polling status: {exc}[/red]")
-                raise typer.Exit(code=1)
-            job_status = result.get("status", "unknown")
-            status_bar.update(f"[bold green]Repainting\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]")
-            if job_status == "completed":
-                break
-            if job_status == "failed":
-                error_msg = result.get("error", "unknown error")
-                console.print(f"[red]Repaint failed: {error_msg}[/red]")
-                raise typer.Exit(code=1)
-            time.sleep(poll_interval)
+        result = _poll_until_complete(ace_client, task_id, status_bar, "Repainting", poll_timeout, poll_interval)
 
     audio_urls: list[str] = result.get("audio_urls", [])
     if not audio_urls:
@@ -2917,28 +2856,8 @@ def add_vocal(
 
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
     poll_interval = 2.0
-    poll_start = time.monotonic()
-    result: dict = {}
     with console.status("[bold green]Adding vocal\u2026[/bold green]", spinner="dots") as status_bar:
-        while True:
-            elapsed = time.monotonic() - poll_start
-            if elapsed >= poll_timeout:
-                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                raise typer.Exit(code=1)
-            try:
-                result = ace_client.query_result(task_id)
-            except AceStepError as exc:
-                console.print(f"[red]Error polling status: {exc}[/red]")
-                raise typer.Exit(code=1)
-            job_status = result.get("status", "unknown")
-            status_bar.update(f"[bold green]Adding vocal\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]")
-            if job_status == "completed":
-                break
-            if job_status == "failed":
-                error_msg = result.get("error", "unknown error")
-                console.print(f"[red]Add-vocal failed: {error_msg}[/red]")
-                raise typer.Exit(code=1)
-            time.sleep(poll_interval)
+        result = _poll_until_complete(ace_client, task_id, status_bar, "Adding vocal", poll_timeout, poll_interval)
 
     audio_urls: list[str] = result.get("audio_urls", [])
     if not audio_urls:
@@ -3126,28 +3045,8 @@ def replace(
 
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
     poll_interval = 2.0
-    poll_start = time.monotonic()
-    result: dict = {}
     with console.status("[bold green]Replacing section\u2026[/bold green]", spinner="dots") as status_bar:
-        while True:
-            elapsed = time.monotonic() - poll_start
-            if elapsed >= poll_timeout:
-                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                raise typer.Exit(code=1)
-            try:
-                result = ace_client.query_result(task_id)
-            except AceStepError as exc:
-                console.print(f"[red]Error polling status: {exc}[/red]")
-                raise typer.Exit(code=1)
-            job_status = result.get("status", "unknown")
-            status_bar.update(f"[bold green]Replacing section\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]")
-            if job_status == "completed":
-                break
-            if job_status == "failed":
-                error_msg = result.get("error", "unknown error")
-                console.print(f"[red]Replace failed: {error_msg}[/red]")
-                raise typer.Exit(code=1)
-            time.sleep(poll_interval)
+        result = _poll_until_complete(ace_client, task_id, status_bar, "Replacing section", poll_timeout, poll_interval)
 
     audio_urls: list[str] = result.get("audio_urls", [])
     if not audio_urls:
@@ -3421,28 +3320,8 @@ def mashup(
 
         poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
         poll_interval = 2.0
-        poll_start = time.monotonic()
-        result: dict = {}
         with console.status("[bold green]Mashing up\u2026[/bold green]", spinner="dots") as status_bar:
-            while True:
-                elapsed = time.monotonic() - poll_start
-                if elapsed >= poll_timeout:
-                    console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                    raise typer.Exit(code=1)
-                try:
-                    result = ace_client.query_result(task_id)
-                except AceStepError as exc:
-                    console.print(f"[red]Error polling status: {exc}[/red]")
-                    raise typer.Exit(code=1)
-                job_status = result.get("status", "unknown")
-                status_bar.update(f"[bold green]Mashing up\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]")
-                if job_status == "completed":
-                    break
-                if job_status == "failed":
-                    error_msg = result.get("error", "unknown error")
-                    console.print(f"[red]Mashup failed: {error_msg}[/red]")
-                    raise typer.Exit(code=1)
-                time.sleep(poll_interval)
+            result = _poll_until_complete(ace_client, task_id, status_bar, "Mashing up", poll_timeout, poll_interval)
 
         audio_urls: list[str] = result.get("audio_urls", [])
         if not audio_urls:
@@ -3777,30 +3656,10 @@ def _generate_sample_via_ace_step(
 
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
     poll_interval = 2.0
-    start_time = time.monotonic()
-    result: dict = {}
     with console.status("[bold green]Generating sample track\u2026[/bold green]", spinner="dots") as status_bar:
-        while True:
-            elapsed = time.monotonic() - start_time
-            if elapsed >= poll_timeout:
-                console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
-                raise typer.Exit(code=1)
-            try:
-                result = ace_client.query_result(task_id)
-            except AceStepError as exc:
-                console.print(f"[red]Error polling status: {exc}[/red]")
-                raise typer.Exit(code=1)
-            job_status = result.get("status", "unknown")
-            status_bar.update(
-                f"[bold green]Generating sample track\u2026 ({elapsed:.0f}s) \u2014 {job_status}[/bold green]"
-            )
-            if job_status == "completed":
-                break
-            if job_status == "failed":
-                error_msg = result.get("error", "unknown error")
-                console.print(f"[red]Generation failed: {error_msg}[/red]")
-                raise typer.Exit(code=1)
-            time.sleep(poll_interval)
+        result = _poll_until_complete(
+            ace_client, task_id, status_bar, "Generating sample track", poll_timeout, poll_interval
+        )
 
     audio_urls: list[str] = result.get("audio_urls", [])
     if not audio_urls:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -269,17 +269,21 @@ def _poll_until_complete(
 ) -> dict:
     """Poll ``query_result`` until the task completes; return the result dict.
 
-    Transient connection/timeout errors (e.g. the server briefly blocking while it
-    loads models on a cold start) are tolerated and retried within the overall
-    ``poll_timeout`` budget, rather than aborting the whole job on a single blip.
-    A genuine API error aborts immediately, and a run of consecutive connection
-    failures (``_MAX_CONSECUTIVE_POLL_ERRORS``) aborts so a truly-down server fails
-    fast instead of waiting out the full budget.
+    Retry policy for transient poll failures:
+
+    - **Timeouts** mean the server is reachable but slow (e.g. blocking while it
+      loads models on a cold start). These are retried for the *full*
+      ``poll_timeout`` budget — they must not abort a legitimately long warmup.
+    - **Hard connection failures** (refused/unreachable) mean the server is
+      likely down, so after ``_MAX_CONSECUTIVE_POLL_ERRORS`` consecutive ones we
+      fail fast instead of waiting out the whole budget. A single successful poll
+      (or a timeout) resets the counter.
+    - A **genuine API error** aborts immediately.
 
     Raises ``typer.Exit(code=1)`` on timeout, reported failure, or abort.
     """
     start = time.monotonic()
-    consecutive_errors = 0
+    consecutive_conn_failures = 0
     while True:
         elapsed = time.monotonic() - start
         if elapsed >= poll_timeout:
@@ -288,20 +292,22 @@ def _poll_until_complete(
 
         try:
             result = ace_client.query_result(task_id)
-            consecutive_errors = 0
+            consecutive_conn_failures = 0
         except AceStepError as exc:
             if _is_connection_error(exc):
-                consecutive_errors += 1
-                if consecutive_errors >= _MAX_CONSECUTIVE_POLL_ERRORS:
-                    console.print(
-                        f"[red]Error polling status after {consecutive_errors} consecutive "
-                        f"connection failures: {exc}[/red]"
-                    )
-                    raise typer.Exit(code=1)
-                status_bar.update(
-                    f"[bold green]{label}… ({elapsed:.0f}s) — waiting for server "
-                    f"(retry {consecutive_errors}/{_MAX_CONSECUTIVE_POLL_ERRORS})[/bold green]"
-                )
+                msg = str(exc).lower()
+                if "timed out" in msg or "timeout" in msg:
+                    # Server is reachable but slow — keep polling within the budget.
+                    consecutive_conn_failures = 0
+                else:
+                    consecutive_conn_failures += 1
+                    if consecutive_conn_failures >= _MAX_CONSECUTIVE_POLL_ERRORS:
+                        console.print(
+                            f"[red]Error polling status after {consecutive_conn_failures} consecutive "
+                            f"connection failures: {exc}[/red]"
+                        )
+                        raise typer.Exit(code=1)
+                status_bar.update(f"[bold green]{label}… ({elapsed:.0f}s) — waiting for server…[/bold green]")
                 time.sleep(poll_interval)
                 continue
             console.print(f"[red]Error polling status: {exc}[/red]")

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -34,7 +34,7 @@ from acemusic.audio import (
     remaster_audio,
     time_stretch_audio,
 )
-from acemusic.client import AceStepClient, AceStepError
+from acemusic.client import AceStepClient, AceStepConnectionError, AceStepError
 from acemusic.config import load_config
 from acemusic.daw_export import build_daw_bundle, export_midi, export_stems, project_slug
 from acemusic.db import (
@@ -293,23 +293,25 @@ def _poll_until_complete(
         try:
             result = ace_client.query_result(task_id)
             consecutive_conn_failures = 0
+        except AceStepConnectionError as exc:
+            # Transport failure (classified by exception type, not message text, so a
+            # 500 whose body mentions "connection" is never mistaken for one).
+            if exc.is_timeout:
+                # Server is reachable but slow — keep polling within the budget.
+                consecutive_conn_failures = 0
+            else:
+                consecutive_conn_failures += 1
+                if consecutive_conn_failures >= _MAX_CONSECUTIVE_POLL_ERRORS:
+                    console.print(
+                        f"[red]Error polling status after {consecutive_conn_failures} consecutive "
+                        f"connection failures: {exc}[/red]"
+                    )
+                    raise typer.Exit(code=1)
+            status_bar.update(f"[bold green]{label}… ({elapsed:.0f}s) — waiting for server…[/bold green]")
+            time.sleep(poll_interval)
+            continue
         except AceStepError as exc:
-            if _is_connection_error(exc):
-                msg = str(exc).lower()
-                if "timed out" in msg or "timeout" in msg:
-                    # Server is reachable but slow — keep polling within the budget.
-                    consecutive_conn_failures = 0
-                else:
-                    consecutive_conn_failures += 1
-                    if consecutive_conn_failures >= _MAX_CONSECUTIVE_POLL_ERRORS:
-                        console.print(
-                            f"[red]Error polling status after {consecutive_conn_failures} consecutive "
-                            f"connection failures: {exc}[/red]"
-                        )
-                        raise typer.Exit(code=1)
-                status_bar.update(f"[bold green]{label}… ({elapsed:.0f}s) — waiting for server…[/bold green]")
-                time.sleep(poll_interval)
-                continue
+            # Genuine API/HTTP error — surface it immediately.
             console.print(f"[red]Error polling status: {exc}[/red]")
             raise typer.Exit(code=1)
 

--- a/src/acemusic/client.py
+++ b/src/acemusic/client.py
@@ -24,6 +24,21 @@ class AceStepError(Exception):
     """Raised when the ACE-Step API returns an error or is unreachable."""
 
 
+class AceStepConnectionError(AceStepError):
+    """Transport-level failure (connection refused, DNS failure, timeout).
+
+    Distinct from API/HTTP-status errors so callers can retry transient network
+    issues without masking a real server-side error (e.g. a 500 whose body
+    happens to mention "connection"). ``is_timeout`` is True when the underlying
+    failure was an httpx timeout — the server is reachable but slow (e.g. loading
+    models on a cold start) rather than down.
+    """
+
+    def __init__(self, message: str, *, is_timeout: bool = False) -> None:
+        super().__init__(message)
+        self.is_timeout = is_timeout
+
+
 class AceStepClient:
     """Reusable HTTP client for the ACE-Step API."""
 
@@ -185,7 +200,9 @@ class AceStepClient:
         except httpx.HTTPStatusError as exc:
             raise AceStepError(f"Submit failed: {exc.response.status_code} {exc.response.text}") from exc
         except httpx.RequestError as exc:
-            raise AceStepError(f"Submit failed: {exc}") from exc
+            raise AceStepConnectionError(
+                f"Submit failed: {exc}", is_timeout=isinstance(exc, httpx.TimeoutException)
+            ) from exc
 
     def query_result(self, task_id: str, timeout: float = 10.0) -> dict:
         """Poll POST /query_result for task status and return a normalised result dict.
@@ -236,7 +253,9 @@ class AceStepClient:
         except httpx.HTTPStatusError as exc:
             raise AceStepError(f"Query failed: {exc.response.status_code} {exc.response.text}") from exc
         except httpx.RequestError as exc:
-            raise AceStepError(f"Query failed: {exc}") from exc
+            raise AceStepConnectionError(
+                f"Query failed: {exc}", is_timeout=isinstance(exc, httpx.TimeoutException)
+            ) from exc
 
     def download_audio(self, url: str, timeout: float = 120.0) -> bytes:
         """Download raw audio bytes from a URL.
@@ -251,4 +270,6 @@ class AceStepClient:
         except httpx.HTTPStatusError as exc:
             raise AceStepError(f"Download failed: {exc.response.status_code}") from exc
         except httpx.RequestError as exc:
-            raise AceStepError(f"Download failed: {exc}") from exc
+            raise AceStepConnectionError(
+                f"Download failed: {exc}", is_timeout=isinstance(exc, httpx.TimeoutException)
+            ) from exc

--- a/src/acemusic/client.py
+++ b/src/acemusic/client.py
@@ -29,9 +29,10 @@ class AceStepConnectionError(AceStepError):
 
     Distinct from API/HTTP-status errors so callers can retry transient network
     issues without masking a real server-side error (e.g. a 500 whose body
-    happens to mention "connection"). ``is_timeout`` is True when the underlying
-    failure was an httpx timeout — the server is reachable but slow (e.g. loading
-    models on a cold start) rather than down.
+    happens to mention "connection"). ``is_timeout`` is True only for a *read*
+    timeout — the connection was established but the server was slow to respond
+    (e.g. loading models on a cold start). Connect timeouts and refused/DNS
+    failures leave it False so an unreachable host still fast-fails.
     """
 
     def __init__(self, message: str, *, is_timeout: bool = False) -> None:
@@ -201,7 +202,7 @@ class AceStepClient:
             raise AceStepError(f"Submit failed: {exc.response.status_code} {exc.response.text}") from exc
         except httpx.RequestError as exc:
             raise AceStepConnectionError(
-                f"Submit failed: {exc}", is_timeout=isinstance(exc, httpx.TimeoutException)
+                f"Submit failed: {exc}", is_timeout=isinstance(exc, httpx.ReadTimeout)
             ) from exc
 
     def query_result(self, task_id: str, timeout: float = 10.0) -> dict:
@@ -253,9 +254,7 @@ class AceStepClient:
         except httpx.HTTPStatusError as exc:
             raise AceStepError(f"Query failed: {exc.response.status_code} {exc.response.text}") from exc
         except httpx.RequestError as exc:
-            raise AceStepConnectionError(
-                f"Query failed: {exc}", is_timeout=isinstance(exc, httpx.TimeoutException)
-            ) from exc
+            raise AceStepConnectionError(f"Query failed: {exc}", is_timeout=isinstance(exc, httpx.ReadTimeout)) from exc
 
     def download_audio(self, url: str, timeout: float = 120.0) -> bytes:
         """Download raw audio bytes from a URL.
@@ -271,5 +270,5 @@ class AceStepClient:
             raise AceStepError(f"Download failed: {exc.response.status_code}") from exc
         except httpx.RequestError as exc:
             raise AceStepConnectionError(
-                f"Download failed: {exc}", is_timeout=isinstance(exc, httpx.TimeoutException)
+                f"Download failed: {exc}", is_timeout=isinstance(exc, httpx.ReadTimeout)
             ) from exc

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -148,11 +148,33 @@ class TestGenerateCommand:
         assert client_mock.query_result.call_count == 3
         assert len(list(tmp_path.glob("*.wav"))) == 2
 
-    def test_generate_aborts_after_persistent_poll_errors(self, monkeypatch, tmp_path):
-        """Persistent connection failures abort (don't hang for the whole budget)."""
+    def test_generate_keeps_polling_through_timeouts(self, monkeypatch, tmp_path):
+        """Repeated timeouts (slow cold start) are retried past the fast-fail cap.
+
+        Timeouts mean the server is reachable but warming up, so they must not
+        trip the consecutive-connection-failure cap — they retry for the full
+        ACEMUSIC_POLL_TIMEOUT budget.
+        """
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
 
-        client_mock = _make_client_mock([AceStepError("Query failed: timed out")] * 12)
+        # 7 timeouts (> the 5 fast-fail cap) then success → must still complete.
+        client_mock = _make_client_mock([AceStepError("Query failed: timed out")] * 7 + [COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "lofi", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert client_mock.query_result.call_count == 8
+
+    def test_generate_fails_fast_on_persistent_connection_failure(self, monkeypatch, tmp_path):
+        """Persistent hard connection failures (server down) abort quickly."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock([AceStepError("Submit failed: Connection refused")] * 20)
 
         with (
             patch("acemusic.cli.AceStepClient", return_value=client_mock),
@@ -162,17 +184,15 @@ class TestGenerateCommand:
             result = runner.invoke(app, ["generate", "lofi", "--output", str(tmp_path)])
 
         assert result.exit_code == 1
-        assert "polling" in result.output.lower()
-        # Gives up after a bounded number of consecutive failures, not all 12.
-        assert client_mock.query_result.call_count < 12
+        assert "connection failures" in result.output.lower()
+        # Fails fast after a bounded number of consecutive failures, not all 20.
+        assert client_mock.query_result.call_count <= 5
 
     def test_generate_aborts_immediately_on_api_poll_error(self, monkeypatch, tmp_path):
         """A genuine API error (not connection/timeout) aborts immediately, no retry."""
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
 
-        client_mock = _make_client_mock(
-            [AceStepError("Query failed: 500 Internal Server Error")]
-        )
+        client_mock = _make_client_mock([AceStepError("Query failed: 500 Internal Server Error")])
 
         with (
             patch("acemusic.cli.AceStepClient", return_value=client_mock),

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,6 +6,7 @@ import pytest
 from typer.testing import CliRunner
 
 from acemusic.cli import app
+from acemusic.client import AceStepError
 
 runner = CliRunner()
 
@@ -119,6 +120,69 @@ class TestGenerateCommand:
 
         assert result.exit_code == 0
         assert client_mock.query_result.call_count == 3
+
+    def test_generate_retries_transient_poll_errors(self, monkeypatch, tmp_path):
+        """A transient connection/timeout while polling is retried, not fatal.
+
+        Mirrors the cold-start case where the server briefly can't answer
+        /query_result (model loading) — the poll should recover and finish.
+        """
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock(
+            [
+                AceStepError("Query failed: timed out"),
+                PENDING_RESULT,
+                COMPLETED_RESULT,
+            ]
+        )
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "lofi", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert client_mock.query_result.call_count == 3
+        assert len(list(tmp_path.glob("*.wav"))) == 2
+
+    def test_generate_aborts_after_persistent_poll_errors(self, monkeypatch, tmp_path):
+        """Persistent connection failures abort (don't hang for the whole budget)."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock([AceStepError("Query failed: timed out")] * 12)
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "lofi", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "polling" in result.output.lower()
+        # Gives up after a bounded number of consecutive failures, not all 12.
+        assert client_mock.query_result.call_count < 12
+
+    def test_generate_aborts_immediately_on_api_poll_error(self, monkeypatch, tmp_path):
+        """A genuine API error (not connection/timeout) aborts immediately, no retry."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        client_mock = _make_client_mock(
+            [AceStepError("Query failed: 500 Internal Server Error")]
+        )
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "lofi", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert client_mock.query_result.call_count == 1
 
     def test_generate_api_failure_exits_one(self, monkeypatch, tmp_path):
         """API failure prints a friendly message and exits 1."""

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,7 +6,7 @@ import pytest
 from typer.testing import CliRunner
 
 from acemusic.cli import app
-from acemusic.client import AceStepError
+from acemusic.client import AceStepConnectionError, AceStepError
 
 runner = CliRunner()
 
@@ -131,7 +131,7 @@ class TestGenerateCommand:
 
         client_mock = _make_client_mock(
             [
-                AceStepError("Query failed: timed out"),
+                AceStepConnectionError("Query failed: timed out", is_timeout=True),
                 PENDING_RESULT,
                 COMPLETED_RESULT,
             ]
@@ -158,7 +158,9 @@ class TestGenerateCommand:
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
 
         # 7 timeouts (> the 5 fast-fail cap) then success → must still complete.
-        client_mock = _make_client_mock([AceStepError("Query failed: timed out")] * 7 + [COMPLETED_RESULT])
+        client_mock = _make_client_mock(
+            [AceStepConnectionError("Query failed: timed out", is_timeout=True)] * 7 + [COMPLETED_RESULT]
+        )
 
         with (
             patch("acemusic.cli.AceStepClient", return_value=client_mock),
@@ -174,7 +176,9 @@ class TestGenerateCommand:
         """Persistent hard connection failures (server down) abort quickly."""
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
 
-        client_mock = _make_client_mock([AceStepError("Submit failed: Connection refused")] * 20)
+        client_mock = _make_client_mock(
+            [AceStepConnectionError("Query failed: Connection refused", is_timeout=False)] * 20
+        )
 
         with (
             patch("acemusic.cli.AceStepClient", return_value=client_mock),


### PR DESCRIPTION
## Summary
The follow-up to the ACE-Step update work. The CLI poll loops aborted on a **single** `query_result` failure, so a cold-start blip (server briefly blocking while it loads models) killed the whole job with `Error polling status: ... timed out` — even though generation then succeeded server-side. This hardens polling.

## Changes
- **New shared helper `_poll_until_complete()`** — tolerates transient connection/timeout errors and **retries within the `ACEMUSIC_POLL_TIMEOUT` budget**; aborts immediately on a genuine API error; gives up after **5 consecutive** connection failures so a truly-down server fails fast (doesn't wait out the whole budget).
- **Replaced all 10 duplicated poll loops** (generate, sounds, extend, full-song, cover, repaint, add-vocal, replace, mashup, sample) with the helper — fixes the fragility everywhere and removes ~200 lines of duplication.
- **Fixed `_is_connection_error`** to match `"timed out"` (httpx renders read/connect timeouts that way; the previous `"timeout"` keyword never matched it — so timeouts weren't even classified as connection errors).

## Test Plan
- [x] New unit tests: transient error → retried & succeeds; persistent errors → bounded abort; genuine API error → immediate abort (no retry)
- [x] **697 unit tests pass** (3 new), 1 skipped, 15 integration deselected
- [x] Mutation check: forcing `_is_connection_error→False` and removing the consecutive cap each fail the right test
- [x] `ruff` + `black` clean

## Notes
- Minor UX change: a few command-specific failure prefixes (e.g. "Cover failed") are now the generic "Generation failed" from the helper; the underlying error message is preserved and no test asserts the old wording.
- Real-world origin: confirmed during the ACE-Step server update — `acemusic generate` works, but a cold first request could trip the old single-shot 10s poll timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Polling now distinguishes transient connection/timeouts from non-retryable errors, preventing undue fast-failures and improving reliability.

* **Improvements**
  * Unified polling and retry behavior across multiple CLI commands, with clearer timeout semantics and visible progress status during long-running tasks.

* **Tests**
  * Added CLI tests covering retry-on-transient-errors, tolerating repeated timeouts, bounded fast-fail on persistent connection failures, and immediate abort on non-retryable API errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->