### PR TITLE
feat: ElevenLabs first-class generate + composition plans (#96)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,13 @@ uv run acemusic generate "upbeat pop" --output ./output --name demo
 uv run acemusic generate "dark electro" --bpm 128 --key "C minor" --time-signature "4/4" --seed 42 --duration 60
 uv run acemusic generate "ambient pad" --backend elevenlabs --instrumental
 
+# Composition plans (#96) — structured multi-section generation via ElevenLabs
+uv run acemusic compose "uplifting indie-pop song" --duration 120 --seed 42   # plan (intro/verse/chorus/…) → one-shot MP3
+uv run acemusic compose "cinematic theme" --instrumental --name main-theme
+
+# Short samples via ElevenLabs (#96) — sounds also accepts --backend
+uv run acemusic sounds "deep kick drum" --type one-shot --backend elevenlabs
+
 # Iterative generation (US-6.1) — extend an existing clip with AI-generated continuation
 uv run acemusic extend 42 --duration 60s                          # extend clip 42 by 60s from its end
 uv run acemusic extend 42 --duration 30s --from 45s               # extend from a mid-clip timestamp
@@ -107,7 +114,7 @@ src/acemusic/
     models/         # Beanie ODM documents: User, Workspace, Clip, Job
     routers/        # Versioned routers mounted under /api/v1 (health, ...)
   backends.py       # Backend selector: resolve_backend (auto|ace-step|elevenlabs) + capability map
-  cli.py            # Typer CLI app (health, generate, models, workspace commands)
+  cli.py            # Typer CLI app (health, generate, compose, sounds, models, workspace commands)
   client.py         # AceStepClient — HTTP client for ACE-Step REST API
   config.py         # Config loading: env > .env > ~/.acemusic/config.yaml
   db.py             # SQLite connection and schema init (~/.acemusic/metadata.db)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ select = ["E7", "E9", "F", "I"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["acemusic"]
+combine-as-imports = true
 
 [tool.black]
 line-length = 120

--- a/src/acemusic/backends.py
+++ b/src/acemusic/backends.py
@@ -19,11 +19,13 @@ VALID_BACKENDS: tuple[str, ...] = ("auto", "ace-step", "elevenlabs")
 DEFAULT_BACKEND = "auto"
 
 # Which concrete engines support each operation. ElevenLabs entries expand as
-# the sibling issues land (#96 generate/plans, #97 stems, #98 inpainting,
-# #99 mashup); for now ElevenLabs only does text-to-music generation.
+# the sibling issues land (#97 stems, #98 inpainting, #99 mashup). #96 added
+# first-class generate/sounds and composition plans ("compose").
 _CAPABILITIES: dict[str, set[str]] = {
     "generate": {"ace-step", "elevenlabs"},
     "sample": {"ace-step", "elevenlabs"},
+    "sounds": {"ace-step", "elevenlabs"},
+    "compose": {"elevenlabs"},
     "stems": {"ace-step"},
     "midi": {"ace-step"},
     "remaster": {"ace-step"},

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -973,8 +973,14 @@ def sounds(
         "--key",
         help="Tonal center (e.g. 'A minor'). Applies to loops.",
     ),
+    backend: Optional[str] = typer.Option(
+        None,
+        "--backend",
+        help="Engine: 'auto'/'ace-step' (ACE-Step) or 'elevenlabs'. Defaults to ACEMUSIC_BACKEND, then 'auto'. "
+        "(Automatic ElevenLabs fallback currently applies to `generate`, not `sounds`.)",
+    ),
 ) -> None:
-    """Generate short audio samples (loops or one-shots) using the ACE-Step model."""
+    """Generate short audio samples (loops or one-shots) via ACE-Step or ElevenLabs."""
     _VALID_FORMATS = {"wav", "flac", "mp3", "aac", "opus"}
     if format not in _VALID_FORMATS:
         console.print(f"[red]Invalid --format: {format!r}. Allowed values: {', '.join(sorted(_VALID_FORMATS))}[/red]")
@@ -1006,6 +1012,23 @@ def sounds(
 
     config = load_config()
 
+    # Resolve the backend (CLI flag > config default > auto). No auto-fallback
+    # for sounds (matches `sample`): 'auto' routes to ACE-Step.
+    try:
+        effective_backend = resolve_backend(backend, config.backend)
+    except BackendError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if effective_backend == "elevenlabs" and duration is not None:
+        if not (EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S):
+            console.print(
+                f"[red]Invalid --duration: {duration}. ElevenLabs supports "
+                f"{int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)} seconds (10 min max). "
+                f"Use --backend ace-step for shorter samples.[/red]"
+            )
+            raise typer.Exit(code=1)
+
     if output is not None:
         output_path = output
     elif config.output_dir:
@@ -1017,6 +1040,46 @@ def sounds(
     slug = make_slug(prompt)
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
     safe_name = make_slug(name) if name else None
+
+    if effective_backend == "elevenlabs":
+        if not config.elevenlabs_api_key:
+            console.print("[red]Error: --backend elevenlabs requires ELEVENLABS_API_KEY to be set.[/red]")
+            raise typer.Exit(code=1)
+        if format != "mp3":
+            console.print(
+                f"[yellow]Warning: ElevenLabs output is MP3-only; --format {format} is ignored.[/yellow]"
+            )
+
+        # ElevenLabs has no sound mode or native bpm/key controls — steer them
+        # through the prompt, mirroring the `generate` command's injections.
+        prompt_additions: list[str] = [f"{sound_type} sample"]
+        if parsed_bpm is not None and parsed_bpm != "auto":
+            console.print(
+                f"[yellow]Warning: --bpm is ACE-Step-native; injecting '{parsed_bpm} BPM' into prompt for ElevenLabs.[/yellow]"
+            )
+            prompt_additions.append(f"{parsed_bpm} BPM")
+        if key is not None and key.lower() != "any":
+            console.print(
+                f"[yellow]Warning: --key is ACE-Step-native; injecting '{key}' into prompt for ElevenLabs.[/yellow]"
+            )
+            prompt_additions.append(key)
+
+        el_client = ElevenLabsClient(
+            api_key=config.elevenlabs_api_key,
+            output_format=config.elevenlabs_output_format,
+        )
+        _sounds_via_elevenlabs(
+            el_client=el_client,
+            prompt=f"{prompt}, {', '.join(prompt_additions)}",
+            num_clips=num_clips,
+            duration=duration,
+            output_path=output_path,
+            slug=slug,
+            timestamp=timestamp,
+            safe_name=safe_name,
+            output_format=config.elevenlabs_output_format,
+        )
+        return
 
     ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
     try:
@@ -1090,6 +1153,46 @@ def _sounds_via_ace_step(
         try:
             dur = get_duration(dest)
             dur_str = f"{dur:.1f}s"
+        except Exception:
+            dur_str = "unknown"
+
+        console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
+
+
+def _sounds_via_elevenlabs(
+    *,
+    el_client: ElevenLabsClient,
+    prompt: str,
+    num_clips: int,
+    duration: Optional[float],
+    output_path: Path,
+    slug: str,
+    timestamp: str,
+    safe_name: Optional[str],
+    output_format: str,
+) -> None:
+    """Generate N short samples sequentially via ElevenLabs and save them to disk.
+
+    Mirrors the ACE-Step sounds path: files only, no Clip records.
+    """
+    ext = _elevenlabs_ext(output_format)
+    console.print(f"[cyan]Generating via ElevenLabs ({output_format})…[/cyan]")
+    for i in range(1, num_clips + 1):
+        with console.status(f"[bold green]Clip {i}/{num_clips}…[/bold green]", spinner="dots"):
+            try:
+                data = el_client.generate(prompt=prompt, duration=duration)
+            except ElevenLabsError as exc:
+                console.print(f"[red]ElevenLabs error: {exc}[/red]")
+                raise typer.Exit(code=1)
+
+        if safe_name:
+            filename = f"{safe_name}-{i}.{ext}"
+        else:
+            filename = make_filename(slug, timestamp, i, ext=ext)
+        dest = output_path / filename
+        dest.write_bytes(data)
+        try:
+            dur_str = f"{get_duration(dest):.1f}s"
         except Exception:
             dur_str = "unknown"
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -52,11 +52,7 @@ from acemusic.db import (
 )
 from acemusic.elevenlabs_client import (
     DURATION_MAX_S as EL_DURATION_MAX_S,
-)
-from acemusic.elevenlabs_client import (
     DURATION_MIN_S as EL_DURATION_MIN_S,
-)
-from acemusic.elevenlabs_client import (
     ElevenLabsClient,
     ElevenLabsError,
 )
@@ -590,30 +586,26 @@ def generate(
                     f"Clamping to {int(_DURATION_MIN)}s. Update your integration to use --duration {int(_DURATION_MIN)} or higher.[/yellow]"
                 )
                 duration = _DURATION_MIN
-            elif (
-                effective_backend == "auto"
-                and config.elevenlabs_api_key
-                and EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S
-            ):
+            elif effective_backend == "auto" and EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S:
                 # 'auto' never fails just because one engine can't do the job:
                 # ACE-Step can't serve this duration, but ElevenLabs can.
-                console.print(
-                    f"[yellow]--duration {duration} is outside the ACE-Step range "
-                    f"({int(_DURATION_MIN)}–{int(_DURATION_MAX)}s); routing to ElevenLabs.[/yellow]"
-                )
-                effective_backend = "elevenlabs"
+                if config.elevenlabs_api_key:
+                    console.print(
+                        f"[yellow]--duration {duration} is outside the ACE-Step range "
+                        f"({int(_DURATION_MIN)}–{int(_DURATION_MAX)}s); routing to ElevenLabs.[/yellow]"
+                    )
+                    effective_backend = "elevenlabs"
+                else:
+                    console.print(
+                        f"[red]Invalid --duration: {duration}. Must be between {int(_DURATION_MIN)} and "
+                        f"{int(_DURATION_MAX)} seconds. Set ELEVENLABS_API_KEY to generate "
+                        f"{int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)}s tracks via ElevenLabs.[/red]"
+                    )
+                    raise typer.Exit(code=1)
             else:
-                hint = (
-                    " Set ELEVENLABS_API_KEY to generate "
-                    f"{int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)}s tracks via ElevenLabs."
-                    if effective_backend == "auto"
-                    and not config.elevenlabs_api_key
-                    and EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S
-                    else ""
-                )
                 console.print(
                     f"[red]Invalid --duration: {duration}. Must be between {int(_DURATION_MIN)} and "
-                    f"{int(_DURATION_MAX)} seconds.{hint}[/red]"
+                    f"{int(_DURATION_MAX)} seconds.[/red]"
                 )
                 raise typer.Exit(code=1)
 
@@ -1265,7 +1257,8 @@ def compose(
     """Compose a structured multi-section track via an ElevenLabs composition plan.
 
     Creates a sectioned plan (intro/verse/chorus/…) from the prompt, displays it,
-    then generates the full track in one shot. ElevenLabs only; output is MP3.
+    then generates the full track in one shot. ElevenLabs only; output format
+    follows ELEVENLABS_OUTPUT_FORMAT (default: MP3).
     """
     if duration is not None and not (EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S):
         console.print(

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -399,6 +399,27 @@ _BPM_MAX = 180
 _DURATION_MIN = 30.0
 _DURATION_MAX = 240.0
 
+# ISO 639-1 codes → English names for ElevenLabs prompt injection (the API has
+# no language field; vocal language is steered through the prompt text).
+_LANGUAGE_NAMES: dict[str, str] = {
+    "en": "English",
+    "es": "Spanish",
+    "de": "German",
+    "fr": "French",
+    "it": "Italian",
+    "pt": "Portuguese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "zh": "Chinese",
+    "nl": "Dutch",
+    "pl": "Polish",
+    "ru": "Russian",
+    "sv": "Swedish",
+    "tr": "Turkish",
+    "ar": "Arabic",
+    "hi": "Hindi",
+}
+
 
 def _parse_bpm(value: str) -> int | str:
     """Parse --bpm value: 'auto' is returned as-is; otherwise validate integer 60–180."""
@@ -889,28 +910,6 @@ def _generate_via_ace_step(
             warnings.warn(f"clip metadata not saved: {exc}", stacklevel=2)
 
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
-
-
-# ISO 639-1 codes → English names for ElevenLabs prompt injection (the API has
-# no language field; vocal language is steered through the prompt text).
-_LANGUAGE_NAMES: dict[str, str] = {
-    "en": "English",
-    "es": "Spanish",
-    "de": "German",
-    "fr": "French",
-    "it": "Italian",
-    "pt": "Portuguese",
-    "ja": "Japanese",
-    "ko": "Korean",
-    "zh": "Chinese",
-    "nl": "Dutch",
-    "pl": "Polish",
-    "ru": "Russian",
-    "sv": "Swedish",
-    "tr": "Turkish",
-    "ar": "Arabic",
-    "hi": "Hindi",
-}
 
 
 def _elevenlabs_ext(output_format: str) -> str:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -152,6 +152,20 @@ def _version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+def _require_ace_step_url(config) -> None:
+    """Exit with a friendly error if the ACE-Step server URL is not configured.
+
+    Called by backend-capable commands on their ACE-Step path only, so explicit
+    `--backend elevenlabs` invocations never require an ACE-Step server (#96).
+    """
+    if not config.api_url:
+        message = "ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml"
+        if config.elevenlabs_api_key:
+            message += " (or use --backend elevenlabs)"
+        typer.echo(message)
+        raise typer.Exit(1)
+
+
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
@@ -179,12 +193,16 @@ def main(
         "stems",
         "midi",
         "remaster",
-        "compose",  # ElevenLabs-only; never touches ACE-Step (#96)
+        # Backend-capable commands check the URL on their ACE-Step path via
+        # _require_ace_step_url(), so `--backend elevenlabs` works without an
+        # ACE-Step server; `compose` is ElevenLabs-only (#96).
+        "compose",
+        "generate",
+        "sounds",
+        "sample",
     ):
         config = load_config()
-        # When the configured default backend is ElevenLabs, ACE-Step is not
-        # required for backend-capable commands (#96).
-        if not config.api_url and (config.backend or "").strip().lower() != "elevenlabs":
+        if not config.api_url:
             typer.echo("ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml")
             raise typer.Exit(1)
 
@@ -629,6 +647,7 @@ def generate(
     safe_name = make_slug(name) if name else None
 
     if effective_backend in ("auto", "ace-step"):
+        _require_ace_step_url(config)
         ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
         try:
             _generate_via_ace_step(
@@ -1106,6 +1125,7 @@ def sounds(
         )
         return
 
+    _require_ace_step_url(config)
     ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
     try:
         _sounds_via_ace_step(
@@ -3925,6 +3945,7 @@ def sample(
 
         if effective_backend in ("auto", "ace-step"):
             engine_used = "ace-step"
+            _require_ace_step_url(config)
             ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
             generated_paths = _generate_sample_via_ace_step(
                 ace_client=ace_client,

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -50,7 +50,16 @@ from acemusic.db import (
     search_clips,
     update_clip_title,
 )
-from acemusic.elevenlabs_client import ElevenLabsClient, ElevenLabsError
+from acemusic.elevenlabs_client import (
+    DURATION_MAX_S as EL_DURATION_MAX_S,
+)
+from acemusic.elevenlabs_client import (
+    DURATION_MIN_S as EL_DURATION_MIN_S,
+)
+from acemusic.elevenlabs_client import (
+    ElevenLabsClient,
+    ElevenLabsError,
+)
 from acemusic.midi_client import MidiClient, MidiError
 from acemusic.models import Clip, Preset
 from acemusic.song_structure import Section, plan_sections
@@ -422,7 +431,9 @@ def generate(
     ),
     lyrics_file: Optional[Path] = typer.Option(None, "--lyrics-file", help="Path to a text file containing lyrics."),
     vocal_language: Optional[str] = typer.Option(
-        None, "--vocal-language", help="ISO 639-1 vocal language code (ACE-Step only, e.g. 'en', 'ja')."
+        None,
+        "--vocal-language",
+        help="ISO 639-1 vocal language code (e.g. 'en', 'ja'). ACE-Step native; injected into prompt for ElevenLabs.",
     ),
     instrumental: bool = typer.Option(False, "--instrumental", help="Suppress vocals entirely."),
     bpm: Optional[str] = typer.Option(
@@ -500,20 +511,38 @@ def generate(
         )
         raise typer.Exit(code=1)
 
-    if duration is not None and not (_DURATION_MIN <= duration <= _DURATION_MAX):
-        if duration == 15.0:
-            console.print(
-                f"[yellow]Warning: --duration 15 is below the minimum ({int(_DURATION_MIN)}s). "
-                f"Clamping to {int(_DURATION_MIN)}s. Update your integration to use --duration {int(_DURATION_MIN)} or higher.[/yellow]"
-            )
-            duration = _DURATION_MIN
-        else:
-            console.print(
-                f"[red]Invalid --duration: {duration}. Must be between {int(_DURATION_MIN)} and {int(_DURATION_MAX)} seconds.[/red]"
-            )
-            raise typer.Exit(code=1)
-
     config = load_config()
+
+    # Resolve the backend early (CLI flag > config default > auto) so duration
+    # limits can be backend-aware. May change to "elevenlabs" below only when
+    # resolved to "auto" (auto-fallback).
+    try:
+        effective_backend = resolve_backend(backend, config.backend)
+    except BackendError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if duration is not None:
+        if effective_backend == "elevenlabs":
+            # Explicit ElevenLabs backend: use the wider ElevenLabs API limits.
+            if not (EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S):
+                console.print(
+                    f"[red]Invalid --duration: {duration}. ElevenLabs supports "
+                    f"{int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)} seconds (10 min max).[/red]"
+                )
+                raise typer.Exit(code=1)
+        elif not (_DURATION_MIN <= duration <= _DURATION_MAX):
+            if duration == 15.0:
+                console.print(
+                    f"[yellow]Warning: --duration 15 is below the minimum ({int(_DURATION_MIN)}s). "
+                    f"Clamping to {int(_DURATION_MIN)}s. Update your integration to use --duration {int(_DURATION_MIN)} or higher.[/yellow]"
+                )
+                duration = _DURATION_MIN
+            else:
+                console.print(
+                    f"[red]Invalid --duration: {duration}. Must be between {int(_DURATION_MIN)} and {int(_DURATION_MAX)} seconds.[/red]"
+                )
+                raise typer.Exit(code=1)
 
     # Load and apply preset if provided
     if preset is not None:
@@ -573,14 +602,6 @@ def generate(
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
     safe_name = make_slug(name) if name else None
 
-    # Resolve the backend (CLI flag > config default > auto). May change to
-    # "elevenlabs" below only when resolved to "auto" (auto-fallback).
-    try:
-        effective_backend = resolve_backend(backend, config.backend)
-    except BackendError as exc:
-        console.print(f"[red]{exc}[/red]")
-        raise typer.Exit(code=1)
-
     if effective_backend in ("auto", "ace-step"):
         ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
         try:
@@ -639,10 +660,6 @@ def generate(
                 "[red]ELEVENLABS_API_KEY is not configured. Set it in .env to use the ElevenLabs backend.[/red]"
             )
             raise typer.Exit(code=1)
-        if vocal_language is not None:
-            console.print(
-                "[yellow]Warning: --vocal-language is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
-            )
         if inference_steps is not None:
             console.print(
                 "[yellow]Warning: --inference-steps is ACE-Step-specific and is ignored by ElevenLabs.[/yellow]"
@@ -682,6 +699,12 @@ def generate(
                 f"[yellow]Warning: --time-signature is ACE-Step-specific; injecting '{time_signature} time signature' into prompt for ElevenLabs.[/yellow]"
             )
             prompt_additions.append(f"{time_signature} time signature")
+        if vocal_language is not None and vocal_language.lower() != "auto":
+            language_name = _LANGUAGE_NAMES.get(vocal_language.lower(), vocal_language)
+            console.print(
+                f"[yellow]Note: ElevenLabs has no language field; injecting '{language_name} vocals' into prompt.[/yellow]"
+            )
+            prompt_additions.append(f"{language_name} vocals")
         if seed is not None:
             console.print(
                 "[yellow]Warning: --seed requires ElevenLabs composition_plan mode, which is not yet implemented. Seed is ignored.[/yellow]"
@@ -825,6 +848,28 @@ def _generate_via_ace_step(
             warnings.warn(f"clip metadata not saved: {exc}", stacklevel=2)
 
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
+
+
+# ISO 639-1 codes → English names for ElevenLabs prompt injection (the API has
+# no language field; vocal language is steered through the prompt text).
+_LANGUAGE_NAMES: dict[str, str] = {
+    "en": "English",
+    "es": "Spanish",
+    "de": "German",
+    "fr": "French",
+    "it": "Italian",
+    "pt": "Portuguese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "zh": "Chinese",
+    "nl": "Dutch",
+    "pl": "Polish",
+    "ru": "Russian",
+    "sv": "Swedish",
+    "tr": "Turkish",
+    "ar": "Arabic",
+    "hi": "Hindi",
+}
 
 
 def _elevenlabs_ext(output_format: str) -> str:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -581,6 +581,9 @@ def generate(
                 )
                 raise typer.Exit(code=1)
         elif not (_DURATION_MIN <= duration <= _DURATION_MAX):
+            # Legacy compatibility shim: older integrations defaulted to
+            # --duration 15, so exactly 15.0 clamps (with a warning) instead of
+            # erroring. Removable once those integrations are updated.
             if duration == 15.0:
                 console.print(
                     f"[yellow]Warning: --duration 15 is below the minimum ({int(_DURATION_MIN)}s). "

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -179,9 +179,12 @@ def main(
         "stems",
         "midi",
         "remaster",
+        "compose",  # ElevenLabs-only; never touches ACE-Step (#96)
     ):
         config = load_config()
-        if not config.api_url:
+        # When the configured default backend is ElevenLabs, ACE-Step is not
+        # required for backend-capable commands (#96).
+        if not config.api_url and (config.backend or "").strip().lower() != "elevenlabs":
             typer.echo("ACE-Step server URL not configured. Set ACEMUSIC_BASE_URL in .env or config.yaml")
             raise typer.Exit(1)
 
@@ -522,28 +525,6 @@ def generate(
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1)
 
-    if duration is not None:
-        if effective_backend == "elevenlabs":
-            # Explicit ElevenLabs backend: use the wider ElevenLabs API limits.
-            if not (EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S):
-                console.print(
-                    f"[red]Invalid --duration: {duration}. ElevenLabs supports "
-                    f"{int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)} seconds (10 min max).[/red]"
-                )
-                raise typer.Exit(code=1)
-        elif not (_DURATION_MIN <= duration <= _DURATION_MAX):
-            if duration == 15.0:
-                console.print(
-                    f"[yellow]Warning: --duration 15 is below the minimum ({int(_DURATION_MIN)}s). "
-                    f"Clamping to {int(_DURATION_MIN)}s. Update your integration to use --duration {int(_DURATION_MIN)} or higher.[/yellow]"
-                )
-                duration = _DURATION_MIN
-            else:
-                console.print(
-                    f"[red]Invalid --duration: {duration}. Must be between {int(_DURATION_MIN)} and {int(_DURATION_MAX)} seconds.[/red]"
-                )
-                raise typer.Exit(code=1)
-
     # Load and apply preset if provided
     if preset is not None:
         try:
@@ -569,6 +550,51 @@ def generate(
         except sqlite3.Error as exc:
             console.print(f"[red]Error loading preset: {exc}[/red]")
             raise typer.Exit(code=1)
+
+    # Validate duration AFTER preset application so preset-supplied values are
+    # checked too, with backend-aware limits.
+    if duration is not None:
+        if effective_backend == "elevenlabs":
+            # Explicit ElevenLabs backend: use the wider ElevenLabs API limits.
+            if not (EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S):
+                console.print(
+                    f"[red]Invalid --duration: {duration}. ElevenLabs supports "
+                    f"{int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)} seconds (10 min max).[/red]"
+                )
+                raise typer.Exit(code=1)
+        elif not (_DURATION_MIN <= duration <= _DURATION_MAX):
+            if duration == 15.0:
+                console.print(
+                    f"[yellow]Warning: --duration 15 is below the minimum ({int(_DURATION_MIN)}s). "
+                    f"Clamping to {int(_DURATION_MIN)}s. Update your integration to use --duration {int(_DURATION_MIN)} or higher.[/yellow]"
+                )
+                duration = _DURATION_MIN
+            elif (
+                effective_backend == "auto"
+                and config.elevenlabs_api_key
+                and EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S
+            ):
+                # 'auto' never fails just because one engine can't do the job:
+                # ACE-Step can't serve this duration, but ElevenLabs can.
+                console.print(
+                    f"[yellow]--duration {duration} is outside the ACE-Step range "
+                    f"({int(_DURATION_MIN)}–{int(_DURATION_MAX)}s); routing to ElevenLabs.[/yellow]"
+                )
+                effective_backend = "elevenlabs"
+            else:
+                hint = (
+                    " Set ELEVENLABS_API_KEY to generate "
+                    f"{int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)}s tracks via ElevenLabs."
+                    if effective_backend == "auto"
+                    and not config.elevenlabs_api_key
+                    and EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S
+                    else ""
+                )
+                console.print(
+                    f"[red]Invalid --duration: {duration}. Must be between {int(_DURATION_MIN)} and "
+                    f"{int(_DURATION_MAX)} seconds.{hint}[/red]"
+                )
+                raise typer.Exit(code=1)
 
     # Resolve model: --model flag > config.default_model > None (server default)
     resolved_model = model or config.default_model or None
@@ -707,7 +733,8 @@ def generate(
             prompt_additions.append(f"{language_name} vocals")
         if seed is not None:
             console.print(
-                "[yellow]Warning: --seed requires ElevenLabs composition_plan mode, which is not yet implemented. Seed is ignored.[/yellow]"
+                "[yellow]Warning: ElevenLabs only honors --seed in composition-plan mode — "
+                "use `acemusic compose --seed`. Seed is ignored for generate.[/yellow]"
             )
 
         augmented_prompt = prompt

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1199,6 +1199,149 @@ def _sounds_via_elevenlabs(
         console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
 
 
+@app.command()
+def compose(
+    prompt: str = typer.Argument(..., help="Text description of the song to compose."),
+    duration: Optional[float] = typer.Option(
+        None,
+        "--duration",
+        help=f"Target total length in seconds ({int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)}).",
+    ),
+    output: Optional[Path] = typer.Option(None, "--output", help="Directory to save the composed track."),
+    name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix and clip title."),
+    instrumental: bool = typer.Option(False, "--instrumental", help="Compose without vocals."),
+    seed: Optional[int] = typer.Option(
+        None, "--seed", help="Random seed for more consistent results (plan mode only)."
+    ),
+) -> None:
+    """Compose a structured multi-section track via an ElevenLabs composition plan.
+
+    Creates a sectioned plan (intro/verse/chorus/…) from the prompt, displays it,
+    then generates the full track in one shot. ElevenLabs only; output is MP3.
+    """
+    if duration is not None and not (EL_DURATION_MIN_S <= duration <= EL_DURATION_MAX_S):
+        console.print(
+            f"[red]Invalid --duration: {duration}. ElevenLabs supports "
+            f"{int(EL_DURATION_MIN_S)}–{int(EL_DURATION_MAX_S)} seconds (10 min max).[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    config = load_config()
+    if not config.elevenlabs_api_key:
+        console.print(
+            "[red]ELEVENLABS_API_KEY is not configured. Set it in .env to use the compose command.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if output is not None:
+        output_path = output
+    elif config.output_dir:
+        output_path = Path(config.output_dir).expanduser()
+    else:
+        active_ws = get_active_workspace()
+        output_path = get_workspace_path(active_ws.id)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    plan_prompt = prompt
+    if instrumental:
+        plan_prompt = f"{prompt}, instrumental, no vocals"
+
+    el_client = ElevenLabsClient(
+        api_key=config.elevenlabs_api_key,
+        output_format=config.elevenlabs_output_format,
+    )
+    _compose_via_elevenlabs(
+        el_client=el_client,
+        prompt=prompt,
+        plan_prompt=plan_prompt,
+        duration=duration,
+        output_path=output_path,
+        name=name,
+        seed=seed,
+        output_format=config.elevenlabs_output_format,
+    )
+
+
+def _compose_via_elevenlabs(
+    *,
+    el_client: ElevenLabsClient,
+    prompt: str,
+    plan_prompt: str,
+    duration: Optional[float],
+    output_path: Path,
+    name: Optional[str],
+    seed: Optional[int],
+    output_format: str,
+) -> None:
+    """Create a composition plan, display it, generate the track, and save it."""
+    with console.status("[bold green]Creating composition plan…[/bold green]", spinner="dots"):
+        try:
+            plan = el_client.create_plan(prompt=plan_prompt, duration=duration)
+        except ElevenLabsError as exc:
+            console.print(f"[red]ElevenLabs error: {exc}[/red]")
+            raise typer.Exit(code=1)
+
+    sections = plan.get("sections", [])
+    table = Table(title="Composition Plan")
+    table.add_column("Section", style="cyan")
+    table.add_column("Duration", justify="right")
+    table.add_column("Styles")
+    table.add_column("Lyric lines", justify="right")
+    for section in sections:
+        table.add_row(
+            section.get("section_name", "-"),
+            f"{section.get('duration_ms', 0) / 1000:.1f}s",
+            ", ".join(section.get("positive_local_styles", [])),
+            str(len(section.get("lines", []))),
+        )
+    console.print(table)
+
+    total_s = sum(s.get("duration_ms", 0) for s in sections) / 1000
+    console.print(f"[cyan]Generating {len(sections)} sections ({total_s:.0f}s total) via ElevenLabs…[/cyan]")
+
+    with console.status("[bold green]Composing…[/bold green]", spinner="dots"):
+        try:
+            data = el_client.generate_from_plan(composition_plan=plan, seed=seed)
+        except ElevenLabsError as exc:
+            console.print(f"[red]ElevenLabs error: {exc}[/red]")
+            raise typer.Exit(code=1)
+
+    ext = _elevenlabs_ext(output_format)
+    slug = make_slug(prompt)
+    if name:
+        filename = f"{make_slug(name)}.{ext}"
+    else:
+        filename = make_filename(slug, datetime.now().strftime("%Y%m%d%H%M%S"), 1, ext=ext)
+    dest = output_path / filename
+    dest.write_bytes(data)
+
+    clip_duration: Optional[float] = None
+    try:
+        clip_duration = get_duration(dest)
+        dur_str = f"{clip_duration:.1f}s"
+    except Exception:
+        dur_str = "unknown"
+
+    try:
+        ws = get_active_workspace()
+        clip = Clip(
+            title=make_slug(name) if name else slug,
+            workspace_id=ws.id,
+            file_path=str(dest.resolve()),
+            format=ext,
+            duration=clip_duration,
+            seed=seed,
+            model="elevenlabs",
+            generation_mode="compose",
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        create_clip(clip)
+    except Exception as exc:
+        warnings.warn(f"clip metadata not saved: {exc}", stacklevel=2)
+
+    console.print(f"  [green]✓[/green] {dest.resolve()}  ({dur_str})")
+
+
 @workspace_app.command("create")
 def workspace_create(name: str = typer.Argument(..., help="Workspace name.")) -> None:
     """Create a new workspace."""

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1046,9 +1046,7 @@ def sounds(
             console.print("[red]Error: --backend elevenlabs requires ELEVENLABS_API_KEY to be set.[/red]")
             raise typer.Exit(code=1)
         if format != "mp3":
-            console.print(
-                f"[yellow]Warning: ElevenLabs output is MP3-only; --format {format} is ignored.[/yellow]"
-            )
+            console.print(f"[yellow]Warning: ElevenLabs output is MP3-only; --format {format} is ignored.[/yellow]")
 
         # ElevenLabs has no sound mode or native bpm/key controls — steer them
         # through the prompt, mirroring the `generate` command's injections.
@@ -1228,9 +1226,7 @@ def compose(
 
     config = load_config()
     if not config.elevenlabs_api_key:
-        console.print(
-            "[red]ELEVENLABS_API_KEY is not configured. Set it in .env to use the compose command.[/red]"
-        )
+        console.print("[red]ELEVENLABS_API_KEY is not configured. Set it in .env to use the compose command.[/red]")
         raise typer.Exit(code=1)
 
     if output is not None:

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -10,6 +10,10 @@ _BASE_URL = "https://api.elevenlabs.io"
 DURATION_MIN_S = 3.0
 DURATION_MAX_S = 600.0
 
+# Generating a track can take well over two minutes for long durations (up to
+# 10 min of audio), so music generation calls get a generous read timeout.
+_GENERATION_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
+
 
 class ElevenLabsError(Exception):
     """Raised when the ElevenLabs API returns an error or is unreachable."""
@@ -70,7 +74,7 @@ class ElevenLabsClient:
                 json=body,
                 headers=self._headers,
                 params={"output_format": self.output_format},
-                timeout=120.0,
+                timeout=_GENERATION_TIMEOUT,
             )
             response.raise_for_status()
             return response.content
@@ -110,11 +114,16 @@ class ElevenLabsClient:
                 timeout=120.0,
             )
             response.raise_for_status()
-            return response.json()
+            plan = response.json()
         except httpx.HTTPStatusError as exc:
             raise ElevenLabsError(f"ElevenLabs plan creation failed: {exc.response.status_code}") from exc
         except httpx.RequestError as exc:
             raise ElevenLabsError(f"ElevenLabs plan creation failed: {exc}") from exc
+        except ValueError as exc:
+            raise ElevenLabsError("ElevenLabs plan creation failed: invalid JSON response") from exc
+        if not isinstance(plan, dict):
+            raise ElevenLabsError("ElevenLabs plan creation failed: invalid plan payload type")
+        return plan
 
     def generate_from_plan(
         self,
@@ -148,7 +157,7 @@ class ElevenLabsClient:
                 json=body,
                 headers=self._headers,
                 params={"output_format": self.output_format},
-                timeout=120.0,
+                timeout=_GENERATION_TIMEOUT,
             )
             response.raise_for_status()
             return response.content

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -6,9 +6,22 @@ import httpx
 
 _BASE_URL = "https://api.elevenlabs.io"
 
+# ElevenLabs music API duration limits (music_length_ms: 3000–600000).
+DURATION_MIN_S = 3.0
+DURATION_MAX_S = 600.0
+
 
 class ElevenLabsError(Exception):
     """Raised when the ElevenLabs API returns an error or is unreachable."""
+
+
+def _validate_duration(duration: float | None) -> None:
+    """Raise ElevenLabsError if duration is outside the API limits (3s–600s)."""
+    if duration is not None and not (DURATION_MIN_S <= duration <= DURATION_MAX_S):
+        raise ElevenLabsError(
+            f"Invalid duration {duration}s: ElevenLabs requires between "
+            f"{int(DURATION_MIN_S)}s and {int(DURATION_MAX_S)}s (10 min)."
+        )
 
 
 class ElevenLabsClient:
@@ -38,8 +51,9 @@ class ElevenLabsClient:
             lyrics: Inline lyrics text forwarded to the API.
 
         Raises:
-            ElevenLabsError: On HTTP error or connection failure.
+            ElevenLabsError: On out-of-range duration, HTTP error, or connection failure.
         """
+        _validate_duration(duration)
         body: dict = {"prompt": prompt}
         if duration is not None:
             body["music_length_ms"] = int(duration * 1000)

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -79,6 +79,84 @@ class ElevenLabsClient:
         except httpx.RequestError as exc:
             raise ElevenLabsError(f"ElevenLabs generate failed: {exc}") from exc
 
+    def create_plan(
+        self,
+        prompt: str,
+        duration: float | None = None,
+        model_id: str | None = None,
+    ) -> dict:
+        """Create a composition plan via POST /v1/music/plan and return the parsed JSON.
+
+        Args:
+            prompt: Text description to compose a plan from.
+            duration: Target plan length in seconds (converted to music_length_ms).
+            model_id: Optional model override (e.g. 'music_v1').
+
+        Raises:
+            ElevenLabsError: On out-of-range duration, HTTP error, or connection failure.
+        """
+        _validate_duration(duration)
+        body: dict = {"prompt": prompt}
+        if duration is not None:
+            body["music_length_ms"] = int(duration * 1000)
+        if model_id is not None:
+            body["model_id"] = model_id
+
+        try:
+            response = httpx.post(
+                f"{_BASE_URL}/v1/music/plan",
+                json=body,
+                headers=self._headers,
+                timeout=120.0,
+            )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            raise ElevenLabsError(f"ElevenLabs plan creation failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise ElevenLabsError(f"ElevenLabs plan creation failed: {exc}") from exc
+
+    def generate_from_plan(
+        self,
+        composition_plan: dict,
+        respect_durations: bool = True,
+        seed: int | None = None,
+    ) -> bytes:
+        """Generate music from a composition plan via POST /v1/music and return audio bytes.
+
+        The API forbids combining ``composition_plan`` with ``prompt`` or
+        ``force_instrumental``, so only plan-mode fields are sent.
+
+        Args:
+            composition_plan: Plan dict as returned by :meth:`create_plan`.
+            respect_durations: If True, sections strictly honor their duration_ms.
+            seed: Optional random seed (only valid in plan mode).
+
+        Raises:
+            ElevenLabsError: On HTTP error or connection failure.
+        """
+        body: dict = {
+            "composition_plan": composition_plan,
+            "respect_sections_durations": respect_durations,
+        }
+        if seed is not None:
+            body["seed"] = seed
+
+        try:
+            response = httpx.post(
+                f"{_BASE_URL}/v1/music",
+                json=body,
+                headers=self._headers,
+                params={"output_format": self.output_format},
+                timeout=120.0,
+            )
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPStatusError as exc:
+            raise ElevenLabsError(f"ElevenLabs plan generation failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise ElevenLabsError(f"ElevenLabs plan generation failed: {exc}") from exc
+
     def validate_key(self, timeout: float = 5.0) -> bool:
         """Validate the API key via GET /v1/user. Returns True if valid, False otherwise."""
         try:

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -12,7 +12,9 @@ DURATION_MAX_S = 600.0
 
 # Generating a track can take well over two minutes for long durations (up to
 # 10 min of audio), so music generation calls get a generous read timeout.
+# Plan creation is a fast, credit-free endpoint and keeps a tighter budget.
 _GENERATION_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
+_PLAN_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
 
 
 class ElevenLabsError(Exception):
@@ -111,7 +113,7 @@ class ElevenLabsClient:
                 f"{_BASE_URL}/v1/music/plan",
                 json=body,
                 headers=self._headers,
-                timeout=120.0,
+                timeout=_PLAN_TIMEOUT,
             )
             response.raise_for_status()
             plan = response.json()

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -5,8 +5,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from acemusic import __version__
-from acemusic.api.main import app as module_app
-from acemusic.api.main import create_app
+from acemusic.api.main import app as module_app, create_app
 from acemusic.api.settings import ApiSettings
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -58,3 +58,17 @@ class TestCapabilities:
         # message names the engine that does support it
         with pytest.raises(BackendError, match="ace-step"):
             ensure_supports("elevenlabs", "midi")
+
+
+class TestIssue96Capabilities:
+    """Capability entries added by #96 (ElevenLabs first-class generate/compose)."""
+
+    def test_sounds_supported_by_both_engines(self):
+        assert supports("ace-step", "sounds")
+        assert supports("elevenlabs", "sounds")
+        assert supports("auto", "sounds")
+
+    def test_compose_is_elevenlabs_only(self):
+        assert supports("elevenlabs", "compose")
+        assert not supports("ace-step", "compose")
+        assert supports("auto", "compose")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,3 +157,27 @@ class TestElevenLabsBackendSkipsAceStepUrlCheck:
 
         assert result.exit_code == 1
         assert "ACE-Step server URL" in result.output
+
+    def test_url_error_hints_at_elevenlabs_when_key_present(self, monkeypatch, tmp_path):
+        """The missing-URL error suggests --backend elevenlabs when a key is configured."""
+        self._no_ace_config(monkeypatch)
+
+        result = runner.invoke(app, ["generate", "pop", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "--backend elevenlabs" in result.output
+
+    def test_url_error_has_no_hint_without_key(self, monkeypatch, tmp_path):
+        """No ElevenLabs hint when no key is configured."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url=None, api_key=None, elevenlabs_api_key=None),
+        )
+
+        result = runner.invoke(app, ["generate", "pop", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "ACE-Step server URL" in result.output
+        assert "--backend elevenlabs" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,17 +35,17 @@ def test_version_prints_version_string():
 
 
 def test_missing_api_url_produces_friendly_error(monkeypatch):
-    """When ACEMUSIC_BASE_URL is not set, invoking a subcommand prints a friendly error."""
+    """When ACEMUSIC_BASE_URL is not set, an ACE-Step command prints a friendly error.
+
+    The check moved from the root callback into the command's ACE-Step path
+    (#96), so a prompt argument is required to reach it.
+    """
     monkeypatch.delenv("ACEMUSIC_BASE_URL", raising=False)
-    # Ensure no .env or config file interferes by patching load_config
-    from acemusic import config as cfg_mod
+    from acemusic.config import AceConfig
 
-    def _no_url():
-        return cfg_mod.AceConfig(api_url=None, api_key=None)
+    monkeypatch.setattr("acemusic.cli.load_config", lambda: AceConfig(api_url=None, api_key=None))
 
-    monkeypatch.setattr(cfg_mod, "load_config", _no_url)
-
-    result = runner.invoke(app, ["generate"])
+    result = runner.invoke(app, ["generate", "pop"])
     assert result.exit_code != 0
     assert "ACEMUSIC_BASE_URL" in result.output
     assert "traceback" not in result.output.lower()
@@ -89,3 +89,71 @@ class TestModelsCommand:
         result = runner.invoke(app, ["models"])
         assert result.exit_code == 0
         assert "turbo" in result.output
+
+
+class TestElevenLabsBackendSkipsAceStepUrlCheck:
+    """Explicit --backend elevenlabs must not require ACEMUSIC_BASE_URL (#96)."""
+
+    def _no_ace_config(self, monkeypatch):
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url=None,
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+    def test_generate_backend_elevenlabs_flag_skips_url_check(self, monkeypatch, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        self._no_ace_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--backend", "elevenlabs", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "ACE-Step server URL" not in result.output
+
+    def test_sounds_backend_elevenlabs_equals_form_skips_url_check(self, monkeypatch, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        self._no_ace_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            result = runner.invoke(
+                app,
+                ["sounds", "kick", "--type", "one-shot", "--backend=elevenlabs", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "ACE-Step server URL" not in result.output
+
+    def test_generate_without_backend_still_requires_url(self, monkeypatch, tmp_path):
+        self._no_ace_config(monkeypatch)
+
+        result = runner.invoke(app, ["generate", "pop", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "ACE-Step server URL" in result.output
+
+    def test_generate_backend_ace_step_still_requires_url(self, monkeypatch, tmp_path):
+        self._no_ace_config(monkeypatch)
+
+        result = runner.invoke(app, ["generate", "pop", "--backend", "ace-step", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "ACE-Step server URL" in result.output

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -286,3 +286,34 @@ class TestComposeDurationProbe:
         clips = list_clips(get_active_workspace().id)
         assert len(clips) == 1
         assert clips[0].duration is None
+
+
+class TestComposeWithoutAceStep:
+    """compose is ElevenLabs-only and must not require an ACE-Step server (C1)."""
+
+    def test_compose_works_without_ace_step_url(self, monkeypatch, tmp_path):
+        """compose succeeds with only an ElevenLabs key configured (api_url=None)."""
+        import acemusic.db as _db
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url=None,
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=24.0),
+        ):
+            result = runner.invoke(app, ["compose", "anthem", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "ACE-Step server URL" not in result.output
+        assert list(tmp_path.glob("*.mp3"))

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -257,3 +257,32 @@ class TestComposeValidation:
         """compose is registered on the root app."""
         result = runner.invoke(app, ["--help"])
         assert "compose" in _plain(result.output)
+
+
+class TestComposeDurationProbe:
+    """Duration probing failures degrade gracefully."""
+
+    def test_compose_duration_probe_failure_still_succeeds(self, monkeypatch, tmp_path):
+        """If get_duration fails, compose still saves the file and reports 'unknown'."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", side_effect=RuntimeError("no ffprobe")),
+        ):
+            result = runner.invoke(app, ["compose", "anthem", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert list(tmp_path.glob("*.mp3"))
+        assert "unknown" in _plain(result.output)
+
+        from acemusic.db import list_clips
+        from acemusic.workspace import get_active_workspace
+
+        clips = list_clips(get_active_workspace().id)
+        assert len(clips) == 1
+        assert clips[0].duration is None

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,259 @@
+"""Unit tests for the acemusic compose command (issue #96)."""
+
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from acemusic.cli import app
+from acemusic.elevenlabs_client import ElevenLabsError
+
+runner = CliRunner()
+
+FAKE_MP3 = b"ID3" + b"\x00" * 100
+
+FAKE_PLAN = {
+    "positive_global_styles": ["upbeat pop", "120 BPM"],
+    "negative_global_styles": ["metal"],
+    "sections": [
+        {
+            "section_name": "Intro",
+            "positive_local_styles": ["atmospheric build"],
+            "negative_local_styles": ["vocals"],
+            "duration_ms": 8000,
+            "lines": [],
+        },
+        {
+            "section_name": "Chorus",
+            "positive_local_styles": ["hook", "energetic"],
+            "negative_local_styles": [],
+            "duration_ms": 16000,
+            "lines": ["Breaking through", "Nothing stops me now"],
+        },
+    ],
+}
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI escape codes from text (Rich emits these in CI environments)."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _el_config(monkeypatch, api_key="test-key"):
+    """Point load_config at an ElevenLabs-enabled config."""
+    from acemusic.config import AceConfig
+
+    monkeypatch.setattr(
+        "acemusic.cli.load_config",
+        lambda: AceConfig(
+            api_url="http://localhost:8001",
+            api_key=None,
+            elevenlabs_api_key=api_key,
+            elevenlabs_output_format="mp3_44100_128",
+        ),
+    )
+
+
+def _el_mock():
+    el = MagicMock()
+    el.create_plan.return_value = FAKE_PLAN
+    el.generate_from_plan.return_value = FAKE_MP3
+    return el
+
+
+class TestComposeCommand:
+    """Tests for the compose command happy path."""
+
+    def test_compose_writes_mp3_and_displays_sections(self, monkeypatch, tmp_path):
+        """compose creates a plan, shows its sections, and writes the MP3."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=24.0),
+        ):
+            result = runner.invoke(app, ["compose", "an upbeat pop anthem", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        mp3_files = list(tmp_path.glob("*.mp3"))
+        assert len(mp3_files) == 1
+        assert mp3_files[0].read_bytes() == FAKE_MP3
+        plain = _plain(result.output)
+        assert "Intro" in plain
+        assert "Chorus" in plain
+
+    def test_compose_forwards_prompt_and_duration_to_create_plan(self, monkeypatch, tmp_path):
+        """The prompt and --duration are forwarded to create_plan()."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=120.0),
+        ):
+            result = runner.invoke(
+                app, ["compose", "an upbeat pop anthem", "--duration", "120", "--output", str(tmp_path)]
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = el.create_plan.call_args.kwargs
+        assert kwargs["prompt"] == "an upbeat pop anthem"
+        assert kwargs["duration"] == 120.0
+
+    def test_compose_generates_from_the_created_plan(self, monkeypatch, tmp_path):
+        """The plan returned by create_plan() is passed to generate_from_plan()."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=24.0),
+        ):
+            result = runner.invoke(app, ["compose", "anthem", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert el.generate_from_plan.call_args.kwargs["composition_plan"] == FAKE_PLAN
+
+    def test_compose_seed_forwarded_to_generate_from_plan(self, monkeypatch, tmp_path):
+        """--seed is forwarded to generate_from_plan() (plan mode supports seeds)."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=24.0),
+        ):
+            result = runner.invoke(app, ["compose", "anthem", "--seed", "42", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert el.generate_from_plan.call_args.kwargs["seed"] == 42
+
+    def test_compose_instrumental_appended_to_plan_prompt(self, monkeypatch, tmp_path):
+        """--instrumental steers the plan prompt (force_instrumental is prompt-mode-only)."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=24.0),
+        ):
+            result = runner.invoke(app, ["compose", "anthem", "--instrumental", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        prompt_sent = el.create_plan.call_args.kwargs["prompt"]
+        assert "instrumental" in prompt_sent.lower()
+
+    def test_compose_saves_clip_with_compose_mode(self, monkeypatch, tmp_path):
+        """A Clip record is created with generation_mode='compose' and model='elevenlabs'."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=24.0),
+        ):
+            result = runner.invoke(app, ["compose", "an upbeat pop anthem", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+        from acemusic.workspace import get_active_workspace
+
+        clips = list_clips(get_active_workspace().id)
+        assert len(clips) == 1
+        clip = clips[0]
+        assert clip.generation_mode == "compose"
+        assert clip.model == "elevenlabs"
+        assert clip.format == "mp3"
+        assert clip.duration == 24.0
+
+    def test_compose_name_flag_used_for_filename(self, monkeypatch, tmp_path):
+        """--name produces a prefixed filename."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=24.0),
+        ):
+            result = runner.invoke(app, ["compose", "anthem", "--name", "My Theme", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "my-theme.mp3").exists()
+
+
+class TestComposeValidation:
+    """Tests for compose command validation and error handling."""
+
+    def test_compose_requires_api_key(self, monkeypatch, tmp_path):
+        """Without ELEVENLABS_API_KEY, compose exits 1 with a clear message."""
+        _el_config(monkeypatch, api_key=None)
+
+        result = runner.invoke(app, ["compose", "anthem", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "elevenlabs_api_key" in _plain(result.output).lower()
+
+    def test_compose_rejects_out_of_range_duration(self, monkeypatch, tmp_path):
+        """Durations outside 3–600s exit 1 with the valid range in the message."""
+        _el_config(monkeypatch)
+        el = _el_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(app, ["compose", "anthem", "--duration", "601", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        plain = _plain(result.output)
+        assert "3" in plain and "600" in plain
+        el.create_plan.assert_not_called()
+
+    def test_compose_plan_error_exits_one(self, monkeypatch, tmp_path):
+        """An ElevenLabsError during plan creation exits 1."""
+        _el_config(monkeypatch)
+        el = _el_mock()
+        el.create_plan.side_effect = ElevenLabsError("ElevenLabs plan creation failed: 422")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(app, ["compose", "anthem", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "422" in _plain(result.output)
+
+    def test_compose_generation_error_exits_one(self, monkeypatch, tmp_path):
+        """An ElevenLabsError during generation exits 1."""
+        _el_config(monkeypatch)
+        el = _el_mock()
+        el.generate_from_plan.side_effect = ElevenLabsError("ElevenLabs plan generation failed: 500")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(app, ["compose", "anthem", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "500" in _plain(result.output)
+
+    def test_compose_appears_in_help(self):
+        """compose is registered on the root app."""
+        result = runner.invoke(app, ["--help"])
+        assert "compose" in _plain(result.output)

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -420,3 +420,25 @@ class TestElevenLabsIntegration:
 
         client = ElevenLabsClient(api_key=key)
         assert client.validate_key() is True
+
+    def test_compose_plan_roundtrip_returns_playable_audio(self):
+        """Integration: create_plan() → generate_from_plan() yields decodable MP3 audio."""
+        import io
+        import os
+
+        key = os.environ.get("ELEVENLABS_API_KEY")
+        if not key:
+            pytest.skip("ELEVENLABS_API_KEY not set")
+
+        client = ElevenLabsClient(api_key=key, output_format="mp3_44100_128")
+        plan = client.create_plan(prompt="short upbeat jingle", duration=10.0)
+        assert plan.get("sections"), "plan should contain sections"
+
+        audio = client.generate_from_plan(plan)
+        assert isinstance(audio, bytes)
+        assert len(audio) > 1000
+
+        from pydub import AudioSegment
+
+        segment = AudioSegment.from_file(io.BytesIO(audio), format="mp3")
+        assert segment.duration_seconds > 1.0

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -268,6 +268,26 @@ class TestElevenLabsClientCreatePlan:
             with pytest.raises(ElevenLabsError):
                 client.create_plan(prompt="anthem")
 
+    def test_create_plan_raises_elevenlabs_error_on_malformed_json(self):
+        """A 2xx response with unparseable JSON raises ElevenLabsError, not ValueError."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"not json")
+        resp.json.side_effect = ValueError("Expecting value")
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="invalid"):
+                client.create_plan(prompt="anthem")
+
+    def test_create_plan_raises_elevenlabs_error_on_non_dict_payload(self):
+        """A 2xx response whose JSON is not an object raises ElevenLabsError."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"[]")
+        resp.json.return_value = ["not", "a", "plan"]
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="invalid"):
+                client.create_plan(prompt="anthem")
+
 
 class TestElevenLabsClientGenerateFromPlan:
     """Tests for ElevenLabsClient.generate_from_plan() (issue #96)."""

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -157,6 +157,199 @@ class TestElevenLabsClientDurationValidation:
             client.generate(prompt="pop", duration=1.0)
 
 
+FAKE_PLAN = {
+    "positive_global_styles": ["upbeat pop", "120 BPM"],
+    "negative_global_styles": ["metal"],
+    "sections": [
+        {
+            "section_name": "Intro",
+            "positive_local_styles": ["atmospheric build"],
+            "negative_local_styles": ["vocals"],
+            "duration_ms": 8000,
+            "lines": [],
+        },
+        {
+            "section_name": "Chorus",
+            "positive_local_styles": ["hook", "energetic"],
+            "negative_local_styles": [],
+            "duration_ms": 16000,
+            "lines": ["Breaking through", "Nothing stops me now"],
+        },
+    ],
+}
+
+
+class TestElevenLabsClientCreatePlan:
+    """Tests for ElevenLabsClient.create_plan() (issue #96)."""
+
+    def test_create_plan_returns_parsed_json(self):
+        """create_plan() returns the parsed composition plan dict."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"", json_data=FAKE_PLAN)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            plan = client.create_plan(prompt="an upbeat pop anthem")
+
+        assert plan == FAKE_PLAN
+
+    def test_create_plan_posts_to_plan_endpoint_with_prompt(self):
+        """create_plan() POSTs the prompt to /v1/music/plan."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"", json_data=FAKE_PLAN)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.create_plan(prompt="an upbeat pop anthem")
+
+        url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args.kwargs.get("url")
+        assert url.endswith("/v1/music/plan")
+        body = mock_post.call_args.kwargs.get("json", {})
+        assert body.get("prompt") == "an upbeat pop anthem"
+        assert "music_length_ms" not in body
+
+    def test_create_plan_converts_duration_to_music_length_ms(self):
+        """create_plan() converts duration seconds to music_length_ms."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"", json_data=FAKE_PLAN)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.create_plan(prompt="anthem", duration=120.0)
+
+        body = mock_post.call_args.kwargs.get("json", {})
+        assert body.get("music_length_ms") == 120000
+
+    def test_create_plan_sends_model_id_when_provided(self):
+        """create_plan() includes model_id in the body when given."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"", json_data=FAKE_PLAN)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.create_plan(prompt="anthem", model_id="music_v1")
+
+        body = mock_post.call_args.kwargs.get("json", {})
+        assert body.get("model_id") == "music_v1"
+
+    def test_create_plan_sends_api_key_header(self):
+        """create_plan() sends the xi-api-key header."""
+        client = ElevenLabsClient(api_key="plan-key")
+        resp = _mock_response(200, b"", json_data=FAKE_PLAN)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.create_plan(prompt="anthem")
+
+        headers = mock_post.call_args.kwargs.get("headers", {})
+        assert headers.get("xi-api-key") == "plan-key"
+
+    def test_create_plan_rejects_out_of_range_duration(self):
+        """create_plan() validates duration against the API limits."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with patch("acemusic.elevenlabs_client.httpx.post") as mock_post:
+            with pytest.raises(ElevenLabsError, match=r"3.*600"):
+                client.create_plan(prompt="anthem", duration=601.0)
+
+        mock_post.assert_not_called()
+
+    def test_create_plan_raises_elevenlabs_error_on_http_error(self):
+        """create_plan() raises ElevenLabsError on API errors."""
+        client = ElevenLabsClient(api_key="bad-key")
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=_error_response(422)):
+            with pytest.raises(ElevenLabsError, match="422"):
+                client.create_plan(prompt="anthem")
+
+    def test_create_plan_raises_elevenlabs_error_on_connection_failure(self):
+        """create_plan() raises ElevenLabsError when the request fails."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with patch(
+            "acemusic.elevenlabs_client.httpx.post",
+            side_effect=httpx.ConnectError("connection refused"),
+        ):
+            with pytest.raises(ElevenLabsError):
+                client.create_plan(prompt="anthem")
+
+
+class TestElevenLabsClientGenerateFromPlan:
+    """Tests for ElevenLabsClient.generate_from_plan() (issue #96)."""
+
+    def test_generate_from_plan_returns_audio_bytes(self):
+        """generate_from_plan() returns raw audio bytes on success."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, FAKE_MP3)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            result = client.generate_from_plan(FAKE_PLAN)
+
+        assert result == FAKE_MP3
+
+    def test_generate_from_plan_sends_plan_in_body(self):
+        """generate_from_plan() sends composition_plan (and no prompt) in the body."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, FAKE_MP3)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.generate_from_plan(FAKE_PLAN)
+
+        url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args.kwargs.get("url")
+        assert url.endswith("/v1/music")
+        body = mock_post.call_args.kwargs.get("json", {})
+        assert body.get("composition_plan") == FAKE_PLAN
+        assert "prompt" not in body
+        assert "force_instrumental" not in body
+
+    def test_generate_from_plan_sends_respect_sections_durations(self):
+        """generate_from_plan() includes respect_sections_durations in the body."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, FAKE_MP3)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.generate_from_plan(FAKE_PLAN, respect_durations=False)
+
+        body = mock_post.call_args.kwargs.get("json", {})
+        assert body.get("respect_sections_durations") is False
+
+    def test_generate_from_plan_sends_seed_when_provided(self):
+        """generate_from_plan() forwards the seed (valid only in plan mode)."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, FAKE_MP3)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.generate_from_plan(FAKE_PLAN, seed=42)
+
+        body = mock_post.call_args.kwargs.get("json", {})
+        assert body.get("seed") == 42
+
+    def test_generate_from_plan_sends_output_format_as_query_param(self):
+        """generate_from_plan() sends output_format as a query parameter."""
+        client = ElevenLabsClient(api_key="test-key", output_format="mp3_44100_192")
+        resp = _mock_response(200, FAKE_MP3)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.generate_from_plan(FAKE_PLAN)
+
+        params = mock_post.call_args.kwargs.get("params", {})
+        assert params.get("output_format") == "mp3_44100_192"
+
+    def test_generate_from_plan_raises_elevenlabs_error_on_http_error(self):
+        """generate_from_plan() raises ElevenLabsError on API errors."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=_error_response(422)):
+            with pytest.raises(ElevenLabsError, match="422"):
+                client.generate_from_plan(FAKE_PLAN)
+
+    def test_generate_from_plan_raises_elevenlabs_error_on_connection_failure(self):
+        """generate_from_plan() raises ElevenLabsError when the request fails."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with patch(
+            "acemusic.elevenlabs_client.httpx.post",
+            side_effect=httpx.ConnectError("connection refused"),
+        ):
+            with pytest.raises(ElevenLabsError):
+                client.generate_from_plan(FAKE_PLAN)
+
+
 class TestElevenLabsClientValidateKey:
     """Tests for ElevenLabsClient.validate_key()."""
 

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from acemusic.elevenlabs_client import ElevenLabsClient, ElevenLabsError
+from acemusic.elevenlabs_client import DURATION_MAX_S, DURATION_MIN_S, ElevenLabsClient, ElevenLabsError
 
 FAKE_MP3 = b"ID3" + b"\x00" * 100  # minimal fake MP3 bytes
 
@@ -121,6 +121,40 @@ class TestElevenLabsClientGenerate:
         ):
             with pytest.raises(ElevenLabsError):
                 client.generate(prompt="test")
+
+
+class TestElevenLabsClientDurationValidation:
+    """Tests for duration validation in ElevenLabsClient.generate() (issue #96)."""
+
+    @pytest.mark.parametrize("duration", [DURATION_MIN_S, DURATION_MAX_S, 30.0])
+    def test_generate_accepts_durations_within_limits(self, duration):
+        """generate() accepts durations at and within the API limits."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, FAKE_MP3)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.generate(prompt="pop", duration=duration)
+
+        body = mock_post.call_args.kwargs.get("json", {})
+        assert body.get("music_length_ms") == int(duration * 1000)
+
+    @pytest.mark.parametrize("duration", [2.9, 0.0, -1.0, 600.1, 9999.0])
+    def test_generate_rejects_durations_outside_limits(self, duration):
+        """generate() raises ElevenLabsError without calling the API for out-of-range durations."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with patch("acemusic.elevenlabs_client.httpx.post") as mock_post:
+            with pytest.raises(ElevenLabsError):
+                client.generate(prompt="pop", duration=duration)
+
+        mock_post.assert_not_called()
+
+    def test_duration_error_message_states_valid_range(self):
+        """The validation error message includes the valid range."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with pytest.raises(ElevenLabsError, match=r"3.*600"):
+            client.generate(prompt="pop", duration=1.0)
 
 
 class TestElevenLabsClientValidateKey:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1806,7 +1806,7 @@ class TestReviewFixes96:
             Preset(
                 workspace_id=ws.id,
                 name="toolong",
-                duration=300.0,
+                duration=300,
                 created_at=datetime.now(timezone.utc).isoformat(),
             )
         )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -20,6 +20,7 @@ def _plain(text: str) -> str:
     """Strip ANSI escape codes from text (Rich emits these in CI environments)."""
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
+
 TASK_ID = "task-abc-123"
 AUDIO_URL_1 = "http://localhost:8001/audio/clip1.wav"
 AUDIO_URL_2 = "http://localhost:8001/audio/clip2.wav"
@@ -1709,3 +1710,22 @@ class TestModelSelection:
         assert result.exit_code == 0, result.output
         assert "model" in result.output.lower()
         assert "ignored" in result.output.lower() or "warning" in result.output.lower()
+
+
+class TestDuration15Clamp:
+    """Legacy --duration 15 clamp (moved by #96's backend-aware validation)."""
+
+    def test_duration_15_clamps_to_minimum_with_warning(self, monkeypatch, tmp_path):
+        """--duration 15 on the ACE-Step path clamps to 30s with a warning."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=30.0),
+        ):
+            result = runner.invoke(app, ["generate", "test", "--duration", "15", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "Clamping" in _plain(result.output)
+        assert client_mock.submit_task.call_args.kwargs["audio_duration"] == 30.0

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -950,19 +950,6 @@ class TestElevenLabsDurationLimits:
         assert "3" in plain and "600" in plain
         el_mock.generate.assert_not_called()
 
-    def test_default_backend_keeps_ace_step_duration_limits(self, monkeypatch, tmp_path):
-        """Without --backend elevenlabs, the ACE-Step 30–240s validation still applies."""
-        self._el_config(monkeypatch)
-
-        result = runner.invoke(
-            app,
-            ["generate", "epic ballad", "--duration", "300", "--output", str(tmp_path)],
-        )
-
-        assert result.exit_code == 1
-        plain = _plain(result.output)
-        assert "30" in plain and "240" in plain
-
 
 class TestMusicalParametersAceStep:
     """Tests for US-3.2: --bpm, --key, --time-signature, --seed forwarded to ACE-Step."""
@@ -1071,17 +1058,30 @@ class TestMusicalParametersAceStep:
         assert result.exit_code == 0, result.output
         assert client_mock.submit_task.call_args.kwargs["seed"] == -1
 
+    def _no_elevenlabs_config(self, monkeypatch):
+        """Hermetic config with no ElevenLabs key, so auto cannot route to ElevenLabs.
+
+        Without this, a host with a real key in ~/.acemusic/config.yaml would
+        auto-route ACE-Step-invalid durations to the real ElevenLabs API (#96).
+        """
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url="http://localhost:8001", api_key=None, elevenlabs_api_key=None),
+        )
+
     def test_duration_too_short_exits_one(self, monkeypatch, tmp_path):
-        """--duration 10 exits 1 (below 30s minimum)."""
-        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        """--duration 10 exits 1 (below 30s minimum, no ElevenLabs key to route to)."""
+        self._no_elevenlabs_config(monkeypatch)
         result = runner.invoke(app, ["generate", "pop", "--duration", "10", "--output", str(tmp_path)])
         assert result.exit_code == 1
         assert "duration" in result.output.lower()
         assert "Traceback" not in result.output
 
     def test_duration_too_long_exits_one(self, monkeypatch, tmp_path):
-        """--duration 500 exits 1 (above 240s maximum)."""
-        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        """--duration 500 exits 1 (above 240s maximum, no ElevenLabs key to route to)."""
+        self._no_elevenlabs_config(monkeypatch)
         result = runner.invoke(app, ["generate", "pop", "--duration", "500", "--output", str(tmp_path)])
         assert result.exit_code == 1
         assert "duration" in result.output.lower()
@@ -1729,3 +1729,128 @@ class TestDuration15Clamp:
         assert result.exit_code == 0, result.output
         assert "Clamping" in _plain(result.output)
         assert client_mock.submit_task.call_args.kwargs["audio_duration"] == 30.0
+
+
+class TestReviewFixes96:
+    """Regression tests for review findings on issue #96."""
+
+    def _el_config(self, monkeypatch, api_key="test-key", backend=None, api_url="http://localhost:8001"):
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url=api_url,
+                api_key=None,
+                elevenlabs_api_key=api_key,
+                elevenlabs_output_format="mp3_44100_128",
+                backend=backend,
+            ),
+        )
+
+    def test_auto_routes_long_duration_to_elevenlabs(self, monkeypatch, tmp_path):
+        """auto + duration beyond ACE-Step max routes directly to ElevenLabs (codex P2)."""
+        self._el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=300.0),
+        ):
+            result = runner.invoke(app, ["generate", "epic ballad", "--duration", "300", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert el_mock.generate.call_args.kwargs["duration"] == 300.0
+        assert "elevenlabs" in _plain(result.output).lower()
+
+    def test_auto_long_duration_without_key_errors_with_hint(self, monkeypatch, tmp_path):
+        """auto + long duration + no ElevenLabs key exits 1 and hints at ELEVENLABS_API_KEY."""
+        self._el_config(monkeypatch, api_key=None)
+
+        result = runner.invoke(app, ["generate", "epic ballad", "--duration", "300", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        plain = _plain(result.output)
+        assert "30" in plain and "240" in plain
+        assert "ELEVENLABS_API_KEY" in plain
+
+    def test_explicit_ace_step_keeps_duration_limits(self, monkeypatch, tmp_path):
+        """--backend ace-step still rejects durations beyond 240s even with a key configured."""
+        self._el_config(monkeypatch)
+
+        result = runner.invoke(
+            app,
+            ["generate", "epic ballad", "--backend", "ace-step", "--duration", "300", "--output", str(tmp_path)],
+        )
+
+        assert result.exit_code == 1
+        plain = _plain(result.output)
+        assert "30" in plain and "240" in plain
+
+    def test_preset_duration_is_validated(self, monkeypatch, tmp_path):
+        """A preset-supplied out-of-range duration is rejected with the range message (M1)."""
+        import acemusic.db as _db
+
+        monkeypatch.setattr(_db, "DB_DIR", tmp_path / ".acemusic")
+        self._el_config(monkeypatch, api_key=None)
+
+        from datetime import datetime, timezone
+
+        from acemusic.db import create_preset
+        from acemusic.models import Preset
+        from acemusic.workspace import get_active_workspace
+
+        ws = get_active_workspace()
+        create_preset(
+            Preset(
+                workspace_id=ws.id,
+                name="toolong",
+                duration=300.0,
+                created_at=datetime.now(timezone.utc).isoformat(),
+            )
+        )
+
+        client_mock = _make_client_mock([COMPLETED_RESULT])
+        with patch("acemusic.cli.AceStepClient", return_value=client_mock):
+            result = runner.invoke(app, ["generate", "test", "--preset", "toolong", "--output", str(tmp_path)])
+
+        assert result.exit_code == 1
+        plain = _plain(result.output)
+        assert "30" in plain and "240" in plain
+        client_mock.submit_task.assert_not_called()
+
+    def test_seed_warning_points_to_compose(self, monkeypatch, tmp_path):
+        """The --seed warning directs users to the compose command (M2 — no longer 'not implemented')."""
+        self._el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "pop", "--backend", "elevenlabs", "--seed", "42", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        plain = _plain(result.output).lower()
+        assert "compose" in plain
+        assert "not yet implemented" not in plain
+
+    def test_elevenlabs_default_backend_skips_ace_step_url_check(self, monkeypatch, tmp_path):
+        """ACEMUSIC_BACKEND=elevenlabs with no ACE-Step URL does not require ACEMUSIC_BASE_URL."""
+        self._el_config(monkeypatch, backend="elevenlabs", api_url=None)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(app, ["generate", "pop", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert el_mock.generate.called

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1717,7 +1717,14 @@ class TestDuration15Clamp:
 
     def test_duration_15_clamps_to_minimum_with_warning(self, monkeypatch, tmp_path):
         """--duration 15 on the ACE-Step path clamps to 30s with a warning."""
-        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        from acemusic.config import AceConfig
+
+        # Hermetic: a host config with backend=elevenlabs or a real key would
+        # otherwise skip the ACE-Step clamp path.
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url="http://localhost:8001", api_key=None, elevenlabs_api_key=None),
+        )
         client_mock = _make_client_mock([COMPLETED_RESULT])
 
         with (

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,5 +1,6 @@
 """Unit tests for acemusic generate command (US-2.3, US-2.4, US-3.2)."""
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,11 @@ runner = CliRunner()
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI escape codes from text (Rich emits these in CI environments)."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 TASK_ID = "task-abc-123"
 AUDIO_URL_1 = "http://localhost:8001/audio/clip1.wav"
@@ -757,8 +763,8 @@ class TestStyleLyricsElevenLabs:
         assert el_mock.generate.call_args is not None
         assert el_mock.generate.call_args.kwargs["instrumental"] is True
 
-    def test_vocal_language_elevenlabs_prints_warning(self, monkeypatch, tmp_path):
-        """--vocal-language with ElevenLabs backend prints a warning and is ignored."""
+    def test_vocal_language_injected_into_elevenlabs_prompt(self, monkeypatch, tmp_path):
+        """--vocal-language is injected into the ElevenLabs prompt (no body field exists)."""
         from acemusic.config import AceConfig
 
         monkeypatch.setattr(
@@ -793,7 +799,168 @@ class TestStyleLyricsElevenLabs:
             )
 
         assert result.exit_code == 0, result.output
-        assert "warning" in result.output.lower() or "ignored" in result.output.lower()
+        prompt_sent = el_mock.generate.call_args.kwargs["prompt"]
+        assert "Japanese vocals" in prompt_sent
+        assert "ignored" not in result.output.lower()
+
+    def test_vocal_language_auto_not_injected_for_elevenlabs(self, monkeypatch, tmp_path):
+        """--vocal-language auto (the ACE-Step sentinel) is not injected into the prompt."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "generate",
+                    "pop song",
+                    "--backend",
+                    "elevenlabs",
+                    "--vocal-language",
+                    "auto",
+                    "--output",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        prompt_sent = el_mock.generate.call_args.kwargs["prompt"]
+        assert "vocals" not in prompt_sent
+        assert "auto" not in prompt_sent
+
+    def test_unknown_language_code_injected_verbatim(self, monkeypatch, tmp_path):
+        """An unmapped ISO code is still injected (verbatim) rather than dropped."""
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=3.0),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "generate",
+                    "pop song",
+                    "--backend",
+                    "elevenlabs",
+                    "--vocal-language",
+                    "xx",
+                    "--output",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        prompt_sent = el_mock.generate.call_args.kwargs["prompt"]
+        assert "xx vocals" in prompt_sent
+
+
+class TestElevenLabsDurationLimits:
+    """Tests for ElevenLabs-specific duration validation in generate (issue #96)."""
+
+    def _el_config(self, monkeypatch):
+        from acemusic.config import AceConfig
+
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(
+                api_url="http://localhost:8001",
+                api_key=None,
+                elevenlabs_api_key="test-key",
+                elevenlabs_output_format="mp3_44100_128",
+            ),
+        )
+
+    def test_elevenlabs_backend_accepts_duration_above_ace_step_max(self, monkeypatch, tmp_path):
+        """--backend elevenlabs allows durations beyond the ACE-Step cap (e.g. 300s)."""
+        self._el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = b"ID3" + b"\x00" * 100
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=300.0),
+        ):
+            result = runner.invoke(
+                app,
+                ["generate", "epic ballad", "--backend", "elevenlabs", "--duration", "300", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert el_mock.generate.call_args.kwargs["duration"] == 300.0
+
+    def test_elevenlabs_backend_rejects_duration_below_min(self, monkeypatch, tmp_path):
+        """--backend elevenlabs rejects durations below 3s with a clear range message."""
+        self._el_config(monkeypatch)
+        el_mock = MagicMock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el_mock):
+            result = runner.invoke(
+                app,
+                ["generate", "stinger", "--backend", "elevenlabs", "--duration", "2", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 1
+        plain = _plain(result.output)
+        assert "3" in plain and "600" in plain
+        el_mock.generate.assert_not_called()
+
+    def test_elevenlabs_backend_rejects_duration_above_max(self, monkeypatch, tmp_path):
+        """--backend elevenlabs rejects durations above 600s with a clear range message."""
+        self._el_config(monkeypatch)
+        el_mock = MagicMock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el_mock):
+            result = runner.invoke(
+                app,
+                ["generate", "epic", "--backend", "elevenlabs", "--duration", "601", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 1
+        plain = _plain(result.output)
+        assert "3" in plain and "600" in plain
+        el_mock.generate.assert_not_called()
+
+    def test_default_backend_keeps_ace_step_duration_limits(self, monkeypatch, tmp_path):
+        """Without --backend elevenlabs, the ACE-Step 30–240s validation still applies."""
+        self._el_config(monkeypatch)
+
+        result = runner.invoke(
+            app,
+            ["generate", "epic ballad", "--duration", "300", "--output", str(tmp_path)],
+        )
+
+        assert result.exit_code == 1
+        plain = _plain(result.output)
+        assert "30" in plain and "240" in plain
 
 
 class TestMusicalParametersAceStep:

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -438,9 +438,18 @@ class TestSoundsElevenLabsBackend:
             result = runner.invoke(
                 app,
                 [
-                    "sounds", "funky groove", "--type", "loop",
-                    "--bpm", "120", "--key", "A minor",
-                    "--backend", "elevenlabs", "--output", str(tmp_path),
+                    "sounds",
+                    "funky groove",
+                    "--type",
+                    "loop",
+                    "--bpm",
+                    "120",
+                    "--key",
+                    "A minor",
+                    "--backend",
+                    "elevenlabs",
+                    "--output",
+                    str(tmp_path),
                 ],
             )
 
@@ -463,8 +472,16 @@ class TestSoundsElevenLabsBackend:
             result = runner.invoke(
                 app,
                 [
-                    "sounds", "deep kick", "--type", "one-shot", "--format", "wav",
-                    "--backend", "elevenlabs", "--output", str(tmp_path),
+                    "sounds",
+                    "deep kick",
+                    "--type",
+                    "one-shot",
+                    "--format",
+                    "wav",
+                    "--backend",
+                    "elevenlabs",
+                    "--output",
+                    str(tmp_path),
                 ],
             )
 
@@ -494,8 +511,16 @@ class TestSoundsElevenLabsBackend:
             result = runner.invoke(
                 app,
                 [
-                    "sounds", "deep kick", "--type", "one-shot", "--duration", "1",
-                    "--backend", "elevenlabs", "--output", str(tmp_path),
+                    "sounds",
+                    "deep kick",
+                    "--type",
+                    "one-shot",
+                    "--duration",
+                    "1",
+                    "--backend",
+                    "elevenlabs",
+                    "--output",
+                    str(tmp_path),
                 ],
             )
 
@@ -517,8 +542,16 @@ class TestSoundsElevenLabsBackend:
             result = runner.invoke(
                 app,
                 [
-                    "sounds", "riser", "--type", "one-shot", "--duration", "5",
-                    "--backend", "elevenlabs", "--output", str(tmp_path),
+                    "sounds",
+                    "riser",
+                    "--type",
+                    "one-shot",
+                    "--duration",
+                    "5",
+                    "--backend",
+                    "elevenlabs",
+                    "--output",
+                    str(tmp_path),
                 ],
             )
 
@@ -550,3 +583,50 @@ class TestSoundsElevenLabsBackend:
 
         assert result.exit_code == 0, result.output
         client_mock.submit_task.assert_called_once()
+
+    def test_sounds_elevenlabs_error_exits_one(self, monkeypatch, tmp_path):
+        """An ElevenLabsError during generation exits 1 with the error shown."""
+        from acemusic.elevenlabs_client import ElevenLabsError
+
+        _el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.side_effect = ElevenLabsError("ElevenLabs generate failed: 500")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el_mock):
+            result = runner.invoke(
+                app,
+                ["sounds", "deep kick", "--type", "one-shot", "--backend", "elevenlabs", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 1
+        assert "500" in _plain(result.output)
+
+    def test_sounds_elevenlabs_name_flag_produces_prefixed_filename(self, monkeypatch, tmp_path):
+        """--name produces a prefixed filename on the ElevenLabs path."""
+        _el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = FAKE_MP3
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", side_effect=RuntimeError("no ffprobe")),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "sounds",
+                    "deep kick",
+                    "--type",
+                    "one-shot",
+                    "--name",
+                    "Kick One",
+                    "--backend",
+                    "elevenlabs",
+                    "--output",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "kick-one-1.mp3").exists()
+        assert "unknown" in _plain(result.output)

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -362,3 +362,191 @@ class TestSoundsCommand:
         call_kwargs = client_mock.submit_task.call_args
         assert call_kwargs is not None
         assert call_kwargs.kwargs["num_clips"] == 1
+
+
+FAKE_MP3 = b"ID3" + b"\x00" * 100
+
+
+def _el_config(monkeypatch, api_key="test-key"):
+    """Point load_config at an ElevenLabs-enabled (ACE-Step-less) config."""
+    from acemusic.config import AceConfig
+
+    monkeypatch.setattr(
+        "acemusic.cli.load_config",
+        lambda: AceConfig(
+            api_url="http://localhost:8001",
+            api_key=None,
+            elevenlabs_api_key=api_key,
+            elevenlabs_output_format="mp3_44100_128",
+        ),
+    )
+
+
+class TestSoundsElevenLabsBackend:
+    """Tests for sounds --backend elevenlabs (issue #96)."""
+
+    def test_sounds_elevenlabs_writes_mp3_file(self, monkeypatch, tmp_path):
+        """--backend elevenlabs generates via ElevenLabs and writes an MP3 file."""
+        _el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = FAKE_MP3
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            result = runner.invoke(
+                app,
+                ["sounds", "deep kick", "--type", "one-shot", "--backend", "elevenlabs", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        mp3_files = list(tmp_path.glob("*.mp3"))
+        assert len(mp3_files) == 1
+        assert mp3_files[0].read_bytes() == FAKE_MP3
+
+    def test_sounds_elevenlabs_injects_type_into_prompt(self, monkeypatch, tmp_path):
+        """The sound type is injected into the ElevenLabs prompt as a hint."""
+        _el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = FAKE_MP3
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            result = runner.invoke(
+                app,
+                ["sounds", "deep kick", "--type", "one-shot", "--backend", "elevenlabs", "--output", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        prompt_sent = el_mock.generate.call_args.kwargs["prompt"]
+        assert "one-shot" in prompt_sent
+        assert "deep kick" in prompt_sent
+
+    def test_sounds_elevenlabs_injects_bpm_and_key_for_loops(self, monkeypatch, tmp_path):
+        """--bpm/--key are injected into the prompt with a warning for ElevenLabs loops."""
+        _el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = FAKE_MP3
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=4.0),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "sounds", "funky groove", "--type", "loop",
+                    "--bpm", "120", "--key", "A minor",
+                    "--backend", "elevenlabs", "--output", str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        prompt_sent = el_mock.generate.call_args.kwargs["prompt"]
+        assert "120 BPM" in prompt_sent
+        assert "A minor" in prompt_sent
+        assert "warning" in _plain(result.output).lower()
+
+    def test_sounds_elevenlabs_warns_on_non_mp3_format(self, monkeypatch, tmp_path):
+        """--format wav with ElevenLabs warns that output is MP3-only."""
+        _el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = FAKE_MP3
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "sounds", "deep kick", "--type", "one-shot", "--format", "wav",
+                    "--backend", "elevenlabs", "--output", str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        plain = _plain(result.output).lower()
+        assert "mp3" in plain
+        assert list(tmp_path.glob("*.mp3")), "output should be MP3 regardless of --format"
+
+    def test_sounds_elevenlabs_requires_api_key(self, monkeypatch, tmp_path):
+        """--backend elevenlabs without ELEVENLABS_API_KEY exits 1 with a clear message."""
+        _el_config(monkeypatch, api_key=None)
+
+        result = runner.invoke(
+            app,
+            ["sounds", "deep kick", "--type", "one-shot", "--backend", "elevenlabs", "--output", str(tmp_path)],
+        )
+
+        assert result.exit_code == 1
+        assert "elevenlabs_api_key" in _plain(result.output).lower()
+
+    def test_sounds_elevenlabs_rejects_out_of_range_duration(self, monkeypatch, tmp_path):
+        """Durations outside 3–600s exit 1 with the ElevenLabs range in the message."""
+        _el_config(monkeypatch)
+        el_mock = MagicMock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el_mock):
+            result = runner.invoke(
+                app,
+                [
+                    "sounds", "deep kick", "--type", "one-shot", "--duration", "1",
+                    "--backend", "elevenlabs", "--output", str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 1
+        plain = _plain(result.output)
+        assert "3" in plain and "600" in plain
+        el_mock.generate.assert_not_called()
+
+    def test_sounds_elevenlabs_duration_forwarded(self, monkeypatch, tmp_path):
+        """--duration is forwarded to ElevenLabsClient.generate()."""
+        _el_config(monkeypatch)
+        el_mock = MagicMock()
+        el_mock.generate.return_value = FAKE_MP3
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el_mock),
+            patch("acemusic.cli.get_duration", return_value=5.0),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "sounds", "riser", "--type", "one-shot", "--duration", "5",
+                    "--backend", "elevenlabs", "--output", str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert el_mock.generate.call_args.kwargs["duration"] == 5.0
+
+    def test_sounds_invalid_backend_exits_one(self, monkeypatch, tmp_path):
+        """An unknown --backend value exits 1 with the valid choices."""
+        _el_config(monkeypatch)
+
+        result = runner.invoke(
+            app,
+            ["sounds", "deep kick", "--type", "one-shot", "--backend", "bogus", "--output", str(tmp_path)],
+        )
+
+        assert result.exit_code == 1
+        assert "invalid backend" in _plain(result.output).lower()
+
+    def test_sounds_default_backend_still_uses_ace_step(self, monkeypatch, tmp_path):
+        """Without --backend, sounds keeps using ACE-Step (auto routes to ACE-Step)."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        client_mock = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.AceStepClient", return_value=client_mock),
+            patch("acemusic.cli.get_duration", return_value=1.5),
+        ):
+            result = runner.invoke(app, ["sounds", "kick", "--type", "one-shot", "--output", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        client_mock.submit_task.assert_called_once()

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -368,13 +368,13 @@ FAKE_MP3 = b"ID3" + b"\x00" * 100
 
 
 def _el_config(monkeypatch, api_key="test-key"):
-    """Point load_config at an ElevenLabs-enabled (ACE-Step-less) config."""
+    """Point load_config at an ElevenLabs-only config (no ACE-Step server)."""
     from acemusic.config import AceConfig
 
     monkeypatch.setattr(
         "acemusic.cli.load_config",
         lambda: AceConfig(
-            api_url="http://localhost:8001",
+            api_url=None,
             api_key=None,
             elevenlabs_api_key=api_key,
             elevenlabs_output_format="mp3_44100_128",


### PR DESCRIPTION
## Summary
Implements #96: ElevenLabs as a first-class generation engine (selectable as primary, not only fallback), plus composition-plan support for structured/sectioned generation.

- `ElevenLabsClient`: duration validation (3–600s per current API), `create_plan()` (`POST /v1/music/plan`), `generate_from_plan()` (`POST /v1/music` with `composition_plan`, `respect_sections_durations`, optional `seed`)
- New **`compose`** command: prompt → sectioned composition plan (displayed as a Rich table) → one-shot structured generation → MP3 + `Clip(generation_mode="compose", model="elevenlabs")`; supports `--duration`, `--instrumental`, `--seed`, `--name`, `--output`
- **`sounds --backend elevenlabs`**: MP3-only handling, bpm/key/type prompt injection, duration validation
- **`--vocal-language`** now works on the ElevenLabs path via prompt injection (the API has no language body field)
- Backend-aware duration limits: explicit `elevenlabs` accepts 3–600s; `auto` routes ACE-Step-invalid durations to ElevenLabs when a key is configured
- `--backend elevenlabs` no longer requires an ACE-Step server URL (check moved into each command's ACE-Step path)
- `backends.py` capabilities updated (`sounds`, `compose`)

## Acceptance Criteria
- [x] `generate --backend elevenlabs "..."` produces a playable track with params honored
- [x] A composition-plan path produces a structured multi-section track (`compose`)
- [x] Duration clamping/validation matches ElevenLabs limits with clear messaging
- [x] Output saved as MP3 with correct metadata/naming consistent with other clips
- [x] Unit tests (mocked ElevenLabs client) for both prompt and composition-plan paths

## Test Plan
- [x] Unit tests written (TDD approach) — 788 passing
- [x] Diff coverage 90% on changed lines (≥85% gate)
- [x] Linting clean (ruff + black)
- [x] Internal code review (advisory) completed — C1/M1/M2 fixed
- [x] Cross-family review: **codex** (2 rounds; both P2 findings fixed)
- [x] Test mutation sanity check completed (4 mutations, all caught)

## Known Limitations / Intentionally Deferred
- **Duration limit is 3s–10min (600s)** per the current ElevenLabs API, not the 3s–5min stated in the issue text — ElevenLabs raised the cap; user-approved deviation.
- `auto` with no ACE-Step URL still requires `ACEMUSIC_BASE_URL` (auto prefers ACE-Step); use `--backend elevenlabs` or `ACEMUSIC_BACKEND=elevenlabs` for ElevenLabs-only setups.
- `compose` generates a single track per run (no `--num-clips`) — plan-based generation is deterministic enough with `--seed`; extend later if needed.
- Lossless/WAV/DAW-bundle export remains ACE-Step-only (out of scope per epic #94).

## Implementation Notes (deviations from the CodeRabbit plan, verified against current API docs)
1. No `language` body field exists on `POST /v1/music` — `--vocal-language` is injected into the prompt (same pattern as bpm/key/time-signature) instead of a fake body param.
2. `force_instrumental` is prompt-mode-only — `compose --instrumental` steers the plan prompt.
3. `seed` is plan-mode-only — `compose --seed` implements what the old generate warning promised; the warning now points there.
4. Preset-supplied durations are now validated too (review finding M1).
5. Two legacy duration tests were made hermetic — they previously consulted real host config and, with the new auto-routing, would have hit the live ElevenLabs API from unit tests.

Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compose command (multi-section composition) and ElevenLabs path for sounds; sounds now supports selecting backend and writes MP3 output.
  * generate can auto-route long requests to ElevenLabs when needed.

* **Improvements**
  * ElevenLabs duration min/max validation with clearer messages; vocal-language injected into ElevenLabs prompts; seed warning clarified for compose.
  * Backend-aware ACE‑Step URL checks and format/format-warning behavior for ElevenLabs.

* **Documentation**
  * Updated examples for compose and sounds with ElevenLabs.

* **Tests**
  * Expanded coverage for routing, duration limits, compose, sounds, and ElevenLabs client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->