### PR TITLE
test: real-API integration test for ElevenLabs separate_stems (#97)

### DIFF
--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -657,3 +657,31 @@ class TestElevenLabsIntegration:
 
         segment = AudioSegment.from_file(io.BytesIO(audio), format="mp3")
         assert segment.duration_seconds > 1.0
+
+    def test_separate_stems_returns_six_playable_stems(self, tmp_path):
+        """Integration: separate_stems() on a real clip yields the six documented labels as decodable MP3s.
+
+        Also pins the undocumented ZIP-entry-naming assumption (#97): the real
+        API's archive filenames must keep mapping onto ELEVENLABS_STEM_LABELS.
+        """
+        import io
+        import os
+
+        key = os.environ.get("ELEVENLABS_API_KEY")
+        if not key:
+            pytest.skip("ELEVENLABS_API_KEY not set")
+
+        from pydub import AudioSegment
+        from pydub.generators import Sine
+
+        src = tmp_path / "fullmix.wav"
+        mix = Sine(220).to_audio_segment(duration=4000).overlay(Sine(330).to_audio_segment(duration=4000))
+        mix.export(src, format="wav")
+
+        client = ElevenLabsClient(api_key=key, output_format="mp3_44100_128")
+        stems = client.separate_stems(src)
+
+        assert set(stems.keys()) == set(ELEVENLABS_STEM_LABELS)
+        for label, data in stems.items():
+            segment = AudioSegment.from_file(io.BytesIO(data), format="mp3")
+            assert segment.duration_seconds > 1.0, label


### PR DESCRIPTION
## Summary
Follow-up to #103: now that a valid `ELEVENLABS_API_KEY` is configured locally, add an integration test that exercises `separate_stems()` against the live API.

- Verifies the six documented stem labels come back from a real separation
- Pins the undocumented ZIP-entry-naming assumption from #97 — if ElevenLabs changes archive filenames, this test catches it
- Each stem must decode as MP3 with >1s of audio
- Skips when `ELEVENLABS_API_KEY` is absent (CI), same as the existing `TestElevenLabsIntegration` tests

## Validation
- Ran against the live API: 6 stems (vocals, drums, bass, guitar, piano, other), all playable 4s MP3s at 44.1 kHz
- Unit suite unaffected (54 passed); ruff + black clean

## Known Limitations / Intentionally Deferred
- Consumes API credits per run (consistent with the existing integration tests)
- None otherwise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * New integration test added to validate audio stem separation functionality. Verifies that separated audio stems are correctly generated in playable format, meet quality duration thresholds, and conform to expected stem categorization structure and naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->