### PR TITLE
feat: ElevenLabs stem separation backend for stems command (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ Set `ACEMUSIC_API_MONGODB_URL` (defaults to `mongodb://localhost:27017`); use an
 Atlas `mongodb+srv://…` string for staging/production. Local integration tests
 run only against a local MongoDB (`uv run pytest -m integration`).
 
+## Stem separation backends
+
+`acemusic stems <clip_id>` separates a clip into stems. Two engines are available
+via `--backend` (or the `ACEMUSIC_BACKEND` default):
+
+- `auto` / `ace-step` — local demucs separation (default). Produces **four** stems:
+  vocals, drums, bass, other, in `wav` or `flac` (`--output-format`).
+- `elevenlabs` — cloud separation via the ElevenLabs API (requires
+  `ELEVENLABS_API_KEY`; no local GPU needed). Produces **six** MP3 stems:
+  vocals, drums, bass, **guitar**, **piano**, other. `--output-format` is
+  ignored — ElevenLabs returns MP3-quality stems, not lossless.
+
+Either way, each stem is registered as a child clip of the source, so downstream
+commands (DAW export, etc.) work the same.
+
 ## Environment
 
 Copy `.env.example` to `.env` and fill in the required values before running.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ via `--backend` (or the `ACEMUSIC_BACKEND` default):
 - `auto` / `ace-step` — local demucs separation (default). Produces **four** stems:
   vocals, drums, bass, other, in `wav` or `flac` (`--output-format`).
 - `elevenlabs` — cloud separation via the ElevenLabs API (requires
-  `ELEVENLABS_API_KEY`; no local GPU needed). Produces **six** MP3 stems:
-  vocals, drums, bass, **guitar**, **piano**, other. `--output-format` is
-  ignored — ElevenLabs returns MP3-quality stems, not lossless.
+  `ELEVENLABS_API_KEY`; no local GPU needed). Produces **six** stems:
+  vocals, drums, bass, **guitar**, **piano**, other, in the format configured
+  by `ELEVENLABS_OUTPUT_FORMAT` (MP3 by default). `--output-format` is
+  ignored — use `ELEVENLABS_OUTPUT_FORMAT` to control the stem format.
 
 Either way, each stem is registered as a child clip of the source, so downstream
 commands (DAW export, etc.) work the same.

--- a/src/acemusic/backends.py
+++ b/src/acemusic/backends.py
@@ -19,14 +19,14 @@ VALID_BACKENDS: tuple[str, ...] = ("auto", "ace-step", "elevenlabs")
 DEFAULT_BACKEND = "auto"
 
 # Which concrete engines support each operation. ElevenLabs entries expand as
