### PR TITLE
feat: ElevenLabs inpainting — repaint a section & extend a clip (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ via `--backend` (or the `ACEMUSIC_BACKEND` default):
 Either way, each stem is registered as a child clip of the source, so downstream
 commands (DAW export, etc.) work the same.
 
+## Repaint & extend backends
+
+`acemusic repaint <clip_id>` regenerates a section of a clip and
+`acemusic extend <clip_id>` lengthens one. Both accept `--backend`
+(or the `ACEMUSIC_BACKEND` default):
+
+- `auto` / `ace-step` — ACE-Step repaint task with local crossfade stitching
+  (default; requires `ACEMUSIC_BASE_URL`).
+- `elevenlabs` — cloud inpainting via ElevenLabs composition plans (requires
+  `ELEVENLABS_API_KEY` and an account with the **enterprise inpainting
+  feature**). The source clip — including ACE-Step-generated WAVs — is uploaded
+  (priced like a generation), kept ranges are referenced server-side, and the
+  result is saved in the `ELEVENLABS_OUTPUT_FORMAT` (MP3 by default).
+  ElevenLabs limits: each plan section must be 3s–120s (so repaint boundaries
+  must leave ≥3s of kept audio on each non-edge side) and the total track is
+  capped at 600s. Range validation runs before the upload, so invalid requests
+  never spend credits.
+
+Either way, results are saved as child clips of the source
+(`parent_clip_id` + `generation_mode`), so lineage-aware commands work the same.
+
 ## Environment
 
 Copy `.env.example` to `.env` and fill in the required values before running.

--- a/src/acemusic/backends.py
+++ b/src/acemusic/backends.py
@@ -19,8 +19,9 @@ VALID_BACKENDS: tuple[str, ...] = ("auto", "ace-step", "elevenlabs")
 DEFAULT_BACKEND = "auto"
 
 # Which concrete engines support each operation. ElevenLabs entries expand as
-# the sibling issues land (#98 inpainting, #99 mashup). #96 added first-class
-# generate/sounds and composition plans ("compose"); #97 added stem separation.
+# the sibling issues land (#99 mashup). #96 added first-class generate/sounds
+# and composition plans ("compose"); #97 added stem separation; #98 added
+# inpainting (repaint/extend).
 _CAPABILITIES: dict[str, set[str]] = {
     "generate": {"ace-step", "elevenlabs"},
     "sample": {"ace-step", "elevenlabs"},
@@ -29,9 +30,9 @@ _CAPABILITIES: dict[str, set[str]] = {
     "stems": {"ace-step", "elevenlabs"},
     "midi": {"ace-step"},
     "remaster": {"ace-step"},
-    "extend": {"ace-step"},
+    "extend": {"ace-step", "elevenlabs"},
     "cover": {"ace-step"},
-    "repaint": {"ace-step"},
+    "repaint": {"ace-step", "elevenlabs"},
     "mashup": {"ace-step"},
     "export": {"ace-step"},
 }

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -55,6 +55,7 @@ from acemusic.elevenlabs_client import (
     DURATION_MIN_S as EL_DURATION_MIN_S,
     ElevenLabsClient,
     ElevenLabsError,
+    build_inpaint_plan,
 )
 from acemusic.midi_client import MidiClient, MidiError
 from acemusic.models import Clip, Preset
@@ -3036,6 +3037,108 @@ def cover(
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_CROSSFADE_MS = 50
+
+
+def _repaint_via_elevenlabs(
+    *,
+    config,
+    source: Clip,
+    clip_id: int,
+    start_ms: int,
+    end_ms: int,
+    source_duration: float,
+    prompt: str,
+    style: Optional[str],
+    output: Optional[Path],
+    name: Optional[str],
+    start_label: str,
+    end_label: str,
+) -> None:
+    """Repaint a clip section via ElevenLabs inpainting (upload → plan → compose).
+
+    The source clip (any supported format, including ACE-Step WAVs) is uploaded
+    to obtain a ``song_id``; a composition plan keeps [0, start] and
+    [end, duration] via ``source_from`` and regenerates [start, end] from the
+    prompt/style. ElevenLabs composes the full track server-side, so no local
+    crossfade stitching is needed.
+    """
+    if not config.elevenlabs_api_key:
+        console.print("[red]Error: --backend elevenlabs requires ELEVENLABS_API_KEY to be set.[/red]")
+        raise typer.Exit(code=1)
+
+    duration_ms_total = int(round(source_duration * 1000))
+    keep_ranges = [(0, start_ms), (end_ms, duration_ms_total)]
+    regenerate_range = (start_ms, end_ms)
+
+    # Validate the plan shape before uploading — uploads are priced like a
+    # generation, so range errors must fail before any credits are spent.
+    try:
+        build_inpaint_plan("pending-upload", keep_ranges, regenerate_range, prompt, style)
+    except ElevenLabsError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    el_client = ElevenLabsClient(api_key=config.elevenlabs_api_key, output_format=config.elevenlabs_output_format)
+    try:
+        with console.status("[bold green]Uploading source clip to ElevenLabs…[/bold green]", spinner="dots"):
+            song_id = el_client.upload_for_inpainting(source.file_path)
+        plan = build_inpaint_plan(song_id, keep_ranges, regenerate_range, prompt, style)
+        with console.status("[bold green]Repainting via ElevenLabs…[/bold green]", spinner="dots"):
+            data = el_client.generate_from_plan(plan)
+    except ElevenLabsError as exc:
+        console.print(f"[red]ElevenLabs error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    clips_dir = output if output is not None else get_workspace_path(source.workspace_id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+    ext = _elevenlabs_ext(config.elevenlabs_output_format)
+    title_slug = make_slug(name or source.title or "clip")
+    dest_path = clips_dir / f"{title_slug}-repaint-{uuid.uuid4().hex[:8]}.{ext}"
+    dest_path.write_bytes(data)
+
+    try:
+        new_duration = get_duration(dest_path)
+    except Exception as exc:
+        warnings.warn(f"repaint clip duration probe failed: {exc}", stacklevel=2)
+        new_duration = None
+
+    if name:
+        new_title = name
+    elif source.title:
+        new_title = f"{source.title} (repaint)"
+    else:
+        new_title = None
+
+    new_clip = Clip(
+        workspace_id=source.workspace_id,
+        file_path=str(dest_path.resolve()),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        title=new_title,
+        format=ext,
+        duration=new_duration,
+        bpm=source.bpm,
+        key=source.key,
+        style_tags=style or source.style_tags,
+        lyrics=source.lyrics,
+        vocal_language=source.vocal_language,
+        model="elevenlabs",
+        parent_clip_id=source.id,
+        generation_mode="repaint",
+    )
+    try:
+        new_id = create_clip(new_clip)
+    except Exception as exc:
+        dest_path.unlink(missing_ok=True)
+        console.print(f"[red]Error saving clip record: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    dur_str = f"{new_duration:.1f}s" if new_duration is not None else "unknown"
+    console.print(f"  [green]✓[/green] Repainted clip {clip_id} ({start_label}–{end_label}) → clip {new_id}")
+    console.print(f"    Path:     {dest_path}")
+    console.print(f"    Duration: {dur_str}")
+
+
 @app.command()
 def repaint(
     clip_id: int = typer.Argument(..., help="ID of the source clip to repaint."),
@@ -3046,9 +3149,16 @@ def repaint(
     output: Optional[Path] = typer.Option(None, "--output", help="Directory to save the repainted clip."),
     name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix for the repainted clip."),
     crossfade_ms: int = typer.Option(
-        50,
+        _DEFAULT_CROSSFADE_MS,
         "--crossfade-ms",
-        help="Crossfade length at the splice boundaries (milliseconds).",
+        help="Crossfade length at the splice boundaries (milliseconds). ACE-Step backend only.",
+    ),
+    backend: Optional[str] = typer.Option(
+        None,
+        "--backend",
+        help="Engine: 'auto'/'ace-step' (ACE-Step repaint + local stitch) or 'elevenlabs' "
+        "(cloud inpainting via composition plan; sections must be 3s–120s). "
+        "Defaults to ACEMUSIC_BACKEND, then 'auto'.",
     ),
 ) -> None:
     """Regenerate a section of a clip while preserving the surrounding audio.
@@ -3117,6 +3227,34 @@ def repaint(
         raise typer.Exit(code=1)
 
     config = load_config()
+    try:
+        effective_backend = resolve_backend(backend, config.backend)
+    except BackendError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if effective_backend == "elevenlabs":
+        if crossfade_ms != _DEFAULT_CROSSFADE_MS:
+            console.print(
+                "[yellow]Warning: --crossfade-ms is ignored with the elevenlabs backend "
+                "(composition happens server-side).[/yellow]"
+            )
+        _repaint_via_elevenlabs(
+            config=config,
+            source=source,
+            clip_id=clip_id,
+            start_ms=int(start_ms),
+            end_ms=int(end_ms),
+            source_duration=source_duration,
+            prompt=prompt,
+            style=style,
+            output=output,
+            name=name,
+            start_label=start,
+            end_label=end,
+        )
+        return
+
     ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
 
     clips_dir = output if output is not None else get_workspace_path(source.workspace_id)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2494,7 +2494,7 @@ def _extend_via_elevenlabs(
     if style:
         prompt, section_style = "continue the song", style
     else:
-        prompt, section_style = source.style_tags or source.title or "continue the song", None
+        prompt, section_style = (source.style_tags or source.title or "continue the song"), None
     keep_ranges = [(0, from_ms)]
     regenerate_range = (from_ms, from_ms + duration_ms)
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2488,14 +2488,20 @@ def _extend_via_elevenlabs(
         console.print("[red]Error: --backend elevenlabs requires ELEVENLABS_API_KEY to be set.[/red]")
         raise typer.Exit(code=1)
 
-    prompt = source.style_tags or source.title or "continue the song"
+    # --style is an override: when given, it alone shapes the new section —
+    # blending in the source's old style tags would send contradictory
+    # directions to the model.
+    if style:
+        prompt, section_style = "continue the song", style
+    else:
+        prompt, section_style = source.style_tags or source.title or "continue the song", None
     keep_ranges = [(0, from_ms)]
     regenerate_range = (from_ms, from_ms + duration_ms)
 
     # Validate the plan shape before uploading — uploads are priced like a
     # generation, so range errors must fail before any credits are spent.
     try:
-        build_inpaint_plan("pending-upload", keep_ranges, regenerate_range, prompt, style, lyrics)
+        build_inpaint_plan("pending-upload", keep_ranges, regenerate_range, prompt, section_style, lyrics)
     except ElevenLabsError as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(code=1)
@@ -2504,7 +2510,7 @@ def _extend_via_elevenlabs(
     try:
         with console.status("[bold green]Uploading source clip to ElevenLabs…[/bold green]", spinner="dots"):
             song_id = el_client.upload_for_inpainting(source.file_path)
-        plan = build_inpaint_plan(song_id, keep_ranges, regenerate_range, prompt, style, lyrics)
+        plan = build_inpaint_plan(song_id, keep_ranges, regenerate_range, prompt, section_style, lyrics)
         with console.status("[bold green]Extending via ElevenLabs…[/bold green]", spinner="dots"):
             data = el_client.generate_from_plan(plan)
     except ElevenLabsError as exc:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2464,6 +2464,93 @@ def _parse_from_flag(value: str, source_duration: float) -> float:
     return parse_time_string(value) / 1000.0
 
 
+def _extend_via_elevenlabs(
+    *,
+    config,
+    source: Clip,
+    clip_id: int,
+    from_ms: int,
+    duration_ms: int,
+    style: Optional[str],
+    lyrics: Optional[str],
+) -> None:
+    """Extend a clip via ElevenLabs inpainting (upload → plan → compose).
+
+    The source clip is uploaded to obtain a ``song_id``; a composition plan
+    keeps [0, from] via ``source_from`` and appends a new [from, from+duration]
+    section described by the source's style (or the overrides). Audio past the
+    splice point is replaced, consistent with the ACE-Step behaviour — no
+    local trimming is needed because the keep range handles it server-side.
+    """
+    if not config.elevenlabs_api_key:
+        console.print("[red]Error: --backend elevenlabs requires ELEVENLABS_API_KEY to be set.[/red]")
+        raise typer.Exit(code=1)
+
+    prompt = source.style_tags or source.title or "continue the song"
+    keep_ranges = [(0, from_ms)]
+    regenerate_range = (from_ms, from_ms + duration_ms)
+
+    # Validate the plan shape before uploading — uploads are priced like a
+    # generation, so range errors must fail before any credits are spent.
+    try:
+        build_inpaint_plan("pending-upload", keep_ranges, regenerate_range, prompt, style, lyrics)
+    except ElevenLabsError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    el_client = ElevenLabsClient(api_key=config.elevenlabs_api_key, output_format=config.elevenlabs_output_format)
+    try:
+        with console.status("[bold green]Uploading source clip to ElevenLabs…[/bold green]", spinner="dots"):
+            song_id = el_client.upload_for_inpainting(source.file_path)
+        plan = build_inpaint_plan(song_id, keep_ranges, regenerate_range, prompt, style, lyrics)
+        with console.status("[bold green]Extending via ElevenLabs…[/bold green]", spinner="dots"):
+            data = el_client.generate_from_plan(plan)
+    except ElevenLabsError as exc:
+        console.print(f"[red]ElevenLabs error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    clips_dir = get_workspace_path(source.workspace_id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+    ext = _elevenlabs_ext(config.elevenlabs_output_format)
+    dest_path = clips_dir / f"{make_slug(source.title or 'clip')}-extend-{uuid.uuid4().hex[:8]}.{ext}"
+    dest_path.write_bytes(data)
+
+    try:
+        new_duration = get_duration(dest_path)
+    except Exception as exc:
+        warnings.warn(f"extended clip duration probe failed: {exc}", stacklevel=2)
+        new_duration = None
+
+    new_title = f"{source.title} (extended)" if source.title else None
+    new_clip = Clip(
+        workspace_id=source.workspace_id,
+        file_path=str(dest_path.resolve()),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        title=new_title,
+        format=ext,
+        duration=new_duration,
+        bpm=source.bpm,
+        key=source.key,
+        style_tags=style or source.style_tags,
+        lyrics=lyrics or source.lyrics,
+        vocal_language=source.vocal_language,
+        model="elevenlabs",
+        parent_clip_id=source.id,
+        generation_mode="extend",
+    )
+    try:
+        new_id = create_clip(new_clip)
+    except Exception as exc:
+        dest_path.unlink(missing_ok=True)
+        console.print(f"[red]Error saving clip record: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    dur_str = f"{new_duration:.1f}s" if new_duration is not None else "unknown"
+    console.print(f"  [green]✓[/green] Extended clip {clip_id} → clip {new_id}")
+    console.print(f"    Path:     {dest_path}")
+    console.print(f"    Duration: {dur_str}")
+
+
 @app.command()
 def extend(
     clip_id: int = typer.Argument(..., help="ID of the source clip to extend."),
@@ -2471,6 +2558,13 @@ def extend(
     from_: str = typer.Option("end", "--from", help="Extension point: 'end' (default) or a timestamp like '45s'."),
     style: Optional[str] = typer.Option(None, "--style", help="Optional style override for the extension."),
     lyrics: Optional[str] = typer.Option(None, "--lyrics", help="Optional lyrics for the extended section."),
+    backend: Optional[str] = typer.Option(
+        None,
+        "--backend",
+        help="Engine: 'auto'/'ace-step' (ACE-Step repaint task) or 'elevenlabs' "
+        "(cloud inpainting via composition plan; sections must be 3s–120s). "
+        "Defaults to ACEMUSIC_BACKEND, then 'auto'.",
+    ),
 ) -> None:
     """Extend an existing clip by generating audio that continues the song.
 
@@ -2527,6 +2621,24 @@ def extend(
     target_audio_duration = repaint_end
 
     config = load_config()
+    try:
+        effective_backend = resolve_backend(backend, config.backend)
+    except BackendError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if effective_backend == "elevenlabs":
+        _extend_via_elevenlabs(
+            config=config,
+            source=source,
+            clip_id=clip_id,
+            from_ms=int(round(from_seconds * 1000)),
+            duration_ms=duration_ms,
+            style=style,
+            lyrics=lyrics,
+        )
+        return
+
     ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
 
     clips_dir = get_workspace_path(source.workspace_id)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2512,16 +2512,20 @@ def _extend_via_elevenlabs(
             song_id = el_client.upload_for_inpainting(source.file_path)
         plan = build_inpaint_plan(song_id, keep_ranges, regenerate_range, prompt, section_style, lyrics)
         with console.status("[bold green]Extending via ElevenLabs…[/bold green]", spinner="dots"):
-            data = el_client.generate_from_plan(plan)
+            data = el_client.generate_from_plan(plan, seed=source.seed)
     except ElevenLabsError as exc:
         console.print(f"[red]ElevenLabs error: {exc}[/red]")
         raise typer.Exit(code=1)
 
-    clips_dir = get_workspace_path(source.workspace_id)
-    clips_dir.mkdir(parents=True, exist_ok=True)
     ext = _elevenlabs_ext(config.elevenlabs_output_format)
-    dest_path = clips_dir / f"{make_slug(source.title or 'clip')}-extend-{uuid.uuid4().hex[:8]}.{ext}"
-    dest_path.write_bytes(data)
+    try:
+        clips_dir = get_workspace_path(source.workspace_id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        dest_path = clips_dir / f"{make_slug(source.title or 'clip')}-extend-{uuid.uuid4().hex[:8]}.{ext}"
+        dest_path.write_bytes(data)
+    except OSError as exc:
+        console.print(f"[red]Error writing extended clip: {exc}[/red]")
+        raise typer.Exit(code=1)
 
     try:
         new_duration = get_duration(dest_path)
@@ -2543,6 +2547,7 @@ def _extend_via_elevenlabs(
         lyrics=lyrics or source.lyrics,
         vocal_language=source.vocal_language,
         model="elevenlabs",
+        seed=source.seed,
         parent_clip_id=source.id,
         generation_mode="extend",
     )
@@ -2712,7 +2717,11 @@ def extend(
             console.print(f"[red]Error downloading extended clip: {exc}[/red]")
             raise typer.Exit(code=1)
 
-        dest_path.write_bytes(data)
+        try:
+            dest_path.write_bytes(data)
+        except OSError as exc:
+            console.print(f"[red]Error writing extended clip: {exc}[/red]")
+            raise typer.Exit(code=1)
     finally:
         if trimmed is not None:
             trimmed.unlink(missing_ok=True)
@@ -3206,17 +3215,21 @@ def _repaint_via_elevenlabs(
             song_id = el_client.upload_for_inpainting(source.file_path)
         plan = build_inpaint_plan(song_id, keep_ranges, regenerate_range, prompt, style)
         with console.status("[bold green]Repainting via ElevenLabs…[/bold green]", spinner="dots"):
-            data = el_client.generate_from_plan(plan)
+            data = el_client.generate_from_plan(plan, seed=source.seed)
     except ElevenLabsError as exc:
         console.print(f"[red]ElevenLabs error: {exc}[/red]")
         raise typer.Exit(code=1)
 
-    clips_dir = output if output is not None else get_workspace_path(source.workspace_id)
-    clips_dir.mkdir(parents=True, exist_ok=True)
     ext = _elevenlabs_ext(config.elevenlabs_output_format)
     title_slug = make_slug(name or source.title or "clip")
-    dest_path = clips_dir / f"{title_slug}-repaint-{uuid.uuid4().hex[:8]}.{ext}"
-    dest_path.write_bytes(data)
+    try:
+        clips_dir = output if output is not None else get_workspace_path(source.workspace_id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        dest_path = clips_dir / f"{title_slug}-repaint-{uuid.uuid4().hex[:8]}.{ext}"
+        dest_path.write_bytes(data)
+    except OSError as exc:
+        console.print(f"[red]Error writing repainted clip: {exc}[/red]")
+        raise typer.Exit(code=1)
 
     try:
         new_duration = get_duration(dest_path)
@@ -3244,6 +3257,7 @@ def _repaint_via_elevenlabs(
         lyrics=source.lyrics,
         vocal_language=source.vocal_language,
         model="elevenlabs",
+        seed=source.seed,
         parent_clip_id=source.id,
         generation_mode="repaint",
     )

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -197,6 +197,8 @@ def main(
         "generate",
         "sounds",
         "sample",
+        "repaint",
+        "extend",
     ):
         config = load_config()
         if not config.api_url:
@@ -2639,6 +2641,7 @@ def extend(
         )
         return
 
+    _require_ace_step_url(config)
     ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
 
     clips_dir = get_workspace_path(source.workspace_id)
@@ -3367,6 +3370,7 @@ def repaint(
         )
         return
 
+    _require_ace_step_url(config)
     ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
 
     clips_dir = output if output is not None else get_workspace_path(source.workspace_id)

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -36,6 +36,130 @@ class ElevenLabsError(Exception):
     """Raised when the ElevenLabs API returns an error or is unreachable."""
 
 
+# Composition plan sections must be 3s–120s each (SongSection.duration_ms).
+SECTION_MIN_MS = 3_000
+SECTION_MAX_MS = 120_000
+
+
+def _split_keep_range(start_ms: int, end_ms: int) -> list[tuple[int, int]]:
+    """Split a keep range into contiguous chunks no longer than SECTION_MAX_MS.
+
+    Uses the minimal number of equal-sized chunks so every chunk stays well
+    above SECTION_MIN_MS (a range needing a split is >120s, so halves are >60s).
+    """
+    total = end_ms - start_ms
+    chunks = -(-total // SECTION_MAX_MS)  # ceil division
+    ranges: list[tuple[int, int]] = []
+    chunk_start = start_ms
+    for i in range(1, chunks + 1):
+        chunk_end = start_ms + (total * i) // chunks
+        ranges.append((chunk_start, chunk_end))
+        chunk_start = chunk_end
+    return ranges
+
+
+def build_inpaint_plan(
+    song_id: str,
+    keep_ranges: list[tuple[int, int]],
+    regenerate_range: tuple[int, int],
+    prompt: str,
+    style: str | None = None,
+    lyrics: str | None = None,
+) -> dict:
+    """Build a composition plan that regenerates one section of a stored song.
+
+    Keep ranges become sections referencing the uploaded song via
+    ``source_from`` so their audio is preserved; the regenerate range becomes
+    a plain section described by ``prompt``/``style``/``lyrics`` that the
+    model fills in. Sections are emitted in chronological order.
+
+    Args:
+        song_id: ID returned by :meth:`ElevenLabsClient.upload_for_inpainting`.
+        keep_ranges: ``(start_ms, end_ms)`` ranges of the source to keep.
+            Empty ranges are skipped; ranges longer than 120s are split into
+            multiple sections (the API caps sections at 120s).
+        regenerate_range: The single ``(start_ms, end_ms)`` range to regenerate.
+        prompt: Description of the regenerated section.
+        style: Optional comma-separated style descriptors for the section.
+        lyrics: Optional lyrics for the section (one line per text line).
+
+    Raises:
+        ElevenLabsError: If any non-empty range is shorter than 3s, the
+            regenerate range is longer than 120s, or it is inverted/empty.
+    """
+    regen_start, regen_end = regenerate_range
+    regen_duration = regen_end - regen_start
+    if regen_duration <= 0:
+        raise ElevenLabsError(
+            f"Invalid regenerate range [{regen_start}ms, {regen_end}ms]: start must be before end."
+        )
+    if regen_duration < SECTION_MIN_MS:
+        raise ElevenLabsError(
+            f"Regenerate range is {regen_duration}ms but ElevenLabs sections must be at least "
+            f"{SECTION_MIN_MS // 1000}s. Widen the region (e.g. adjust --start/--end or --duration)."
+        )
+    if regen_duration > SECTION_MAX_MS:
+        raise ElevenLabsError(
+            f"Regenerate range is {regen_duration}ms but ElevenLabs sections are capped at "
+            f"{SECTION_MAX_MS // 1000}s (120s). Narrow the region or run multiple passes."
+        )
+
+    entries: list[tuple[int, int, bool]] = [(regen_start, regen_end, True)]
+    for start_ms, end_ms in keep_ranges:
+        duration = end_ms - start_ms
+        if duration <= 0:
+            continue
+        if duration < SECTION_MIN_MS:
+            raise ElevenLabsError(
+                f"Kept range [{start_ms}ms, {end_ms}ms] is {duration}ms but ElevenLabs sections "
+                f"must be at least {SECTION_MIN_MS // 1000}s. Move the repaint boundary so at "
+                f"least 3s of audio is kept on that side, or extend the region to the clip edge."
+            )
+        for chunk_start, chunk_end in _split_keep_range(start_ms, end_ms):
+            entries.append((chunk_start, chunk_end, False))
+    entries.sort(key=lambda entry: entry[0])
+
+    positive_styles = [prompt]
+    if style:
+        positive_styles.extend(part.strip() for part in style.split(",") if part.strip())
+    lines = [line.strip() for line in lyrics.splitlines() if line.strip()] if lyrics else []
+
+    sections: list[dict] = []
+    keep_index = 0
+    for start_ms, end_ms, is_regen in entries:
+        if is_regen:
+            sections.append(
+                {
+                    "section_name": "Regenerated",
+                    "positive_local_styles": positive_styles,
+                    "negative_local_styles": [],
+                    "duration_ms": end_ms - start_ms,
+                    "lines": lines,
+                }
+            )
+        else:
+            keep_index += 1
+            sections.append(
+                {
+                    "section_name": f"Keep {keep_index}",
+                    "positive_local_styles": [],
+                    "negative_local_styles": [],
+                    "duration_ms": end_ms - start_ms,
+                    "lines": [],
+                    "source_from": {
+                        "song_id": song_id,
+                        "range": {"start_ms": start_ms, "end_ms": end_ms},
+                    },
+                }
+            )
+
+    return {
+        "positive_global_styles": [],
+        "negative_global_styles": [],
+        "sections": sections,
+    }
+
+
 def _validate_duration(duration: float | None) -> None:
     """Raise ElevenLabsError if duration is outside the API limits (3s–600s)."""
     if duration is not None and not (DURATION_MIN_S <= duration <= DURATION_MAX_S):

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -27,6 +27,9 @@ ELEVENLABS_STEM_LABELS: list[str] = ["vocals", "drums", "bass", "guitar", "piano
 _GENERATION_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
 _PLAN_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
 _STEMS_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=10.0)
+# Uploading for inpainting (#98) is priced like a generation and the server
+# inspects the audio (copyright check), so give it the same headroom as stems.
+_UPLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=10.0)
 
 
 class ElevenLabsError(Exception):
@@ -258,6 +261,57 @@ class ElevenLabsClient:
         except httpx.RequestError as exc:
             raise ElevenLabsError(f"ElevenLabs stem separation failed: {exc}") from exc
         return _parse_stem_zip(response.content)
+
+    def upload_for_inpainting(self, audio_path: str | Path) -> str:
+        """Upload an audio file for inpainting via POST /v1/music/upload.
+
+        The uploaded song can then be referenced by ``song_id`` from a
+        composition plan section's ``source_from`` to keep ranges of the
+        original audio while regenerating others. Only available to accounts
+        with access to the ElevenLabs inpainting feature; uploading is priced
+        the same as a generation.
+
+        Args:
+            audio_path: Path to the audio file to upload.
+
+        Returns:
+            The ``song_id`` assigned to the uploaded song.
+
+        Raises:
+            ElevenLabsError: On unreadable input file, HTTP error, connection
+                failure, or a response without a ``song_id``.
+        """
+        audio_path = Path(audio_path)
+        try:
+            with open(audio_path, "rb") as fh:
+                response = httpx.post(
+                    f"{_BASE_URL}/v1/music/upload",
+                    files={"file": (audio_path.name, fh)},
+                    headers=self._headers,
+                    timeout=_UPLOAD_TIMEOUT,
+                )
+            response.raise_for_status()
+        except OSError as exc:
+            raise ElevenLabsError(f"ElevenLabs upload failed: cannot read {audio_path}: {exc}") from exc
+        except httpx.HTTPStatusError as exc:
+            # Include the response body (truncated) — 403 carries the
+            # enterprise-gating reason and 422 the validation detail.
+            detail = (exc.response.text or "").strip()[:200]
+            message = f"ElevenLabs upload failed: {exc.response.status_code}"
+            if detail:
+                message = f"{message} — {detail}"
+            raise ElevenLabsError(message) from exc
+        except httpx.RequestError as exc:
+            raise ElevenLabsError(f"ElevenLabs upload failed: {exc}") from exc
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ElevenLabsError("ElevenLabs upload failed: invalid JSON response") from exc
+        song_id = payload.get("song_id") if isinstance(payload, dict) else None
+        if not song_id:
+            raise ElevenLabsError("ElevenLabs upload failed: response contains no song_id")
+        return str(song_id)
 
     def validate_key(self, timeout: float = 5.0) -> bool:
         """Validate the API key via GET /v1/user. Returns True if valid, False otherwise."""

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -36,9 +36,11 @@ class ElevenLabsError(Exception):
     """Raised when the ElevenLabs API returns an error or is unreachable."""
 
 
-# Composition plan sections must be 3s–120s each (SongSection.duration_ms).
+# Composition plan sections must be 3s–120s each (SongSection.duration_ms),
+# and the whole track is capped at 600s (music_length_ms limit).
 SECTION_MIN_MS = 3_000
 SECTION_MAX_MS = 120_000
+TRACK_MAX_MS = int(DURATION_MAX_S * 1000)
 
 
 def _split_keep_range(start_ms: int, end_ms: int) -> list[tuple[int, int]]:
@@ -116,6 +118,15 @@ def build_inpaint_plan(
         for chunk_start, chunk_end in _split_keep_range(start_ms, end_ms):
             entries.append((chunk_start, chunk_end, False))
     entries.sort(key=lambda entry: entry[0])
+
+    # The whole composed track is capped at 600s — fail here so callers can
+    # validate before paying for an upload that could never compose.
+    total_ms = sum(end_ms - start_ms for start_ms, end_ms, _ in entries)
+    if total_ms > TRACK_MAX_MS:
+        raise ElevenLabsError(
+            f"Inpainting plan totals {total_ms}ms but ElevenLabs tracks are capped at "
+            f"{TRACK_MAX_MS // 1000}s (10 min). Use a shorter source clip or a smaller extension."
+        )
 
     positive_styles = [prompt]
     if style:

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -90,9 +90,7 @@ def build_inpaint_plan(
     regen_start, regen_end = regenerate_range
     regen_duration = regen_end - regen_start
     if regen_duration <= 0:
-        raise ElevenLabsError(
-            f"Invalid regenerate range [{regen_start}ms, {regen_end}ms]: start must be before end."
-        )
+        raise ElevenLabsError(f"Invalid regenerate range [{regen_start}ms, {regen_end}ms]: start must be before end.")
     if regen_duration < SECTION_MIN_MS:
         raise ElevenLabsError(
             f"Regenerate range is {regen_duration}ms but ElevenLabs sections must be at least "

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -419,6 +419,9 @@ class ElevenLabsClient:
             with open(audio_path, "rb") as fh:
                 response = httpx.post(
                     f"{_BASE_URL}/v1/music/upload",
+                    # No explicit content-type: httpx infers it from the
+                    # filename (e.g. audio/x-wav, audio/mpeg) — same pattern
+                    # proven against the live API by separate_stems (#97).
                     files={"file": (audio_path.name, fh)},
                     headers=self._headers,
                     timeout=_UPLOAD_TIMEOUT,

--- a/tests/helpers_elevenlabs.py
+++ b/tests/helpers_elevenlabs.py
@@ -1,0 +1,35 @@
+"""Shared ElevenLabs test helpers (#97 stems, #98 inpainting).
+
+Imported by the command test modules (`test_stems.py`, `test_repaint.py`,
+`test_extend.py`) so the mock client shape and config wiring stay in sync
+as more ElevenLabs-backed commands land.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+FAKE_EL_MP3 = b"ID3" + b"\x00" * 200
+
+
+def _el_config(monkeypatch, api_key="test-key", output_format="mp3_44100_128"):
+    """Point load_config at an ElevenLabs-enabled config."""
+    from acemusic.config import AceConfig
+
+    monkeypatch.setattr(
+        "acemusic.cli.load_config",
+        lambda: AceConfig(
+            api_url="http://localhost:8001",
+            api_key=None,
+            elevenlabs_api_key=api_key,
+            elevenlabs_output_format=output_format,
+        ),
+    )
+
+
+def _make_elevenlabs_client_mock(audio_bytes: bytes = FAKE_EL_MP3, song_id: str = "song-123"):
+    """MagicMock ElevenLabsClient with a happy-path upload→plan→compose default."""
+    el = MagicMock()
+    el.upload_for_inpainting.return_value = song_id
+    el.generate_from_plan.return_value = audio_bytes
+    return el

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -60,6 +60,20 @@ class TestCapabilities:
             ensure_supports("elevenlabs", "midi")
 
 
+class TestIssue98Capabilities:
+    """Capability entries added by #98 (ElevenLabs inpainting: repaint/extend)."""
+
+    def test_repaint_supported_by_both_engines(self):
+        assert supports("ace-step", "repaint")
+        assert supports("elevenlabs", "repaint")
+        assert supports("auto", "repaint")
+
+    def test_extend_supported_by_both_engines(self):
+        assert supports("ace-step", "extend")
+        assert supports("elevenlabs", "extend")
+        assert supports("auto", "extend")
+
+
 class TestIssue96Capabilities:
     """Capability entries added by #96 (ElevenLabs first-class generate/compose)."""
 

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -15,6 +15,7 @@ from acemusic.elevenlabs_client import (
     ELEVENLABS_STEM_LABELS,
     ElevenLabsClient,
     ElevenLabsError,
+    build_inpaint_plan,
 )
 
 FAKE_MP3 = b"ID3" + b"\x00" * 100  # minimal fake MP3 bytes
@@ -712,6 +713,192 @@ class TestElevenLabsClientUploadForInpainting:
 
         with pytest.raises(ElevenLabsError):
             client.upload_for_inpainting(tmp_path / "does-not-exist.wav")
+
+
+class TestBuildInpaintPlan:
+    """Tests for build_inpaint_plan() (issue #98)."""
+
+    def test_repaint_plan_has_keep_regen_keep_sections_in_order(self):
+        """A mid-clip repaint yields keep / regenerate / keep sections chronologically."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 10_000), (20_000, 30_000)],
+            regenerate_range=(10_000, 20_000),
+            prompt="add a guitar solo",
+        )
+
+        sections = plan["sections"]
+        assert len(sections) == 3
+        # keep before
+        assert sections[0]["source_from"] == {
+            "song_id": "song-1",
+            "range": {"start_ms": 0, "end_ms": 10_000},
+        }
+        assert sections[0]["duration_ms"] == 10_000
+        # regenerate (no source_from)
+        assert "source_from" not in sections[1]
+        assert sections[1]["duration_ms"] == 10_000
+        assert "add a guitar solo" in sections[1]["positive_local_styles"]
+        # keep after
+        assert sections[2]["source_from"] == {
+            "song_id": "song-1",
+            "range": {"start_ms": 20_000, "end_ms": 30_000},
+        }
+
+    def test_plan_has_required_top_level_and_section_fields(self):
+        """Every section carries the fields required by the MusicPrompt schema."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 10_000)],
+            regenerate_range=(10_000, 20_000),
+            prompt="new outro",
+        )
+
+        assert plan["positive_global_styles"] == []
+        assert plan["negative_global_styles"] == []
+        for section in plan["sections"]:
+            for field in (
+                "section_name",
+                "positive_local_styles",
+                "negative_local_styles",
+                "duration_ms",
+                "lines",
+            ):
+                assert field in section, field
+
+    def test_extend_plan_appends_new_section(self):
+        """An extend (no trailing keep) yields keep + new section."""
+        plan = build_inpaint_plan(
+            song_id="song-2",
+            keep_ranges=[(0, 30_000)],
+            regenerate_range=(30_000, 45_000),
+            prompt="epic finale",
+        )
+
+        sections = plan["sections"]
+        assert len(sections) == 2
+        assert sections[0]["source_from"]["range"] == {"start_ms": 0, "end_ms": 30_000}
+        assert "source_from" not in sections[1]
+        assert sections[1]["duration_ms"] == 15_000
+
+    def test_style_descriptors_are_added_to_regenerate_section(self):
+        """Comma-separated style descriptors land in positive_local_styles."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 10_000)],
+            regenerate_range=(10_000, 20_000),
+            prompt="bridge",
+            style="dark synthwave, heavy bass",
+        )
+
+        regen = plan["sections"][-1]
+        assert "dark synthwave" in regen["positive_local_styles"]
+        assert "heavy bass" in regen["positive_local_styles"]
+
+    def test_lyrics_are_split_into_lines(self):
+        """Lyrics text becomes the regenerate section's lines (blank lines dropped)."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 10_000)],
+            regenerate_range=(10_000, 20_000),
+            prompt="verse",
+            lyrics="first line\n\nsecond line\n",
+        )
+
+        regen = plan["sections"][-1]
+        assert regen["lines"] == ["first line", "second line"]
+
+    def test_keep_sections_have_no_lyrics_or_styles(self):
+        """Keep sections carry empty styles and lines."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 10_000)],
+            regenerate_range=(10_000, 20_000),
+            prompt="verse",
+            lyrics="la la la",
+        )
+
+        keep = plan["sections"][0]
+        assert keep["positive_local_styles"] == []
+        assert keep["lines"] == []
+
+    def test_empty_keep_ranges_are_skipped(self):
+        """Zero-length keep ranges (e.g. repaint starting at 0ms) are omitted."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 0), (10_000, 20_000)],
+            regenerate_range=(0, 10_000),
+            prompt="new intro",
+        )
+
+        sections = plan["sections"]
+        assert len(sections) == 2
+        assert "source_from" not in sections[0]
+        assert sections[1]["source_from"]["range"] == {"start_ms": 10_000, "end_ms": 20_000}
+
+    def test_long_keep_range_is_split_into_chunks(self):
+        """Keep ranges longer than 120s are split into <=120s chunks (all >=3s)."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 250_000)],
+            regenerate_range=(250_000, 260_000),
+            prompt="outro",
+        )
+
+        keep_sections = [s for s in plan["sections"] if "source_from" in s]
+        assert len(keep_sections) == 3
+        # Chunks tile the original range contiguously.
+        assert keep_sections[0]["source_from"]["range"]["start_ms"] == 0
+        assert keep_sections[-1]["source_from"]["range"]["end_ms"] == 250_000
+        for i in range(len(keep_sections) - 1):
+            assert (
+                keep_sections[i]["source_from"]["range"]["end_ms"]
+                == keep_sections[i + 1]["source_from"]["range"]["start_ms"]
+            )
+        for section in keep_sections:
+            assert 3_000 <= section["duration_ms"] <= 120_000
+            rng = section["source_from"]["range"]
+            assert section["duration_ms"] == rng["end_ms"] - rng["start_ms"]
+
+    def test_too_short_keep_range_raises(self):
+        """A keep range shorter than 3s raises ElevenLabsError with guidance."""
+        with pytest.raises(ElevenLabsError, match="(?i)3"):
+            build_inpaint_plan(
+                song_id="song-1",
+                keep_ranges=[(0, 1_000)],
+                regenerate_range=(1_000, 10_000),
+                prompt="solo",
+            )
+
+    def test_too_short_regenerate_range_raises(self):
+        """A regenerate range shorter than 3s raises ElevenLabsError."""
+        with pytest.raises(ElevenLabsError, match="(?i)3"):
+            build_inpaint_plan(
+                song_id="song-1",
+                keep_ranges=[(0, 10_000)],
+                regenerate_range=(10_000, 11_000),
+                prompt="blip",
+            )
+
+    def test_too_long_regenerate_range_raises(self):
+        """A regenerate range longer than 120s raises ElevenLabsError."""
+        with pytest.raises(ElevenLabsError, match="120"):
+            build_inpaint_plan(
+                song_id="song-1",
+                keep_ranges=[(0, 10_000)],
+                regenerate_range=(10_000, 140_000),
+                prompt="megasolo",
+            )
+
+    def test_inverted_regenerate_range_raises(self):
+        """A regenerate range with start >= end raises ElevenLabsError."""
+        with pytest.raises(ElevenLabsError):
+            build_inpaint_plan(
+                song_id="song-1",
+                keep_ranges=[(0, 10_000)],
+                regenerate_range=(20_000, 20_000),
+                prompt="nothing",
+            )
 
 
 @pytest.mark.integration

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -634,7 +634,7 @@ class TestElevenLabsClientUploadForInpainting:
         with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
             client.upload_for_inpainting(audio_file)
 
-        url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args.kwargs.get("url")
+        url = mock_post.call_args.args[0]
         assert url.endswith("/v1/music/upload")
 
     def test_upload_sends_file_as_multipart(self, audio_file):

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -900,6 +900,26 @@ class TestBuildInpaintPlan:
                 prompt="nothing",
             )
 
+    def test_total_duration_over_track_limit_raises(self):
+        """A plan totalling more than 600s (the track limit) raises ElevenLabsError."""
+        with pytest.raises(ElevenLabsError, match="600"):
+            build_inpaint_plan(
+                song_id="song-1",
+                keep_ranges=[(0, 590_000), (605_000, 660_000)],
+                regenerate_range=(590_000, 605_000),
+                prompt="midsection",
+            )
+
+    def test_total_duration_at_track_limit_is_allowed(self):
+        """A plan totalling exactly 600s passes validation."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 590_000)],
+            regenerate_range=(590_000, 600_000),
+            prompt="outro",
+        )
+        assert sum(s["duration_ms"] for s in plan["sections"]) == 600_000
+
 
 @pytest.mark.integration
 class TestElevenLabsIntegration:

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -836,6 +836,19 @@ class TestBuildInpaintPlan:
         assert "source_from" not in sections[0]
         assert sections[1]["source_from"]["range"] == {"start_ms": 10_000, "end_ms": 20_000}
 
+    def test_keep_range_at_exactly_section_max_stays_one_chunk(self):
+        """A keep range of exactly 120s produces a single section, not two."""
+        plan = build_inpaint_plan(
+            song_id="song-1",
+            keep_ranges=[(0, 120_000)],
+            regenerate_range=(120_000, 130_000),
+            prompt="outro",
+        )
+
+        keep_sections = [s for s in plan["sections"] if "source_from" in s]
+        assert len(keep_sections) == 1
+        assert keep_sections[0]["duration_ms"] == 120_000
+
     def test_long_keep_range_is_split_into_chunks(self):
         """Keep ranges longer than 120s are split into <=120s chunks (all >=3s)."""
         plan = build_inpaint_plan(

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -606,6 +606,114 @@ class TestElevenLabsClientSeparateStems:
             client.separate_stems(tmp_path / "does-not-exist.wav")
 
 
+class TestElevenLabsClientUploadForInpainting:
+    """Tests for ElevenLabsClient.upload_for_inpainting() (issue #98)."""
+
+    @pytest.fixture
+    def audio_file(self, tmp_path):
+        path = tmp_path / "source.wav"
+        path.write_bytes(b"fake audio data")
+        return path
+
+    def test_upload_returns_song_id(self, audio_file):
+        """upload_for_inpainting() returns the song_id from the JSON response."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"", json_data={"song_id": "song-abc123"})
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            result = client.upload_for_inpainting(audio_file)
+
+        assert result == "song-abc123"
+
+    def test_upload_posts_to_upload_endpoint(self, audio_file):
+        """upload_for_inpainting() POSTs to /v1/music/upload."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"", json_data={"song_id": "song-abc123"})
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.upload_for_inpainting(audio_file)
+
+        url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args.kwargs.get("url")
+        assert url.endswith("/v1/music/upload")
+
+    def test_upload_sends_file_as_multipart(self, audio_file):
+        """upload_for_inpainting() uploads the audio under the 'file' multipart field."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"", json_data={"song_id": "song-abc123"})
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.upload_for_inpainting(audio_file)
+
+        files = mock_post.call_args.kwargs.get("files", {})
+        assert "file" in files
+
+    def test_upload_sends_api_key_header(self, audio_file):
+        """upload_for_inpainting() sends xi-api-key in request headers."""
+        client = ElevenLabsClient(api_key="secret-key-123")
+        resp = _mock_response(200, b"", json_data={"song_id": "song-abc123"})
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp) as mock_post:
+            client.upload_for_inpainting(audio_file)
+
+        headers = mock_post.call_args.kwargs.get("headers", {})
+        assert headers.get("xi-api-key") == "secret-key-123"
+
+    def test_upload_raises_elevenlabs_error_on_403(self, audio_file):
+        """upload_for_inpainting() raises ElevenLabsError on 403 (enterprise gate)."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=_error_response(403)):
+            with pytest.raises(ElevenLabsError, match="403"):
+                client.upload_for_inpainting(audio_file)
+
+    def test_upload_surfaces_error_response_detail(self, audio_file):
+        """upload_for_inpainting() includes the API's error body in the message."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _error_response(403)
+        resp.text = '{"detail": "inpainting requires an enterprise plan"}'
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="enterprise plan"):
+                client.upload_for_inpainting(audio_file)
+
+    def test_upload_raises_elevenlabs_error_on_connection_failure(self, audio_file):
+        """upload_for_inpainting() raises ElevenLabsError when the request fails."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with patch(
+            "acemusic.elevenlabs_client.httpx.post",
+            side_effect=httpx.ConnectError("connection refused"),
+        ):
+            with pytest.raises(ElevenLabsError):
+                client.upload_for_inpainting(audio_file)
+
+    def test_upload_raises_elevenlabs_error_on_missing_song_id(self, audio_file):
+        """upload_for_inpainting() raises ElevenLabsError when the response has no song_id."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"", json_data={"unexpected": "shape"})
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="(?i)song_id"):
+                client.upload_for_inpainting(audio_file)
+
+    def test_upload_raises_elevenlabs_error_on_invalid_json(self, audio_file):
+        """upload_for_inpainting() raises ElevenLabsError when the response is not JSON."""
+        client = ElevenLabsClient(api_key="test-key")
+        resp = _mock_response(200, b"")
+        resp.json.side_effect = ValueError("not json")
+
+        with patch("acemusic.elevenlabs_client.httpx.post", return_value=resp):
+            with pytest.raises(ElevenLabsError, match="(?i)json"):
+                client.upload_for_inpainting(audio_file)
+
+    def test_upload_raises_elevenlabs_error_on_missing_file(self, tmp_path):
+        """upload_for_inpainting() raises ElevenLabsError when the audio file does not exist."""
+        client = ElevenLabsClient(api_key="test-key")
+
+        with pytest.raises(ElevenLabsError):
+            client.upload_for_inpainting(tmp_path / "does-not-exist.wav")
+
+
 @pytest.mark.integration
 class TestElevenLabsIntegration:
     """Integration tests requiring a real ELEVENLABS_API_KEY."""

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -375,6 +375,7 @@ def workspace_with_long_clip(isolated_db, write_tone):
         style_tags="ambient",
         lyrics="og lyric",
         model="acestep-v1",
+        seed=4242,
         generation_mode="generate",
     )
     clip_id = create_clip(clip)
@@ -487,6 +488,44 @@ class TestExtendElevenLabsBackend:
         assert result.exit_code == 0, result.output
         new_section = el.generate_from_plan.call_args.args[0]["sections"][-1]
         assert "ambient" in new_section["positive_local_styles"]
+
+    def test_seed_is_threaded_through_and_persisted(self, workspace_with_long_clip, monkeypatch):
+        """The source's seed is passed to generate_from_plan and kept on the child clip."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["extend", str(clip_id), "--duration", "5s", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert el.generate_from_plan.call_args.kwargs.get("seed") == 4242
+
+        from acemusic.db import list_clips
+
+        child = [c for c in list_clips(ws.id) if c.generation_mode == "extend"][0]
+        assert child.seed == 4242
+
+    def test_write_failure_exits_cleanly(self, workspace_with_long_clip, monkeypatch):
+        """A disk write failure exits 1 without a traceback."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.Path.write_bytes", side_effect=OSError("read-only file system")),
+        ):
+            result = runner.invoke(
+                app,
+                ["extend", str(clip_id), "--duration", "5s", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 1
+        assert "read-only file system" in result.output
 
     def test_too_short_extension_fails_before_upload(self, workspace_with_long_clip, monkeypatch):
         """--duration under 3s exits with guidance without spending an upload."""

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -317,3 +317,224 @@ class TestExtendValidation:
             result = runner.invoke(app, ["extend", str(clip_id), "--duration", "1s"])
         assert result.exit_code == 1
         assert "fail" in result.output.lower() or "error" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs backend (#98)
+# ---------------------------------------------------------------------------
+
+FAKE_EL_MP3 = b"ID3" + b"\x00" * 200
+
+
+def _el_config(monkeypatch, api_key="test-key", output_format="mp3_44100_128"):
+    """Point load_config at an ElevenLabs-enabled config."""
+    from acemusic.config import AceConfig
+
+    monkeypatch.setattr(
+        "acemusic.cli.load_config",
+        lambda: AceConfig(
+            api_url="http://localhost:8001",
+            api_key=None,
+            elevenlabs_api_key=api_key,
+            elevenlabs_output_format=output_format,
+        ),
+    )
+
+
+def _make_elevenlabs_client_mock(audio_bytes: bytes = FAKE_EL_MP3, song_id: str = "song-123"):
+    """MagicMock ElevenLabsClient with a happy-path upload→plan→compose default."""
+    el = MagicMock()
+    el.upload_for_inpainting.return_value = song_id
+    el.generate_from_plan.return_value = audio_bytes
+    return el
+
+
+@pytest.fixture
+def workspace_with_long_clip(isolated_db, write_tone):
+    """Workspace + 12-second ACE-Step-style source WAV (long enough for >=3s sections)."""
+    from acemusic.db import create_clip
+    from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+    ensure_default_workspace()
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    src_wav = clips_dir / "source-long.wav"
+    write_tone(src_wav, duration_s=12.0)
+
+    clip = Clip(
+        workspace_id=ws.id,
+        file_path=str(src_wav),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        format="wav",
+        duration=12.0,
+        bpm=120,
+        key="C major",
+        style_tags="ambient",
+        lyrics="og lyric",
+        model="acestep-v1",
+        generation_mode="generate",
+    )
+    clip_id = create_clip(clip)
+    return ws, clip_id, src_wav
+
+
+class TestExtendElevenLabsBackend:
+    """Tests for `extend --backend elevenlabs` (#98)."""
+
+    def test_append_at_end_creates_mp3_child_clip_with_lineage(self, workspace_with_long_clip, monkeypatch):
+        """Default --from end keeps the whole clip and appends a new section."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock(song_id="song-ext")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["extend", str(clip_id), "--duration", "5s", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        el.upload_for_inpainting.assert_called_once()
+        assert str(el.upload_for_inpainting.call_args.args[0]) == str(src_wav)
+
+        plan = el.generate_from_plan.call_args.args[0]
+        sections = plan["sections"]
+        assert len(sections) == 2
+        assert sections[0]["source_from"] == {
+            "song_id": "song-ext",
+            "range": {"start_ms": 0, "end_ms": 12000},
+        }
+        assert "source_from" not in sections[1]
+        assert sections[1]["duration_ms"] == 5000
+
+        from acemusic.db import list_clips
+
+        extended = [c for c in list_clips(ws.id) if c.generation_mode == "extend"]
+        assert len(extended) == 1
+        child = extended[0]
+        assert child.parent_clip_id == clip_id
+        assert child.model == "elevenlabs"
+        assert child.format == "mp3"
+        from pathlib import Path as _P
+
+        assert _P(child.file_path).read_bytes() == FAKE_EL_MP3
+
+    def test_from_midpoint_keeps_only_audio_before_splice(self, workspace_with_long_clip, monkeypatch):
+        """--from 6s keeps [0,6s] and generates [6s,11s]; audio past 6s is replaced."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["extend", str(clip_id), "--duration", "5s", "--from", "6s", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        plan = el.generate_from_plan.call_args.args[0]
+        sections = plan["sections"]
+        assert len(sections) == 2
+        assert sections[0]["source_from"]["range"] == {"start_ms": 0, "end_ms": 6000}
+        assert "source_from" not in sections[1]
+        assert sections[1]["duration_ms"] == 5000
+
+    def test_style_and_lyrics_shape_the_new_section(self, workspace_with_long_clip, monkeypatch):
+        """--style and --lyrics land in the new section's styles and lines."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                [
+                    "extend",
+                    str(clip_id),
+                    "--duration",
+                    "5s",
+                    "--style",
+                    "epic strings",
+                    "--lyrics",
+                    "new line one\nnew line two",
+                    "--backend",
+                    "elevenlabs",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        new_section = el.generate_from_plan.call_args.args[0]["sections"][-1]
+        assert "epic strings" in new_section["positive_local_styles"]
+        assert new_section["lines"] == ["new line one", "new line two"]
+
+    def test_too_short_extension_fails_before_upload(self, workspace_with_long_clip, monkeypatch):
+        """--duration under 3s exits with guidance without spending an upload."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["extend", str(clip_id), "--duration", "1s", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 1
+        assert "3s" in result.output
+        el.upload_for_inpainting.assert_not_called()
+
+    def test_missing_api_key_errors(self, workspace_with_long_clip, monkeypatch):
+        """--backend elevenlabs without ELEVENLABS_API_KEY exits 1 with a clear message."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch, api_key=None)
+
+        result = runner.invoke(
+            app,
+            ["extend", str(clip_id), "--duration", "5s", "--backend", "elevenlabs"],
+        )
+
+        assert result.exit_code == 1
+        assert "elevenlabs_api_key" in result.output.lower()
+
+    def test_upload_error_surfaces_as_friendly_message(self, workspace_with_long_clip, monkeypatch):
+        """An ElevenLabsError during upload exits 1 with the error message."""
+        from acemusic.elevenlabs_client import ElevenLabsError
+
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+        el.upload_for_inpainting.side_effect = ElevenLabsError("ElevenLabs upload failed: 403 — enterprise plan")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["extend", str(clip_id), "--duration", "5s", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 1
+        assert "enterprise plan" in result.output
+
+    def test_invalid_backend_errors(self, workspace_with_long_clip, monkeypatch):
+        """An unknown --backend value exits 1 with the valid choices."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+
+        result = runner.invoke(
+            app,
+            ["extend", str(clip_id), "--duration", "5s", "--backend", "suno"],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid backend" in result.output
+
+    def test_ace_step_path_unchanged_by_default(self, workspace_with_clip):
+        """Without --backend, extend still uses the ACE-Step path."""
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(app, ["extend", str(clip_id), "--duration", "1s"])
+        assert result.exit_code == 0, result.output
+        client.submit_task.assert_called_once()

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -418,9 +419,7 @@ class TestExtendElevenLabsBackend:
         assert child.parent_clip_id == clip_id
         assert child.model == "elevenlabs"
         assert child.format == "mp3"
-        from pathlib import Path as _P
-
-        assert _P(child.file_path).read_bytes() == FAKE_EL_MP3
+        assert Path(child.file_path).read_bytes() == FAKE_EL_MP3
 
     def test_from_midpoint_keeps_only_audio_before_splice(self, workspace_with_long_clip, monkeypatch):
         """--from 6s keeps [0,6s] and generates [6s,11s]; audio past 6s is replaced."""

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -468,6 +468,25 @@ class TestExtendElevenLabsBackend:
         new_section = el.generate_from_plan.call_args.args[0]["sections"][-1]
         assert "epic strings" in new_section["positive_local_styles"]
         assert new_section["lines"] == ["new line one", "new line two"]
+        # --style is an override: the source's old style tags must not be
+        # blended in, or the section gets contradictory directions.
+        assert "ambient" not in new_section["positive_local_styles"]
+
+    def test_source_style_shapes_the_new_section_without_override(self, workspace_with_long_clip, monkeypatch):
+        """Without --style, the source's style tags describe the new section."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["extend", str(clip_id), "--duration", "5s", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        new_section = el.generate_from_plan.call_args.args[0]["sections"][-1]
+        assert "ambient" in new_section["positive_local_styles"]
 
     def test_too_short_extension_fails_before_upload(self, workspace_with_long_clip, monkeypatch):
         """--duration under 3s exits with guidance without spending an upload."""

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -14,6 +14,7 @@ from typer.testing import CliRunner
 
 from acemusic.cli import app
 from acemusic.models import Clip
+from tests.helpers_elevenlabs import FAKE_EL_MP3, _el_config, _make_elevenlabs_client_mock
 
 runner = CliRunner()
 
@@ -323,31 +324,6 @@ class TestExtendValidation:
 # ---------------------------------------------------------------------------
 # ElevenLabs backend (#98)
 # ---------------------------------------------------------------------------
-
-FAKE_EL_MP3 = b"ID3" + b"\x00" * 200
-
-
-def _el_config(monkeypatch, api_key="test-key", output_format="mp3_44100_128"):
-    """Point load_config at an ElevenLabs-enabled config."""
-    from acemusic.config import AceConfig
-
-    monkeypatch.setattr(
-        "acemusic.cli.load_config",
-        lambda: AceConfig(
-            api_url="http://localhost:8001",
-            api_key=None,
-            elevenlabs_api_key=api_key,
-            elevenlabs_output_format=output_format,
-        ),
-    )
-
-
-def _make_elevenlabs_client_mock(audio_bytes: bytes = FAKE_EL_MP3, song_id: str = "song-123"):
-    """MagicMock ElevenLabsClient with a happy-path upload→plan→compose default."""
-    el = MagicMock()
-    el.upload_for_inpainting.return_value = song_id
-    el.generate_from_plan.return_value = audio_bytes
-    return el
 
 
 @pytest.fixture

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -537,3 +537,39 @@ class TestExtendElevenLabsBackend:
             result = runner.invoke(app, ["extend", str(clip_id), "--duration", "1s"])
         assert result.exit_code == 0, result.output
         client.submit_task.assert_called_once()
+
+    def test_works_without_ace_step_url(self, workspace_with_long_clip, monkeypatch):
+        """--backend elevenlabs works in an ElevenLabs-only setup (no ACEMUSIC_BASE_URL)."""
+        from acemusic.config import AceConfig
+
+        ws, clip_id, src_wav = workspace_with_long_clip
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url=None, api_key=None, elevenlabs_api_key="test-key"),
+        )
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["extend", str(clip_id), "--duration", "5s", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        el.generate_from_plan.assert_called_once()
+
+    def test_ace_step_path_without_url_suggests_elevenlabs(self, workspace_with_long_clip, monkeypatch):
+        """The ACE-Step path still requires a URL and hints at --backend elevenlabs."""
+        from acemusic.config import AceConfig
+
+        ws, clip_id, src_wav = workspace_with_long_clip
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url=None, api_key=None, elevenlabs_api_key="test-key"),
+        )
+
+        result = runner.invoke(app, ["extend", str(clip_id), "--duration", "5s"])
+
+        assert result.exit_code == 1
+        assert "not configured" in result.output
+        assert "--backend elevenlabs" in result.output

--- a/tests/test_repaint.py
+++ b/tests/test_repaint.py
@@ -337,3 +337,295 @@ class TestCrossfadeStitchHelper:
         # Should not raise even though fade_ms > segment durations
         out = crossfade_stitch(before, middle, after, fade_ms=100)
         assert len(out) > 0
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs backend (#98)
+# ---------------------------------------------------------------------------
+
+FAKE_EL_MP3 = b"ID3" + b"\x00" * 200
+
+
+def _el_config(monkeypatch, api_key="test-key", output_format="mp3_44100_128"):
+    """Point load_config at an ElevenLabs-enabled config."""
+    from acemusic.config import AceConfig
+
+    monkeypatch.setattr(
+        "acemusic.cli.load_config",
+        lambda: AceConfig(
+            api_url="http://localhost:8001",
+            api_key=None,
+            elevenlabs_api_key=api_key,
+            elevenlabs_output_format=output_format,
+        ),
+    )
+
+
+def _make_elevenlabs_client_mock(audio_bytes: bytes = FAKE_EL_MP3, song_id: str = "song-123"):
+    """MagicMock ElevenLabsClient with a happy-path upload→plan→compose default."""
+    el = MagicMock()
+    el.upload_for_inpainting.return_value = song_id
+    el.generate_from_plan.return_value = audio_bytes
+    return el
+
+
+@pytest.fixture
+def workspace_with_long_clip(isolated_db, write_tone):
+    """Workspace + 12-second ACE-Step-style source WAV (long enough for >=3s sections)."""
+    from acemusic.db import create_clip
+    from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+    ensure_default_workspace()
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    src_wav = clips_dir / "source-long.wav"
+    write_tone(src_wav, duration_s=12.0, frequency=440.0)
+
+    clip = Clip(
+        workspace_id=ws.id,
+        file_path=str(src_wav),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        format="wav",
+        duration=12.0,
+        bpm=120,
+        key="C major",
+        style_tags="ambient",
+        model="acestep-v1",
+        generation_mode="generate",
+    )
+    clip_id = create_clip(clip)
+    return ws, clip_id, src_wav
+
+
+class TestRepaintElevenLabsBackend:
+    """Tests for `repaint --backend elevenlabs` (#98)."""
+
+    def _invoke(self, clip_id, *extra):
+        return runner.invoke(
+            app,
+            [
+                "repaint",
+                str(clip_id),
+                "--start",
+                "3s",
+                "--end",
+                "6s",
+                "--prompt",
+                "add a guitar solo",
+                "--backend",
+                "elevenlabs",
+                *extra,
+            ],
+        )
+
+    def test_succeeds_and_creates_mp3_child_clip_with_lineage(self, workspace_with_long_clip, monkeypatch):
+        """An ACE-Step WAV source yields an MP3 child clip with full lineage."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = self._invoke(clip_id)
+
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        repainted = [c for c in list_clips(ws.id) if c.generation_mode == "repaint"]
+        assert len(repainted) == 1
+        child = repainted[0]
+        assert child.parent_clip_id == clip_id
+        assert child.model == "elevenlabs"
+        assert child.format == "mp3"
+        assert child.file_path.endswith(".mp3")
+        from pathlib import Path as _P
+
+        assert _P(child.file_path).read_bytes() == FAKE_EL_MP3
+
+    def test_uploads_source_clip_for_inpainting(self, workspace_with_long_clip, monkeypatch):
+        """The source file is uploaded to obtain a song_id."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = self._invoke(clip_id)
+
+        assert result.exit_code == 0, result.output
+        el.upload_for_inpainting.assert_called_once()
+        uploaded = str(el.upload_for_inpainting.call_args.args[0])
+        assert uploaded == str(src_wav)
+
+    def test_plan_keeps_surrounding_audio_and_regenerates_target(self, workspace_with_long_clip, monkeypatch):
+        """The composition plan keeps [0,start] + [end,duration] and regenerates [start,end]."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock(song_id="song-xyz")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = self._invoke(clip_id)
+
+        assert result.exit_code == 0, result.output
+        el.generate_from_plan.assert_called_once()
+        plan = el.generate_from_plan.call_args.args[0]
+        sections = plan["sections"]
+        assert len(sections) == 3
+        assert sections[0]["source_from"] == {
+            "song_id": "song-xyz",
+            "range": {"start_ms": 0, "end_ms": 3000},
+        }
+        assert "source_from" not in sections[1]
+        assert sections[1]["duration_ms"] == 3000
+        assert "add a guitar solo" in sections[1]["positive_local_styles"]
+        assert sections[2]["source_from"] == {
+            "song_id": "song-xyz",
+            "range": {"start_ms": 6000, "end_ms": 12000},
+        }
+
+    def test_repaint_from_zero_omits_leading_keep_section(self, workspace_with_long_clip, monkeypatch):
+        """--start 0s produces a plan with no keep section before the regenerated one."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                [
+                    "repaint",
+                    str(clip_id),
+                    "--start",
+                    "0s",
+                    "--end",
+                    "4s",
+                    "--prompt",
+                    "new intro",
+                    "--backend",
+                    "elevenlabs",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        plan = el.generate_from_plan.call_args.args[0]
+        sections = plan["sections"]
+        assert len(sections) == 2
+        assert "source_from" not in sections[0]
+        assert sections[1]["source_from"]["range"] == {"start_ms": 4000, "end_ms": 12000}
+
+    def test_too_narrow_keep_margin_fails_before_upload(self, workspace_with_long_clip, monkeypatch):
+        """A keep range under 3s exits with guidance without spending an upload."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                [
+                    "repaint",
+                    str(clip_id),
+                    "--start",
+                    "1s",
+                    "--end",
+                    "5s",
+                    "--prompt",
+                    "solo",
+                    "--backend",
+                    "elevenlabs",
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert "3s" in result.output
+        el.upload_for_inpainting.assert_not_called()
+
+    def test_missing_api_key_errors(self, workspace_with_long_clip, monkeypatch):
+        """--backend elevenlabs without ELEVENLABS_API_KEY exits 1 with a clear message."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch, api_key=None)
+
+        result = self._invoke(clip_id)
+
+        assert result.exit_code == 1
+        assert "elevenlabs_api_key" in result.output.lower()
+
+    def test_upload_error_surfaces_as_friendly_message(self, workspace_with_long_clip, monkeypatch):
+        """An ElevenLabsError during upload exits 1 with the error message."""
+        from acemusic.elevenlabs_client import ElevenLabsError
+
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+        el.upload_for_inpainting.side_effect = ElevenLabsError("ElevenLabs upload failed: 403 — enterprise plan")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = self._invoke(clip_id)
+
+        assert result.exit_code == 1
+        assert "enterprise plan" in result.output
+
+    def test_generation_error_surfaces_as_friendly_message(self, workspace_with_long_clip, monkeypatch):
+        """An ElevenLabsError during plan generation exits 1 with the error message."""
+        from acemusic.elevenlabs_client import ElevenLabsError
+
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+        el.generate_from_plan.side_effect = ElevenLabsError("ElevenLabs plan generation failed: 500")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = self._invoke(clip_id)
+
+        assert result.exit_code == 1
+        assert "500" in result.output
+
+    def test_warns_crossfade_is_ignored(self, workspace_with_long_clip, monkeypatch):
+        """A non-default --crossfade-ms triggers an 'ignored' warning on the elevenlabs path."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = self._invoke(clip_id, "--crossfade-ms", "100")
+
+        assert result.exit_code == 0, result.output
+        assert "crossfade" in result.output.lower()
+        assert "ignor" in result.output.lower()
+
+    def test_invalid_backend_errors(self, workspace_with_long_clip, monkeypatch):
+        """An unknown --backend value exits 1 with the valid choices."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+
+        result = runner.invoke(
+            app,
+            [
+                "repaint",
+                str(clip_id),
+                "--start",
+                "3s",
+                "--end",
+                "6s",
+                "--prompt",
+                "solo",
+                "--backend",
+                "suno",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid backend" in result.output
+
+    def test_ace_step_path_unchanged_by_default(self, workspace_with_clip):
+        """Without --backend, repaint still uses the ACE-Step path."""
+        ws, clip_id, src_wav = workspace_with_clip
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(
+                app,
+                ["repaint", str(clip_id), "--start", "1s", "--end", "2s", "--prompt", "guitar solo"],
+            )
+        assert result.exit_code == 0, result.output
+        client.submit_task.assert_called_once()

--- a/tests/test_repaint.py
+++ b/tests/test_repaint.py
@@ -628,3 +628,73 @@ class TestRepaintElevenLabsBackend:
             )
         assert result.exit_code == 0, result.output
         client.submit_task.assert_called_once()
+
+    def test_works_without_ace_step_url(self, workspace_with_long_clip, monkeypatch):
+        """--backend elevenlabs works in an ElevenLabs-only setup (no ACEMUSIC_BASE_URL)."""
+        from acemusic.config import AceConfig
+
+        ws, clip_id, src_wav = workspace_with_long_clip
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url=None, api_key=None, elevenlabs_api_key="test-key"),
+        )
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = self._invoke(clip_id)
+
+        assert result.exit_code == 0, result.output
+        el.generate_from_plan.assert_called_once()
+
+    def test_ace_step_path_without_url_suggests_elevenlabs(self, workspace_with_long_clip, monkeypatch):
+        """The ACE-Step path still requires a URL and hints at --backend elevenlabs."""
+        from acemusic.config import AceConfig
+
+        ws, clip_id, src_wav = workspace_with_long_clip
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url=None, api_key=None, elevenlabs_api_key="test-key"),
+        )
+
+        result = runner.invoke(
+            app,
+            ["repaint", str(clip_id), "--start", "3s", "--end", "6s", "--prompt", "solo"],
+        )
+
+        assert result.exit_code == 1
+        assert "not configured" in result.output
+        assert "--backend elevenlabs" in result.output
+
+    def test_oversized_total_duration_fails_before_upload(self, workspace_with_long_clip, monkeypatch):
+        """A source clip over the 600s track limit exits with guidance, never uploading."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        # Fake an 11-minute source via metadata (file content is irrelevant here:
+        # validation must trip before any upload happens).
+        from acemusic.db import get_db
+
+        with get_db() as conn:
+            conn.execute("UPDATE clips SET duration = 660.0 WHERE id = ?", (clip_id,))
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                [
+                    "repaint",
+                    str(clip_id),
+                    "--start",
+                    "60s",
+                    "--end",
+                    "70s",
+                    "--prompt",
+                    "new bridge",
+                    "--backend",
+                    "elevenlabs",
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert "600" in result.output
+        el.upload_for_inpainting.assert_not_called()

--- a/tests/test_repaint.py
+++ b/tests/test_repaint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -440,9 +441,7 @@ class TestRepaintElevenLabsBackend:
         assert child.model == "elevenlabs"
         assert child.format == "mp3"
         assert child.file_path.endswith(".mp3")
-        from pathlib import Path as _P
-
-        assert _P(child.file_path).read_bytes() == FAKE_EL_MP3
+        assert Path(child.file_path).read_bytes() == FAKE_EL_MP3
 
     def test_uploads_source_clip_for_inpainting(self, workspace_with_long_clip, monkeypatch):
         """The source file is uploaded to obtain a song_id."""

--- a/tests/test_repaint.py
+++ b/tests/test_repaint.py
@@ -394,6 +394,7 @@ def workspace_with_long_clip(isolated_db, write_tone):
         key="C major",
         style_tags="ambient",
         model="acestep-v1",
+        seed=4242,
         generation_mode="generate",
     )
     clip_id = create_clip(clip)
@@ -664,6 +665,38 @@ class TestRepaintElevenLabsBackend:
         assert result.exit_code == 1
         assert "not configured" in result.output
         assert "--backend elevenlabs" in result.output
+
+    def test_seed_is_threaded_through_and_persisted(self, workspace_with_long_clip, monkeypatch):
+        """The source's seed is passed to generate_from_plan and kept on the child clip."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = self._invoke(clip_id)
+
+        assert result.exit_code == 0, result.output
+        assert el.generate_from_plan.call_args.kwargs.get("seed") == 4242
+
+        from acemusic.db import list_clips
+
+        child = [c for c in list_clips(ws.id) if c.generation_mode == "repaint"][0]
+        assert child.seed == 4242
+
+    def test_write_failure_exits_cleanly(self, workspace_with_long_clip, monkeypatch):
+        """A disk write failure (e.g. read-only --output) exits 1 without a traceback."""
+        ws, clip_id, src_wav = workspace_with_long_clip
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.Path.write_bytes", side_effect=OSError("read-only file system")),
+        ):
+            result = self._invoke(clip_id)
+
+        assert result.exit_code == 1
+        assert "read-only file system" in result.output
 
     def test_oversized_total_duration_fails_before_upload(self, workspace_with_long_clip, monkeypatch):
         """A source clip over the 600s track limit exits with guidance, never uploading."""

--- a/tests/test_repaint.py
+++ b/tests/test_repaint.py
@@ -14,6 +14,7 @@ from typer.testing import CliRunner
 
 from acemusic.cli import app
 from acemusic.models import Clip
+from tests.helpers_elevenlabs import FAKE_EL_MP3, _el_config, _make_elevenlabs_client_mock
 
 runner = CliRunner()
 
@@ -343,31 +344,6 @@ class TestCrossfadeStitchHelper:
 # ---------------------------------------------------------------------------
 # ElevenLabs backend (#98)
 # ---------------------------------------------------------------------------
-
-FAKE_EL_MP3 = b"ID3" + b"\x00" * 200
-
-
-def _el_config(monkeypatch, api_key="test-key", output_format="mp3_44100_128"):
-    """Point load_config at an ElevenLabs-enabled config."""
-    from acemusic.config import AceConfig
-
-    monkeypatch.setattr(
-        "acemusic.cli.load_config",
-        lambda: AceConfig(
-            api_url="http://localhost:8001",
-            api_key=None,
-            elevenlabs_api_key=api_key,
-            elevenlabs_output_format=output_format,
-        ),
-    )
-
-
-def _make_elevenlabs_client_mock(audio_bytes: bytes = FAKE_EL_MP3, song_id: str = "song-123"):
-    """MagicMock ElevenLabsClient with a happy-path upload→plan→compose default."""
-    el = MagicMock()
-    el.upload_for_inpainting.return_value = song_id
-    el.generate_from_plan.return_value = audio_bytes
-    return el
 
 
 @pytest.fixture

--- a/tests/test_stems.py
+++ b/tests/test_stems.py
@@ -13,6 +13,7 @@ from acemusic.cli import app
 from acemusic.elevenlabs_client import ELEVENLABS_STEM_LABELS, ElevenLabsError
 from acemusic.models import Clip
 from acemusic.stems_client import STEM_LABELS
+from tests.helpers_elevenlabs import _el_config
 
 runner = CliRunner()
 
@@ -76,21 +77,6 @@ def _write_stub_stem(out_dir: Path, base: str, label: str, fmt: str) -> Path:
     path = out_dir / f"{base}-{label}.{fmt}"
     path.write_bytes(b"fake stem audio")
     return path
-
-
-def _el_config(monkeypatch, api_key="test-key", output_format="mp3_44100_128"):
-    """Point load_config at an ElevenLabs-enabled config."""
-    from acemusic.config import AceConfig
-
-    monkeypatch.setattr(
-        "acemusic.cli.load_config",
-        lambda: AceConfig(
-            api_url="http://localhost:8001",
-            api_key=None,
-            elevenlabs_api_key=api_key,
-            elevenlabs_output_format=output_format,
-        ),
-    )
 
 
 def _el_stems_mock():


### PR DESCRIPTION
## Summary
Implements #98: ElevenLabs inpainting — repaint a section & extend a clip.

- `ElevenLabsClient.upload_for_inpainting()` — multipart `POST /v1/music/upload` returning the `song_id` used by composition-plan `source_from` references
- `build_inpaint_plan()` — pure helper that builds a `MusicPrompt` plan: keep ranges become `source_from` sections, the regenerate range becomes a plain section shaped by prompt/style/lyrics; enforces the API's real limits (sections 3s–120s, track ≤600s) **before** the paid upload
- `repaint --backend elevenlabs` — upload → keep/regenerate/keep plan → `generate_from_plan()` → MP3 child clip with `parent_clip_id`, `generation_mode="repaint"`, `model="elevenlabs"`; server-side composition (no local crossfade stitching)
- `extend --backend elevenlabs` — keep [0, from] + new section [from, from+duration]; `--from <t>` needs no temp trim file (the keep range handles it server-side); `--style` is a true override (source style tags are not blended in)
- `repaint`/`extend` now work in ElevenLabs-only setups (exempted from the startup ACE-Step URL guard, following the #96 pattern); the ACE-Step path still requires the URL and hints at `--backend elevenlabs`
- Capability matrix: `repaint`/`extend` gain `elevenlabs`; `auto` still routes to ACE-Step (no silent cloud spend)
- Seed threading (`generate_from_plan(seed=...)` + persisted on child clips) and guarded disk writes on both new paths (plus the pre-existing unguarded write on the ACE-Step extend path)

## Acceptance Criteria
- [x] `repaint <clip> --backend elevenlabs ...` regenerates the targeted section and leaves the rest intact
- [x] `extend <clip> --backend elevenlabs ...` lengthens the clip with a new section
- [x] Works on an uploaded/external clip (e.g. an ACE-Step WAV), not only ElevenLabs-native tracks
- [x] Resulting clips carry correct lineage and are saved consistently (MP3)
- [x] Unit tests (mocked client) for store→inpaint→persist

## Test Plan
- [x] Unit tests written (TDD approach) — 36 new tests across client/plan/CLI layers
- [x] All tests passing (874 passed, 1 skipped)
- [x] Diff coverage 98% on changed lines (gate: ≥85%) — remaining misses are rare error paths
- [x] Linting clean (ruff + black)
- [x] Internal code review (advisory) completed — no Critical/Major findings
- [x] Cross-family review pass: **codex** (3 rounds; all P1/P2 findings verified and fixed: ACE-Step URL guard exemption, 600s track-limit pre-upload validation, --style override semantics, seed threading, guarded writes)
- [x] Test mutation sanity check completed (4 mutations, all killed by tests)

## Known Limitations / Intentionally Deferred
- **ElevenLabs inpainting is enterprise-gated**: `POST /v1/music/upload` is only available to enterprise accounts with the inpainting feature; non-enterprise keys get a 403 whose response detail is surfaced verbatim. Unit tests are fully mocked, so CI does not depend on entitlements.
- **Upload cost**: uploading for inpainting is priced like a generation (per ElevenLabs docs); validation runs before upload so invalid ranges never spend credits, but each successful repaint/extend pays upload + generation.
- **Repaint boundaries must leave ≥3s kept on each non-edge side and the region itself must be 3s–120s** — hard ElevenLabs section limits, reported as actionable CLI errors.
- **Output format follows `ELEVENLABS_OUTPUT_FORMAT`** (MP3 by default) — consistent with the existing `generate`/`compose`/`stems` ElevenLabs paths; "(MP3)" in the AC is the default, not forced.
- **True melody-preserving cover stays ACE-Step-only** (US-6.2) — out of scope per the epic (#94); ElevenLabs does style-driven section regeneration.
- `extend` does not pre-validate the source file extension against `SUPPORTED_FORMATS` (pre-existing behavior shared with the ACE-Step path; unsupported sources fail at upload with a surfaced error).

## Implementation Notes
Deviations from the CodeRabbit plan on the issue (all verified against live ElevenLabs API docs):
1. No `compose_with_plan` twin method — the existing `generate_from_plan()` already POSTs `composition_plan` to `/v1/music` and is reused.
2. Real `source_from` schema is `{song_id, range:{start_ms,end_ms}}` nested in a full `SongSection`; the plan's sketch used bare tuples.
3. Section duration limits (3s–120s) and the 600s track cap are enforced client-side, pre-upload.
4. Shared `resolve_backend()`/`ensure_supports()` plumbing (stems pattern) instead of bespoke `frozenset`s.
5. Kept `parent_clip_id` (single int) matching the SQLite Clip model and the ACE-Step lineage paths the issue references.

Closes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `extend` and `repaint` commands now support ElevenLabs backend via new `--backend` option
  * Users can choose between local ACE-Step stitching and ElevenLabs server-side inpainting for audio generation

* **Improvements**
  * Backend capability routing expanded to support multiple engines per operation
  * Enhanced error handling for backend-specific operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->