### PR TITLE
fix: ElevenLabs fallback on poll-time ACE-Step outages (#93)

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -267,6 +267,7 @@ def _poll_until_complete(
     label: str,
     poll_timeout: float,
     poll_interval: float = 2.0,
+    raise_on_transport_error: bool = False,
 ) -> dict:
     """Poll ``query_result`` until the task completes; return the result dict.
 
@@ -281,13 +282,27 @@ def _poll_until_complete(
       (or a timeout) resets the counter.
     - A **genuine API error** aborts immediately.
 
-    Raises ``typer.Exit(code=1)`` on timeout, reported failure, or abort.
+    Transport outages (the consecutive-failure abort and timeout-budget
+    exhaustion) normally print and ``typer.Exit(code=1)``. When
+    ``raise_on_transport_error`` is True, they instead re-raise
+    ``AceStepConnectionError`` so the caller can decide whether to fall back to
+    another backend (used by ``generate``). Reported ``failed`` status and
+    genuine API errors always exit — they are never a transport problem and must
+    not trigger a fallback.
+
+    Raises:
+        AceStepConnectionError: transport failure when ``raise_on_transport_error``.
+        typer.Exit: otherwise on timeout/failure/abort.
     """
     start = time.monotonic()
     consecutive_conn_failures = 0
     while True:
         elapsed = time.monotonic() - start
         if elapsed >= poll_timeout:
+            if raise_on_transport_error:
+                raise AceStepConnectionError(
+                    f"ACE-Step timed out after {poll_timeout:.0f}s while polling", is_timeout=True
+                )
             console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
             raise typer.Exit(code=1)
 
@@ -303,6 +318,8 @@ def _poll_until_complete(
             else:
                 consecutive_conn_failures += 1
                 if consecutive_conn_failures >= _MAX_CONSECUTIVE_POLL_ERRORS:
+                    if raise_on_transport_error:
+                        raise
                     console.print(
                         f"[red]Error polling status after {consecutive_conn_failures} consecutive "
                         f"connection failures: {exc}[/red]"
@@ -312,7 +329,7 @@ def _poll_until_complete(
             time.sleep(poll_interval)
             continue
         except AceStepError as exc:
-            # Genuine API/HTTP error — surface it immediately.
+            # Genuine API/HTTP error — surface it immediately (never a fallback case).
             console.print(f"[red]Error polling status: {exc}[/red]")
             raise typer.Exit(code=1)
 
@@ -569,10 +586,15 @@ def generate(
                 style_influence=style_influence,
                 thinking=thinking,
                 model=resolved_model,
+                # Let poll-time transport outages propagate (not exit) so they
+                # reach the fallback logic below, like submit-time failures do.
+                raise_on_transport_error=True,
             )
             return
         except AceStepError as exc:
-            if not _is_connection_error(exc):
+            # Transport failures (submit- or poll-time) are connection errors;
+            # AceStepConnectionError is always one, regardless of message text.
+            if not (isinstance(exc, AceStepConnectionError) or _is_connection_error(exc)):
                 # API-level error — do not fall back
                 console.print(f"[red]Error: {exc}[/red]")
                 raise typer.Exit(code=1)
@@ -693,8 +715,14 @@ def _generate_via_ace_step(
     style_influence: int = 50,
     thinking: bool = False,
     model: Optional[str] = None,
+    raise_on_transport_error: bool = False,
 ) -> None:
-    """Submit, poll, and download audio via the ACE-Step backend."""
+    """Submit, poll, and download audio via the ACE-Step backend.
+
+    When ``raise_on_transport_error`` is set, a poll-time transport outage
+    re-raises ``AceStepConnectionError`` (rather than exiting) so ``generate``
+    can fall back to ElevenLabs just as it does for submit-time failures.
+    """
     poll_timeout = float(os.environ.get("ACEMUSIC_POLL_TIMEOUT", "600"))
     poll_interval = 2.0
 
@@ -720,7 +748,15 @@ def _generate_via_ace_step(
     console.print(f"Task submitted: [cyan]{task_id}[/cyan]")
 
     with console.status("[bold green]Generating…[/bold green]", spinner="dots") as status:
-        result = _poll_until_complete(ace_client, task_id, status, "Generating", poll_timeout, poll_interval)
+        result = _poll_until_complete(
+            ace_client,
+            task_id,
+            status,
+            "Generating",
+            poll_timeout,
+            poll_interval,
+            raise_on_transport_error=raise_on_transport_error,
+        )
 
     audio_urls: list[str] = result.get("audio_urls", [])
     for i, url in enumerate(audio_urls, start=1):

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -282,16 +282,17 @@ def _poll_until_complete(
       (or a timeout) resets the counter.
     - A **genuine API error** aborts immediately.
 
-    Transport outages (the consecutive-failure abort and timeout-budget
-    exhaustion) normally print and ``typer.Exit(code=1)``. When
-    ``raise_on_transport_error`` is True, they instead re-raise
-    ``AceStepConnectionError`` so the caller can decide whether to fall back to
-    another backend (used by ``generate``). Reported ``failed`` status and
-    genuine API errors always exit — they are never a transport problem and must
-    not trigger a fallback.
+    When ``raise_on_transport_error`` is True, a **persistent connection failure**
+    (the consecutive-failure abort — ACE-Step is unreachable) re-raises
+    ``AceStepConnectionError`` so the caller can fall back to another backend
+    (used by ``generate``). A **timeout** does NOT trigger fallback: it means
+    ACE-Step is reachable but slow, the job may still finish, and ACE-Step flags
+    were requested — so timeouts always ``typer.Exit``. Reported ``failed`` status
+    and genuine API errors also always exit (never a transport problem).
 
     Raises:
-        AceStepConnectionError: transport failure when ``raise_on_transport_error``.
+        AceStepConnectionError: persistent connection failure when
+            ``raise_on_transport_error`` is set.
         typer.Exit: otherwise on timeout/failure/abort.
     """
     start = time.monotonic()
@@ -299,10 +300,9 @@ def _poll_until_complete(
     while True:
         elapsed = time.monotonic() - start
         if elapsed >= poll_timeout:
-            if raise_on_transport_error:
-                raise AceStepConnectionError(
-                    f"ACE-Step timed out after {poll_timeout:.0f}s while polling", is_timeout=True
-                )
+            # A timeout means ACE-Step is reachable but slow (cold start / long job),
+            # not down — do NOT fall back (the job may still finish, and ACE-Step
+            # flags like --model/--thinking were requested). Always exit here.
             console.print(f"[red]Timed out after {poll_timeout:.0f} seconds.[/red]")
             raise typer.Exit(code=1)
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -257,6 +257,27 @@ def _is_connection_error(exc: AceStepError) -> bool:
     )
 
 
+def _is_timeout_error(exc: AceStepError) -> bool:
+    """Return True if the failure is a timeout (server slow-but-reachable)."""
+    if isinstance(exc, AceStepConnectionError):
+        return exc.is_timeout
+    msg = str(exc).lower()
+    return "timed out" in msg or "timeout" in msg
+
+
+def _should_fall_back(exc: AceStepError) -> bool:
+    """Whether an ACE-Step failure warrants switching to ElevenLabs.
+
+    Only a **hard connection failure** (server unreachable) qualifies. Timeouts
+    mean ACE-Step is slow-but-reachable (the job may still finish, and ACE-Step
+    flags were requested), and API/HTTP errors mean the server responded — neither
+    should switch backends.
+    """
+    if isinstance(exc, AceStepConnectionError):
+        return not exc.is_timeout
+    return _is_connection_error(exc) and not _is_timeout_error(exc)
+
+
 _MAX_CONSECUTIVE_POLL_ERRORS = 5
 
 
@@ -592,10 +613,10 @@ def generate(
             )
             return
         except AceStepError as exc:
-            # Transport failures (submit- or poll-time) are connection errors;
-            # AceStepConnectionError is always one, regardless of message text.
-            if not (isinstance(exc, AceStepConnectionError) or _is_connection_error(exc)):
-                # API-level error — do not fall back
+            # Fall back only on a hard connection failure (server unreachable),
+            # submit- or poll-time. Timeouts (slow-but-reachable) and API errors
+            # exit without switching backends.
+            if not _should_fall_back(exc):
                 console.print(f"[red]Error: {exc}[/red]")
                 raise typer.Exit(code=1)
             # Connection failure. Only 'auto' falls back; explicit 'ace-step' does not.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -516,3 +516,125 @@ class TestBackendSelector:
         result = runner.invoke(app, ["generate", "test", "--backend", "suno", "--output", str(tmp_path)])
         assert result.exit_code == 1
         assert "backend" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# #93: ElevenLabs fallback on POLL-TIME ACE-Step outages
+# ---------------------------------------------------------------------------
+
+
+class TestPollTimeFallback:
+    """generate falls back when ACE-Step drops during polling (not just at submit)."""
+
+    @staticmethod
+    def _ace_mock_submit_ok_then_poll(side_effect):
+        """ACE-Step client: submit succeeds, query_result raises/returns per side_effect."""
+        from acemusic.client import AceStepError  # noqa: F401
+
+        ace = MagicMock()
+        ace.submit_task.return_value = "task-123"
+        ace.query_result.side_effect = side_effect
+        ace.download_audio.return_value = b""
+        return ace
+
+    def _config_with_el(self, monkeypatch, el_key="test-key"):
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key=el_key,
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+    def test_poll_connection_failure_falls_back_to_elevenlabs(self, monkeypatch, tmp_path):
+        """Persistent poll-time connection failure (auto) → fall back to ElevenLabs (exit 0)."""
+        from acemusic.client import AceStepConnectionError
+
+        self._config_with_el(monkeypatch)
+        # submit ok, then query_result keeps failing with a hard connection error
+        ace = self._ace_mock_submit_ok_then_poll(
+            [AceStepConnectionError("Query failed: connection refused", is_timeout=False)] * 20
+        )
+        el = _elevenlabs_client_mock(FAKE_MP3)
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=ace),
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "test", "--backend", "auto", "--output", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        el.generate.assert_called()  # fell back after submit succeeded but polling failed
+
+    def test_poll_failed_status_does_not_fall_back(self, monkeypatch, tmp_path):
+        """A reported job 'failed' status exits 1 — no fallback (server worked, request was bad)."""
+        self._config_with_el(monkeypatch)
+        ace = self._ace_mock_submit_ok_then_poll([{"status": "failed", "error": "bad prompt"}])
+        el = _elevenlabs_client_mock(FAKE_MP3)
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=ace),
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "test", "--backend", "auto", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        el.generate.assert_not_called()
+
+    def test_poll_api_error_does_not_fall_back(self, monkeypatch, tmp_path):
+        """A genuine API error during polling exits 1 — no fallback."""
+        from acemusic.client import AceStepError
+
+        self._config_with_el(monkeypatch)
+        ace = self._ace_mock_submit_ok_then_poll([AceStepError("Query failed: 500 Internal Server Error")])
+        el = _elevenlabs_client_mock(FAKE_MP3)
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=ace),
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "test", "--backend", "auto", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        el.generate.assert_not_called()
+
+    def test_poll_connection_failure_no_key_exits_with_message(self, monkeypatch, tmp_path):
+        """Poll-time connection failure without ELEVENLABS_API_KEY exits 1 with actionable message."""
+        from acemusic.client import AceStepConnectionError
+
+        self._config_with_el(monkeypatch, el_key=None)
+        ace = self._ace_mock_submit_ok_then_poll(
+            [AceStepConnectionError("Query failed: connection refused", is_timeout=False)] * 20
+        )
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=ace),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "test", "--backend", "auto", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        assert "elevenlabs_api_key" in result.output.lower() or "elevenlabs" in result.output.lower()
+
+    def test_explicit_ace_step_poll_failure_no_fallback(self, monkeypatch, tmp_path):
+        """Explicit --backend ace-step + poll-time connection failure → exit 1, no fallback."""
+        from acemusic.client import AceStepConnectionError
+
+        self._config_with_el(monkeypatch)  # key IS set but explicit ace-step must not use it
+        ace = self._ace_mock_submit_ok_then_poll(
+            [AceStepConnectionError("Query failed: connection refused", is_timeout=False)] * 20
+        )
+        el = _elevenlabs_client_mock(FAKE_MP3)
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=ace),
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+            patch("acemusic.cli.time.sleep"),
+        ):
+            result = runner.invoke(app, ["generate", "test", "--backend", "ace-step", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        el.generate.assert_not_called()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -636,3 +636,33 @@ class TestPollTimeFallback:
             result = runner.invoke(app, ["generate", "test", "--backend", "ace-step", "--output", str(tmp_path)])
         assert result.exit_code == 1
         el.generate.assert_not_called()
+
+
+class TestTimeoutNeverFallsBack:
+    """Timeouts (slow-but-reachable ACE-Step) must NOT fall back — only hard
+    connection failures do (#93 / codex P2 / CodeRabbit)."""
+
+    def test_submit_timeout_does_not_fall_back(self, monkeypatch, tmp_path):
+        from acemusic.client import AceStepConnectionError
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="test-key",  # key set, but a timeout must NOT use it
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+        ace = MagicMock()
+        ace.submit_task.side_effect = AceStepConnectionError("Submit failed: timed out", is_timeout=True)
+        el = _elevenlabs_client_mock(FAKE_MP3)
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=ace),
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=2.0),
+        ):
+            result = runner.invoke(app, ["generate", "test", "--backend", "auto", "--output", str(tmp_path)])
+        assert result.exit_code == 1
+        el.generate.assert_not_called()  # timeout → exit, not fallback

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -529,8 +529,6 @@ class TestPollTimeFallback:
     @staticmethod
     def _ace_mock_submit_ok_then_poll(side_effect):
         """ACE-Step client: submit succeeds, query_result raises/returns per side_effect."""
-        from acemusic.client import AceStepError  # noqa: F401
-
         ace = MagicMock()
         ace.submit_task.return_value = "task-123"
         ace.query_result.side_effect = side_effect

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,14 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from acemusic.client import AceStepClient, AceStepError
+from acemusic.client import AceStepClient, AceStepConnectionError, AceStepError
+
+
+def test_connection_error_is_an_acestep_error():
+    """generate's poll-time fallback relies on this: a raised
+    AceStepConnectionError must be caught by ``except AceStepError``."""
+    assert issubclass(AceStepConnectionError, AceStepError)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -173,8 +173,14 @@ class TestGenerateCommand:
         assert client_mock.query_result.call_count == 8
 
     def test_generate_fails_fast_on_persistent_connection_failure(self, monkeypatch, tmp_path):
-        """Persistent hard connection failures (server down) abort quickly."""
+        """Persistent hard connection failures abort quickly (bounded retries).
+
+        With no ElevenLabs key, the poll-time transport failure has nowhere to
+        fall back (#93), so it exits 1 — but still after a bounded number of
+        consecutive failures, not the whole budget.
+        """
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)  # no fallback available
 
         client_mock = _make_client_mock(
             [AceStepConnectionError("Query failed: Connection refused", is_timeout=False)] * 20
@@ -188,8 +194,8 @@ class TestGenerateCommand:
             result = runner.invoke(app, ["generate", "lofi", "--output", str(tmp_path)])
 
         assert result.exit_code == 1
-        assert "connection failures" in result.output.lower()
-        # Fails fast after a bounded number of consecutive failures, not all 20.
+        assert "elevenlabs_api_key" in result.output.lower()  # "Set ELEVENLABS_API_KEY ..."
+        # Bounded: gave up after the consecutive-failure cap, not all 20 polls.
         assert client_mock.query_result.call_count <= 5
 
     def test_generate_aborts_immediately_on_api_poll_error(self, monkeypatch, tmp_path):
@@ -242,8 +248,9 @@ class TestGenerateCommand:
         assert "Traceback" not in result.output
 
     def test_generate_timeout_exits_one(self, monkeypatch, tmp_path):
-        """Polling timeout exits 1 with a clear message."""
+        """Polling timeout exits 1 with a clear message (no ElevenLabs fallback available)."""
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)  # no fallback → deterministic exit
 
         client_mock = _make_client_mock([PENDING_RESULT] * 1000)
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -179,8 +179,14 @@ class TestGenerateCommand:
         fall back (#93), so it exits 1 — but still after a bounded number of
         consecutive failures, not the whole budget.
         """
-        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
-        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)  # no fallback available
+        # Patch load_config (not just env) so the test is independent of any
+        # ~/.acemusic/config.yaml ElevenLabs key on the host.
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url="http://localhost:8001", api_key=None, elevenlabs_api_key=None),
+        )
 
         client_mock = _make_client_mock(
             [AceStepConnectionError("Query failed: Connection refused", is_timeout=False)] * 20
@@ -248,9 +254,12 @@ class TestGenerateCommand:
         assert "Traceback" not in result.output
 
     def test_generate_timeout_exits_one(self, monkeypatch, tmp_path):
-        """Polling timeout exits 1 with a clear message (no ElevenLabs fallback available)."""
+        """Polling timeout exits 1 with a clear message.
+
+        A timeout means ACE-Step is slow (not down), so it never falls back to
+        ElevenLabs (#93) — this holds regardless of any configured key.
+        """
         monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
-        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)  # no fallback → deterministic exit
 
         client_mock = _make_client_mock([PENDING_RESULT] * 1000)
 


### PR DESCRIPTION
## Summary
Closes #93. `generate` now falls back to ElevenLabs when ACE-Step drops **during polling**, not only at submit — closing the gap surfaced by the codex review of #92.

- **`_poll_until_complete(..., raise_on_transport_error=False)`**: when set, a **persistent connection failure** (consecutive-failure cap — ACE-Step unreachable) re-raises `AceStepConnectionError` so the caller can fall back. Default `False` ⇒ the **other 9 poll-helper callers are unchanged**.
- **`_generate_via_ace_step`** forwards the flag; **`generate`** passes `True`, and its existing `except` (from #95) routes the transport error: `auto` → ElevenLabs fallback; explicit `ace-step` → exit with "use --backend auto"; no key → "Set ELEVENLABS_API_KEY". Connection check also matches `AceStepConnectionError` by type.
- **Timeouts do NOT fall back** (codex P2): a timeout means ACE-Step is slow (cold start/long job), not down — it exits with the existing "Timed out" message, preserving the in-flight job and ACE-Step-only flags. Only connection failures fall back.

## Acceptance Criteria
- [x] Poll-time connection failure + `ELEVENLABS_API_KEY` (auto) → fall back, exit 0
- [x] Reported `failed` status → exit 1, no fallback
- [x] Genuine API error during polling → exit 1, no fallback
- [x] No key + poll-time connection failure → exit 1, actionable message
- [x] Unit tests cover all four paths (+ explicit ace-step poll failure)

## Test Plan
- [x] 719 unit tests pass; 5 new (`TestPollTimeFallback`); lint + format clean
- [x] Mutation checks: disabling the raise-on-cap and making `failed` status raise each fail the right test
- [x] Cross-family review: **codex** — P2 (timeout-no-fallback) + P3 (host-independent tests) addressed

## Known Limitations / Intentionally Deferred
- **Generate-only**, per the issue's open question: the other backend-capable commands (cover/extend/mashup/…) keep exit-on-failure — ElevenLabs has no equivalent operation, so fallback there is meaningless.
- Fallback triggers on **connection** failures (server unreachable), not timeouts (slow-but-up) — deliberate (codex P2).

Closes #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback to ElevenLabs when ACE-Step experiences connection failures during the polling phase
  * Enhanced error messages to specify missing API key requirements
  * Refined handling to distinguish between connection issues, timeouts, and API errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->