### PR TITLE
fix(api): bind OAuth state to the initiating client (#110)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,10 @@ ACEMUSIC_API_JWT_SECRET_KEY=
 ACEMUSIC_API_JWT_ALGORITHM=HS256
 ACEMUSIC_API_ACCESS_TOKEN_EXPIRE_MINUTES=15
 ACEMUSIC_API_REFRESH_TOKEN_EXPIRE_DAYS=7
-# Marks the OAuth `state` cookie (login-CSRF binding) Secure so it is sent only
-# over HTTPS. Keep True in production; set False for local/dev over plain HTTP.
+# OAuth `state` cookie policy (login-CSRF binding). SECURE marks it HTTPS-only
+# (keep true in production; set false for local/dev over plain HTTP). SAMESITE is
+# `lax` for a same-origin frontend+API; a split-origin SPA needs `none` (which the
+# browser only honours when the cookie is also Secure, i.e. over HTTPS) so the
+# cookie is sent on the cross-site callback.
 ACEMUSIC_API_OAUTH_COOKIE_SECURE=true
+ACEMUSIC_API_OAUTH_COOKIE_SAMESITE=lax

--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,6 @@ ACEMUSIC_API_JWT_SECRET_KEY=
 ACEMUSIC_API_JWT_ALGORITHM=HS256
 ACEMUSIC_API_ACCESS_TOKEN_EXPIRE_MINUTES=15
 ACEMUSIC_API_REFRESH_TOKEN_EXPIRE_DAYS=7
+# Marks the OAuth `state` cookie (login-CSRF binding) Secure so it is sent only
+# over HTTPS. Keep True in production; set False for local/dev over plain HTTP.
+ACEMUSIC_API_OAUTH_COOKIE_SECURE=true

--- a/README.md
+++ b/README.md
@@ -41,15 +41,25 @@ token plus a rotating, single-use refresh token. All `/api/v1` routes except
 
 | Endpoint | Purpose |
 | --- | --- |
-| `POST /api/v1/auth/login/{provider}` | Returns the provider authorization URL |
-| `POST /api/v1/auth/callback/{provider}` | Exchanges the code, upserts the user, mints tokens |
+| `POST /api/v1/auth/login/{provider}` | Returns the provider authorization URL and sets the CSRF state cookie |
+| `POST /api/v1/auth/callback/{provider}` | Validates state against the cookie, exchanges the code, upserts the user, mints tokens |
 | `POST /api/v1/auth/refresh` | Rotates the refresh token for a new access token |
 | `POST /api/v1/auth/logout` | Revokes a refresh token (idempotent) |
 
+The OAuth `state` is bound to the initiating client to prevent login CSRF /
+session fixation: `/login` sets a per-flow, HttpOnly+SameSite cookie holding a
+nonce, and `/callback` requires that cookie to match the signed `state`. **The
+client must therefore preserve cookies between `/login` and `/callback`.** Use a
+same-origin frontend/API in dev (the default `SameSite=Lax` works); a split-origin
+SPA must serve over HTTPS with `ACEMUSIC_API_OAUTH_COOKIE_SAMESITE=none` and make
+credentialed requests (a cross-origin **plain-HTTP** pair cannot carry the cookie —
+a browser constraint, not a code limitation).
+
 Configure provider credentials and the JWT signing secret via the
 `ACEMUSIC_API_GOOGLE_*`, `ACEMUSIC_API_DISCORD_*`, and `ACEMUSIC_API_JWT_SECRET_KEY`
-environment variables (see `.env.example`). `jwt_algorithm` is restricted to the
-HMAC family (`HS256`/`HS384`/`HS512`).
+environment variables (see `.env.example`); cookie behavior is tuned via
+`ACEMUSIC_API_OAUTH_COOKIE_SECURE` / `ACEMUSIC_API_OAUTH_COOKIE_SAMESITE`.
+`jwt_algorithm` is restricted to the HMAC family (`HS256`/`HS384`/`HS512`).
 
 ## Stem separation backends
 

--- a/src/acemusic/api/auth/oauth.py
+++ b/src/acemusic/api/auth/oauth.py
@@ -28,6 +28,7 @@ Provider differences (Google OIDC vs. Discord) are normalized to a single
 import hashlib
 import hmac
 import secrets
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
@@ -56,12 +57,22 @@ DISCORD_SCOPE = "identify email"
 STATE_TOKEN_TYPE = "oauth_state"
 #: ``state`` JWTs are short-lived: the round trip to the provider is seconds.
 STATE_EXPIRE_MINUTES = 10
-#: Cookie carrying the raw client-bound nonce whose hash is committed in ``state``.
-STATE_COOKIE_NAME = "oauth_state_nonce"
+#: Prefix for the per-flow cookie carrying the raw client-bound nonce. Each login
+#: gets its own ``<prefix><flow_id>`` cookie so concurrent flows (multi-tab,
+#: double-click) don't clobber each other's nonce — the ``state`` names its cookie
+#: via the ``sid`` claim.
+STATE_COOKIE_PREFIX = "oauth_state_"
 #: Bytes of entropy for the state nonce (``secrets.token_urlsafe`` argument).
 STATE_NONCE_BYTES = 32
+#: Bytes of entropy for the per-flow id that namespaces the state cookie.
+STATE_FLOW_ID_BYTES = 8
 
 SUPPORTED_PROVIDERS = ("google", "discord")
+
+
+def state_cookie_name(flow_id: str) -> str:
+    """Cookie name carrying the nonce for the login flow identified by ``flow_id``."""
+    return f"{STATE_COOKIE_PREFIX}{flow_id}"
 
 
 class OAuthError(Exception):
@@ -88,13 +99,15 @@ class AuthorizationRequest:
     """An authorization URL plus the raw nonce that binds its ``state`` to a client.
 
     ``url`` is the provider authorization URL (the client redirects to it).
-    ``state_nonce`` is the high-entropy secret the caller must set in an
-    HttpOnly+SameSite cookie; only its SHA-256 is committed inside the signed
-    ``state``, so the URL never carries the nonce itself.
+    ``state_nonce`` is the high-entropy secret the caller must set in the
+    ``cookie_name`` cookie (HttpOnly+SameSite); only its SHA-256 is committed
+    inside the signed ``state``, so the URL never carries the nonce itself.
+    ``cookie_name`` is per-flow so concurrent logins don't overwrite each other.
     """
 
     url: str
     state_nonce: str
+    cookie_name: str
 
 
 def _provider_config(provider: str, settings: ApiSettings) -> dict:
@@ -143,11 +156,12 @@ def _hash_nonce(nonce: str) -> str:
     return hashlib.sha256(nonce.encode("utf-8")).hexdigest()
 
 
-def _create_state(provider: str, nonce: str, settings: ApiSettings) -> str:
+def _create_state(provider: str, nonce: str, flow_id: str, settings: ApiSettings) -> str:
     """Mint a short-lived signed JWT used as the CSRF ``state`` value.
 
     The ``cnf`` (confirmation) claim binds the state to the client: it holds the
-    SHA-256 of ``nonce``, whose raw value the client returns via cookie.
+    SHA-256 of ``nonce``, whose raw value the client returns via cookie. The
+    ``sid`` claim names that per-flow cookie so the callback reads the right one.
     """
     secret = _require_secret(settings)
     now = datetime.now(timezone.utc)
@@ -155,6 +169,7 @@ def _create_state(provider: str, nonce: str, settings: ApiSettings) -> str:
         "type": STATE_TOKEN_TYPE,
         "provider": provider,
         "cnf": _hash_nonce(nonce),
+        "sid": flow_id,
         "iat": now,
         "exp": now + timedelta(minutes=STATE_EXPIRE_MINUTES),
     }
@@ -165,38 +180,41 @@ def build_authorization_request(provider: str, settings: ApiSettings) -> Authori
     """Build the provider authorization URL plus the client-binding state nonce.
 
     Returns an :class:`AuthorizationRequest`; the caller redirects to ``.url`` and
-    must set ``.state_nonce`` in an HttpOnly+SameSite cookie so the callback can
-    prove the same client is completing the flow.
+    must set ``.state_nonce`` in the ``.cookie_name`` HttpOnly+SameSite cookie so
+    the callback can prove the same client is completing the flow.
 
     Raises :class:`UnknownProviderError` for an unknown provider and
     :class:`OAuthError` if the provider's credentials are unconfigured.
     """
     config = _provider_config(provider, settings)
     nonce = secrets.token_urlsafe(STATE_NONCE_BYTES)