-# the sibling issues land (#97 stems, #98 inpainting, #99 mashup). #96 added
-# first-class generate/sounds and composition plans ("compose").
+# the sibling issues land (#98 inpainting, #99 mashup). #96 added first-class
+# generate/sounds and composition plans ("compose"); #97 added stem separation.
 _CAPABILITIES: dict[str, set[str]] = {
     "generate": {"ace-step", "elevenlabs"},
     "sample": {"ace-step", "elevenlabs"},
     "sounds": {"ace-step", "elevenlabs"},
     "compose": {"elevenlabs"},
-    "stems": {"ace-step"},
+    "stems": {"ace-step", "elevenlabs"},
     "midi": {"ace-step"},
     "remaster": {"ace-step"},
     "extend": {"ace-step"},

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2234,7 +2234,7 @@ def stems(
     # Derive base name from source file
     base_name = Path(source.file_path).stem
 
-    # Separate stems via the selected backend
+    # Separate stems
     start_time = time.time()
     if effective_backend == "elevenlabs":
         stem_path_map = _separate_stems_via_elevenlabs(config, source, stems_dir, base_name)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2185,7 +2185,8 @@ def stems(
     output_format: Optional[str] = typer.Option(
         None,
         "--output-format",
-        help="Stem output format: wav or flac (default: wav). Demucs backend only — ElevenLabs stems are MP3.",
+        help="Stem output format: wav or flac (default: wav). Demucs backend only — "
+        "ElevenLabs stems use ELEVENLABS_OUTPUT_FORMAT (MP3 by default).",
     ),
     output: Optional[Path] = typer.Option(None, "--output", help="Output directory (default: stems/ next to source)."),
     backend: Optional[str] = typer.Option(
@@ -2199,8 +2200,8 @@ def stems(
 
     The local demucs backend (auto/ace-step) produces four stems: vocals,
     drums, bass, other. The elevenlabs backend uploads the clip to the
-    ElevenLabs cloud API and produces six MP3 stems: vocals, drums, bass,
-    guitar, piano, other.
+    ElevenLabs cloud API and produces six stems: vocals, drums, bass,
+    guitar, piano, other (format from ELEVENLABS_OUTPUT_FORMAT, MP3 default).
     """
     config = load_config()
     try:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2129,17 +2129,94 @@ def speed(
 # ---------------------------------------------------------------------------
 
 
+def _separate_stems_via_demucs(source: Clip, stems_dir: Path, base_name: str, output_format: str) -> dict[str, Path]:
+    """Separate stems locally with demucs and return a label → path mapping."""
+    client = StemsClient()
+    try:
+        with console.status("[bold green]Loading model and separating stems...") as status:
+
+            def _progress(msg: str) -> None:
+                status.update(f"[bold green]{msg}")
+
+            stem_data = client.separate(source.file_path, progress_callback=_progress)
+            status.update("[bold green]Saving stems...")
+            return client.save_stems(
+                stem_data,
+                stems_dir,
+                base_name,
+                sample_rate=client.model_samplerate,
+                output_format=output_format,
+            )
+    except StemsError as exc:
+        console.print(f"[red]Error during separation: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+
+def _separate_stems_via_elevenlabs(config, source: Clip, stems_dir: Path, base_name: str) -> dict[str, Path]:
+    """Separate stems via the ElevenLabs cloud API and return a label → path mapping."""
+    if not config.elevenlabs_api_key:
+        console.print("[red]Error: --backend elevenlabs requires ELEVENLABS_API_KEY to be set.[/red]")
+        raise typer.Exit(code=1)
+
+    el_client = ElevenLabsClient(api_key=config.elevenlabs_api_key, output_format=config.elevenlabs_output_format)
+    try:
+        with console.status("[bold green]Uploading clip and separating stems via ElevenLabs..."):
+            stem_bytes = el_client.separate_stems(source.file_path)
+    except ElevenLabsError as exc:
+        console.print(f"[red]Error during separation: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    stem_path_map: dict[str, Path] = {}
+    for label, data in stem_bytes.items():
+        stem_path = stems_dir / f"{base_name}-{label}.mp3"
+        stem_path.write_bytes(data)
+        stem_path_map[label] = stem_path
+    return stem_path_map
+
+
 @app.command()
 def stems(
     clip_id: int = typer.Argument(..., help="ID of the source clip to separate into stems."),
-    output_format: str = typer.Option("wav", "--output-format", help="Stem output format: wav or flac."),
+    output_format: Optional[str] = typer.Option(
+        None,
+        "--output-format",
+        help="Stem output format: wav or flac (default: wav). Demucs backend only — ElevenLabs stems are MP3.",
+    ),
     output: Optional[Path] = typer.Option(None, "--output", help="Output directory (default: stems/ next to source)."),
+    backend: Optional[str] = typer.Option(
+        None,
+        "--backend",
+        help="Engine: 'auto' (default — local demucs), 'ace-step' (local demucs, 4 stems), or "
+        "'elevenlabs' (cloud, 6 stems: adds guitar and piano). Defaults to ACEMUSIC_BACKEND, then 'auto'.",
+    ),
 ) -> None:
-    """Separate a clip into individual stems (vocals, drums, bass, other) using AI source separation."""
-    # Validate output format
-    if output_format not in ("wav", "flac"):
-        console.print(f"[red]Error: --output-format must be wav or flac, got {output_format!r}.[/red]")
+    """Separate a clip into individual stems using AI source separation.
+
+    The local demucs backend (auto/ace-step) produces four stems: vocals,
+    drums, bass, other. The elevenlabs backend uploads the clip to the
+    ElevenLabs cloud API and produces six MP3 stems: vocals, drums, bass,
+    guitar, piano, other.
+    """
+    config = load_config()
+    try:
+        effective_backend = resolve_backend(backend, config.backend)
+    except BackendError as exc:
+        console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1)
+
+    if effective_backend == "elevenlabs":
+        if output_format is not None:
+            console.print(
+                "[yellow]Warning: --output-format is ignored with the elevenlabs backend "
+                "(stems are returned as MP3).[/yellow]"
+            )
+    else:
+        # Validate output format (demucs path; None means the wav default)
+        if output_format is None:
+            output_format = "wav"
+        if output_format not in ("wav", "flac"):
+            console.print(f"[red]Error: --output-format must be wav or flac, got {output_format!r}.[/red]")
+            raise typer.Exit(code=1)
 
     # Get source clip
     source = get_clip(clip_id)
@@ -2157,27 +2234,14 @@ def stems(
     # Derive base name from source file
     base_name = Path(source.file_path).stem
 
-    # Separate stems
-    client = StemsClient()
+    # Separate stems via the selected backend
     start_time = time.time()
-    try:
-        with console.status("[bold green]Loading model and separating stems...") as status:
-
-            def _progress(msg: str) -> None:
-                status.update(f"[bold green]{msg}")
-
-            stem_data = client.separate(source.file_path, progress_callback=_progress)
-            status.update("[bold green]Saving stems...")
-            stem_path_map = client.save_stems(
-                stem_data,
-                stems_dir,
-                base_name,
-                sample_rate=client.model_samplerate,
-                output_format=output_format,
-            )
-    except StemsError as exc:
-        console.print(f"[red]Error during separation: {exc}[/red]")
-        raise typer.Exit(code=1)
+    if effective_backend == "elevenlabs":
+        stem_path_map = _separate_stems_via_elevenlabs(config, source, stems_dir, base_name)
+        clip_format = "mp3"
+    else:
+        stem_path_map = _separate_stems_via_demucs(source, stems_dir, base_name, output_format)
+        clip_format = output_format
 
     elapsed = time.time() - start_time
 
@@ -2189,7 +2253,7 @@ def stems(
             workspace_id=source.workspace_id,
             file_path=str(stem_path.resolve()),
             created_at=datetime.now(timezone.utc).isoformat(),
-            format=output_format,
+            format=clip_format,
             duration=dur,
             bpm=source.bpm,
             key=source.key,

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2153,7 +2153,11 @@ def _separate_stems_via_demucs(source: Clip, stems_dir: Path, base_name: str, ou
 
 
 def _separate_stems_via_elevenlabs(config, source: Clip, stems_dir: Path, base_name: str) -> dict[str, Path]:
-    """Separate stems via the ElevenLabs cloud API and return a label → path mapping."""
+    """Separate stems via the ElevenLabs cloud API and return a label → path mapping.
+
+    Stem files take their extension from the configured ELEVENLABS_OUTPUT_FORMAT
+    (mp3 by default), matching the other ElevenLabs code paths.
+    """
     if not config.elevenlabs_api_key:
         console.print("[red]Error: --backend elevenlabs requires ELEVENLABS_API_KEY to be set.[/red]")
         raise typer.Exit(code=1)
@@ -2166,9 +2170,10 @@ def _separate_stems_via_elevenlabs(config, source: Clip, stems_dir: Path, base_n
         console.print(f"[red]Error during separation: {exc}[/red]")
         raise typer.Exit(code=1)
 
+    ext = _elevenlabs_ext(config.elevenlabs_output_format)
     stem_path_map: dict[str, Path] = {}
     for label, data in stem_bytes.items():
-        stem_path = stems_dir / f"{base_name}-{label}.mp3"
+        stem_path = stems_dir / f"{base_name}-{label}.{ext}"
         stem_path.write_bytes(data)
         stem_path_map[label] = stem_path
     return stem_path_map
@@ -2208,7 +2213,7 @@ def stems(
         if output_format is not None:
             console.print(
                 "[yellow]Warning: --output-format is ignored with the elevenlabs backend "
-                "(stems are returned as MP3).[/yellow]"
+                "(stems use the configured ELEVENLABS_OUTPUT_FORMAT, MP3 by default).[/yellow]"
             )
     else:
         # Validate output format (demucs path; None means the wav default)
@@ -2238,7 +2243,7 @@ def stems(
     start_time = time.time()
     if effective_backend == "elevenlabs":
         stem_path_map = _separate_stems_via_elevenlabs(config, source, stems_dir, base_name)
-        clip_format = "mp3"
+        clip_format = _elevenlabs_ext(config.elevenlabs_output_format)
     else:
         stem_path_map = _separate_stems_via_demucs(source, stems_dir, base_name, output_format)
         clip_format = output_format

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -238,7 +238,13 @@ class ElevenLabsClient:
         except OSError as exc:
             raise ElevenLabsError(f"ElevenLabs stem separation failed: cannot read {audio_path}: {exc}") from exc
         except httpx.HTTPStatusError as exc:
-            raise ElevenLabsError(f"ElevenLabs stem separation failed: {exc.response.status_code}") from exc
+            # Include the response body (truncated) — 422 carries the reason
+            # (e.g. file too large), which the bare status code would hide.
+            detail = (exc.response.text or "").strip()[:200]
+            message = f"ElevenLabs stem separation failed: {exc.response.status_code}"
+            if detail:
+                message = f"{message} — {detail}"
+            raise ElevenLabsError(message) from exc
         except httpx.RequestError as exc:
             raise ElevenLabsError(f"ElevenLabs stem separation failed: {exc}") from exc
         return _parse_stem_zip(response.content)

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -58,6 +58,10 @@ def _parse_stem_zip(content: bytes) -> dict[str, bytes]:
                 continue
             name = Path(info.filename).stem.lower()
             label = next((known for known in ELEVENLABS_STEM_LABELS if known in name), name)
+            if label in stems:
+                # Two entries matched the same known label — keep both by
+                # falling back to the filename stem instead of overwriting.
+                label = name
             stems[label] = archive.read(info)
 
     if not stems:

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import io
+import zipfile
+from pathlib import Path
+
 import httpx
 
 _BASE_URL = "https://api.elevenlabs.io"
@@ -10,11 +14,18 @@ _BASE_URL = "https://api.elevenlabs.io"
 DURATION_MIN_S = 3.0
 DURATION_MAX_S = 600.0
 
+# Stem labels produced by the six_stems_v1 separation model (#97). Demucs
+# produces four (vocals/drums/bass/other); ElevenLabs adds guitar and piano.
+ELEVENLABS_STEM_LABELS: list[str] = ["vocals", "drums", "bass", "guitar", "piano", "other"]
+
 # Generating a track can take well over two minutes for long durations (up to
 # 10 min of audio), so music generation calls get a generous read timeout.
 # Plan creation is a fast, credit-free endpoint and keeps a tighter budget.
+# Stem separation is documented as high-latency and uploads the source file,
+# so it gets a long read timeout plus extra write headroom for the upload.
 _GENERATION_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
 _PLAN_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
+_STEMS_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=10.0)
 
 
 class ElevenLabsError(Exception):
@@ -28,6 +39,30 @@ def _validate_duration(duration: float | None) -> None:
             f"Invalid duration {duration}s: ElevenLabs requires between "
             f"{int(DURATION_MIN_S)}s and {int(DURATION_MAX_S)}s (10 min)."
         )
+
+
+def _parse_stem_zip(content: bytes) -> dict[str, bytes]:
+    """Parse a stem-separation ZIP response into a label → audio-bytes mapping.
+
+    Raises ElevenLabsError if the archive is malformed or contains no stems.
+    """
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(content))
+    except zipfile.BadZipFile as exc:
+        raise ElevenLabsError("ElevenLabs stem separation failed: response is not a valid ZIP archive") from exc
+
+    stems: dict[str, bytes] = {}
+    with archive:
+        for info in archive.infolist():
+            if info.is_dir():
+                continue
+            name = Path(info.filename).stem.lower()
+            label = next((known for known in ELEVENLABS_STEM_LABELS if known in name), name)
+            stems[label] = archive.read(info)
+
+    if not stems:
+        raise ElevenLabsError("ElevenLabs stem separation failed: ZIP archive contains no stems")
+    return stems
 
 
 class ElevenLabsClient:
@@ -167,6 +202,46 @@ class ElevenLabsClient:
             raise ElevenLabsError(f"ElevenLabs plan generation failed: {exc.response.status_code}") from exc
         except httpx.RequestError as exc:
             raise ElevenLabsError(f"ElevenLabs plan generation failed: {exc}") from exc
+
+    def separate_stems(
+        self,
+        audio_path: str | Path,
+        stem_variation_id: str = "six_stems_v1",
+    ) -> dict[str, bytes]:
+        """Separate an audio file into stems via POST /v1/music/stem-separation.
+
+        Uploads the file as multipart form data and parses the ZIP response
+        into a mapping of stem label to audio bytes. ZIP entries are matched
+        against :data:`ELEVENLABS_STEM_LABELS` by filename; unrecognised
+        entries fall back to their filename stem as the label.
+
+        Args:
+            audio_path: Path to the audio file to separate.
+            stem_variation_id: Separation model ('six_stems_v1' or 'two_stems_v1').
+
+        Raises:
+            ElevenLabsError: On unreadable input file, HTTP error, connection
+                failure, or a malformed/empty ZIP response.
+        """
+        audio_path = Path(audio_path)
+        try:
+            with open(audio_path, "rb") as fh:
+                response = httpx.post(
+                    f"{_BASE_URL}/v1/music/stem-separation",
+                    files={"file": (audio_path.name, fh)},
+                    data={"stem_variation_id": stem_variation_id},
+                    headers=self._headers,
+                    params={"output_format": self.output_format},
+                    timeout=_STEMS_TIMEOUT,
+                )
+            response.raise_for_status()
+        except OSError as exc:
+            raise ElevenLabsError(f"ElevenLabs stem separation failed: cannot read {audio_path}: {exc}") from exc
+        except httpx.HTTPStatusError as exc:
+            raise ElevenLabsError(f"ElevenLabs stem separation failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise ElevenLabsError(f"ElevenLabs stem separation failed: {exc}") from exc
+        return _parse_stem_zip(response.content)
 
     def validate_key(self, timeout: float = 5.0) -> bool:
         """Validate the API key via GET /v1/user. Returns True if valid, False otherwise."""

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import zipfile
+import zlib
 from pathlib import Path
 
 import httpx
@@ -52,17 +53,22 @@ def _parse_stem_zip(content: bytes) -> dict[str, bytes]:
         raise ElevenLabsError("ElevenLabs stem separation failed: response is not a valid ZIP archive") from exc
 
     stems: dict[str, bytes] = {}
-    with archive:
-        for info in archive.infolist():
-            if info.is_dir():
-                continue
-            name = Path(info.filename).stem.lower()
-            label = next((known for known in ELEVENLABS_STEM_LABELS if known in name), name)
-            if label in stems:
-                # Two entries matched the same known label — keep both by
-                # falling back to the filename stem instead of overwriting.
-                label = name
-            stems[label] = archive.read(info)
+    try:
+        with archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                name = Path(info.filename).stem.lower()
+                label = next((known for known in ELEVENLABS_STEM_LABELS if known in name), name)
+                if label in stems:
+                    # Two entries matched the same known label — keep both by
+                    # falling back to the filename stem instead of overwriting.
+                    label = name
+                stems[label] = archive.read(info)
+    except (zipfile.BadZipFile, zlib.error, OSError, ValueError) as exc:
+        # Corruption can also surface mid-read (bad CRC, truncated entry) —
+        # normalize to the documented ElevenLabsError contract.
+        raise ElevenLabsError("ElevenLabs stem separation failed: ZIP archive entry is corrupted") from exc
 
     if not stems:
         raise ElevenLabsError("ElevenLabs stem separation failed: ZIP archive contains no stems")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -72,3 +72,15 @@ class TestIssue96Capabilities:
         assert supports("elevenlabs", "compose")
         assert not supports("ace-step", "compose")
         assert supports("auto", "compose")
+
+
+class TestIssue97Capabilities:
+    """Capability entries added by #97 (ElevenLabs stem separation)."""
+
+    def test_stems_supported_by_both_engines(self):
+        assert supports("ace-step", "stems")
+        assert supports("elevenlabs", "stems")
+        assert supports("auto", "stems")
+
+    def test_ensure_supports_passes_for_elevenlabs_stems(self):
+        ensure_supports("elevenlabs", "stems")  # must not raise

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -574,6 +574,21 @@ class TestElevenLabsClientSeparateStems:
             with pytest.raises(ElevenLabsError, match="(?i)zip"):
                 client.separate_stems(audio_file)
 
+    def test_separate_stems_raises_elevenlabs_error_on_corrupted_zip_entry(self, audio_file):
+        """A ZIP that opens but whose entry data is corrupted raises ElevenLabsError, not BadZipFile."""
+        client = ElevenLabsClient(api_key="test-key")
+        # Build a valid archive, then corrupt the stored entry bytes so the
+        # central directory parses but reading the entry fails its CRC check.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("vocals.mp3", b"A" * 100)
+        corrupted = buf.getvalue().replace(b"A" * 100, b"B" * 100)
+        resp = _mock_response(200, corrupted)
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="(?i)zip"):
+                client.separate_stems(audio_file)
+
     def test_separate_stems_raises_elevenlabs_error_on_empty_zip(self, audio_file):
         """separate_stems() raises ElevenLabsError when the ZIP contains no stems."""
         client = ElevenLabsClient(api_key="test-key")

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import io
+import zipfile
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
-from acemusic.elevenlabs_client import DURATION_MAX_S, DURATION_MIN_S, ElevenLabsClient, ElevenLabsError
+from acemusic.elevenlabs_client import (
+    DURATION_MAX_S,
+    DURATION_MIN_S,
+    ELEVENLABS_STEM_LABELS,
+    ElevenLabsClient,
+    ElevenLabsError,
+)
 
 FAKE_MP3 = b"ID3" + b"\x00" * 100  # minimal fake MP3 bytes
 
@@ -409,6 +417,157 @@ class TestElevenLabsClientValidateKey:
 
         headers = mock_get.call_args.kwargs.get("headers", {})
         assert headers.get("xi-api-key") == "my-key"
+
+
+def _make_stem_zip(labels: list[str], ext: str = "mp3") -> bytes:
+    """Build an in-memory ZIP archive containing one fake audio file per label."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for label in labels:
+            zf.writestr(f"{label}.{ext}", FAKE_MP3)
+    return buf.getvalue()
+
+
+class TestElevenLabsClientSeparateStems:
+    """Tests for ElevenLabsClient.separate_stems() (issue #97)."""
+
+    @pytest.fixture
+    def audio_file(self, tmp_path):
+        path = tmp_path / "fullmix.wav"
+        path.write_bytes(b"fake audio data")
+        return path
+
+    def test_separate_stems_returns_all_six_labels(self, audio_file):
+        """separate_stems() returns a dict with all six stem labels mapped to bytes."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, _make_stem_zip(ELEVENLABS_STEM_LABELS))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            result = client.separate_stems(audio_file)
+
+        assert set(result.keys()) == set(ELEVENLABS_STEM_LABELS)
+        for label, data in result.items():
+            assert isinstance(data, bytes), label
+            assert len(data) > 0, label
+
+    def test_separate_stems_sends_api_key_header(self, audio_file):
+        """separate_stems() sends xi-api-key in request headers."""
+        client = ElevenLabsClient(api_key="secret-key-123")
+        resp = _mock_response(200, _make_stem_zip(ELEVENLABS_STEM_LABELS))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.separate_stems(audio_file)
+
+        headers = mock_post.call_args.kwargs.get("headers", {})
+        assert headers.get("xi-api-key") == "secret-key-123"
+
+    def test_separate_stems_sends_stem_variation_id_as_form_field(self, audio_file):
+        """separate_stems() passes stem_variation_id as multipart form data."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, _make_stem_zip(ELEVENLABS_STEM_LABELS))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.separate_stems(audio_file, stem_variation_id="two_stems_v1")
+
+        data = mock_post.call_args.kwargs.get("data", {})
+        assert data.get("stem_variation_id") == "two_stems_v1"
+
+    def test_separate_stems_defaults_to_six_stems_variation(self, audio_file):
+        """separate_stems() defaults stem_variation_id to six_stems_v1."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, _make_stem_zip(ELEVENLABS_STEM_LABELS))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.separate_stems(audio_file)
+
+        data = mock_post.call_args.kwargs.get("data", {})
+        assert data.get("stem_variation_id") == "six_stems_v1"
+
+    def test_separate_stems_uploads_file_as_multipart(self, audio_file):
+        """separate_stems() uploads the audio under the 'file' multipart field."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, _make_stem_zip(ELEVENLABS_STEM_LABELS))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.separate_stems(audio_file)
+
+        files = mock_post.call_args.kwargs.get("files", {})
+        assert "file" in files
+
+    def test_separate_stems_sends_output_format_as_query_param(self, audio_file):
+        """separate_stems() sends the client output_format as a query parameter."""
+        client = ElevenLabsClient(api_key="test-key", output_format="mp3_44100_128")
+        resp = _mock_response(200, _make_stem_zip(ELEVENLABS_STEM_LABELS))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.separate_stems(audio_file)
+
+        params = mock_post.call_args.kwargs.get("params", {})
+        assert params.get("output_format") == "mp3_44100_128"
+
+    def test_separate_stems_maps_unknown_filenames_to_filename_stem(self, audio_file):
+        """ZIP entries with unrecognised names fall back to the filename stem as label."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, _make_stem_zip(["mystery_track"]))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            result = client.separate_stems(audio_file)
+
+        assert set(result.keys()) == {"mystery_track"}
+
+    def test_separate_stems_matches_labels_within_longer_filenames(self, audio_file):
+        """ZIP entries like 'track_01_vocals.mp3' map to the known 'vocals' label."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, _make_stem_zip(["track_01_vocals", "track_02_drums"]))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            result = client.separate_stems(audio_file)
+
+        assert set(result.keys()) == {"vocals", "drums"}
+
+    def test_separate_stems_raises_elevenlabs_error_on_401(self, audio_file):
+        """separate_stems() raises ElevenLabsError on 401 Unauthorized."""
+        client = ElevenLabsClient(api_key="bad-key")
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=_error_response(401)):
+            with pytest.raises(ElevenLabsError, match="401"):
+                client.separate_stems(audio_file)
+
+    def test_separate_stems_raises_elevenlabs_error_on_connection_failure(self, audio_file):
+        """separate_stems() raises ElevenLabsError when the request fails."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with patch(
+            "acemusic.elevenlabs_client.httpx.post",
+            side_effect=httpx.ConnectError("connection refused"),
+        ):
+            with pytest.raises(ElevenLabsError):
+                client.separate_stems(audio_file)
+
+    def test_separate_stems_raises_elevenlabs_error_on_malformed_zip(self, audio_file):
+        """separate_stems() raises ElevenLabsError when the response is not a valid ZIP."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"this is not a zip archive")
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="(?i)zip"):
+                client.separate_stems(audio_file)
+
+    def test_separate_stems_raises_elevenlabs_error_on_empty_zip(self, audio_file):
+        """separate_stems() raises ElevenLabsError when the ZIP contains no stems."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, _make_stem_zip([]))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="(?i)no stems"):
+                client.separate_stems(audio_file)
+
+    def test_separate_stems_raises_elevenlabs_error_on_missing_file(self, tmp_path):
+        """separate_stems() raises ElevenLabsError when the audio file does not exist."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with pytest.raises(ElevenLabsError):
+            client.separate_stems(tmp_path / "does-not-exist.wav")
 
 
 @pytest.mark.integration

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -533,6 +533,16 @@ class TestElevenLabsClientSeparateStems:
             with pytest.raises(ElevenLabsError, match="401"):
                 client.separate_stems(audio_file)
 
+    def test_separate_stems_surfaces_422_response_detail(self, audio_file):
+        """separate_stems() includes the API's error body (e.g. file too large) in the message."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _error_response(422)
+        resp.text = '{"detail": "file too large"}'
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="file too large"):
+                client.separate_stems(audio_file)
+
     def test_separate_stems_raises_elevenlabs_error_on_connection_failure(self, audio_file):
         """separate_stems() raises ElevenLabsError when the request fails."""
         client = ElevenLabsClient(api_key="test-key")

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -525,6 +525,17 @@ class TestElevenLabsClientSeparateStems:
 
         assert set(result.keys()) == {"vocals", "drums"}
 
+    def test_separate_stems_does_not_collapse_duplicate_label_matches(self, audio_file):
+        """Two entries matching the same known label keep distinct keys (no silent overwrite)."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, _make_stem_zip(["lead_vocals", "harmony_vocals"]))
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            result = client.separate_stems(audio_file)
+
+        # First match claims the known label; the collision falls back to its filename stem.
+        assert set(result.keys()) == {"vocals", "harmony_vocals"}
+
     def test_separate_stems_raises_elevenlabs_error_on_401(self, audio_file):
         """separate_stems() raises ElevenLabsError on 401 Unauthorized."""
         client = ElevenLabsClient(api_key="bad-key")

--- a/tests/test_stems.py
+++ b/tests/test_stems.py
@@ -78,7 +78,7 @@ def _write_stub_stem(out_dir: Path, base: str, label: str, fmt: str) -> Path:
     return path
 
 
-def _el_config(monkeypatch, api_key="test-key"):
+def _el_config(monkeypatch, api_key="test-key", output_format="mp3_44100_128"):
     """Point load_config at an ElevenLabs-enabled config."""
     from acemusic.config import AceConfig
 
@@ -88,7 +88,7 @@ def _el_config(monkeypatch, api_key="test-key"):
             api_url="http://localhost:8001",
             api_key=None,
             elevenlabs_api_key=api_key,
-            elevenlabs_output_format="mp3_44100_128",
+            elevenlabs_output_format=output_format,
         ),
     )
 
@@ -342,6 +342,29 @@ class TestStemsElevenLabsBackend:
         stems_dir = src_wav.parent / "stems"
         assert len(list(stems_dir.glob("*.mp3"))) == 6
         assert list(stems_dir.glob("*.wav")) == []
+
+    def test_elevenlabs_non_mp3_output_format_reflected_in_files_and_metadata(
+        self, workspace_with_clips_dir, monkeypatch
+    ):
+        """A non-MP3 ELEVENLABS_OUTPUT_FORMAT (pcm → wav) drives stem extensions and clip format."""
+        from acemusic.db import list_clips
+
+        ws, clip_id, src_wav = _make_source_clip()
+        _el_config(monkeypatch, output_format="pcm_44100")
+        el = _el_stems_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=180.0),
+        ):
+            result = runner.invoke(app, ["stems", str(clip_id), "--backend", "elevenlabs"])
+
+        assert result.exit_code == 0, result.output
+        stems_dir = src_wav.parent / "stems"
+        assert len(list(stems_dir.glob("*.wav"))) == 6
+        assert list(stems_dir.glob("*.mp3")) == []
+        stem_clips = [c for c in list_clips(ws.id) if c.generation_mode == "stems"]
+        assert {c.format for c in stem_clips} == {"wav"}
 
     def test_invalid_backend_value_errors(self, workspace_with_clips_dir, monkeypatch):
         """An unknown --backend value exits 1 with the resolver's message."""

