### PR TITLE
feat: status command reports real health (#106)

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -2024,7 +2024,6 @@ def speed(
     ),
 ) -> None:
     """Adjust playback speed of a clip without changing pitch (time-stretch). Original is preserved."""
-    # Validate that exactly one of --target-bpm or --rate is provided
     if target_bpm is not None and rate is not None:
         console.print("[red]Error: provide either --target-bpm or --rate, not both.[/red]")
         raise typer.Exit(code=1)
@@ -2033,13 +2032,11 @@ def speed(
         console.print("[red]Error: must provide either --target-bpm or --rate.[/red]")
         raise typer.Exit(code=1)
 
-    # Get source clip
     source = get_clip(clip_id)
     if source is None:
         console.print(f"[red]Error: clip {clip_id} not found.[/red]")
         raise typer.Exit(code=1)
 
-    # Determine the rate to use
     if target_bpm is not None:
         if source.bpm is None:
             console.print(f"[red]Error: --target-bpm requires BPM metadata on clip {clip_id}, but none is set.[/red]")
@@ -2052,7 +2049,6 @@ def speed(
     else:
         final_rate = rate
 
-    # Validate rate
     if final_rate <= 0:
         console.print(f"[red]Error: rate must be positive, got {final_rate}.[/red]")
         raise typer.Exit(code=1)
@@ -2067,7 +2063,6 @@ def speed(
             console.print(f"[red]Error: rate must be between 0.5 and 2.0, got {final_rate}.[/red]")
         raise typer.Exit(code=1)
 
-    # Validate source has duration
     if source.duration is None:
         console.print(
             f"[red]Error: clip {clip_id} has no duration metadata — cannot calculate new duration. "
@@ -2075,7 +2070,6 @@ def speed(
         )
         raise typer.Exit(code=1)
 
-    # Get workspace and create output path
     try:
         clips_dir = get_workspace_path(source.workspace_id)
         clips_dir.mkdir(parents=True, exist_ok=True)
@@ -2087,7 +2081,6 @@ def speed(
     dest_name = f"{uuid.uuid4().hex}{src_ext}"
     dest_path = clips_dir / dest_name
 
-    # Perform time-stretch
     try:
         time_stretch_audio(
             input_path=source.file_path,
@@ -2098,13 +2091,11 @@ def speed(
         console.print(f"[red]Error during time-stretch: {exc}[/red]")
         raise typer.Exit(code=1)
 
-    # Calculate new duration and BPM
     new_duration_s = source.duration / final_rate
     new_bpm = None
     if source.bpm is not None:
         new_bpm = source.bpm * final_rate
 
-    # Create new clip record
     new_clip = Clip(
         workspace_id=source.workspace_id,
         file_path=str(dest_path.resolve()),
@@ -2123,7 +2114,6 @@ def speed(
         console.print(f"[red]Error saving clip record: {exc}[/red]")
         raise typer.Exit(code=1)
 
-    # Format output message
     rate_pct = final_rate * 100
     bpm_str = f" (→ {new_bpm:.1f} BPM)" if new_bpm is not None else ""
     console.print(f"  [green]✓[/green] Speed adjusted on clip {clip_id} → clip {new_id}")
@@ -2230,23 +2220,19 @@ def stems(
             console.print(f"[red]Error: --output-format must be wav or flac, got {output_format!r}.[/red]")
             raise typer.Exit(code=1)
 
-    # Get source clip
     source = get_clip(clip_id)
     if source is None:
         console.print(f"[red]Error: clip {clip_id} not found.[/red]")
         raise typer.Exit(code=1)
 
-    # Resolve output directory
     if output is not None:
         stems_dir = output
     else:
         stems_dir = Path(source.file_path).parent / "stems"
     stems_dir.mkdir(parents=True, exist_ok=True)
 
-    # Derive base name from source file
     base_name = Path(source.file_path).stem
 
-    # Separate stems
     start_time = time.time()
     if effective_backend == "elevenlabs":
         stem_path_map = _separate_stems_via_elevenlabs(config, source, stems_dir, base_name)
@@ -2257,7 +2243,6 @@ def stems(
 
     elapsed = time.time() - start_time
 
-    # Register each stem as a child clip
     new_ids = []
     for label, stem_path in stem_path_map.items():
         dur = get_duration(stem_path)
@@ -2280,7 +2265,6 @@ def stems(
             console.print(f"[red]Error saving {label} clip record: {exc}[/red]")
             raise typer.Exit(code=1)
 
-    # Print summary
     console.print(f"\n  [green]✓[/green] Separated clip {clip_id} into {len(new_ids)} stems ({elapsed:.1f}s)")
     for label, nid, spath, dur in new_ids:
         dur_str = _fmt_duration(dur)
@@ -2308,7 +2292,6 @@ def midi(
         console.print("[red]Error: --bpm must be between 20 and 300.[/red]")
         raise typer.Exit(code=1)
 
-    # Resolve output directory
     if output is not None:
         midi_dir = output
     else:
@@ -2317,7 +2300,6 @@ def midi(
 
     base_name = Path(source.file_path).stem
 
-    # Load stem paths if requested
     stem_paths = None
     if from_stems:
         clips = list_clips(source.workspace_id)
@@ -4674,8 +4656,6 @@ def preset_save(
         ensure_default_workspace()
         ws = get_active_workspace()
 
-        # TODO: If from_last, load last generation parameters from config or state file
-        # For now, just require explicit parameters
         if from_last:
             console.print("[red]Error: --from-last not yet implemented (requires tracking last generation).[/red]")
             raise typer.Exit(code=1)

--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -1464,8 +1464,8 @@ def workspace_delete(
 
 @app.command()
 def status() -> None:
-    """Check the status of the ACE-Step server."""
-    typer.echo("Not yet implemented")
+    """Check ACE-Step server and ElevenLabs key status (alias for `health`)."""
+    health()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -106,3 +106,50 @@ class TestHealthCommand:
         result = runner.invoke(app, ["health"], env={"ACEMUSIC_BASE_URL": integration_url})
         assert result.exit_code == 0, result.output
         assert "healthy" in result.output.lower()
+
+
+class TestStatusCommand:
+    """`status` is an alias for `health` (#106 — previously an unimplemented stub)."""
+
+    def test_status_no_longer_a_stub(self, monkeypatch):
+        """status never prints the old 'Not yet implemented' placeholder."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        mock_resp = _mock_response(200, HEALTHY_STATS)
+
+        with patch("acemusic.client.httpx.get", return_value=mock_resp):
+            result = runner.invoke(app, ["status"])
+
+        assert "not yet implemented" not in result.output.lower()
+
+    def test_status_reports_health_on_success(self, monkeypatch):
+        """status reports the server as healthy, exactly like health."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+        mock_resp = _mock_response(200, HEALTHY_STATS)
+
+        with patch("acemusic.client.httpx.get", return_value=mock_resp):
+            result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 0, result.output
+        assert "healthy" in result.output.lower()
+
+    def test_status_matches_health_output(self, monkeypatch):
+        """status and health produce identical reports for the same server state."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        outputs = {}
+        for command in ("health", "status"):
+            mock_resp = _mock_response(200, HEALTHY_STATS)
+            with patch("acemusic.client.httpx.get", return_value=mock_resp):
+                outputs[command] = runner.invoke(app, [command]).output
+
+        assert outputs["status"] == outputs["health"]
+
+    def test_status_unreachable_exits_one(self, monkeypatch):
+        """status reports 'unreachable' and exits 1 when the server is down."""
+        monkeypatch.setenv("ACEMUSIC_BASE_URL", "http://localhost:8001")
+
+        with patch("acemusic.client.httpx.get", side_effect=httpx.ConnectError("Connection refused")):
+            result = runner.invoke(app, ["status"])
+
+        assert result.exit_code == 1
+        assert "unreachable" in result.output.lower()


### PR DESCRIPTION
## Summary
Implements #106: replace the `status` stub ("Not yet implemented", scaffolding from US-2.2) with a working alias for `health`, which already reports ACE-Step server stats and ElevenLabs key status. Also applies the cosmetic cleanup documented in the same issue: 18 restatement-only section comments in `speed`/`stems`/`midi` and the stale `--from-last` TODO block in `preset save` (the runtime guard remains).

## Acceptance Criteria (self-authored plan, approved)
- [x] `acemusic status` no longer prints "Not yet implemented"
- [x] `status` reports server + ElevenLabs status identically to `health` (`test_status_matches_health_output`)
- [x] `status` remains in `--help` — the existing `test_cli.py` contract test passes unchanged
- [x] Unit tests cover healthy + unreachable paths
- [x] Scan-noted comments/TODO removed with zero behavior change (915 tests green)

## Test Plan
- [x] TDD: 4 new tests (stub text gone, healthy, output parity with health, unreachable exit 1)
- [x] All tests passing (915 passed); diff coverage 100%
- [x] Lint clean (ruff + black)
- [x] Mutation check: re-stubbing the body fails 3/4 tests
- [x] Cross-family review: **codex** — "no discrete regressions"; internal advisory folded into the primary pass given the 4-line code diff

## Known Limitations / Intentionally Deferred
- `status` shares `health`'s requirement for `ACEMUSIC_BASE_URL` (both gated by `main()`'s URL check) — consistent, unchanged behavior.
- `preset save --from-last` remains unimplemented (it errors clearly at runtime); only its stale TODO comment was removed. Out of scope.
- Alias chosen over removal: removal would break the existing `--help` contract test and any scripts invoking `acemusic status`.

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `status` command to the CLI as an alternative way to check system health status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->