+    flow_id = secrets.token_urlsafe(STATE_FLOW_ID_BYTES)
     params = {
         "client_id": config["client_id"],
         "redirect_uri": config["redirect_uri"],
         "response_type": "code",
         "scope": config["scope"],
-        "state": _create_state(provider, nonce, settings),
+        "state": _create_state(provider, nonce, flow_id, settings),
     }
     return AuthorizationRequest(
         url=f"{config['authorize_url']}?{urlencode(params)}",
         state_nonce=nonce,
+        cookie_name=state_cookie_name(flow_id),
     )
 
 
-def validate_state(state: str, provider: str, settings: ApiSettings, nonce: str | None) -> bool:
-    """Verify the signed CSRF ``state`` for ``provider`` against the client ``nonce``.
+def validate_state(state: str, provider: str, settings: ApiSettings, cookies: Mapping[str, str]) -> str:
+    """Verify the signed CSRF ``state`` for ``provider`` against the client's cookies.
 
-    ``nonce`` is the raw value the client returns from its state cookie; it must
-    hash to the ``cnf`` committed when the state was minted. A missing or
-    mismatched nonce means the caller is not the client that started the flow.
+    The state names its own cookie (``sid`` claim); ``cookies`` is the request's
+    cookie jar. The raw nonce in that cookie must hash to the ``cnf`` committed
+    when the state was minted — a missing or mismatched nonce means the caller is
+    not the client that started the flow.
 
-    Returns ``True`` on success; raises :class:`UnknownProviderError` for an
-    unsupported provider, or :class:`OAuthError` if the state is expired,
-    tampered, the wrong token type, for a different provider, or not bound to
-    this client.
+    Returns the name of the consumed cookie (so the caller can clear it); raises
+    :class:`UnknownProviderError` for an unsupported provider, or
+    :class:`OAuthError` if the state is expired, tampered, the wrong token type,
+    for a different provider, or not bound to this client.
     """
     if provider not in SUPPORTED_PROVIDERS:
         raise UnknownProviderError(f"Unsupported OAuth provider: {provider!r}")
@@ -212,14 +230,17 @@ def validate_state(state: str, provider: str, settings: ApiSettings, nonce: str 
         raise OAuthError("OAuth state provider mismatch.")
 
     committed = payload.get("cnf")
-    if not committed:
+    flow_id = payload.get("sid")
+    if not committed or not flow_id:
         raise OAuthError("OAuth state is not bound to a client.")
+    cookie_name = state_cookie_name(flow_id)
+    nonce = cookies.get(cookie_name)
     if not nonce:
         raise OAuthError("Missing OAuth state cookie.")
     # Constant-time compare so a mismatch can't be probed by timing.
     if not hmac.compare_digest(committed, _hash_nonce(nonce)):
         raise OAuthError("OAuth state does not match the initiating client.")
-    return True
+    return cookie_name
 
 
 def _coerce_bool(value: object) -> bool:

--- a/src/acemusic/api/auth/oauth.py
+++ b/src/acemusic/api/auth/oauth.py
@@ -1,10 +1,20 @@
 """OAuth2 provider clients for Google and Discord (US-8.3, Step 5).
 
 The platform API is stateless — there is no session middleware — so CSRF