--- a/tests/test_stems.py
+++ b/tests/test_stems.py
@@ -1,4 +1,4 @@
-"""Tests for the stems CLI command (US-5.3)."""
+"""Tests for the stems CLI command (US-5.3, #97 elevenlabs backend)."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from acemusic.cli import app
+from acemusic.elevenlabs_client import ELEVENLABS_STEM_LABELS, ElevenLabsError
 from acemusic.models import Clip
 from acemusic.stems_client import STEM_LABELS
 
@@ -75,6 +76,43 @@ def _write_stub_stem(out_dir: Path, base: str, label: str, fmt: str) -> Path:
     path = out_dir / f"{base}-{label}.{fmt}"
     path.write_bytes(b"fake stem audio")
     return path
+
+
+def _el_config(monkeypatch, api_key="test-key"):
+    """Point load_config at an ElevenLabs-enabled config."""
+    from acemusic.config import AceConfig
+
+    monkeypatch.setattr(
+        "acemusic.cli.load_config",
+        lambda: AceConfig(
+            api_url="http://localhost:8001",
+            api_key=None,
+            elevenlabs_api_key=api_key,
+            elevenlabs_output_format="mp3_44100_128",
+        ),
+    )
+
+
+def _el_stems_mock():
+    """Mock ElevenLabsClient whose separate_stems() returns six fake stems."""
+    el = MagicMock()
+    el.separate_stems.return_value = {label: b"fake stem audio " + label.encode() for label in ELEVENLABS_STEM_LABELS}
+    return el
+
+
+def _make_source_clip():
+    """Create a source clip on disk + in the DB; returns (workspace, clip_id, src_path)."""
+    from acemusic.db import create_clip
+    from acemusic.workspace import get_active_workspace, get_workspace_path
+
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    src_wav = clips_dir / "fullmix.wav"
+    src_wav.write_bytes(b"fake audio data")
+
+    src_clip = _make_clip(ws.id, str(src_wav), duration=180.0, bpm=120)
+    clip_id = create_clip(src_clip)
+    return ws, clip_id, src_wav
 
 
 # ---------------------------------------------------------------------------
@@ -197,6 +235,138 @@ class TestStemsCommand:
         assert original is not None
         assert original.generation_mode != "stems"
         assert original.parent_clip_id is None
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs backend (#97)
+# ---------------------------------------------------------------------------
+
+
+class TestStemsElevenLabsBackend:
+    def test_elevenlabs_produces_six_output_files(self, workspace_with_clips_dir, monkeypatch):
+        """--backend elevenlabs writes six MP3 stem files."""
+        ws, clip_id, src_wav = _make_source_clip()
+        _el_config(monkeypatch)
+        el = _el_stems_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=180.0),
+        ):
+            result = runner.invoke(app, ["stems", str(clip_id), "--backend", "elevenlabs"])
+
+        assert result.exit_code == 0, result.output
+        stems_dir = src_wav.parent / "stems"
+        mp3_files = list(stems_dir.glob("*.mp3"))
+        assert len(mp3_files) == 6
+        for label in ELEVENLABS_STEM_LABELS:
+            assert label in result.output.lower()
+
+    def test_elevenlabs_uploads_source_clip(self, workspace_with_clips_dir, monkeypatch):
+        """--backend elevenlabs passes the source file path to separate_stems()."""
+        ws, clip_id, src_wav = _make_source_clip()
+        _el_config(monkeypatch)
+        el = _el_stems_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=180.0),
+        ):
+            result = runner.invoke(app, ["stems", str(clip_id), "--backend", "elevenlabs"])
+
+        assert result.exit_code == 0, result.output
+        el.separate_stems.assert_called_once()
+        uploaded = el.separate_stems.call_args.args[0]
+        assert str(uploaded) == str(src_wav)
+
+    def test_elevenlabs_registers_six_child_clips(self, workspace_with_clips_dir, monkeypatch):
+        """Six child clips are registered with lineage, mp3 format, and inherited bpm."""
+        from acemusic.db import list_clips
+
+        ws, clip_id, _src_wav = _make_source_clip()
+        _el_config(monkeypatch)
+        el = _el_stems_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=180.0),
+        ):
+            result = runner.invoke(app, ["stems", str(clip_id), "--backend", "elevenlabs"])
+
+        assert result.exit_code == 0, result.output
+        stem_clips = [c for c in list_clips(ws.id) if c.generation_mode == "stems"]
+        assert len(stem_clips) == 6
+        assert {c.title for c in stem_clips} == set(ELEVENLABS_STEM_LABELS)
+        for sc in stem_clips:
+            assert sc.parent_clip_id == clip_id
+            assert sc.format == "mp3"
+            assert sc.bpm == 120
+
+    def test_elevenlabs_missing_api_key_errors(self, workspace_with_clips_dir, monkeypatch):
+        """--backend elevenlabs without ELEVENLABS_API_KEY exits 1 with a clear message."""
+        ws, clip_id, _src_wav = _make_source_clip()
+        _el_config(monkeypatch, api_key=None)
+
+        result = runner.invoke(app, ["stems", str(clip_id), "--backend", "elevenlabs"])
+
+        assert result.exit_code == 1
+        assert "elevenlabs_api_key" in result.output.lower()
+
+    def test_elevenlabs_error_surfaces_as_friendly_message(self, workspace_with_clips_dir, monkeypatch):
+        """ElevenLabsError from the client surfaces as a user-facing error, exit 1."""
+        ws, clip_id, _src_wav = _make_source_clip()
+        _el_config(monkeypatch)
+        el = MagicMock()
+        el.separate_stems.side_effect = ElevenLabsError("ElevenLabs stem separation failed: 401")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(app, ["stems", str(clip_id), "--backend", "elevenlabs"])
+
+        assert result.exit_code == 1
+        assert "401" in result.output
+
+    def test_elevenlabs_warns_when_output_format_specified(self, workspace_with_clips_dir, monkeypatch):
+        """--output-format with elevenlabs backend warns it is ignored; stems are MP3."""
+        ws, clip_id, src_wav = _make_source_clip()
+        _el_config(monkeypatch)
+        el = _el_stems_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.get_duration", return_value=180.0),
+        ):
+            result = runner.invoke(app, ["stems", str(clip_id), "--backend", "elevenlabs", "--output-format", "wav"])
+
+        assert result.exit_code == 0, result.output
+        assert "ignored" in result.output.lower()
+        stems_dir = src_wav.parent / "stems"
+        assert len(list(stems_dir.glob("*.mp3"))) == 6
+        assert list(stems_dir.glob("*.wav")) == []
+
+    def test_invalid_backend_value_errors(self, workspace_with_clips_dir, monkeypatch):
+        """An unknown --backend value exits 1 with the resolver's message."""
+        ws, clip_id, _src_wav = _make_source_clip()
+        _el_config(monkeypatch)
+
+        result = runner.invoke(app, ["stems", str(clip_id), "--backend", "suno"])
+
+        assert result.exit_code == 1
+        assert "invalid backend" in result.output.lower()
+
+    def test_ace_step_backend_uses_demucs_path(self, workspace_with_clips_dir, monkeypatch):
+        """--backend ace-step routes to the local demucs separation path."""
+        ws, clip_id, _src_wav = _make_source_clip()
+        _el_config(monkeypatch)
+        stems_client_mock = _make_stems_client_mock()
+
+        with (
+            patch("acemusic.cli.StemsClient", stems_client_mock),
+            patch("acemusic.cli.get_duration", return_value=180.0),
+        ):
+            result = runner.invoke(app, ["stems", str(clip_id), "--backend", "ace-step"])
+
+        assert result.exit_code == 0, result.output
+        stems_client_mock.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements #97: ElevenLabs stem separation backend (alt to demucs)

