### PR TITLE
feat: ElevenLabs mashup — combine sections from multiple clips (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ commands (DAW export, etc.) work the same.
 Either way, results are saved as child clips of the source
 (`parent_clip_id` + `generation_mode`), so lineage-aware commands work the same.
 
+## Mashup backends
+
+`acemusic mashup <clip_id> <clip_id> [...]` combines source clips. The two
+engines blend differently:
+
+- `auto` / `ace-step` — audio-level blend of **exactly two** clips
+  (`--blend layered|sequential|ai-guided`, BPM alignment, local stitching).
+- `elevenlabs` — **two or more** clips are uploaded and recombined at the
+  **section/composition level**: each source plays in sequence under an
+  optional unifying `--style`, composed server-side (same enterprise gating,
+  per-upload pricing, and 3s/120s/600s limits as repaint/extend; `--blend`
+  does not apply). With `auto`, three or more clips route here automatically
+  when `ELEVENLABS_API_KEY` is set, since only ElevenLabs can combine them.
+
+Mashup results record **all** sources in `parent_clip_ids` (JSON list; existing
+databases are migrated automatically) plus `parent_clip_id` for the primary.
+
 ## Environment
 
 Copy `.env.example` to `.env` and fill in the required values before running.

--- a/src/acemusic/backends.py
+++ b/src/acemusic/backends.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 VALID_BACKENDS: tuple[str, ...] = ("auto", "ace-step", "elevenlabs")
 DEFAULT_BACKEND = "auto"
 
-# Which concrete engines support each operation. ElevenLabs entries expand as
-# the sibling issues land (#99 mashup). #96 added first-class generate/sounds
-# and composition plans ("compose"); #97 added stem separation; #98 added
-# inpainting (repaint/extend).
+# Which concrete engines support each operation. #96 added first-class
+# generate/sounds and composition plans ("compose"); #97 added stem
+# separation; #98 added inpainting (repaint/extend); #99 added mashup.
 _CAPABILITIES: dict[str, set[str]] = {
     "generate": {"ace-step", "elevenlabs"},
     "sample": {"ace-step", "elevenlabs"},
@@ -33,7 +32,7 @@ _CAPABILITIES: dict[str, set[str]] = {
     "extend": {"ace-step", "elevenlabs"},
     "cover": {"ace-step"},
     "repaint": {"ace-step", "elevenlabs"},
-    "mashup": {"ace-step"},
+    "mashup": {"ace-step", "elevenlabs"},
     "export": {"ace-step"},
 }
 

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -35,7 +35,7 @@ from acemusic.audio import (
     remaster_audio,
     time_stretch_audio,
 )
-from acemusic.backends import BackendError, resolve_backend
+from acemusic.backends import BackendError, ensure_supports, resolve_backend
 from acemusic.client import AceStepClient, AceStepConnectionError, AceStepError
 from acemusic.config import load_config
 from acemusic.daw_export import build_daw_bundle, export_midi, export_stems, project_slug
@@ -4155,6 +4155,7 @@ def mashup(
     config = load_config()
     try:
         effective_backend = resolve_backend(backend, config.backend)
+        ensure_supports(effective_backend, "mashup")
     except BackendError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -4159,6 +4159,21 @@ def mashup(
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1)
 
+    # auto prefers ACE-Step, but 3+ sources are an ElevenLabs-only capability —
+    # auto never fails just because one engine can't do a job another can.
+    if effective_backend == "auto" and len(clips) > 2:
+        if config.elevenlabs_api_key:
+            console.print(
+                "[cyan]Using the elevenlabs backend (ACE-Step mashup supports exactly two clips).[/cyan]"
+            )
+            effective_backend = "elevenlabs"
+        else:
+            console.print(
+                "[red]Error: the ACE-Step backend supports exactly two clips. "
+                "Set ELEVENLABS_API_KEY (or pass --backend elevenlabs) to combine more sources.[/red]"
+            )
+            raise typer.Exit(code=1)
+
     if effective_backend == "elevenlabs":
         if blend != "layered":
             console.print(

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -3998,15 +3998,25 @@ def _mashup_via_elevenlabs(
                 song_id = el_client.upload_for_inpainting(clip.file_path)
         except ElevenLabsError as exc:
             console.print(f"[red]Error uploading clip {clip.id}: {exc}[/red]")
+            if song_sources:
+                # ElevenLabs has no upload-delete API; set cost expectations.
+                console.print(
+                    f"[yellow]Note: {len(song_sources)} earlier upload(s) succeeded and may "
+                    "already have been billed (uploads are priced like a generation).[/yellow]"
+                )
             raise typer.Exit(code=1)
         song_sources.append((song_id, duration_ms))
 
-    plan = build_mashup_plan(song_sources, style)
     try:
+        plan = build_mashup_plan(song_sources, style)
         with console.status("[bold green]Composing mashup via ElevenLabs…[/bold green]", spinner="dots"):
             data = el_client.generate_from_plan(plan)
     except ElevenLabsError as exc:
         console.print(f"[red]ElevenLabs error: {exc}[/red]")
+        console.print(
+            f"[yellow]Note: {len(song_sources)} upload(s) succeeded and may already have "
+            "been billed (uploads are priced like a generation).[/yellow]"
+        )
         raise typer.Exit(code=1)
 
     primary = sources[0]

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import json
 import os
 import shutil
 import sqlite3
@@ -56,6 +57,7 @@ from acemusic.elevenlabs_client import (
     ElevenLabsClient,
     ElevenLabsError,
     build_inpaint_plan,
+    build_mashup_plan,
 )
 from acemusic.midi_client import MidiClient, MidiError
 from acemusic.models import Clip, Preset
@@ -199,6 +201,7 @@ def main(
         "sample",
         "repaint",
         "extend",
+        "mashup",
     ):
         config = load_config()
         if not config.api_url:
@@ -3943,66 +3946,230 @@ def _align_clips_bpm(
     return aligned_path
 
 
+def _mashup_via_elevenlabs(
+    *,
+    config,
+    sources: list[Clip],
+    style: Optional[str],
+    output: Optional[Path],
+    name: Optional[str],
+) -> None:
+    """Mash up clips via ElevenLabs composition plans (upload each → combine).
+
+    Every source clip is uploaded to obtain a ``song_id``; a composition plan
+    then references each source's full range via ``source_from`` in CLI order
+    and ElevenLabs composes one combined track. Unlike ACE-Step's audio-level
+    blend, recombination happens at the section/composition level, so
+    ``--blend`` strategies do not apply.
+    """
+    if not config.elevenlabs_api_key:
+        console.print("[red]Error: --backend elevenlabs requires ELEVENLABS_API_KEY to be set.[/red]")
+        raise typer.Exit(code=1)
+
+    durations_ms: list[int] = []
+    for clip in sources:
+        duration = clip.duration
+        if duration is None or duration <= 0:
+            try:
+                duration = get_duration(Path(clip.file_path))
+            except Exception as exc:
+                console.print(f"[red]Error: unable to determine duration for clip {clip.id}: {exc}[/red]")
+                raise typer.Exit(code=1)
+            if duration is None or duration <= 0:
+                console.print(f"[red]Error: clip {clip.id} has no valid duration metadata.[/red]")
+                raise typer.Exit(code=1)
+        durations_ms.append(int(round(duration * 1000)))
+
+    # Validate the plan shape before uploading — every upload is priced like a
+    # generation, so size errors must fail before the first credit is spent.
+    # Sentinel ids name the actual clips so validation errors stay actionable.
+    sentinel_sources = [(f"clip {clip.id}", duration_ms) for clip, duration_ms in zip(sources, durations_ms)]
+    try:
+        build_mashup_plan(sentinel_sources, style)
+    except ElevenLabsError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    el_client = ElevenLabsClient(api_key=config.elevenlabs_api_key, output_format=config.elevenlabs_output_format)
+    song_sources: list[tuple[str, int]] = []
+    for clip, duration_ms in zip(sources, durations_ms):
+        try:
+            with console.status(f"[bold green]Uploading clip {clip.id} to ElevenLabs…[/bold green]", spinner="dots"):
+                song_id = el_client.upload_for_inpainting(clip.file_path)
+        except ElevenLabsError as exc:
+            console.print(f"[red]Error uploading clip {clip.id}: {exc}[/red]")
+            raise typer.Exit(code=1)
+        song_sources.append((song_id, duration_ms))
+
+    plan = build_mashup_plan(song_sources, style)
+    try:
+        with console.status("[bold green]Composing mashup via ElevenLabs…[/bold green]", spinner="dots"):
+            data = el_client.generate_from_plan(plan)
+    except ElevenLabsError as exc:
+        console.print(f"[red]ElevenLabs error: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    primary = sources[0]
+    ext = _elevenlabs_ext(config.elevenlabs_output_format)
+    titles = [clip.title for clip in sources if clip.title]
+    default_title = f"{' + '.join(titles)} (mashup)" if titles else None
+    title_slug = make_slug(name or (f"{'-'.join(titles)}-mashup" if titles else "mashup"))
+    try:
+        clips_dir = output if output is not None else get_workspace_path(primary.workspace_id)
+        clips_dir.mkdir(parents=True, exist_ok=True)
+        dest_path = clips_dir / f"{title_slug}-{uuid.uuid4().hex[:8]}.{ext}"
+        dest_path.write_bytes(data)
+    except OSError as exc:
+        console.print(f"[red]Error writing mashup clip: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        new_duration = get_duration(dest_path)
+    except Exception as exc:
+        warnings.warn(f"mashup clip duration probe failed: {exc}", stacklevel=2)
+        new_duration = None
+
+    new_clip = Clip(
+        workspace_id=primary.workspace_id,
+        file_path=str(dest_path.resolve()),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        title=name or default_title,
+        format=ext,
+        duration=new_duration,
+        style_tags=_merge_style_tags(*(clip.style_tags for clip in sources), style),
+        model="elevenlabs",
+        parent_clip_id=primary.id,
+        parent_clip_ids=json.dumps([clip.id for clip in sources]),
+        generation_mode="mashup",
+    )
+    try:
+        new_id = create_clip(new_clip)
+    except Exception as exc:
+        dest_path.unlink(missing_ok=True)
+        console.print(f"[red]Error saving clip record: {exc}[/red]")
+        raise typer.Exit(code=1)
+
+    dur_str = f"{new_duration:.1f}s" if new_duration is not None else "unknown"
+    ids_str = " + ".join(str(clip.id) for clip in sources)
+    console.print(f"  [green]✓[/green] Mashed up clips {ids_str} → clip {new_id}")
+    console.print(f"    Path:     {dest_path}")
+    console.print(f"    Duration: {dur_str}")
+
+
+def _merge_style_tags(*sources: Optional[str]) -> Optional[str]:
+    """Merge comma-separated style tags from several sources, deduplicated case-insensitively."""
+    seen: set[str] = set()
+    merged: list[str] = []
+    for source in sources:
+        if not source:
+            continue
+        for tag in (t.strip() for t in source.split(",")):
+            if tag and tag.lower() not in seen:
+                seen.add(tag.lower())
+                merged.append(tag)
+    return ", ".join(merged) or None
+
+
 @app.command()
 def mashup(
-    clip_id_1: int = typer.Argument(..., help="ID of the primary source clip."),
-    clip_id_2: int = typer.Argument(..., help="ID of the secondary source clip to blend with."),
+    clip_ids: list[int] = typer.Argument(
+        ...,
+        help="IDs of the source clips to combine (two or more; the ACE-Step backend supports exactly two).",
+    ),
     blend: str = typer.Option(
         "layered",
         "--blend",
-        help="Blend strategy: 'layered' (concurrent), 'sequential' (section-by-section), or 'ai-guided'.",
+        help="Blend strategy: 'layered' (concurrent), 'sequential' (section-by-section), or 'ai-guided'. "
+        "ACE-Step backend only.",
     ),
     style: Optional[str] = typer.Option(
         None, "--style", help="Optional unifying style descriptor (e.g. 'lo-fi hip hop')."
     ),
     output: Optional[Path] = typer.Option(None, "--output", help="Directory to save the mashup file."),
     name: Optional[str] = typer.Option(None, "--name", help="Custom filename prefix and title for the mashup."),
+    backend: Optional[str] = typer.Option(
+        None,
+        "--backend",
+        help="Engine: 'auto'/'ace-step' (audio-level blend of exactly two clips) or 'elevenlabs' "
+        "(section-level composition of two or more uploaded clips; sections 3s–120s, total ≤600s). "
+        "Defaults to ACEMUSIC_BACKEND, then 'auto'.",
+    ),
 ) -> None:
-    """Combine elements from two clips into a single hybrid clip.
+    """Combine elements from multiple clips into a single hybrid clip.
 
-    Submits a ``task_type=mashup`` request to ACE-Step with both source clips and
-    a blend strategy. When the two clips have known but differing BPMs, the
-    secondary clip is time-stretched to match the primary clip's tempo before
-    submission (US-5.2 alignment). The result is saved as a new clip with
-    ``parent_clip_id`` pointing to the primary source and ``generation_mode='mashup'``.
+    With the ACE-Step backend (default), submits a ``task_type=mashup`` request
+    with exactly two source clips and a blend strategy; differing BPMs are
+    aligned by time-stretching the secondary clip (US-5.2). With the
+    ElevenLabs backend, two or more source clips are uploaded and recombined
+    at the section/composition level — ``--blend`` does not apply there.
 
-    Note: Requires ACE-Step to run on the same host (or with shared filesystem
-    access), since source audio is passed via absolute server-side paths.
+    The result is saved as a new clip with ``parent_clip_ids`` recording all
+    sources (and ``parent_clip_id`` the first) and ``generation_mode='mashup'``.
+
+    Note: The ACE-Step backend requires ACE-Step on the same host (or shared
+    filesystem), since source audio is passed via absolute server-side paths.
     """
     if blend not in VALID_BLEND_MODES:
         console.print(f"[red]Error: --blend must be one of {sorted(VALID_BLEND_MODES)}, got {blend!r}.[/red]")
         raise typer.Exit(code=1)
 
-    if clip_id_1 == clip_id_2:
-        console.print("[red]Error: clip_id_1 and clip_id_2 must be different clips.[/red]")
+    if len(clip_ids) < 2:
+        console.print("[red]Error: mashup needs at least two clip IDs.[/red]")
         raise typer.Exit(code=1)
 
-    primary = get_clip(clip_id_1)
-    if primary is None:
-        console.print(f"[red]Error: clip {clip_id_1} not found.[/red]")
-        raise typer.Exit(code=1)
-    secondary = get_clip(clip_id_2)
-    if secondary is None:
-        console.print(f"[red]Error: clip {clip_id_2} not found.[/red]")
+    if len(set(clip_ids)) != len(clip_ids):
+        console.print("[red]Error: clip IDs must be different clips.[/red]")
         raise typer.Exit(code=1)
 
-    primary_path = Path(primary.file_path)
-    secondary_path = Path(secondary.file_path)
-    if not primary_path.exists():
-        console.print(f"[red]Error: source file not found: {primary_path}[/red]")
-        raise typer.Exit(code=1)
-    if not secondary_path.exists():
-        console.print(f"[red]Error: source file not found: {secondary_path}[/red]")
-        raise typer.Exit(code=1)
+    clips: list[Clip] = []
+    for clip_id in clip_ids:
+        clip = get_clip(clip_id)
+        if clip is None:
+            console.print(f"[red]Error: clip {clip_id} not found.[/red]")
+            raise typer.Exit(code=1)
+        clips.append(clip)
 
-    for label, path in (("clip_id_1", primary_path), ("clip_id_2", secondary_path)):
+    for clip in clips:
+        path = Path(clip.file_path)
+        if not path.exists():
+            console.print(f"[red]Error: source file not found: {path}[/red]")
+            raise typer.Exit(code=1)
         if path.suffix.lower() not in SUPPORTED_FORMATS:
             console.print(
-                f"[red]Error: {label} is not a supported audio file "
+                f"[red]Error: clip {clip.id} is not a supported audio file "
                 f"({path.suffix or 'no extension'}). Mashup requires one of: "
                 f"{', '.join(sorted(SUPPORTED_FORMATS))}.[/red]"
             )
             raise typer.Exit(code=1)
+
+    config = load_config()
+    try:
+        effective_backend = resolve_backend(backend, config.backend)
+    except BackendError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
+
+    if effective_backend == "elevenlabs":
+        if blend != "layered":
+            console.print(
+                "[yellow]Warning: --blend is ignored with the elevenlabs backend "
+                "(sources are recombined at the section/composition level).[/yellow]"
+            )
+        _mashup_via_elevenlabs(config=config, sources=clips, style=style, output=output, name=name)
+        return
+
+    if len(clips) != 2:
+        console.print(
+            "[red]Error: the ACE-Step backend supports exactly two clips. "
+            "Use --backend elevenlabs to combine more sources.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    _require_ace_step_url(config)
+    primary, secondary = clips
+    clip_id_1, clip_id_2 = clip_ids
+    primary_path = Path(primary.file_path)
+    secondary_path = Path(secondary.file_path)
 
     duration = primary.duration
     if duration is None or duration <= 0:
@@ -4015,7 +4182,6 @@ def mashup(
             console.print(f"[red]Error: clip {clip_id_1} has no valid duration metadata.[/red]")
             raise typer.Exit(code=1)
 
-    config = load_config()
     ace_client = AceStepClient(base_url=config.api_url, api_key=config.api_key)
 
     clips_dir = output if output is not None else get_workspace_path(primary.workspace_id)
@@ -4106,17 +4272,6 @@ def mashup(
     else:
         new_title = None
 
-    seen: set[str] = set()
-    merged_tags: list[str] = []
-    for source in (primary.style_tags, secondary.style_tags, style):
-        if not source:
-            continue
-        for tag in (t.strip() for t in source.split(",")):
-            if tag and tag.lower() not in seen:
-                seen.add(tag.lower())
-                merged_tags.append(tag)
-    style_tags = ", ".join(merged_tags) or None
-
     new_clip = Clip(
         workspace_id=primary.workspace_id,
         file_path=str(dest_path.resolve()),
@@ -4126,8 +4281,9 @@ def mashup(
         duration=new_duration,
         bpm=primary.bpm,
         key=submitted_key,
-        style_tags=style_tags,
+        style_tags=_merge_style_tags(primary.style_tags, secondary.style_tags, style),
         parent_clip_id=primary.id,
+        parent_clip_ids=json.dumps([primary.id, secondary.id]),
         generation_mode="mashup",
     )
     try:

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -4163,9 +4163,7 @@ def mashup(
     # auto never fails just because one engine can't do a job another can.
     if effective_backend == "auto" and len(clips) > 2:
         if config.elevenlabs_api_key:
-            console.print(
-                "[cyan]Using the elevenlabs backend (ACE-Step mashup supports exactly two clips).[/cyan]"
-            )
+            console.print("[cyan]Using the elevenlabs backend (ACE-Step mashup supports exactly two clips).[/cyan]")
             effective_backend = "elevenlabs"
         else:
             console.print(

--- a/src/acemusic/db.py
+++ b/src/acemusic/db.py
@@ -51,11 +51,18 @@ def _init_schema(conn: sqlite3.Connection) -> None:
             seed             INTEGER,
             inference_steps  INTEGER,
             parent_clip_id   INTEGER REFERENCES clips(id),
+            parent_clip_ids  TEXT,
             generation_mode  TEXT,
             created_at       TEXT NOT NULL
         )
         """)
     conn.commit()
+    # Migration: databases created before #99 lack parent_clip_ids. ALTER is
+    # cheap and idempotent thanks to the PRAGMA check.
+    clip_columns = [row[1] for row in conn.execute("PRAGMA table_info(clips)").fetchall()]
+    if "parent_clip_ids" not in clip_columns:
+        conn.execute("ALTER TABLE clips ADD COLUMN parent_clip_ids TEXT")
+        conn.commit()
     conn.execute("""
         CREATE TABLE IF NOT EXISTS presets (
             id               INTEGER PRIMARY KEY,
@@ -105,6 +112,7 @@ def _row_to_clip(row: sqlite3.Row) -> Clip:
         seed=row["seed"],
         inference_steps=row["inference_steps"],
         parent_clip_id=row["parent_clip_id"],
+        parent_clip_ids=row["parent_clip_ids"],
         generation_mode=row["generation_mode"],
         created_at=row["created_at"],
     )
@@ -118,8 +126,8 @@ def create_clip(clip: Clip) -> int:
             """INSERT INTO clips
                (title, workspace_id, file_path, format, duration, bpm, key,
                 style_tags, lyrics, vocal_language, model, seed, inference_steps,
-                parent_clip_id, generation_mode, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                parent_clip_id, parent_clip_ids, generation_mode, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 clip.title,
                 clip.workspace_id,
@@ -135,6 +143,7 @@ def create_clip(clip: Clip) -> int:
                 clip.seed,
                 clip.inference_steps,
                 clip.parent_clip_id,
+                clip.parent_clip_ids,
                 clip.generation_mode,
                 clip.created_at,
             ),

--- a/src/acemusic/db.py
+++ b/src/acemusic/db.py
@@ -57,12 +57,8 @@ def _init_schema(conn: sqlite3.Connection) -> None:
         )
         """)
     conn.commit()
-    # Migration: databases created before #99 lack parent_clip_ids. ALTER is
-    # cheap and idempotent thanks to the PRAGMA check.
     clip_columns = [row[1] for row in conn.execute("PRAGMA table_info(clips)").fetchall()]
-    if "parent_clip_ids" not in clip_columns:
-        conn.execute("ALTER TABLE clips ADD COLUMN parent_clip_ids TEXT")
-        conn.commit()
+    _migrate_clips_schema(conn, existing_columns=clip_columns)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS presets (
             id               INTEGER PRIMARY KEY,
@@ -88,6 +84,22 @@ def _init_schema(conn: sqlite3.Connection) -> None:
         )
         """)
     conn.commit()
+
+
+def _migrate_clips_schema(conn: sqlite3.Connection, existing_columns: list[str]) -> None:
+    """Add columns introduced after a database was created (#99: parent_clip_ids).
+
+    The PRAGMA check makes re-runs cheap, but a concurrent process can add the
+    column between the check and the ALTER (TOCTOU), so a duplicate-column
+    error is tolerated rather than aborting startup.
+    """
+    if "parent_clip_ids" not in existing_columns:
+        try:
+            conn.execute("ALTER TABLE clips ADD COLUMN parent_clip_ids TEXT")
+            conn.commit()
+        except sqlite3.OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/src/acemusic/elevenlabs_client.py
+++ b/src/acemusic/elevenlabs_client.py
@@ -169,6 +169,70 @@ def build_inpaint_plan(
     }
 
 
+def build_mashup_plan(
+    sources: list[tuple[str, int]],
+    style: str | None = None,
+) -> dict:
+    """Build a composition plan that combines whole sections from stored songs.
+
+    Each source becomes one (or more, when longer than 120s) ``source_from``
+    sections covering its full [0, duration] range, emitted in the given
+    order. Unlike ACE-Step's audio-level mashup, ElevenLabs recombines at the
+    section/composition level — sources play in sequence with the optional
+    ``style`` applied globally to unify the result.
+
+    Args:
+        sources: ``(song_id, duration_ms)`` pairs in playback order. The
+            song_ids come from :meth:`ElevenLabsClient.upload_for_inpainting`.
+        style: Optional comma-separated style descriptors applied globally.
+
+    Raises:
+        ElevenLabsError: With fewer than two sources, a source shorter than
+            3s (named in the message), or a combined duration over 600s.
+    """
+    if len(sources) < 2:
+        raise ElevenLabsError("Mashup needs at least two source clips.")
+
+    total_ms = 0
+    for song_id, duration_ms in sources:
+        if duration_ms < SECTION_MIN_MS:
+            raise ElevenLabsError(
+                f"Source {song_id} is {duration_ms}ms but ElevenLabs sections must be at "
+                f"least {SECTION_MIN_MS // 1000}s. Use a longer clip."
+            )
+        total_ms += duration_ms
+    if total_ms > TRACK_MAX_MS:
+        raise ElevenLabsError(
+            f"Combined sources total {total_ms}ms but ElevenLabs tracks are capped at "
+            f"{TRACK_MAX_MS // 1000}s (10 min). Use fewer or shorter clips."
+        )
+
+    sections: list[dict] = []
+    for index, (song_id, duration_ms) in enumerate(sources, start=1):
+        for chunk_index, (chunk_start, chunk_end) in enumerate(_split_keep_range(0, duration_ms), start=1):
+            suffix = f".{chunk_index}" if chunk_end - chunk_start != duration_ms else ""
+            sections.append(
+                {
+                    "section_name": f"Source {index}{suffix}",
+                    "positive_local_styles": [],
+                    "negative_local_styles": [],
+                    "duration_ms": chunk_end - chunk_start,
+                    "lines": [],
+                    "source_from": {
+                        "song_id": song_id,
+                        "range": {"start_ms": chunk_start, "end_ms": chunk_end},
+                    },
+                }
+            )
+
+    global_styles = [part.strip() for part in style.split(",") if part.strip()] if style else []
+    return {
+        "positive_global_styles": global_styles,
+        "negative_global_styles": [],
+        "sections": sections,
+    }
+
+
 def _validate_duration(duration: float | None) -> None:
     """Raise ElevenLabsError if duration is outside the API limits (3s–600s)."""
     if duration is not None and not (DURATION_MIN_S <= duration <= DURATION_MAX_S):

--- a/src/acemusic/models.py
+++ b/src/acemusic/models.py
@@ -26,6 +26,9 @@ class Clip:
     seed: Optional[int] = None
     inference_steps: Optional[int] = None
     parent_clip_id: Optional[int] = None
+    # JSON-encoded list of source clip ids (e.g. "[1, 2]") for multi-parent
+    # operations like mashup (#99); mirrors the MongoDB model's parent_clip_ids.
+    parent_clip_ids: Optional[str] = None
     generation_mode: Optional[str] = None
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -74,6 +74,15 @@ class TestIssue98Capabilities:
         assert supports("auto", "extend")
 
 
+class TestIssue99Capabilities:
+    """Capability entry added by #99 (ElevenLabs mashup)."""
+
+    def test_mashup_supported_by_both_engines(self):
+        assert supports("ace-step", "mashup")
+        assert supports("elevenlabs", "mashup")
+        assert supports("auto", "mashup")
+
+
 class TestIssue96Capabilities:
     """Capability entries added by #96 (ElevenLabs first-class generate/compose)."""
 

--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -210,6 +210,22 @@ class TestParentClipIds:
             conn.close()
             assert "parent_clip_ids" in cols
 
+    def test_migration_tolerates_concurrent_duplicate_column(self, isolated_db):
+        """A racing process adding the column between check and ALTER is tolerated.
+
+        Simulates the TOCTOU window by handing the migration a stale column
+        list that misses parent_clip_ids even though the DB already has it.
+        """
+        import acemusic.db as _db
+
+        conn = _db.get_db()  # fully migrated: column exists
+        try:
+            _db._migrate_clips_schema(conn, existing_columns=[])  # stale view → duplicate ALTER
+            cols = [r[1] for r in conn.execute("PRAGMA table_info(clips)").fetchall()]
+            assert "parent_clip_ids" in cols
+        finally:
+            conn.close()
+
 
 # ---------------------------------------------------------------------------
 # DB layer: CRUD

--- a/tests/test_clips.py
+++ b/tests/test_clips.py
@@ -95,6 +95,123 @@ class TestSchemaInit:
 
 
 # ---------------------------------------------------------------------------
+# DB layer: multi-parent lineage (#99)
+# ---------------------------------------------------------------------------
+
+
+class TestParentClipIds:
+    """parent_clip_ids JSON-text lineage field (#99)."""
+
+    def test_create_and_get_round_trips_parent_clip_ids(self, isolated_db):
+        from acemusic.db import create_clip, get_clip
+        from acemusic.models import Clip
+
+        clip = Clip(
+            workspace_id="ws-1",
+            file_path="/tmp/mashup.mp3",
+            created_at=datetime.now(timezone.utc).isoformat(),
+            parent_clip_id=1,
+            parent_clip_ids="[1, 2, 3]",
+            generation_mode="mashup",
+        )
+        clip_id = create_clip(clip)
+
+        retrieved = get_clip(clip_id)
+        assert retrieved is not None
+        assert retrieved.parent_clip_ids == "[1, 2, 3]"
+        assert retrieved.parent_clip_id == 1
+
+    def test_parent_clip_ids_defaults_to_none(self, isolated_db):
+        from acemusic.db import create_clip, get_clip
+        from acemusic.models import Clip
+
+        clip = Clip(
+            workspace_id="ws-1",
+            file_path="/tmp/plain.wav",
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        clip_id = create_clip(clip)
+
+        retrieved = get_clip(clip_id)
+        assert retrieved.parent_clip_ids is None
+
+    def test_list_clips_includes_parent_clip_ids(self, isolated_db):
+        from acemusic.db import create_clip, list_clips
+        from acemusic.models import Clip
+
+        clip = Clip(
+            workspace_id="ws-1",
+            file_path="/tmp/mashup.mp3",
+            created_at=datetime.now(timezone.utc).isoformat(),
+            parent_clip_ids="[4, 5]",
+        )
+        create_clip(clip)
+
+        clips = list_clips("ws-1")
+        assert clips[0].parent_clip_ids == "[4, 5]"
+
+    def test_pre_existing_db_without_column_is_migrated(self, isolated_db):
+        """A DB created with the old schema gains parent_clip_ids transparently."""
+
+        # Build an old-schema DB by hand (no parent_clip_ids column).
+        db_path = _get_db_path(isolated_db)
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE clips (
+                id               INTEGER PRIMARY KEY,
+                title            TEXT,
+                workspace_id     TEXT NOT NULL,
+                file_path        TEXT NOT NULL,
+                format           TEXT,
+                duration         REAL,
+                bpm              INTEGER,
+                key              TEXT,
+                style_tags       TEXT,
+                lyrics           TEXT,
+                vocal_language   TEXT,
+                model            TEXT,
+                seed             INTEGER,
+                inference_steps  INTEGER,
+                parent_clip_id   INTEGER REFERENCES clips(id),
+                generation_mode  TEXT,
+                created_at       TEXT NOT NULL
+            )
+        """)
+        conn.commit()
+        conn.close()
+        old_id = _insert_test_clip(db_path)
+
+        # Opening through the normal path must migrate and keep old rows readable.
+        from acemusic.db import create_clip, get_clip
+        from acemusic.models import Clip
+
+        old_clip = get_clip(old_id)
+        assert old_clip is not None
+        assert old_clip.parent_clip_ids is None
+
+        new_id = create_clip(
+            Clip(
+                workspace_id="ws-test",
+                file_path="/tmp/new.mp3",
+                created_at=datetime.now(timezone.utc).isoformat(),
+                parent_clip_ids="[1, 2]",
+            )
+        )
+        assert get_clip(new_id).parent_clip_ids == "[1, 2]"
+
+    def test_migration_is_idempotent(self, isolated_db):
+        """Re-initialising an already-migrated DB does not error."""
+        import acemusic.db as _db
+
+        for _ in range(2):
+            conn = _db.get_db()
+            cols = [r[1] for r in conn.execute("PRAGMA table_info(clips)").fetchall()]
+            conn.close()
+            assert "parent_clip_ids" in cols
+
+
+# ---------------------------------------------------------------------------
 # DB layer: CRUD
 # ---------------------------------------------------------------------------
 

--- a/tests/test_elevenlabs_client.py
+++ b/tests/test_elevenlabs_client.py
@@ -16,6 +16,7 @@ from acemusic.elevenlabs_client import (
     ElevenLabsClient,
     ElevenLabsError,
     build_inpaint_plan,
+    build_mashup_plan,
 )
 
 FAKE_MP3 = b"ID3" + b"\x00" * 100  # minimal fake MP3 bytes
@@ -932,6 +933,91 @@ class TestBuildInpaintPlan:
             prompt="outro",
         )
         assert sum(s["duration_ms"] for s in plan["sections"]) == 600_000
+
+
+class TestBuildMashupPlan:
+    """Tests for build_mashup_plan() (issue #99)."""
+
+    def test_two_sources_become_two_sections_in_order(self):
+        """Each source contributes one source_from section, in CLI order."""
+        plan = build_mashup_plan(
+            sources=[("song-a", 10_000), ("song-b", 8_000)],
+        )
+
+        sections = plan["sections"]
+        assert len(sections) == 2
+        assert sections[0]["source_from"] == {
+            "song_id": "song-a",
+            "range": {"start_ms": 0, "end_ms": 10_000},
+        }
+        assert sections[0]["duration_ms"] == 10_000
+        assert sections[1]["source_from"] == {
+            "song_id": "song-b",
+            "range": {"start_ms": 0, "end_ms": 8_000},
+        }
+
+    def test_three_sources_supported(self):
+        """More than two sources are combined in order."""
+        plan = build_mashup_plan(
+            sources=[("song-a", 5_000), ("song-b", 5_000), ("song-c", 5_000)],
+        )
+
+        song_ids = [s["source_from"]["song_id"] for s in plan["sections"]]
+        assert song_ids == ["song-a", "song-b", "song-c"]
+
+    def test_sections_have_required_fields(self):
+        """Every section carries the fields required by the MusicPrompt schema."""
+        plan = build_mashup_plan(sources=[("song-a", 10_000), ("song-b", 8_000)])
+
+        for section in plan["sections"]:
+            for field in (
+                "section_name",
+                "positive_local_styles",
+                "negative_local_styles",
+                "duration_ms",
+                "lines",
+            ):
+                assert field in section, field
+
+    def test_style_lands_in_global_styles(self):
+        """A unifying style descriptor becomes positive_global_styles."""
+        plan = build_mashup_plan(
+            sources=[("song-a", 10_000), ("song-b", 8_000)],
+            style="lo-fi hip hop, mellow",
+        )
+
+        assert "lo-fi hip hop" in plan["positive_global_styles"]
+        assert "mellow" in plan["positive_global_styles"]
+
+    def test_no_style_means_empty_global_styles(self):
+        plan = build_mashup_plan(sources=[("song-a", 10_000), ("song-b", 8_000)])
+        assert plan["positive_global_styles"] == []
+        assert plan["negative_global_styles"] == []
+
+    def test_long_source_is_split_into_chunks(self):
+        """A source longer than 120s is split into <=120s contiguous sections."""
+        plan = build_mashup_plan(sources=[("song-a", 250_000), ("song-b", 10_000)])
+
+        a_sections = [s for s in plan["sections"] if s["source_from"]["song_id"] == "song-a"]
+        assert len(a_sections) == 3
+        assert a_sections[0]["source_from"]["range"]["start_ms"] == 0
+        assert a_sections[-1]["source_from"]["range"]["end_ms"] == 250_000
+        for section in a_sections:
+            assert 3_000 <= section["duration_ms"] <= 120_000
+
+    def test_fewer_than_two_sources_raises(self):
+        with pytest.raises(ElevenLabsError, match="(?i)at least two"):
+            build_mashup_plan(sources=[("song-a", 10_000)])
+
+    def test_too_short_source_raises_naming_the_source(self):
+        """A source under 3s raises ElevenLabsError naming the offending source."""
+        with pytest.raises(ElevenLabsError, match="song-b"):
+            build_mashup_plan(sources=[("song-a", 10_000), ("song-b", 1_000)])
+
+    def test_combined_duration_over_track_limit_raises(self):
+        """Sources totalling more than 600s raise ElevenLabsError."""
+        with pytest.raises(ElevenLabsError, match="600"):
+            build_mashup_plan(sources=[("song-a", 500_000), ("song-b", 150_000)])
 
 
 @pytest.mark.integration

--- a/tests/test_mashup.py
+++ b/tests/test_mashup.py
@@ -621,15 +621,47 @@ class TestMashupCommand:
         mashups = [c for c in list_clips(ws.id) if c.generation_mode == "mashup"]
         assert json.loads(mashups[0].parent_clip_ids) == [clip1, clip2]
 
-    def test_ace_step_three_clips_errors(self, workspace_with_three_long_clips):
-        """The ACE-Step path supports exactly two clips and says so."""
+    def test_explicit_ace_step_three_clips_errors(self, workspace_with_three_long_clips, monkeypatch):
+        """--backend ace-step with three clips errors: that engine takes exactly two."""
         ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(app, ["mashup", *[str(i) for i in ids], "--backend", "ace-step"])
+        assert result.exit_code == 1
+        assert "exactly two" in result.output.lower()
+        assert "--backend elevenlabs" in result.output
+        client.submit_task.assert_not_called()
+
+    def test_auto_routes_three_clips_to_elevenlabs(self, workspace_with_three_long_clips, monkeypatch):
+        """auto + 3 clips routes to ElevenLabs (the only engine that can do the job)."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+        el.upload_for_inpainting.side_effect = ["song-1", "song-2", "song-3"]
+        ace = _make_client_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.AceStepClient", return_value=ace),
+        ):
+            result = runner.invoke(app, ["mashup", *[str(i) for i in ids]])
+
+        assert result.exit_code == 0, result.output
+        el.generate_from_plan.assert_called_once()
+        ace.submit_task.assert_not_called()
+        assert "elevenlabs" in result.output.lower()
+
+    def test_auto_three_clips_without_key_errors_actionably(self, workspace_with_three_long_clips, monkeypatch):
+        """auto + 3 clips with no ElevenLabs key explains both ways forward."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch, api_key=None)
         client = _make_client_mock()
         with patch("acemusic.cli.AceStepClient", return_value=client):
             result = runner.invoke(app, ["mashup", *[str(i) for i in ids]])
         assert result.exit_code == 1
         assert "exactly two" in result.output.lower()
-        assert "--backend elevenlabs" in result.output
+        assert "ELEVENLABS_API_KEY" in result.output
         client.submit_task.assert_not_called()
 
 

--- a/tests/test_mashup.py
+++ b/tests/test_mashup.py
@@ -804,6 +804,8 @@ class TestMashupElevenLabsBackend:
         assert result.exit_code == 1
         assert f"clip {ids[1]}" in result.output
         assert "enterprise plan" in result.output
+        # The first upload succeeded — the user is told it may have been billed.
+        assert "billed" in result.output
 
     def test_blend_is_ignored_with_warning(self, workspace_with_three_long_clips, monkeypatch):
         """--blend is ACE-Step-only; the elevenlabs path warns and proceeds."""

--- a/tests/test_mashup.py
+++ b/tests/test_mashup.py
@@ -880,3 +880,71 @@ class TestMashupElevenLabsBackend:
 
         assert result.exit_code == 1
         assert "Invalid backend" in result.output
+
+    def test_single_clip_id_errors(self, workspace_with_three_long_clips, monkeypatch):
+        """Fewer than two clip IDs is rejected up front."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+
+        result = runner.invoke(app, ["mashup", str(ids[0]), "--backend", "elevenlabs"])
+
+        assert result.exit_code == 1
+        assert "at least two" in result.output.lower()
+
+    def test_compose_error_surfaces_as_friendly_message(self, workspace_with_three_long_clips, monkeypatch):
+        """An ElevenLabsError during composition exits 1 with the error message."""
+        from acemusic.elevenlabs_client import ElevenLabsError
+
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+        el.generate_from_plan.side_effect = ElevenLabsError("ElevenLabs plan generation failed: 500")
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 1
+        assert "500" in result.output
+
+    def test_write_failure_exits_cleanly(self, workspace_with_three_long_clips, monkeypatch):
+        """A disk write failure exits 1 without a traceback."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with (
+            patch("acemusic.cli.ElevenLabsClient", return_value=el),
+            patch("acemusic.cli.Path.write_bytes", side_effect=OSError("read-only file system")),
+        ):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 1
+        assert "read-only file system" in result.output
+
+    def test_duration_probed_when_metadata_missing(self, workspace_with_three_long_clips, monkeypatch):
+        """A source without duration metadata is probed from the file."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        from acemusic.db import get_db
+
+        with get_db() as conn:
+            conn.execute("UPDATE clips SET duration = NULL WHERE id = ?", (ids[0],))
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        plan = el.generate_from_plan.call_args.args[0]
+        # Probed from the real 12s WAV on disk.
+        assert plan["sections"][0]["duration_ms"] == pytest.approx(12_000, abs=100)

--- a/tests/test_mashup.py
+++ b/tests/test_mashup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -14,6 +15,7 @@ from typer.testing import CliRunner
 from acemusic.cli import app
 from acemusic.client import AceStepError
 from acemusic.models import Clip
+from tests.helpers_elevenlabs import FAKE_EL_MP3, _el_config, _make_elevenlabs_client_mock
 
 runner = CliRunner()
 
@@ -603,3 +605,278 @@ class TestMashupCommand:
         # Fallback: ref_audio_path is the original secondary clip, not an aligned temp file
         kwargs = client.submit_task.call_args.kwargs
         assert kwargs["ref_audio_path"] == str(src2.resolve())
+
+    def test_ace_step_records_parent_clip_ids(self, workspace_with_two_clips):
+        """The ACE-Step mashup result records both sources in parent_clip_ids (#99)."""
+        import json
+
+        ws, clip1, clip2, _src1, _src2 = workspace_with_two_clips
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(app, ["mashup", str(clip1), str(clip2)])
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        mashups = [c for c in list_clips(ws.id) if c.generation_mode == "mashup"]
+        assert json.loads(mashups[0].parent_clip_ids) == [clip1, clip2]
+
+    def test_ace_step_three_clips_errors(self, workspace_with_three_long_clips):
+        """The ACE-Step path supports exactly two clips and says so."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        client = _make_client_mock()
+        with patch("acemusic.cli.AceStepClient", return_value=client):
+            result = runner.invoke(app, ["mashup", *[str(i) for i in ids]])
+        assert result.exit_code == 1
+        assert "exactly two" in result.output.lower()
+        assert "--backend elevenlabs" in result.output
+        client.submit_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs backend (#99)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace_with_three_long_clips(isolated_db, write_tone):
+    """Workspace + three source WAVs long enough for ElevenLabs sections (>=3s)."""
+    from acemusic.db import create_clip
+    from acemusic.workspace import ensure_default_workspace, get_active_workspace, get_workspace_path
+
+    ensure_default_workspace()
+    ws = get_active_workspace()
+    clips_dir = get_workspace_path(ws.id)
+    clips_dir.mkdir(parents=True, exist_ok=True)
+
+    ids: list[int] = []
+    paths: list[Path] = []
+    for index, (duration_s, freq, title, tags) in enumerate(
+        [(12.0, 440.0, "Track A", "ambient"), (8.0, 550.0, "Track B", "rock"), (6.0, 660.0, "Track C", "jazz")],
+        start=1,
+    ):
+        src = clips_dir / f"long-{index}.wav"
+        write_tone(src, duration_s=duration_s, frequency=freq)
+        clip_id = create_clip(
+            Clip(
+                workspace_id=ws.id,
+                file_path=str(src),
+                created_at=datetime.now(timezone.utc).isoformat(),
+                title=title,
+                format="wav",
+                duration=duration_s,
+                style_tags=tags,
+                model="acestep-v1",
+                generation_mode="generate",
+            )
+        )
+        ids.append(clip_id)
+        paths.append(src)
+    return ws, ids, paths
+
+
+class TestMashupElevenLabsBackend:
+    """Tests for `mashup --backend elevenlabs` (#99)."""
+
+    def test_two_clips_create_mp3_with_full_lineage(self, workspace_with_three_long_clips, monkeypatch):
+        """Happy path: one combined MP3 child clip recording all sources."""
+        import json
+
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        mashups = [c for c in list_clips(ws.id) if c.generation_mode == "mashup"]
+        assert len(mashups) == 1
+        child = mashups[0]
+        assert child.model == "elevenlabs"
+        assert child.format == "mp3"
+        assert child.parent_clip_id == ids[0]
+        assert json.loads(child.parent_clip_ids) == [ids[0], ids[1]]
+        assert Path(child.file_path).read_bytes() == FAKE_EL_MP3
+
+    def test_three_clips_uploaded_in_order(self, workspace_with_three_long_clips, monkeypatch):
+        """Variadic sources: every clip is uploaded, plan references them in CLI order."""
+        ws, ids, paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+        el.upload_for_inpainting.side_effect = ["song-1", "song-2", "song-3"]
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", *[str(i) for i in ids], "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        uploaded = [str(c.args[0]) for c in el.upload_for_inpainting.call_args_list]
+        assert uploaded == [str(p) for p in paths]
+
+        plan = el.generate_from_plan.call_args.args[0]
+        song_ids = [s["source_from"]["song_id"] for s in plan["sections"]]
+        assert song_ids == ["song-1", "song-2", "song-3"]
+
+    def test_style_lands_in_global_styles(self, workspace_with_three_long_clips, monkeypatch):
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--style", "lo-fi hip hop", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        plan = el.generate_from_plan.call_args.args[0]
+        assert "lo-fi hip hop" in plan["positive_global_styles"]
+
+    def test_combined_too_long_fails_before_any_upload(self, workspace_with_three_long_clips, monkeypatch):
+        """Sources whose metadata totals over 600s exit before spending a single upload."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        from acemusic.db import get_db
+
+        with get_db() as conn:
+            conn.execute("UPDATE clips SET duration = 400.0 WHERE id IN (?, ?)", (ids[0], ids[1]))
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 1
+        assert "600" in result.output
+        el.upload_for_inpainting.assert_not_called()
+
+    def test_too_short_source_fails_before_upload_naming_the_clip(self, workspace_with_three_long_clips, monkeypatch):
+        """A source under 3s exits with the offending clip named, before any upload."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        from acemusic.db import get_db
+
+        with get_db() as conn:
+            conn.execute("UPDATE clips SET duration = 2.0 WHERE id = ?", (ids[1],))
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 1
+        assert f"clip {ids[1]}" in result.output
+        el.upload_for_inpainting.assert_not_called()
+
+    def test_upload_failure_names_the_failing_clip(self, workspace_with_three_long_clips, monkeypatch):
+        """A mid-batch upload failure exits cleanly and names the clip that failed."""
+        from acemusic.elevenlabs_client import ElevenLabsError
+
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+        el.upload_for_inpainting.side_effect = [
+            "song-1",
+            ElevenLabsError("ElevenLabs upload failed: 403 — enterprise plan"),
+        ]
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 1
+        assert f"clip {ids[1]}" in result.output
+        assert "enterprise plan" in result.output
+
+    def test_blend_is_ignored_with_warning(self, workspace_with_three_long_clips, monkeypatch):
+        """--blend is ACE-Step-only; the elevenlabs path warns and proceeds."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--blend", "sequential", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "blend" in result.output.lower()
+        assert "ignor" in result.output.lower()
+
+    def test_missing_api_key_errors(self, workspace_with_three_long_clips, monkeypatch):
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch, api_key=None)
+
+        result = runner.invoke(
+            app,
+            ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+        )
+
+        assert result.exit_code == 1
+        assert "elevenlabs_api_key" in result.output.lower()
+
+    def test_works_without_ace_step_url(self, workspace_with_three_long_clips, monkeypatch):
+        """--backend elevenlabs works in an ElevenLabs-only setup (no ACEMUSIC_BASE_URL)."""
+        from acemusic.config import AceConfig
+
+        ws, ids, _paths = workspace_with_three_long_clips
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url=None, api_key=None, elevenlabs_api_key="test-key"),
+        )
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+        el.generate_from_plan.assert_called_once()
+
+    def test_ace_step_path_without_url_suggests_elevenlabs(self, workspace_with_three_long_clips, monkeypatch):
+        """The ACE-Step path still requires a URL and hints at --backend elevenlabs."""
+        from acemusic.config import AceConfig
+
+        ws, ids, _paths = workspace_with_three_long_clips
+        monkeypatch.setattr(
+            "acemusic.cli.load_config",
+            lambda: AceConfig(api_url=None, api_key=None, elevenlabs_api_key="test-key"),
+        )
+
+        result = runner.invoke(app, ["mashup", str(ids[0]), str(ids[1])])
+
+        assert result.exit_code == 1
+        assert "not configured" in result.output
+        assert "--backend elevenlabs" in result.output
+
+    def test_invalid_backend_errors(self, workspace_with_three_long_clips, monkeypatch):
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+
+        result = runner.invoke(
+            app,
+            ["mashup", str(ids[0]), str(ids[1]), "--backend", "suno"],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid backend" in result.output

--- a/tests/test_mashup.py
+++ b/tests/test_mashup.py
@@ -710,7 +710,7 @@ def workspace_with_three_long_clips(isolated_db, write_tone):
 class TestMashupElevenLabsBackend:
     """Tests for `mashup --backend elevenlabs` (#99)."""
 
-    def test_two_clips_create_mp3_with_full_lineage(self, workspace_with_three_long_clips, monkeypatch):
+    def test_two_of_three_clips_create_mp3_with_full_lineage(self, workspace_with_three_long_clips, monkeypatch):
         """Happy path: one combined MP3 child clip recording all sources."""
         import json
 
@@ -960,6 +960,26 @@ class TestMashupElevenLabsBackend:
 
         assert result.exit_code == 1
         assert "read-only file system" in result.output
+
+    def test_name_sets_title_and_filename(self, workspace_with_three_long_clips, monkeypatch):
+        """--name flows through to the clip title and the output filename slug."""
+        ws, ids, _paths = workspace_with_three_long_clips
+        _el_config(monkeypatch)
+        el = _make_elevenlabs_client_mock()
+
+        with patch("acemusic.cli.ElevenLabsClient", return_value=el):
+            result = runner.invoke(
+                app,
+                ["mashup", str(ids[0]), str(ids[1]), "--name", "My Hybrid Track", "--backend", "elevenlabs"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+        from acemusic.db import list_clips
+
+        child = [c for c in list_clips(ws.id) if c.generation_mode == "mashup"][0]
+        assert child.title == "My Hybrid Track"
+        assert "my-hybrid-track" in child.file_path.lower()
 
     def test_duration_probed_when_metadata_missing(self, workspace_with_three_long_clips, monkeypatch):
         """A source without duration metadata is probed from the file."""


### PR DESCRIPTION
## Summary
Implements #99: ElevenLabs mashup — combine sections from multiple clips.

- **`parent_clip_ids` multi-parent lineage**: JSON TEXT field on the SQLite `Clip` (mirroring the MongoDB model) with an idempotent `PRAGMA`-guarded `ALTER TABLE` migration for pre-existing databases; populated by **both** mashup backends (the ACE-Step path previously recorded only the primary parent)
- **`build_mashup_plan(sources, style)`**: pure helper composing one `source_from` section per source clip in CLI order (auto-chunked ≤120s), with the unifying `--style` as global styles; enforces per-source ≥3s and combined ≤600s limits **before any paid upload**
- **`mashup` is now variadic** (`clip_ids: list[int]`, 2+): the ElevenLabs backend combines any number of sources; the ACE-Step backend keeps its exactly-two audio-level blend with a clear error pointing at the alternative
- **`--backend` dispatch** via shared `resolve_backend`/`ensure_supports`; `mashup` exempted from the startup ACE-Step URL guard (the #96/#98 pattern), so ElevenLabs-only setups work
- **`auto` routes 3+-clip mashups to ElevenLabs** when `ELEVENLABS_API_KEY` is set (auto's documented contract: never fail when another engine can do the job — same precedent as `compose`); without a key the error names both remedies
- **Cost-aware failure handling**: per-clip upload errors name the failing clip and disclose that earlier uploads may already have been billed (no delete API exists); plan-shape validation uses clip-id sentinels so errors are actionable pre-upload
- Reuses #98's verified upload/compose layer (`upload_for_inpainting`, `generate_from_plan`) — no new HTTP endpoints

## Acceptance Criteria
- [x] `mashup --backend elevenlabs <clip_a> <clip_b> ...` produces one combined clip
- [x] Lineage records all source clips (`parent_clip_ids` JSON + `parent_clip_id` back-compat)
- [x] Works with uploaded/external clips (sources resolved from the workspace DB regardless of origin)
- [x] Clear handling when a source can't be stored/used (named per-clip errors, pre-upload validation, billed-upload disclosure)
- [x] Unit tests (mocked client) for the multi-source combine path

## Test Plan
- [x] Unit tests written (TDD) — 38 new tests (client plan / db lineage+migration / CLI)
- [x] All tests passing (909 passed, 1 skipped)
- [x] Diff coverage 98% on changed lines (gate ≥85%)
- [x] Linting clean (ruff + black)
- [x] Internal code review (advisory) — no Critical/Major; S1 (billed-upload disclosure) and N1 (guarded post-upload plan build) applied
- [x] Cross-family review: **codex** ×2 rounds — round-1 P2 (auto routing for 3+ clips) verified & fixed; round-2 P2 rebutted (see below)
- [x] Mutation sanity check: 5 mutations (lineage, ordering, 600s cap, auto-routing, migration), all killed

## Known Limitations / Intentionally Deferred
- **`auto` + two clips still prefers ACE-Step** (and errors with a `--backend elevenlabs` hint when no ACE-Step URL is configured). Deliberate, per codex round-2 triage: the two engines' 2-clip semantics differ materially (audio-level blend vs sequential section composition), so silently substituting a different musical operation — while spending billed uploads — is worse than the actionable hint. Matches merged repaint/extend/stems behavior. 3+ clips routes automatically because only one engine can do the job at all.
- **Blend semantics differ by design**: ElevenLabs recombines at the **section/composition level** (sources in sequence under a unifying style), not ACE-Step's audio-level blend; `--blend` is warned-and-ignored on the ElevenLabs path. Documented in README.
- **Enterprise gating + cost**: `/v1/music/upload` is enterprise-only and each upload is priced like a generation (N sources → N uploads + 1 generation). Validation prevents spending on invalid plans; partial-failure messages disclose already-billed uploads. Unit tests are fully mocked.
- **No upload cleanup on partial failure** — ElevenLabs exposes no upload-delete endpoint; disclosed in the error message instead.
- Pre-existing `status()` stub and cosmetic comment cleanup found during the deslop scan are tracked separately in #106 (out of scope).

## Implementation Notes
Deviations from the CodeRabbit plan on the issue (it predates #98):
1. Its proposed `upload()`/`compose()`/`create_composition_plan()` client methods already exist from #98 — reused, not duplicated.
2. `build_mashup_plan(sources=[(song_id, duration_ms)])` pairs ids with durations (no parallel-list zip bugs) and inherits #98's 3s/120s/600s limit enforcement, which the plan didn't know about.
3. Shared `resolve_backend()` plumbing instead of a bespoke validation set; `mashup` added to the `main()` URL-guard exemption tuple.

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mashup command accepts 3+ clips, with a new --backend option (auto/ace-step/elevenlabs) and updated routing logic.
  * ElevenLabs-backed mashup via composition plans; merged style tag handling and full source-lineage tracking.

* **Bug Fixes**
  * Database migration adds multi-parent lineage column idempotently and tolerates concurrent migration races.

* **Tests**
  * Added comprehensive tests covering mashup plans, CLI routing, DB lineage, and migration robustness.

* **Documentation**
  * README updated with Mashup backends and lineage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->