-protection cannot rely on a server-side session. Instead the ``state`` parameter
-is a short-lived signed JWT (``type="oauth_state"``) bound to the provider; the
-callback verifies it with :func:`validate_state`. This gives stateless,
-tamper-evident CSRF protection using the same ``jwt_secret_key`` as access tokens.
+protection cannot rely on a server-side session. The ``state`` parameter is a
+short-lived signed JWT (``type="oauth_state"``) bound to the provider; the
+callback verifies it with :func:`validate_state`.
+
+A signed ``state`` is tamper-evident but, on its own, **not bound to the client
+that started the flow** — anyone can mint one and replay it in a victim's
+callback (login CSRF / session fixation, issue #110). To close that, the state is
+bound to a per-client *nonce* using a stateless double-submit pattern:
+:func:`build_authorization_request` mints a high-entropy ``state_nonce``, commits
+only its SHA-256 into the signed state (the ``cnf`` claim), and returns the raw
+nonce so the route can set it in an HttpOnly+SameSite cookie. At the callback,
+:func:`validate_state` requires that cookie nonce to hash to the committed value.
+An attacker can neither forge the signed state nor read/set the victim's HttpOnly
+cookie, so a replayed state no longer validates.
 
 The authorization URL is built directly (deterministic, easy to assert) while the
 code-for-token exchange and the userinfo fetch use Authlib's
@@ -15,6 +25,9 @@ Provider differences (Google OIDC vs. Discord) are normalized to a single
 :class:`OAuthUserInfo` so callers never branch on the provider.
 """
 
+import hashlib
+import hmac
+import secrets
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
@@ -43,6 +56,10 @@ DISCORD_SCOPE = "identify email"
 STATE_TOKEN_TYPE = "oauth_state"
 #: ``state`` JWTs are short-lived: the round trip to the provider is seconds.
 STATE_EXPIRE_MINUTES = 10
+#: Cookie carrying the raw client-bound nonce whose hash is committed in ``state``.
+STATE_COOKIE_NAME = "oauth_state_nonce"
+#: Bytes of entropy for the state nonce (``secrets.token_urlsafe`` argument).
+STATE_NONCE_BYTES = 32
 
 SUPPORTED_PROVIDERS = ("google", "discord")
 
@@ -64,6 +81,20 @@ class OAuthUserInfo:
     email: str
     name: str
     email_verified: bool
+
+
+@dataclass
+class AuthorizationRequest:
+    """An authorization URL plus the raw nonce that binds its ``state`` to a client.
+
+    ``url`` is the provider authorization URL (the client redirects to it).
+    ``state_nonce`` is the high-entropy secret the caller must set in an
+    HttpOnly+SameSite cookie; only its SHA-256 is committed inside the signed
+    ``state``, so the URL never carries the nonce itself.
+    """
+
+    url: str
+    state_nonce: str
 
 
 def _provider_config(provider: str, settings: ApiSettings) -> dict:
@@ -107,42 +138,65 @@ def _require_secret(settings: ApiSettings) -> str:
     return settings.jwt_secret_key
 
 
-def _create_state(provider: str, settings: ApiSettings) -> str:
-    """Mint a short-lived signed JWT used as the CSRF ``state`` value."""
+def _hash_nonce(nonce: str) -> str:
+    """SHA-256 of the client-bound nonce, committed into the signed ``state``."""
+    return hashlib.sha256(nonce.encode("utf-8")).hexdigest()
+
+
+def _create_state(provider: str, nonce: str, settings: ApiSettings) -> str:
+    """Mint a short-lived signed JWT used as the CSRF ``state`` value.
+
+    The ``cnf`` (confirmation) claim binds the state to the client: it holds the
+    SHA-256 of ``nonce``, whose raw value the client returns via cookie.
+    """
     secret = _require_secret(settings)
     now = datetime.now(timezone.utc)
     payload = {
         "type": STATE_TOKEN_TYPE,
         "provider": provider,
+        "cnf": _hash_nonce(nonce),
         "iat": now,
         "exp": now + timedelta(minutes=STATE_EXPIRE_MINUTES),
     }
     return jwt.encode(payload, secret, algorithm=settings.jwt_algorithm)
 
 
-def get_authorization_url(provider: str, settings: ApiSettings) -> str:
-    """Build the provider's authorization URL (with a signed ``state``).
+def build_authorization_request(provider: str, settings: ApiSettings) -> AuthorizationRequest:
+    """Build the provider authorization URL plus the client-binding state nonce.
+
+    Returns an :class:`AuthorizationRequest`; the caller redirects to ``.url`` and
+    must set ``.state_nonce`` in an HttpOnly+SameSite cookie so the callback can
+    prove the same client is completing the flow.
 
     Raises :class:`UnknownProviderError` for an unknown provider and
     :class:`OAuthError` if the provider's credentials are unconfigured.
     """
     config = _provider_config(provider, settings)
+    nonce = secrets.token_urlsafe(STATE_NONCE_BYTES)
     params = {
         "client_id": config["client_id"],
         "redirect_uri": config["redirect_uri"],
         "response_type": "code",
         "scope": config["scope"],
-        "state": _create_state(provider, settings),
+        "state": _create_state(provider, nonce, settings),
     }
-    return f"{config['authorize_url']}?{urlencode(params)}"
+    return AuthorizationRequest(
+        url=f"{config['authorize_url']}?{urlencode(params)}",
+        state_nonce=nonce,
+    )
 
 
-def validate_state(state: str, provider: str, settings: ApiSettings) -> bool:
-    """Verify the signed CSRF ``state`` for ``provider``.
+def validate_state(state: str, provider: str, settings: ApiSettings, nonce: str | None) -> bool:
+    """Verify the signed CSRF ``state`` for ``provider`` against the client ``nonce``.
+
+    ``nonce`` is the raw value the client returns from its state cookie; it must
+    hash to the ``cnf`` committed when the state was minted. A missing or
+    mismatched nonce means the caller is not the client that started the flow.
 
     Returns ``True`` on success; raises :class:`UnknownProviderError` for an
     unsupported provider, or :class:`OAuthError` if the state is expired,
-    tampered, the wrong token type, or for a different provider.
+    tampered, the wrong token type, for a different provider, or not bound to
+    this client.
     """
     if provider not in SUPPORTED_PROVIDERS:
         raise UnknownProviderError(f"Unsupported OAuth provider: {provider!r}")
@@ -156,6 +210,15 @@ def validate_state(state: str, provider: str, settings: ApiSettings) -> bool:
         raise OAuthError("Invalid OAuth state: not a state token.")
     if payload.get("provider") != provider:
         raise OAuthError("OAuth state provider mismatch.")
+
+    committed = payload.get("cnf")
+    if not committed:
+        raise OAuthError("OAuth state is not bound to a client.")
+    if not nonce:
+        raise OAuthError("Missing OAuth state cookie.")
+    # Constant-time compare so a mismatch can't be probed by timing.
+    if not hmac.compare_digest(committed, _hash_nonce(nonce)):
+        raise OAuthError("OAuth state does not match the initiating client.")
     return True
 
 

--- a/src/acemusic/api/routers/auth.py
+++ b/src/acemusic/api/routers/auth.py
@@ -25,6 +25,13 @@ means the client MUST preserve cookies between ``/login`` and ``/callback``:
   (``credentials: 'include'``; CORS already allows credentials). Set
   ``ACEMUSIC_API_OAUTH_COOKIE_SAMESITE=none`` for that deployment.
 
+Local development: a cross-origin **plain-HTTP** pair (e.g. ``localhost:3000`` →
+``localhost:8000``) cannot carry this cookie at all — ``SameSite=None`` needs
+``Secure`` and ``Secure`` needs HTTPS. This is a browser constraint, not a
+limitation of this code: any login-CSRF defense needs a secret the victim's
+browser holds, which over cross-origin HTTP is impossible. Run the SPA as a
+same-origin proxy to the API in dev (recommended) or serve both over HTTPS.
+
 HTTP status choices (documented for callers):
 * unknown provider → ``400`` (client asked for something we don't support)
 * unconfigured provider credentials → ``503`` (server misconfiguration, retryable

--- a/src/acemusic/api/routers/auth.py
+++ b/src/acemusic/api/routers/auth.py
@@ -29,7 +29,13 @@ from fastapi import APIRouter, HTTPException, Request, Response, status
 from pydantic import BaseModel
 
 from ..auth import oauth, services
-from ..auth.oauth import OAuthError, UnknownProviderError, get_authorization_url
+from ..auth.oauth import (
+    STATE_COOKIE_NAME,
+    STATE_EXPIRE_MINUTES,
+    OAuthError,
+    UnknownProviderError,
+    build_authorization_request,
+)
 from ..auth.tokens import create_access_token, create_refresh_token
 from ..models import User
 from ..settings import ApiSettings
@@ -65,6 +71,20 @@ def _settings(request: Request) -> ApiSettings:
     return request.app.state.settings
 
 
+def _state_cookie_path(request: Request) -> str:
+    """Scope the state cookie to the auth prefix (e.g. ``/api/v1/auth``).
+
+    Derived from the request path so the router stays agnostic of the mount
+    prefix; ``/login`` and ``/callback`` resolve to the same path, so the cookie
+    set at login is sent to (and can be cleared by) the callback.
+    """
+    path = request.url.path
+    for marker in ("/login/", "/callback/"):
+        if marker in path:
+            return path.rsplit(marker, 1)[0] or "/"
+    return "/"
+
+
 def _mint_token_pair(user: User, settings: ApiSettings) -> tuple[str, str]:
     """Mint a fresh ``(access_token, refresh_token)`` pair for ``user``."""
     access = create_access_token(
@@ -78,11 +98,16 @@ def _mint_token_pair(user: User, settings: ApiSettings) -> tuple[str, str]:
 
 
 @router.post("/login/{provider}", response_model=LoginResponse)
-def login(provider: str, request: Request) -> LoginResponse:
-    """Return the provider's authorization URL for the client to redirect to."""
+def login(provider: str, request: Request, response: Response) -> LoginResponse:
+    """Return the provider's authorization URL for the client to redirect to.
+
+    Also sets the client-binding state cookie (issue #110): its raw nonce is
+    returned to the same client and re-checked at the callback, so a ``state``
+    minted here cannot be replayed in another client's callback.
+    """
     settings = _settings(request)
     try:
-        url = get_authorization_url(provider, settings)
+        auth_request = build_authorization_request(provider, settings)
     except UnknownProviderError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except OAuthError as exc:
@@ -91,20 +116,34 @@ def login(provider: str, request: Request) -> LoginResponse:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=f"OAuth provider {provider!r} is not configured.",
         ) from exc
-    return LoginResponse(authorization_url=url)
+    response.set_cookie(
+        key=STATE_COOKIE_NAME,
+        value=auth_request.state_nonce,
+        max_age=STATE_EXPIRE_MINUTES * 60,
+        httponly=True,
+        secure=settings.oauth_cookie_secure,
+        samesite="lax",
+        path=_state_cookie_path(request),
+    )
+    return LoginResponse(authorization_url=auth_request.url)
 
 
 @router.post("/callback/{provider}", response_model=TokenResponse)
-async def callback(provider: str, body: CallbackRequest, request: Request) -> TokenResponse:
+async def callback(provider: str, body: CallbackRequest, request: Request, response: Response) -> TokenResponse:
     """Complete the OAuth flow: validate state, exchange code, upsert user, mint tokens."""
     settings = _settings(request)
 
+    nonce = request.cookies.get(STATE_COOKIE_NAME)
     try:
-        oauth.validate_state(body.state, provider, settings)
+        oauth.validate_state(body.state, provider, settings, nonce)
     except UnknownProviderError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except OAuthError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state.") from exc
+
+    # Single-use: the state has served its purpose, so clear the cookie regardless
+    # of how the rest of the callback resolves.
+    response.delete_cookie(STATE_COOKIE_NAME, path=_state_cookie_path(request))
 
     try:
         info = await oauth.exchange_code_for_user(provider, body.code, settings)

--- a/src/acemusic/api/routers/auth.py
+++ b/src/acemusic/api/routers/auth.py
@@ -12,6 +12,19 @@ State (CSRF) validation is stateless via the signed ``state`` JWT minted in
 the ``oauth`` module (not imported by name) so route tests can substitute a stub
 for the external provider HTTP without touching our own logic.
 