- `ElevenLabsClient.separate_stems(audio_path, stem_variation_id="six_stems_v1")` — multipart upload to `POST /v1/music/stem-separation`, parses the ZIP response into `dict[label, bytes]` with tolerant filename→label mapping; dedicated high-latency timeout (read 300s, write 30s)
- `stems` command gains `--backend` (`auto`/`ace-step`/`elevenlabs`) via the central `resolve_backend()` selector from #95; `auto`/`ace-step` keep the local demucs path (refactored into `_separate_stems_via_demucs`), `elevenlabs` routes to the new `_separate_stems_via_elevenlabs` cloud path
- `_CAPABILITIES["stems"]` now includes `elevenlabs`
- Stem files take their extension and clip `format` from the configured `ELEVENLABS_OUTPUT_FORMAT` (`_elevenlabs_ext()`, MP3 default), and all six stems are registered as child clips with the existing lineage pattern (`parent_clip_id`, `generation_mode="stems"`, inherited workspace/bpm/key)
- `--output-format` is warned-as-ignored under the elevenlabs backend; README documents six-stem (elevenlabs) vs four-stem (demucs) labeling

## Acceptance Criteria
- [x] `stems <clip> --backend elevenlabs` uploads the clip and produces playable stem files linked to the parent
- [x] Stem outputs integrate with existing clip/lineage storage and naming
- [x] Six-stem vs four-stem labeling is handled and documented
- [x] Errors (auth, file too large, latency/timeout) surface clearly — HTTP errors include the truncated response body (422 reasons), connection errors map to `ElevenLabsError`, missing API key exits 1 with a clear message
- [x] Unit tests (mocked client) cover the upload + persistence path

## Test Plan
- [x] Unit tests written (TDD approach — RED observed before every implementation step)
- [x] All tests passing (817 passed, 1 skipped)
- [x] Diff coverage 99% on changed lines (gate: ≥85%)
- [x] Linting clean (ruff + black)
- [x] Internal code review (advisory) completed
- [x] Cross-family review pass: codex — one P2 finding (hardcoded MP3 extension vs configured `ELEVENLABS_OUTPUT_FORMAT`) fixed in c1a390d
- [x] Test mutation sanity check completed (2 targeted mutations, both killed)

## Known Limitations / Intentionally Deferred
- `two_stems_v1` variation is supported by the client but not exposed as a CLI flag — out of scope for #97 (six-stem separation); trivially exposable later if needed
- No `auto`→elevenlabs fallback for stems: `auto` routes to local demucs, matching every backend-capable command except `generate` (only `generate` implements transport-failure fallback per #95)
- ZIP entry filenames are not documented by ElevenLabs; label mapping matches known labels by substring and falls back to the filename stem (tolerant by design)
- ElevenLabs stems are lossy (MP3 by default, per configured output format), noted in README — not lossless like the demucs wav/flac path

## Implementation Notes
Deviations from the CodeRabbit plan on the issue (approved before implementation):
- Backend choices are `auto|ace-step|elevenlabs` (central selector from #95), not the plan's `demucs|elevenlabs`
- Added the `_CAPABILITIES["stems"]` update the plan missed
- `--output-format` default changed `"wav"` → `None` so explicit use can be warned under elevenlabs without changing demucs behavior
- Tolerant ZIP label mapping instead of hard-failing on missing labels

Closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two stem-separation backends: local Demucs (default, 4 stems) and ElevenLabs cloud (6 MP3 stems).
  * New --backend option to choose engine; --output-format is optional and only affects local separation. ElevenLabs returns MP3 by default (output-format ignored unless configured).
  * Produced stems are saved and registered as child clips, preserving metadata/lineage.

* **Documentation**
  * README adds backend selection, behavior, and output-format guidance.

* **Tests**
  * Added tests covering both backends, ElevenLabs responses, CLI flows, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->