+**Client-binding cookie (issue #110).** ``/login`` sets a per-flow, HttpOnly state
+cookie whose nonce ``/callback`` must echo back, which is what stops a replayed
+``state`` from completing in another browser (login CSRF / session fixation). This
+means the client MUST preserve cookies between ``/login`` and ``/callback``:
+
+* Same-origin frontend + API (recommended; e.g. the SPA served behind the same
+  origin as the API via a reverse proxy): the default ``SameSite=Lax`` works.
+* Split-origin SPA (frontend and API on different origins): the browser only
+  sends the cookie on the cross-site callback when it is ``SameSite=None`` AND
+  ``Secure`` (so, over HTTPS) and the fetch is credentialed
+  (``credentials: 'include'``; CORS already allows credentials). Set
+  ``ACEMUSIC_API_OAUTH_COOKIE_SAMESITE=none`` for that deployment.
+
 HTTP status choices (documented for callers):
 * unknown provider → ``400`` (client asked for something we don't support)
 * unconfigured provider credentials → ``503`` (server misconfiguration, retryable
@@ -121,7 +134,7 @@ def login(provider: str, request: Request, response: Response) -> LoginResponse:
         max_age=STATE_EXPIRE_MINUTES * 60,
         httponly=True,
         secure=settings.oauth_cookie_secure,
-        samesite="lax",
+        samesite=settings.oauth_cookie_samesite,
         path=_state_cookie_path(request),
     )
     return LoginResponse(authorization_url=auth_request.url)

--- a/src/acemusic/api/routers/auth.py
+++ b/src/acemusic/api/routers/auth.py
@@ -30,7 +30,6 @@ from pydantic import BaseModel
 
 from ..auth import oauth, services
 from ..auth.oauth import (
-    STATE_COOKIE_NAME,
     STATE_EXPIRE_MINUTES,
     OAuthError,
     UnknownProviderError,
@@ -117,7 +116,7 @@ def login(provider: str, request: Request, response: Response) -> LoginResponse:
             detail=f"OAuth provider {provider!r} is not configured.",
         ) from exc
     response.set_cookie(
-        key=STATE_COOKIE_NAME,
+        key=auth_request.cookie_name,
         value=auth_request.state_nonce,
         max_age=STATE_EXPIRE_MINUTES * 60,
         httponly=True,
@@ -133,17 +132,15 @@ async def callback(provider: str, body: CallbackRequest, request: Request, respo
     """Complete the OAuth flow: validate state, exchange code, upsert user, mint tokens."""
     settings = _settings(request)
 
-    nonce = request.cookies.get(STATE_COOKIE_NAME)
     try:
-        oauth.validate_state(body.state, provider, settings, nonce)
+        consumed_cookie = oauth.validate_state(body.state, provider, settings, request.cookies)
     except UnknownProviderError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except OAuthError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state.") from exc
 
-    # Single-use: the state has served its purpose, so clear the cookie regardless
-    # of how the rest of the callback resolves.
-    response.delete_cookie(STATE_COOKIE_NAME, path=_state_cookie_path(request))
+    # Single-use: the state has served its purpose, so clear its per-flow cookie.
+    response.delete_cookie(consumed_cookie, path=_state_cookie_path(request))
 
     try:
         info = await oauth.exchange_code_for_user(provider, body.code, settings)

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -17,6 +17,12 @@ DEFAULT_CORS_ORIGINS = ["http://localhost:3000", "http://localhost:8000"]
 # than startup, so the allowed set is restricted to the HS family.
 ALLOWED_JWT_ALGORITHMS = ("HS256", "HS384", "HS512")
 
+# SameSite policies for the OAuth state cookie. "lax" suits a same-origin
+# deployment (frontend and API behind one origin); "none" is required for a
+# split-origin SPA so the cookie is sent on the cross-site callback (browsers
+# also require Secure in that case).
+ALLOWED_COOKIE_SAMESITE = ("lax", "strict", "none")
+
 
 class ApiSettings(BaseSettings):
     """Runtime configuration for the FastAPI service.
@@ -63,10 +69,37 @@ class ApiSettings(BaseSettings):
     access_token_expire_minutes: int = Field(default=15, ge=1)
     refresh_token_expire_days: int = Field(default=7, ge=1)
 
-    # Marks the OAuth ``state`` cookie (issue #110, login-CSRF binding) ``Secure``
-    # so it is only sent over HTTPS. Defaults to True for production; override to
-    # False for local/dev or test clients served over plain HTTP.
+    # OAuth ``state`` cookie policy (issue #110, login-CSRF binding). The login
+    # flow sets a per-client nonce cookie that the callback requires.
+    # ``oauth_cookie_secure`` marks it Secure (HTTPS-only); keep True in
+    # production, set False only for local/dev or tests over plain HTTP.
+    # ``oauth_cookie_samesite`` is "lax" for a same-origin frontend/API; a
+    # split-origin SPA must use "none" (which the browser only honours when the
+    # cookie is also Secure, i.e. over HTTPS) so the cookie is sent on the
+    # cross-site callback.
     oauth_cookie_secure: bool = True
+    oauth_cookie_samesite: str = "lax"
+
+    @field_validator("oauth_cookie_samesite")
+    @classmethod
+    def _check_cookie_samesite(cls, value: str) -> str:
+        """Normalize and validate the SameSite policy at parse time."""
+        normalized = value.strip().lower()
+        if normalized not in ALLOWED_COOKIE_SAMESITE:
+            raise ValueError(
+                f"oauth_cookie_samesite {value!r} is not supported; "
+                f"choose one of {', '.join(ALLOWED_COOKIE_SAMESITE)}"
+            )
+        return normalized
+
+    @model_validator(mode="after")
+    def _samesite_none_requires_secure(self) -> "ApiSettings":
+        """SameSite=None cookies are ignored by browsers unless also Secure."""
+        if self.oauth_cookie_samesite == "none" and not self.oauth_cookie_secure:
+            raise ValueError(
+                "oauth_cookie_samesite='none' requires oauth_cookie_secure=True (browsers ignore it otherwise)."
+            )
+        return self
 
     @field_validator("jwt_algorithm")
     @classmethod

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -63,6 +63,11 @@ class ApiSettings(BaseSettings):
     access_token_expire_minutes: int = Field(default=15, ge=1)
     refresh_token_expire_days: int = Field(default=7, ge=1)
 
+    # Marks the OAuth ``state`` cookie (issue #110, login-CSRF binding) ``Secure``
+    # so it is only sent over HTTPS. Defaults to True for production; override to
+    # False for local/dev or test clients served over plain HTTP.
+    oauth_cookie_secure: bool = True
+
     @field_validator("jwt_algorithm")
     @classmethod
     def _check_jwt_algorithm(cls, value: str) -> str:

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -63,6 +63,7 @@ class TestAuthSettings:
         "ACEMUSIC_API_JWT_ALGORITHM",
         "ACEMUSIC_API_ACCESS_TOKEN_EXPIRE_MINUTES",
         "ACEMUSIC_API_REFRESH_TOKEN_EXPIRE_DAYS",
+        "ACEMUSIC_API_OAUTH_COOKIE_SECURE",
     )
 
     @pytest.fixture(autouse=True)
@@ -116,6 +117,15 @@ class TestAuthSettings:
         assert settings.jwt_algorithm == "HS512"
         assert settings.access_token_expire_minutes == 30
         assert settings.refresh_token_expire_days == 14
+
+    def test_oauth_cookie_secure_defaults_true(self):
+        """The OAuth state cookie (issue #110) is Secure by default for production."""
+        assert ApiSettings(_env_file=None).oauth_cookie_secure is True
+
+    def test_oauth_cookie_secure_overridable_for_http_dev(self, monkeypatch):
+        """Local/dev over plain HTTP can disable Secure so the cookie is returned."""
+        monkeypatch.setenv("ACEMUSIC_API_OAUTH_COOKIE_SECURE", "false")
+        assert ApiSettings(_env_file=None).oauth_cookie_secure is False
 
     @pytest.mark.parametrize("algorithm", ["HS256", "HS384", "HS512"])
     def test_jwt_algorithm_allows_hmac_family(self, monkeypatch, algorithm):

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -64,6 +64,7 @@ class TestAuthSettings:
         "ACEMUSIC_API_ACCESS_TOKEN_EXPIRE_MINUTES",
         "ACEMUSIC_API_REFRESH_TOKEN_EXPIRE_DAYS",
         "ACEMUSIC_API_OAUTH_COOKIE_SECURE",
+        "ACEMUSIC_API_OAUTH_COOKIE_SAMESITE",
     )
 
     @pytest.fixture(autouse=True)
@@ -126,6 +127,27 @@ class TestAuthSettings:
         """Local/dev over plain HTTP can disable Secure so the cookie is returned."""
         monkeypatch.setenv("ACEMUSIC_API_OAUTH_COOKIE_SECURE", "false")
         assert ApiSettings(_env_file=None).oauth_cookie_secure is False
+
+    def test_oauth_cookie_samesite_defaults_lax(self):
+        """A same-origin frontend/API deployment uses Lax by default."""
+        assert ApiSettings(_env_file=None).oauth_cookie_samesite == "lax"
+
+    def test_oauth_cookie_samesite_normalized_and_overridable(self, monkeypatch):
+        """Split-origin SPAs set 'none'; the value is normalized to lowercase."""
+        monkeypatch.setenv("ACEMUSIC_API_OAUTH_COOKIE_SAMESITE", "None")
+        assert ApiSettings(_env_file=None).oauth_cookie_samesite == "none"
+
+    def test_oauth_cookie_samesite_rejects_unknown(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_OAUTH_COOKIE_SAMESITE", "bogus")
+        with pytest.raises(ValueError, match="oauth_cookie_samesite"):
+            ApiSettings(_env_file=None)
+
+    def test_oauth_cookie_samesite_none_requires_secure(self, monkeypatch):
+        """SameSite=None without Secure is rejected (browsers would ignore it)."""
+        monkeypatch.setenv("ACEMUSIC_API_OAUTH_COOKIE_SAMESITE", "none")
+        monkeypatch.setenv("ACEMUSIC_API_OAUTH_COOKIE_SECURE", "false")
+        with pytest.raises(ValueError, match="requires oauth_cookie_secure"):
+            ApiSettings(_env_file=None)
 
     @pytest.mark.parametrize("algorithm", ["HS256", "HS384", "HS512"])
     def test_jwt_algorithm_allows_hmac_family(self, monkeypatch, algorithm):

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -21,11 +21,12 @@ from acemusic.api.auth.oauth import (
     GOOGLE_AUTHORIZE_URL,
     GOOGLE_TOKEN_URL,
     GOOGLE_USERINFO_URL,
+    AuthorizationRequest,
     OAuthError,
     OAuthUserInfo,
     UnknownProviderError,
+    build_authorization_request,
     exchange_code_for_user,
-    get_authorization_url,
     validate_state,
 )
 from acemusic.api.settings import ApiSettings
@@ -46,70 +47,101 @@ def _settings(**overrides) -> ApiSettings:
     return ApiSettings(**base)
 
 
+def _request(provider: str, settings: ApiSettings) -> AuthorizationRequest:
+    """Build the authorization request and return the (url, state_nonce) bundle."""
+    return build_authorization_request(provider, settings)
+
+
+def _state_of(req: AuthorizationRequest) -> str:
+    return parse_qs(urlparse(req.url).query)["state"][0]
+
+
 class TestAuthorizationUrl:
     def test_google_url_has_expected_params(self):
         settings = _settings()
-        url = get_authorization_url("google", settings)
-        parsed = urlparse(url)
-        assert url.startswith(GOOGLE_AUTHORIZE_URL)
+        req = _request("google", settings)
+        assert isinstance(req, AuthorizationRequest)
+        parsed = urlparse(req.url)
+        assert req.url.startswith(GOOGLE_AUTHORIZE_URL)
         qs = parse_qs(parsed.query)
         assert qs["client_id"] == ["google-id"]
         assert qs["redirect_uri"] == [settings.google_redirect_uri]
         assert qs["response_type"] == ["code"]
         assert qs["scope"] == ["openid email profile"]
         assert "state" in qs
+        # The raw client-bound nonce is returned separately for the cookie; it
+        # is never placed in the URL/state (only its hash is committed there).
+        assert req.state_nonce
+        assert req.state_nonce not in req.url
 
     def test_discord_url_has_expected_params(self):
         settings = _settings()
-        url = get_authorization_url("discord", settings)
-        parsed = urlparse(url)
-        assert url.startswith(DISCORD_AUTHORIZE_URL)
+        req = _request("discord", settings)
+        parsed = urlparse(req.url)
+        assert req.url.startswith(DISCORD_AUTHORIZE_URL)
         qs = parse_qs(parsed.query)
         assert qs["client_id"] == ["discord-id"]
         assert qs["redirect_uri"] == [settings.discord_redirect_uri]
         assert qs["response_type"] == ["code"]
         assert qs["scope"] == ["identify email"]
         assert "state" in qs
+        assert req.state_nonce
+
+    def test_each_request_has_a_unique_nonce(self):
+        settings = _settings()
+        first = _request("google", settings)
+        second = _request("google", settings)
+        assert first.state_nonce != second.state_nonce
 
     def test_unknown_provider_raises(self):
         with pytest.raises(UnknownProviderError):
-            get_authorization_url("github", _settings())
+            build_authorization_request("github", _settings())
 
     def test_missing_credentials_raises(self):
         settings = _settings(google_client_id=None)
         with pytest.raises(OAuthError):
-            get_authorization_url("google", settings)
+            build_authorization_request("google", settings)
 
 
 class TestStateRoundTrip:
-    def test_state_validates_for_correct_provider(self):
+    def test_state_validates_with_matching_nonce(self):
         settings = _settings()
-        url = get_authorization_url("google", settings)
-        state = parse_qs(urlparse(url).query)["state"][0]
-        assert validate_state(state, "google", settings) is True
+        req = _request("google", settings)
+        assert validate_state(_state_of(req), "google", settings, req.state_nonce) is True
+
+    def test_missing_nonce_rejected(self):
+        """A state replayed without the client's cookie nonce must fail (login CSRF)."""
+        settings = _settings()
+        req = _request("google", settings)
+        with pytest.raises(OAuthError):
+            validate_state(_state_of(req), "google", settings, None)
+
+    def test_wrong_nonce_rejected(self):
+        """A state bound to one client cannot be completed with a different nonce."""
+        settings = _settings()
+        req = _request("google", settings)
+        with pytest.raises(OAuthError):
+            validate_state(_state_of(req), "google", settings, "some-other-clients-nonce")
 
     def test_tampered_state_rejected(self):
         settings = _settings()
-        url = get_authorization_url("google", settings)
-        state = parse_qs(urlparse(url).query)["state"][0]
+        req = _request("google", settings)
         with pytest.raises(OAuthError):
-            validate_state(state + "tampered", "google", settings)
+            validate_state(_state_of(req) + "tampered", "google", settings, req.state_nonce)
 
     def test_wrong_provider_rejected(self):
         settings = _settings()
-        url = get_authorization_url("google", settings)
-        state = parse_qs(urlparse(url).query)["state"][0]
+        req = _request("google", settings)
         with pytest.raises(OAuthError):
-            validate_state(state, "discord", settings)
+            validate_state(_state_of(req), "discord", settings, req.state_nonce)
 
     def test_expired_state_rejected(self):
         settings = _settings()
         with freeze_time("2026-01-01 12:00:00"):
-            url = get_authorization_url("google", settings)
-            state = parse_qs(urlparse(url).query)["state"][0]
+            req = _request("google", settings)
         with freeze_time("2026-01-01 12:30:00"):
             with pytest.raises(OAuthError):
-                validate_state(state, "google", settings)
+                validate_state(_state_of(req), "google", settings, req.state_nonce)
 
     def test_non_oauth_state_jwt_rejected(self):
         """A validly-signed JWT that is not an oauth_state token must be rejected."""
@@ -120,7 +152,7 @@ class TestStateRoundTrip:
             algorithm=settings.jwt_algorithm,
         )
         with pytest.raises(OAuthError):
-            validate_state(forged, "google", settings)
+            validate_state(forged, "google", settings, "nonce")
 
 
 class TestExchangeCodeForUser:

--- a/tests/test_auth_oauth.py
+++ b/tests/test_auth_oauth.py
@@ -87,11 +87,13 @@ class TestAuthorizationUrl:
         assert "state" in qs
         assert req.state_nonce
 
-    def test_each_request_has_a_unique_nonce(self):
+    def test_each_request_has_a_unique_nonce_and_cookie(self):
         settings = _settings()
         first = _request("google", settings)
         second = _request("google", settings)
         assert first.state_nonce != second.state_nonce
+        # Per-flow cookie names keep concurrent logins from clobbering each other.
+        assert first.cookie_name != second.cookie_name
 
     def test_unknown_provider_raises(self):
         with pytest.raises(UnknownProviderError):
@@ -103,37 +105,55 @@ class TestAuthorizationUrl:
             build_authorization_request("google", settings)
 
 
+def _cookies(req: AuthorizationRequest) -> dict[str, str]:
+    """The cookie jar a well-behaved client would present at the callback."""
+    return {req.cookie_name: req.state_nonce}
+
+
 class TestStateRoundTrip:
-    def test_state_validates_with_matching_nonce(self):
+    def test_state_validates_with_matching_cookie(self):
         settings = _settings()
         req = _request("google", settings)
-        assert validate_state(_state_of(req), "google", settings, req.state_nonce) is True
+        # Returns the consumed cookie name so the caller can clear it.
+        assert validate_state(_state_of(req), "google", settings, _cookies(req)) == req.cookie_name
 
-    def test_missing_nonce_rejected(self):
-        """A state replayed without the client's cookie nonce must fail (login CSRF)."""
+    def test_missing_cookie_rejected(self):
+        """A state replayed without the client's cookie must fail (login CSRF)."""
         settings = _settings()
         req = _request("google", settings)
         with pytest.raises(OAuthError):
-            validate_state(_state_of(req), "google", settings, None)
+            validate_state(_state_of(req), "google", settings, {})
 
     def test_wrong_nonce_rejected(self):
         """A state bound to one client cannot be completed with a different nonce."""
         settings = _settings()
         req = _request("google", settings)
         with pytest.raises(OAuthError):
-            validate_state(_state_of(req), "google", settings, "some-other-clients-nonce")
+            validate_state(_state_of(req), "google", settings, {req.cookie_name: "some-other-clients-nonce"})
+
+    def test_other_flows_cookie_does_not_satisfy_state(self):
+        """Concurrent flows are independent: flow A's cookie can't complete flow B."""
+        settings = _settings()
+        a = _request("google", settings)
+        b = _request("google", settings)
+        # Present only A's cookie while completing B's state.
+        with pytest.raises(OAuthError):
+            validate_state(_state_of(b), "google", settings, _cookies(a))
+        # Each still validates with its own cookie.
+        assert validate_state(_state_of(a), "google", settings, _cookies(a)) == a.cookie_name
+        assert validate_state(_state_of(b), "google", settings, _cookies(b)) == b.cookie_name
 
     def test_tampered_state_rejected(self):
         settings = _settings()
         req = _request("google", settings)
         with pytest.raises(OAuthError):
-            validate_state(_state_of(req) + "tampered", "google", settings, req.state_nonce)
+            validate_state(_state_of(req) + "tampered", "google", settings, _cookies(req))
 
     def test_wrong_provider_rejected(self):
         settings = _settings()
         req = _request("google", settings)
         with pytest.raises(OAuthError):
-            validate_state(_state_of(req), "discord", settings, req.state_nonce)
+            validate_state(_state_of(req), "discord", settings, _cookies(req))
 
     def test_expired_state_rejected(self):
         settings = _settings()
@@ -141,7 +161,7 @@ class TestStateRoundTrip:
             req = _request("google", settings)
         with freeze_time("2026-01-01 12:30:00"):
             with pytest.raises(OAuthError):
-                validate_state(_state_of(req), "google", settings, req.state_nonce)
+                validate_state(_state_of(req), "google", settings, _cookies(req))
 
     def test_non_oauth_state_jwt_rejected(self):
         """A validly-signed JWT that is not an oauth_state token must be rejected."""
@@ -152,7 +172,7 @@ class TestStateRoundTrip:
             algorithm=settings.jwt_algorithm,
         )
         with pytest.raises(OAuthError):
-            validate_state(forged, "google", settings, "nonce")
+            validate_state(forged, "google", settings, {"oauth_state_x": "nonce"})
 
 
 class TestExchangeCodeForUser:

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -22,7 +22,12 @@ from fastapi import APIRouter, Depends
 
 from acemusic.api.auth import oauth as oauth_module
 from acemusic.api.auth.dependencies import CurrentUser, get_current_user
-from acemusic.api.auth.oauth import OAuthError, OAuthUserInfo, get_authorization_url
+from acemusic.api.auth.oauth import (
+    STATE_COOKIE_NAME,
+    OAuthError,
+    OAuthUserInfo,
+    build_authorization_request,
+)
 from acemusic.api.auth.tokens import create_access_token, decode_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import User
@@ -42,6 +47,9 @@ def _auth_settings(mongo_settings: ApiSettings) -> ApiSettings:
             "discord_client_id": "discord-id",
             "discord_client_secret": "discord-secret",
             "discord_redirect_uri": "https://app.example.com/api/v1/auth/callback/discord",
+            # The test client speaks plain HTTP, so a Secure cookie would never be
+            # sent back; disable Secure here (production default stays True).
+            "oauth_cookie_secure": False,
         }
     )
 
@@ -63,9 +71,18 @@ async def client(settings):
         yield ac
 
 
-def _valid_state(provider: str, settings: ApiSettings) -> str:
-    url = get_authorization_url(provider, settings)
-    return parse_qs(urlparse(url).query)["state"][0]
+def _bind_state(client: httpx.AsyncClient, provider: str, settings: ApiSettings) -> str:
+    """Mint a client-bound state and place its nonce in the client's cookie jar.
+
+    Mirrors what ``POST /login/{provider}`` does (issue #110): the callback only
+    succeeds when the request carries the cookie nonce matching the state. The
+    real login-sets-the-cookie path is covered separately by
+    ``TestLogin::test_login_sets_state_cookie`` and ``TestCallback::
+    test_end_to_end_login_then_callback``.
+    """
+    req = build_authorization_request(provider, settings)
+    client.cookies.set(STATE_COOKIE_NAME, req.state_nonce)
+    return parse_qs(urlparse(req.url).query)["state"][0]
 
 
 def _fake_exchange(monkeypatch, info: OAuthUserInfo) -> None:
@@ -92,8 +109,89 @@ class TestLogin:
         resp = await client.post(f"{API_V1_PREFIX}/auth/login/github")
         assert resp.status_code == 400
 
+    async def test_login_sets_client_binding_state_cookie(self, client):
+        """Login must set the HttpOnly+SameSite state cookie that binds the flow
+        to this client (issue #110)."""
+        resp = await client.post(f"{API_V1_PREFIX}/auth/login/google")
+        assert resp.status_code == 200
+        set_cookie = resp.headers.get("set-cookie")
+        assert set_cookie is not None
+        assert STATE_COOKIE_NAME in set_cookie
+        assert "httponly" in set_cookie.lower()
+        assert "samesite=lax" in set_cookie.lower()
+        # Secure is disabled only because the test client speaks HTTP; the
+        # production default (oauth_cookie_secure=True) would add it.
+        assert "secure" not in set_cookie.lower()
+        assert client.cookies.get(STATE_COOKIE_NAME)
+
 
 class TestCallback:
+    async def test_end_to_end_login_then_callback(self, client, settings, monkeypatch):
+        """The cookie set by the real /login flows to /callback and validates."""
+        _fake_exchange(
+            monkeypatch,
+            OAuthUserInfo(provider="google", oauth_id="e2e-1", email="e2e@example.com", name="E", email_verified=True),
+        )
+        login = await client.post(f"{API_V1_PREFIX}/auth/login/google")
+        assert login.status_code == 200
+        state = parse_qs(urlparse(login.json()["authorization_url"]).query)["state"][0]
+        # The state cookie is now in the client jar from login; reuse the client.
+        resp = await client.post(
+            f"{API_V1_PREFIX}/auth/callback/google",
+            json={"code": "auth-code", "state": state},
+        )
+        assert resp.status_code == 200
+
+    async def test_callback_without_state_cookie_returns_400(self, client, settings, monkeypatch):
+        """A state replayed without the initiating client's cookie is rejected
+        (login CSRF / session fixation, issue #110)."""
+        _fake_exchange(
+            monkeypatch,
+            OAuthUserInfo(provider="google", oauth_id="csrf-1", email="v@example.com", name="V", email_verified=True),
+        )
+        # Mint a perfectly valid, signed state but DON'T set the matching cookie.
+        req = build_authorization_request("google", settings)
+        state = parse_qs(urlparse(req.url).query)["state"][0]
+        resp = await client.post(
+            f"{API_V1_PREFIX}/auth/callback/google",
+            json={"code": "auth-code", "state": state},
+        )
+        assert resp.status_code == 400
+        # The victim's account is never created from a replayed state.
+        assert await User.find_one(User.email == "v@example.com") is None
+
+    async def test_callback_with_mismatched_state_cookie_returns_400(self, client, settings, monkeypatch):
+        """A state bound to one client cannot be completed with a different nonce."""
+        _fake_exchange(
+            monkeypatch,
+            OAuthUserInfo(provider="google", oauth_id="csrf-2", email="w@example.com", name="W", email_verified=True),
+        )
+        req = build_authorization_request("google", settings)
+        state = parse_qs(urlparse(req.url).query)["state"][0]
+        # Attacker-controlled cookie that does not match the state's commitment.
+        client.cookies.set(STATE_COOKIE_NAME, "some-other-clients-nonce")
+        resp = await client.post(
+            f"{API_V1_PREFIX}/auth/callback/google",
+            json={"code": "auth-code", "state": state},
+        )
+        assert resp.status_code == 400
+
+    async def test_callback_clears_state_cookie_on_success(self, client, settings, monkeypatch):
+        """The single-use state cookie is cleared once the callback consumes it."""
+        _fake_exchange(
+            monkeypatch,
+            OAuthUserInfo(provider="google", oauth_id="clr-1", email="clr@example.com", name="C", email_verified=True),
+        )
+        state = _bind_state(client, "google", settings)
+        resp = await client.post(
+            f"{API_V1_PREFIX}/auth/callback/google",
+            json={"code": "auth-code", "state": state},
+        )
+        assert resp.status_code == 200
+        set_cookie = (resp.headers.get("set-cookie") or "").lower()
+        assert STATE_COOKIE_NAME in set_cookie
+        assert "max-age=0" in set_cookie or "expires=" in set_cookie
+
     async def test_google_callback_creates_user_and_returns_jwt(self, client, settings, monkeypatch):
         _fake_exchange(
             monkeypatch,
@@ -101,7 +199,7 @@ class TestCallback:
                 provider="google", oauth_id="g-1", email="alice@example.com", name="Alice", email_verified=True
             ),
         )
-        state = _valid_state("google", settings)
+        state = _bind_state(client, "google", settings)
         resp = await client.post(
             f"{API_V1_PREFIX}/auth/callback/google",
             json={"code": "auth-code", "state": state},
@@ -123,7 +221,7 @@ class TestCallback:
             monkeypatch,
             OAuthUserInfo(provider="discord", oauth_id="d-1", email="bob@example.com", name="Bob", email_verified=True),
         )
-        state = _valid_state("discord", settings)
+        state = _bind_state(client, "discord", settings)
         resp = await client.post(
             f"{API_V1_PREFIX}/auth/callback/discord",
             json={"code": "auth-code", "state": state},
@@ -141,7 +239,7 @@ class TestCallback:
         )
         await client.post(
             f"{API_V1_PREFIX}/auth/callback/google",
-            json={"code": "c1", "state": _valid_state("google", settings)},
+            json={"code": "c1", "state": _bind_state(client, "google", settings)},
         )
         _fake_exchange(
             monkeypatch,
@@ -149,7 +247,7 @@ class TestCallback:
         )
         await client.post(
             f"{API_V1_PREFIX}/auth/callback/google",
-            json={"code": "c2", "state": _valid_state("google", settings)},
+            json={"code": "c2", "state": _bind_state(client, "google", settings)},
         )
         users = await User.find(User.oauth_provider == "google", User.oauth_id == "g-9").to_list()
         assert len(users) == 1
@@ -166,7 +264,7 @@ class TestCallback:
         )
         resp = await client.post(
             f"{API_V1_PREFIX}/auth/callback/google",
-            json={"code": "auth-code", "state": _valid_state("google", settings)},
+            json={"code": "auth-code", "state": _bind_state(client, "google", settings)},
         )
         assert resp.status_code == 403
         # No account is created on an unverified address.
@@ -182,7 +280,7 @@ class TestCallback:
         )
         first = await client.post(
             f"{API_V1_PREFIX}/auth/callback/google",
-            json={"code": "c1", "state": _valid_state("google", settings)},
+            json={"code": "c1", "state": _bind_state(client, "google", settings)},
         )
         assert first.status_code == 200
         # Same email arrives via a second provider (Discord). The single-identity
@@ -196,7 +294,7 @@ class TestCallback:
         )
         second = await client.post(
             f"{API_V1_PREFIX}/auth/callback/discord",
-            json={"code": "c2", "state": _valid_state("discord", settings)},
+            json={"code": "c2", "state": _bind_state(client, "discord", settings)},
         )
         assert second.status_code == 409
         # No duplicate account was created for the shared email.
@@ -217,7 +315,7 @@ class TestCallback:
         )
         a = await client.post(
             f"{API_V1_PREFIX}/auth/callback/google",
-            json={"code": "cA", "state": _valid_state("google", settings)},
+            json={"code": "cA", "state": _bind_state(client, "google", settings)},
         )
         assert a.status_code == 200
 
@@ -228,7 +326,7 @@ class TestCallback:
         )
         b = await client.post(
             f"{API_V1_PREFIX}/auth/callback/discord",
-            json={"code": "cB", "state": _valid_state("discord", settings)},
+            json={"code": "cB", "state": _bind_state(client, "discord", settings)},
         )
         assert b.status_code == 200
         account_b_id = decode_access_token(b.json()["access_token"], settings)["sub"]
@@ -242,7 +340,7 @@ class TestCallback:
         )
         resp = await client.post(
             f"{API_V1_PREFIX}/auth/callback/discord",
-            json={"code": "cB2", "state": _valid_state("discord", settings)},
+            json={"code": "cB2", "state": _bind_state(client, "discord", settings)},
         )
         # No duplicate-key 500; B logs into its own account, email unchanged.
         assert resp.status_code == 200
@@ -292,7 +390,7 @@ class TestCallback:
         monkeypatch.setattr(oauth_module, "exchange_code_for_user", _boom)
         resp = await client.post(
             f"{API_V1_PREFIX}/auth/callback/google",
-            json={"code": "bad", "state": _valid_state("google", settings)},
+            json={"code": "bad", "state": _bind_state(client, "google", settings)},
         )
         assert resp.status_code == 502
 
@@ -304,7 +402,7 @@ async def _login(client, settings, monkeypatch, *, oauth_id="r-1", email="r@exam
     )
     resp = await client.post(
         f"{API_V1_PREFIX}/auth/callback/google",
-        json={"code": "code", "state": _valid_state("google", settings)},
+        json={"code": "code", "state": _bind_state(client, "google", settings)},
     )
     assert resp.status_code == 200
     return resp.json()

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -23,7 +23,7 @@ from fastapi import APIRouter, Depends
 from acemusic.api.auth import oauth as oauth_module
 from acemusic.api.auth.dependencies import CurrentUser, get_current_user
 from acemusic.api.auth.oauth import (
-    STATE_COOKIE_NAME,
+    STATE_COOKIE_PREFIX,
     OAuthError,
     OAuthUserInfo,
     build_authorization_request,
@@ -81,7 +81,7 @@ def _bind_state(client: httpx.AsyncClient, provider: str, settings: ApiSettings)
     test_end_to_end_login_then_callback``.
     """
     req = build_authorization_request(provider, settings)
-    client.cookies.set(STATE_COOKIE_NAME, req.state_nonce)
+    client.cookies.set(req.cookie_name, req.state_nonce)
     return parse_qs(urlparse(req.url).query)["state"][0]
 
 
@@ -116,13 +116,13 @@ class TestLogin:
         assert resp.status_code == 200
         set_cookie = resp.headers.get("set-cookie")
         assert set_cookie is not None
-        assert STATE_COOKIE_NAME in set_cookie
+        assert STATE_COOKIE_PREFIX in set_cookie
         assert "httponly" in set_cookie.lower()
         assert "samesite=lax" in set_cookie.lower()
         # Secure is disabled only because the test client speaks HTTP; the
         # production default (oauth_cookie_secure=True) would add it.
         assert "secure" not in set_cookie.lower()
-        assert client.cookies.get(STATE_COOKIE_NAME)
+        assert any(name.startswith(STATE_COOKIE_PREFIX) for name in client.cookies.keys())
 
 
 class TestCallback:
@@ -168,8 +168,9 @@ class TestCallback:
         )
         req = build_authorization_request("google", settings)
         state = parse_qs(urlparse(req.url).query)["state"][0]
-        # Attacker-controlled cookie that does not match the state's commitment.
-        client.cookies.set(STATE_COOKIE_NAME, "some-other-clients-nonce")
+        # Attacker-controlled cookie (right name, wrong value) that does not match
+        # the state's commitment.
+        client.cookies.set(req.cookie_name, "some-other-clients-nonce")
         resp = await client.post(
             f"{API_V1_PREFIX}/auth/callback/google",
             json={"code": "auth-code", "state": state},
@@ -189,8 +190,30 @@ class TestCallback:
         )
         assert resp.status_code == 200
         set_cookie = (resp.headers.get("set-cookie") or "").lower()
-        assert STATE_COOKIE_NAME in set_cookie
+        assert STATE_COOKIE_PREFIX in set_cookie
         assert "max-age=0" in set_cookie or "expires=" in set_cookie
+
+    async def test_concurrent_logins_do_not_clobber_each_other(self, client, settings, monkeypatch):
+        """Two login flows in one browser stay independent (per-flow cookies).
+
+        Regression guard: a single shared cookie would let the second /login
+        overwrite the first flow's nonce, breaking the first callback.
+        """
+        _fake_exchange(
+            monkeypatch,
+            OAuthUserInfo(provider="google", oauth_id="cc-1", email="cc@example.com", name="CC", email_verified=True),
+        )
+        first = await client.post(f"{API_V1_PREFIX}/auth/login/google")
+        first_state = parse_qs(urlparse(first.json()["authorization_url"]).query)["state"][0]
+        # A second login (e.g. another tab / double-click) before the first completes.
+        second = await client.post(f"{API_V1_PREFIX}/auth/login/google")
+        assert second.status_code == 200
+        # The first flow still completes — its per-flow cookie was not overwritten.
+        resp = await client.post(
+            f"{API_V1_PREFIX}/auth/callback/google",
+            json={"code": "auth-code", "state": first_state},
+        )
+        assert resp.status_code == 200
 
     async def test_google_callback_creates_user_and_returns_jwt(self, client, settings, monkeypatch):
         _fake_exchange(

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -124,6 +124,17 @@ class TestLogin:
         assert "secure" not in set_cookie.lower()
         assert any(name.startswith(STATE_COOKIE_PREFIX) for name in client.cookies.keys())
 
+    async def test_login_cookie_honors_samesite_none_for_split_origin(self, settings):
+        """A split-origin deployment can emit SameSite=None; Secure so the cookie
+        is sent on the cross-site callback (issue #110 contract)."""
+        split = settings.model_copy(update={"oauth_cookie_samesite": "none", "oauth_cookie_secure": True})
+        async with _async_client(create_app(split)) as ac:
+            resp = await ac.post(f"{API_V1_PREFIX}/auth/login/google")
+        assert resp.status_code == 200
+        set_cookie = (resp.headers.get("set-cookie") or "").lower()
+        assert "samesite=none" in set_cookie
+        assert "secure" in set_cookie
+
 
 class TestCallback:
     async def test_end_to_end_login_then_callback(self, client, settings, monkeypatch):


### PR DESCRIPTION
## Summary
Implements #110: the OAuth `state` was a signed JWT bound only to the *provider*, so any caller could mint a valid `state` via `POST /login/{provider}` and replay it in a victim's `POST /callback/{provider}` — login CSRF / session fixation.

State is now bound to the initiating client with a **stateless double-submit pattern**:
- `POST /login/{provider}` mints a high-entropy nonce, commits `sha256(nonce)` into the signed `state` (`cnf` claim), and sets the raw nonce in a **per-flow, HttpOnly, SameSite, Secure** cookie (`oauth_state_<sid>`, named by the state's `sid` claim).
- `POST /callback/{provider}` requires the cookie nonce to match the state's commitment (constant-time compare) and clears the cookie on success.

An attacker can neither forge the signed `state` (no secret) nor read/set the victim's HttpOnly cookie, so a replayed `state` no longer validates.

Key changes:
- `oauth.py`: `get_authorization_url` → `build_authorization_request` (returns `url` + `state_nonce` + per-flow `cookie_name`); `validate_state` now takes the request cookie jar and returns the consumed cookie name.
- `settings.py`: `oauth_cookie_secure` (default `True`) and `oauth_cookie_samesite` (default `lax`; `none` validated to require Secure).
- Per-flow cookie keying so concurrent logins (multi-tab / double-click) don't clobber each other.

## Acceptance Criteria
- [x] `state` is bound to a per-client verifier (nonce in HttpOnly+SameSite cookie)
- [x] A `state` minted for one client cannot complete `/callback` for another (no/wrong cookie → 400)
- [x] `/login` sets an HttpOnly, SameSite, Secure (configurable) cookie; `/callback` clears it
- [x] Existing tamper / expiry / provider-mismatch protections still hold
- [x] Full suite green; lint/format clean

## Test Plan
- [x] Unit tests written first (TDD): `test_auth_oauth.py` (state binding, missing/wrong/other-flow nonce, tamper/expiry), `test_api_settings.py` (cookie settings + validation)
- [x] Integration tests (real MongoDB): `test_auth_routes.py` — login sets cookie, end-to-end login→callback, missing-cookie 400, mismatched-cookie 400, cookie cleared, concurrent logins independent, split-origin SameSite=None wiring
- [x] All auth tests passing (104) + full unit suite green (974)
- [x] Linting (ruff) + formatting (black) clean
- [x] Cross-family review pass: **codex review** (3 rounds; see Implementation Notes)
- [x] Internal review (advisory) via the codex passes

## Known Limitations / Intentionally Deferred
- **Cross-origin plain-HTTP local dev cannot carry the state cookie.** This is an inherent browser constraint: cross-site cookies require `SameSite=None; Secure`, and `Secure` requires HTTPS — so a `localhost:3000 → localhost:8000` (different origin, plain HTTP) pair has no working combination. *Any* login-CSRF defense needs a victim-browser-held secret, which is impossible cross-origin over HTTP. Run the SPA as a same-origin proxy to the API in dev (recommended), or serve both over HTTPS and set `ACEMUSIC_API_OAUTH_COOKIE_SAMESITE=none`. Documented in the router docstring and `.env.example`.
- **The `/callback` contract changed** (it now requires the login-issued cookie). This was explicitly accepted by the issue author ("This changes the `/callback` contract... which is why it was deferred out of US-8.3's stateless scope"). No frontend consumes the API yet, so there are no existing clients to break.
- **Multi-identity account linking** remains future work (unchanged from US-8.3): a verified email already registered under another provider still returns 409.

## Implementation Notes
- **Approach choice:** double-submit cookie nonce over PKCE. In this server-driven flow PKCE would still need a cookie/session to carry the `code_verifier` across the redirect and targets code interception, not login CSRF — so it doesn't fit better and adds moving parts.
- **codex review loop (3 rounds):**
  1. Flagged a concurrency regression (single shared cookie clobbered on a second `/login`) → fixed with **per-flow cookie keying** (`sid` claim names the cookie) + a concurrency regression test.
  2. Flagged split-origin cookie delivery → made **SameSite configurable** (`none` for HTTPS split-origin) + None-requires-Secure guard + docs.
  3. Re-flagged the cross-origin plain-HTTP localhost case → this is an inherent web-platform constraint (no code fix exists without weakening the security goal) and a contract change the issue pre-accepted; addressed with explicit dev-topology guidance rather than an insecure default.

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ACEMUSIC_API_OAUTH_COOKIE_SECURE and ACEMUSIC_API_OAUTH_COOKIE_SAMESITE environment config.
  * Login now sets a per-flow HttpOnly SameSite state cookie; callback validates and clears that cookie.
  * Docs updated with OAuth cookie behavior, SameSite defaults (lax), and SameSite=None requiring secure transport.
* **Tests**
  * Expanded tests covering cookie settings, validation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->