### PR TITLE
US-8.4: User registration and profile CRUD (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ token plus a rotating, single-use refresh token. All `/api/v1` routes except
 | `POST /api/v1/auth/refresh` | Rotates the refresh token for a new access token |
 | `POST /api/v1/auth/logout` | Revokes a refresh token (idempotent) |
 
+### User profile
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/v1/users/me` | Returns the authenticated user's full profile |
+| `PATCH /api/v1/users/me` | Partially updates the profile (`display_name`, `handle`, `bio`, `style_tags`); unset fields are left unchanged |
+
+Profile fields: `display_name` (user-editable name, 1–100 chars), `handle` (unique public identifier — alphanumeric + hyphens, 3–30 chars, must start and end with a letter or number; currently case-sensitive), `bio` (up to 500 chars), `style_tags` (up to 20 tags, 30 chars each). A duplicate handle returns `409 Conflict`; an invalid handle or unknown PATCH key returns `422`.
+
 The OAuth `state` is bound to the initiating client to prevent login CSRF /
 session fixation: `/login` sets a per-flow, HttpOnly+SameSite cookie holding a
 nonce, and `/callback` requires that cookie to match the signed `state`. **The

--- a/src/acemusic/api/exceptions.py
+++ b/src/acemusic/api/exceptions.py
@@ -1,0 +1,18 @@
+"""Domain exceptions for the API service layer (US-8.4).
+
+These are raised by the service layer so it stays decoupled from HTTP. The
+FastAPI app maps them to status codes (see ``main.py`` for ``HandleConflictError``;
+the auth router maps ``EmailAlreadyRegisteredError`` to 409).
+"""
+
+
+class HandleConflictError(Exception):
+    """A profile update tried to claim a handle already taken by another user."""
+
+
+class EmailAlreadyRegisteredError(Exception):
+    """An OAuth identity's verified email already belongs to a different account.
+
+    The User model holds a single OAuth identity and email is unique-indexed, so a
+    second provider reporting an already-registered address cannot be linked yet.
+    """

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -12,13 +12,15 @@ import logging
 import time
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from acemusic import __version__
 
 from . import database
-from .routers import auth, health
+from .exceptions import HandleConflictError
+from .routers import auth, health, users
 from .settings import ApiSettings
 
 API_V1_PREFIX = "/api/v1"
@@ -93,6 +95,13 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     # require a valid Bearer access token.
     app.include_router(health.router, prefix=API_V1_PREFIX)
     app.include_router(auth.router, prefix=API_V1_PREFIX)
+    app.include_router(users.router, prefix=API_V1_PREFIX)
+
+    # A handle collision surfaces from the service layer as a domain exception;
+    # translate it to 409 Conflict here so the router stays free of HTTP plumbing.
+    @app.exception_handler(HandleConflictError)
+    async def _handle_conflict(_request: Request, _exc: HandleConflictError) -> JSONResponse:
+        return JSONResponse(status_code=409, content={"detail": "Handle already taken"})
 
     return app
 

--- a/src/acemusic/api/models/user.py
+++ b/src/acemusic/api/models/user.py
@@ -10,13 +10,25 @@ from .common import utcnow
 
 
 class User(Document):
-    """A platform user. ``email`` is validated and uniquely indexed."""
+    """A platform user. ``email`` is validated and uniquely indexed.
+
+    ``name`` is the raw display name reported by the OAuth provider; ``display_name``
+    is the user-editable profile name (defaulted from ``name`` on first login).
+    ``handle`` is the unique, user-chosen public identifier (US-8.4).
+    """
 
     email: EmailStr
     name: str
     oauth_provider: str | None = None
     oauth_id: str | None = None
     subscription_tier: str = "free"
+    # Profile fields (US-8.4). All optional so existing/OAuth-created users remain
+    # valid; ``handle`` stays null until the user claims one.
+    display_name: str | None = None
+    handle: str | None = None
+    bio: str | None = None
+    style_tags: list[str] = Field(default_factory=list)
+    avatar_url: str | None = None
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime | None = None
 
@@ -35,5 +47,13 @@ class User(Document):
                     "oauth_provider": {"$type": "string"},
                     "oauth_id": {"$type": "string"},
                 },
+            ),
+            # Handles are globally unique. Partial (same reasoning as the OAuth
+            # index): the many users with a null handle must not collide on a
+            # single null key under a plain unique index.
+            IndexModel(
+                [("handle", ASCENDING)],
+                unique=True,
+                partialFilterExpression={"handle": {"$type": "string"}},
             ),
         ]

--- a/src/acemusic/api/routers/auth.py
+++ b/src/acemusic/api/routers/auth.py
@@ -56,7 +56,9 @@ from ..auth.oauth import (
     build_authorization_request,
 )
 from ..auth.tokens import create_access_token, create_refresh_token
+from ..exceptions import EmailAlreadyRegisteredError
 from ..models import User
+from ..services import users as user_service
 from ..settings import ApiSettings
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -180,37 +182,25 @@ async def callback(provider: str, body: CallbackRequest, request: Request, respo
             detail="The OAuth provider has not verified this email address.",
         )
 
-    user = await User.find_one(User.oauth_provider == info.provider, User.oauth_id == info.oauth_id)
-    if user is None:
-        # No account for this provider identity. The User model holds a single
-        # OAuth identity and email is unique-indexed, so if the verified address
-        # is already registered under another provider we cannot link a second
-        # identity yet: reject deterministically (409) rather than 500 on the
-        # index or silently create a duplicate. Multi-identity linking is tracked
-        # as future work (see PR "Known limitations").
-        if await User.find_one(User.email == info.email) is not None:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="This email is already registered with a different sign-in provider.",
-            )
-        user = User(
+    # Upsert the user for this verified OAuth identity (US-8.4 owns the service;
+    # it also seeds the profile display_name from the provider name on creation).
+    # The User model holds a single OAuth identity and email is unique-indexed, so
+    # an email already registered under another provider cannot be linked yet:
+    # reject deterministically (409) rather than 500 on the index or silently
+    # create a duplicate. Multi-identity linking is future work (see PR "Known
+    # limitations").
+    try:
+        user = await user_service.get_or_create_user(
             email=info.email,
-            name=info.name,
-            oauth_provider=info.provider,
+            provider=info.provider,
             oauth_id=info.oauth_id,
+            name=info.name,
         )
-        await user.insert()
-    else:
-        # Known identity. The provider may report a changed email; only apply it
-        # when the address is free (or already ours), otherwise keep our current
-        # email so the user still logs into their own account without violating
-        # the unique index.
-        email_owner = await User.find_one(User.email == info.email)
-        if email_owner is None or email_owner.id == user.id:
-            user.email = info.email
-            user.name = info.name
-            user.updated_at = datetime.now(timezone.utc)
-            await user.save()
+    except EmailAlreadyRegisteredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This email is already registered with a different sign-in provider.",
+        ) from exc
 
     access, refresh = _mint_token_pair(user, settings)
     expires_at = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)

--- a/src/acemusic/api/routers/users.py
+++ b/src/acemusic/api/routers/users.py
@@ -13,13 +13,22 @@ handle validator is reused from the service layer so the rules have one home.
 """
 
 from datetime import datetime
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import User
 from ..services import users as user_service
+
+# Free-text profile fields are stored verbatim and re-served on every
+# GET /users/me, so cap them: one PATCH must not be able to bloat the document
+# (and thus every later read). Handle has its own format rules (see service).
+DISPLAY_NAME_MAX_LENGTH = 100
+BIO_MAX_LENGTH = 500
+STYLE_TAG_MAX_LENGTH = 30
+STYLE_TAGS_MAX_ITEMS = 20
 
 # Router-level dependency gates every route; endpoints additionally take
 # ``current`` to read the identity. FastAPI caches the dependency, so
@@ -66,10 +75,16 @@ class UserProfileUpdate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    display_name: str | None = None
+    display_name: Annotated[str, Field(max_length=DISPLAY_NAME_MAX_LENGTH)] | None = None
     handle: str | None = None
-    bio: str | None = None
-    style_tags: list[str] | None = None
+    bio: Annotated[str, Field(max_length=BIO_MAX_LENGTH)] | None = None
+    style_tags: (
+        Annotated[
+            list[Annotated[str, Field(max_length=STYLE_TAG_MAX_LENGTH)]],
+            Field(max_length=STYLE_TAGS_MAX_ITEMS),
+        ]
+        | None
+    ) = None
 
     @field_validator("handle")
     @classmethod

--- a/src/acemusic/api/routers/users.py
+++ b/src/acemusic/api/routers/users.py
@@ -1,0 +1,116 @@
+"""User profile router (US-8.4), mounted under ``/api/v1/users``.
+
+Endpoints (all require a valid Bearer access token):
+
+* ``GET  /users/me``  → the authenticated user's full profile
+* ``PATCH /users/me`` → partial profile update (display_name, handle, bio, style_tags)
+
+Avatar upload (``PUT /users/me/avatar``) is intentionally deferred to US-8.5
+(file storage) and is not part of this surface yet.
+
+Request/response schemas live here (same convention as the auth router). The
+handle validator is reused from the service layer so the rules have one home.
+"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import User
+from ..services import users as user_service
+
+# Router-level dependency gates every route; endpoints additionally take
+# ``current`` to read the identity. FastAPI caches the dependency, so
+# ``get_current_user`` still runs once per request.
+router = APIRouter(prefix="/users", tags=["users"], dependencies=[Depends(get_current_user)])
+
+
+class UserProfileResponse(BaseModel):
+    id: str
+    email: str
+    name: str
+    display_name: str | None
+    handle: str | None
+    bio: str | None
+    style_tags: list[str]
+    avatar_url: str | None
+    subscription_tier: str
+    created_at: datetime
+    updated_at: datetime | None
+
+    @classmethod
+    def from_user(cls, user: User) -> "UserProfileResponse":
+        return cls(
+            id=str(user.id),
+            email=user.email,
+            name=user.name,
+            display_name=user.display_name,
+            handle=user.handle,
+            bio=user.bio,
+            style_tags=user.style_tags,
+            avatar_url=user.avatar_url,
+            subscription_tier=user.subscription_tier,
+            created_at=user.created_at,
+            updated_at=user.updated_at,
+        )
+
+
+class UserProfileUpdate(BaseModel):
+    """Partial profile update; unset fields are left unchanged.
+
+    ``extra="forbid"`` rejects unknown keys with 422 rather than silently dropping
+    them, so a client typo surfaces instead of appearing to succeed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str | None = None
+    handle: str | None = None
+    bio: str | None = None
+    style_tags: list[str] | None = None
+
+    @field_validator("handle")
+    @classmethod
+    def _check_handle(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        try:
+            return user_service.validate_handle(value)
+        except user_service.HandleValidationError as exc:
+            # Surface the precise rule violation as a 422 via Pydantic.
+            raise ValueError(str(exc)) from exc
+
+
+def _not_found() -> HTTPException:
+    # An authenticated token whose user no longer exists (e.g. deleted account).
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+
+
+@router.get("/me", response_model=UserProfileResponse)
+async def get_me(current: CurrentUser = Depends(get_current_user)) -> UserProfileResponse:
+    user = await user_service.get_user_by_id(current.user_id)
+    if user is None:
+        raise _not_found()
+    return UserProfileResponse.from_user(user)
+
+
+@router.patch("/me", response_model=UserProfileResponse)
+async def update_me(
+    body: UserProfileUpdate,
+    current: CurrentUser = Depends(get_current_user),
+) -> UserProfileResponse:
+    """Update the authenticated user's profile and return the new state.
+
+    Invalid handle format → 422 (Pydantic). Duplicate handle → 409 (mapped from
+    ``HandleConflictError`` in ``main.py``).
+    """
+    updates = body.model_dump(exclude_unset=True)
+    if not updates:
+        user = await user_service.get_user_by_id(current.user_id)
+    else:
+        user = await user_service.update_user_profile(current.user_id, updates)
+    if user is None:
+        raise _not_found()
+    return UserProfileResponse.from_user(user)

--- a/src/acemusic/api/routers/users.py
+++ b/src/acemusic/api/routers/users.py
@@ -75,7 +75,7 @@ class UserProfileUpdate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    display_name: Annotated[str, Field(max_length=DISPLAY_NAME_MAX_LENGTH)] | None = None
+    display_name: Annotated[str, Field(min_length=1, max_length=DISPLAY_NAME_MAX_LENGTH)] | None = None
     handle: str | None = None
     bio: Annotated[str, Field(max_length=BIO_MAX_LENGTH)] | None = None
     style_tags: (
@@ -96,6 +96,20 @@ class UserProfileUpdate(BaseModel):
         except user_service.HandleValidationError as exc:
             # Surface the precise rule violation as a 422 via Pydantic.
             raise ValueError(str(exc)) from exc
+
+    @field_validator("style_tags")
+    @classmethod
+    def _clean_style_tags(cls, value: list[str] | None) -> list[str]:
+        # The validator only runs when the field is *present*. An explicit null
+        # means "clear my tags": coerce to [] (style_tags is a non-nullable list
+        # on the model, so storing None would 500 on read-back). An omitted field
+        # never reaches here and is left unchanged by exclude_unset.
+        if value is None:
+            return []
+        cleaned = [tag.strip() for tag in value]
+        if any(not tag for tag in cleaned):
+            raise ValueError("Style tags must not be empty or whitespace-only.")
+        return cleaned
 
 
 def _not_found() -> HTTPException:

--- a/src/acemusic/api/services/__init__.py
+++ b/src/acemusic/api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer: reusable business logic consumed by routers (US-8.4)."""

--- a/src/acemusic/api/services/users.py
+++ b/src/acemusic/api/services/users.py
@@ -1,0 +1,128 @@
+"""User profile service layer (US-8.4).
+
+Module-level async functions (mirroring :mod:`acemusic.api.auth.services`) that
+encapsulate user profile operations so routers — and US-8.3's OAuth callback —
+share one implementation. The layer raises domain exceptions
+(:mod:`acemusic.api.exceptions`), never ``HTTPException``, so it stays
+transport-agnostic.
+"""
+
+import re
+
+from beanie import PydanticObjectId
+from bson.errors import InvalidId
+from pymongo.errors import DuplicateKeyError
+
+from ..exceptions import EmailAlreadyRegisteredError, HandleConflictError
+from ..models import User
+from ..models.common import utcnow
+
+HANDLE_MIN_LENGTH = 3
+HANDLE_MAX_LENGTH = 30
+_HANDLE_PATTERN = re.compile(r"^[A-Za-z0-9-]+$")
+
+# Only these fields are writable through the profile-update path. Everything else
+# on the User document (email, subscription_tier, oauth_*) is off-limits here so a
+# PATCH body cannot escalate privileges or hijack an OAuth identity.
+_UPDATABLE_FIELDS = ("display_name", "handle", "bio", "style_tags")
+
+
+class HandleValidationError(ValueError):
+    """A handle failed format validation. The message is safe to show the user."""
+
+
+def validate_handle(handle: str) -> str:
+    """Return ``handle`` unchanged if it is well-formed, else raise.
+
+    Rules: 3–30 characters, letters/digits/hyphens only. Each failure mode gets a
+    distinct message so the API can tell the user exactly what to fix.
+    """
+    if len(handle) < HANDLE_MIN_LENGTH:
+        raise HandleValidationError(f"Handle must be at least {HANDLE_MIN_LENGTH} characters.")
+    if len(handle) > HANDLE_MAX_LENGTH:
+        raise HandleValidationError(f"Handle must be at most {HANDLE_MAX_LENGTH} characters.")
+    if not _HANDLE_PATTERN.match(handle):
+        raise HandleValidationError("Handle may contain only letters, numbers, and hyphens.")
+    return handle
+
+
+def _to_object_id(user_id: str | PydanticObjectId) -> PydanticObjectId | None:
+    if isinstance(user_id, PydanticObjectId):
+        return user_id
+    try:
+        return PydanticObjectId(user_id)
+    except (InvalidId, ValueError, TypeError):
+        return None
+
+
+async def get_user_by_id(user_id: str | PydanticObjectId) -> User | None:
+    """Fetch a user by id. Returns ``None`` for unknown or malformed ids."""
+    oid = _to_object_id(user_id)
+    if oid is None:
+        return None
+    return await User.get(oid)
+
+
+async def get_or_create_user(*, email: str, provider: str, oauth_id: str, name: str) -> User:
+    """Find the user for an OAuth identity, creating one on first login.
+
+    This is the canonical upsert US-8.3's callback invokes. On creation the
+    profile ``display_name`` is seeded from the provider-reported ``name``.
+
+    Raises :class:`EmailAlreadyRegisteredError` when the verified email already
+    belongs to a *different* OAuth identity (single-identity model; linking is
+    future work).
+    """
+    user = await User.find_one(User.oauth_provider == provider, User.oauth_id == oauth_id)
+    if user is not None:
+        # Known identity. The provider may report a changed email; only apply it
+        # when the address is free (or already ours), otherwise keep our current
+        # email so the user still logs into their own account without violating
+        # the unique index.
+        email_owner = await User.find_one(User.email == email)
+        if email_owner is None or email_owner.id == user.id:
+            user.email = email
+            user.name = name
+            user.updated_at = utcnow()
+            await user.save()
+        return user
+
+    if await User.find_one(User.email == email) is not None:
+        raise EmailAlreadyRegisteredError(email)
+
+    user = User(
+        email=email,
+        name=name,
+        display_name=name,
+        oauth_provider=provider,
+        oauth_id=oauth_id,
+    )
+    await user.insert()
+    return user
+
+
+async def update_user_profile(user_id: str | PydanticObjectId, updates: dict) -> User | None:
+    """Apply profile ``updates`` to the user, returning the saved document.
+
+    Only :data:`_UPDATABLE_FIELDS` are written; unknown keys are ignored. Returns
+    ``None`` if the user does not exist. Raises :class:`HandleConflictError` if the
+    requested handle is already taken, and :class:`HandleValidationError` if a
+    provided handle is malformed (defense in depth — the API schema validates first).
+    """
+    user = await get_user_by_id(user_id)
+    if user is None:
+        return None
+
+    fields = {k: v for k, v in updates.items() if k in _UPDATABLE_FIELDS}
+    if "handle" in fields and fields["handle"] is not None:
+        validate_handle(fields["handle"])
+
+    for field, value in fields.items():
+        setattr(user, field, value)
+    user.updated_at = utcnow()
+
+    try:
+        await user.save()
+    except DuplicateKeyError as exc:
+        raise HandleConflictError(fields.get("handle")) from exc
+    return user

--- a/src/acemusic/api/services/users.py
+++ b/src/acemusic/api/services/users.py
@@ -19,7 +19,9 @@ from ..models.common import utcnow
 
 HANDLE_MIN_LENGTH = 3
 HANDLE_MAX_LENGTH = 30
-_HANDLE_PATTERN = re.compile(r"^[A-Za-z0-9-]+$")
+# Letters/digits/hyphens, but must start and end with an alphanumeric — so
+# "-foo", "foo-" and "---" are rejected as the entry errors they look like.
+_HANDLE_PATTERN = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$")
 
 # Only these fields are writable through the profile-update path. Everything else
 # on the User document (email, subscription_tier, oauth_*) is off-limits here so a
@@ -42,7 +44,9 @@ def validate_handle(handle: str) -> str:
     if len(handle) > HANDLE_MAX_LENGTH:
         raise HandleValidationError(f"Handle must be at most {HANDLE_MAX_LENGTH} characters.")
     if not _HANDLE_PATTERN.match(handle):
-        raise HandleValidationError("Handle may contain only letters, numbers, and hyphens.")
+        raise HandleValidationError(
+            "Handle may contain only letters, numbers, and hyphens, " "and must start and end with a letter or number."
+        )
     return handle
 
 
@@ -97,7 +101,19 @@ async def get_or_create_user(*, email: str, provider: str, oauth_id: str, name: 
         oauth_provider=provider,
         oauth_id=oauth_id,
     )
-    await user.insert()
+    try:
+        await user.insert()
+    except DuplicateKeyError:
+        # A concurrent first-login for the same identity (or email) raced us
+        # between the checks above and this insert. The unique indexes are the
+        # real guard, so re-resolve rather than 500: if our identity won
+        # elsewhere, return that row (first-login is idempotent); if a different
+        # identity claimed the email first, surface the same 409 as the non-race
+        # path.
+        existing = await User.find_one(User.oauth_provider == provider, User.oauth_id == oauth_id)
+        if existing is not None:
+            return existing
+        raise EmailAlreadyRegisteredError(email) from None
     return user
 
 
@@ -124,5 +140,9 @@ async def update_user_profile(user_id: str | PydanticObjectId, updates: dict) ->
     try:
         await user.save()
     except DuplicateKeyError as exc:
+        # ``handle`` is the only writable field (see _UPDATABLE_FIELDS) that
+        # carries a unique index, so a duplicate-key error on this path can only
+        # be a handle collision. If a future writable field gains a unique index,
+        # narrow this catch (inspect exc.details) so it isn't misreported as 409.
         raise HandleConflictError(fields.get("handle")) from exc
     return user

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -1,0 +1,125 @@
+"""Tests for the user profile service layer (US-8.4).
+
+Handle-validation tests are pure (no DB). Service-function tests run against a
+real local MongoDB via the ``mongo_db`` fixture (same pattern as the auth
+service/route tests) — no mocking of the database.
+"""
+
+import pytest
+
+from acemusic.api.exceptions import EmailAlreadyRegisteredError, HandleConflictError
+from acemusic.api.services import users as user_service
+from acemusic.api.services.users import HandleValidationError, validate_handle
+
+
+class TestHandleValidation:
+    @pytest.mark.parametrize("handle", ["abc", "a-b-c", "User123", "x" * 30, "a1-b2-c3"])
+    def test_accepts_valid_handles(self, handle):
+        assert validate_handle(handle) == handle
+
+    def test_rejects_too_short(self):
+        with pytest.raises(HandleValidationError) as exc:
+            validate_handle("ab")
+        assert "at least" in str(exc.value).lower()
+
+    def test_rejects_too_long(self):
+        with pytest.raises(HandleValidationError) as exc:
+            validate_handle("x" * 31)
+        assert "at most" in str(exc.value).lower()
+
+    @pytest.mark.parametrize("handle", ["bad handle", "no_underscores", "emoji😀", "dot.dot", "slash/x"])
+    def test_rejects_invalid_characters(self, handle):
+        with pytest.raises(HandleValidationError) as exc:
+            validate_handle(handle)
+        msg = str(exc.value).lower()
+        assert "letters" in msg or "hyphen" in msg
+
+
+@pytest.mark.integration
+class TestGetOrCreateUser:
+    async def test_creates_new_user_with_oauth_defaults(self, mongo_db):
+        from acemusic.api.models import User
+
+        user = await user_service.get_or_create_user(
+            email="newbie@example.com", provider="google", oauth_id="g-new", name="Newbie"
+        )
+        assert user.email == "newbie@example.com"
+        assert user.name == "Newbie"
+        # Display name defaults to the OAuth-provided name on first login.
+        assert user.display_name == "Newbie"
+        assert user.oauth_provider == "google"
+        # Persisted, not just constructed.
+        assert await User.get(user.id) is not None
+
+    async def test_returns_existing_user_for_known_identity(self, mongo_db):
+        first = await user_service.get_or_create_user(
+            email="repeat@example.com", provider="google", oauth_id="g-repeat", name="Repeat"
+        )
+        again = await user_service.get_or_create_user(
+            email="repeat@example.com", provider="google", oauth_id="g-repeat", name="Repeat"
+        )
+        assert again.id == first.id
+
+    async def test_raises_when_email_owned_by_different_provider(self, mongo_db):
+        await user_service.get_or_create_user(
+            email="shared@example.com", provider="google", oauth_id="g-1", name="Shared"
+        )
+        with pytest.raises(EmailAlreadyRegisteredError):
+            await user_service.get_or_create_user(
+                email="shared@example.com", provider="discord", oauth_id="d-1", name="Shared"
+            )
+
+
+@pytest.mark.integration
+class TestUpdateUserProfile:
+    async def test_updates_allowed_fields(self, mongo_db):
+        user = await user_service.get_or_create_user(
+            email="editor@example.com", provider="google", oauth_id="g-edit", name="Editor"
+        )
+        updated = await user_service.update_user_profile(
+            str(user.id),
+            {"display_name": "Edited", "handle": "editor-1", "bio": "hi", "style_tags": ["lofi"]},
+        )
+        assert updated.display_name == "Edited"
+        assert updated.handle == "editor-1"
+        assert updated.bio == "hi"
+        assert updated.style_tags == ["lofi"]
+        assert updated.updated_at is not None
+
+    async def test_ignores_unknown_fields(self, mongo_db):
+        user = await user_service.get_or_create_user(
+            email="safe@example.com", provider="google", oauth_id="g-safe", name="Safe"
+        )
+        updated = await user_service.update_user_profile(
+            str(user.id), {"subscription_tier": "pro", "email": "hacked@example.com"}
+        )
+        # Non-profile fields are not writable through this path.
+        assert updated.subscription_tier == "free"
+        assert updated.email == "safe@example.com"
+
+    async def test_duplicate_handle_raises_conflict(self, mongo_db):
+        a = await user_service.get_or_create_user(email="a@example.com", provider="google", oauth_id="g-a", name="A")
+        b = await user_service.get_or_create_user(email="b@example.com", provider="google", oauth_id="g-b", name="B")
+        await user_service.update_user_profile(str(a.id), {"handle": "taken"})
+        with pytest.raises(HandleConflictError):
+            await user_service.update_user_profile(str(b.id), {"handle": "taken"})
+
+    async def test_returns_none_for_unknown_user(self, mongo_db):
+        from bson import ObjectId
+
+        result = await user_service.update_user_profile(str(ObjectId()), {"bio": "x"})
+        assert result is None
+
+
+@pytest.mark.integration
+class TestGetUserById:
+    async def test_returns_user(self, mongo_db):
+        user = await user_service.get_or_create_user(
+            email="byid@example.com", provider="google", oauth_id="g-byid", name="ById"
+        )
+        found = await user_service.get_user_by_id(str(user.id))
+        assert found is not None
+        assert found.id == user.id
+
+    async def test_returns_none_for_malformed_id(self, mongo_db):
+        assert await user_service.get_user_by_id("not-an-object-id") is None

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -27,7 +27,10 @@ class TestHandleValidation:
             validate_handle("x" * 31)
         assert "at most" in str(exc.value).lower()
 
-    @pytest.mark.parametrize("handle", ["bad handle", "no_underscores", "emoji😀", "dot.dot", "slash/x"])
+    @pytest.mark.parametrize(
+        "handle",
+        ["bad handle", "no_underscores", "emoji😀", "dot.dot", "slash/x", "-lead", "trail-", "---"],
+    )
     def test_rejects_invalid_characters(self, handle):
         with pytest.raises(HandleValidationError) as exc:
             validate_handle(handle)
@@ -67,6 +70,81 @@ class TestGetOrCreateUser:
         with pytest.raises(EmailAlreadyRegisteredError):
             await user_service.get_or_create_user(
                 email="shared@example.com", provider="discord", oauth_id="d-1", name="Shared"
+            )
+
+    async def test_concurrent_first_login_is_idempotent(self, mongo_db):
+        """Concurrent first-logins for one identity stay idempotent against the
+        real DB: whatever the interleaving, they resolve to one user and one row."""
+        import asyncio
+
+        from acemusic.api.models import User
+
+        results = await asyncio.gather(
+            *[
+                user_service.get_or_create_user(
+                    email="race@example.com", provider="google", oauth_id="g-race", name="Racer"
+                )
+                for _ in range(6)
+            ]
+        )
+        assert len({str(u.id) for u in results}) == 1
+        assert await User.find(User.email == "race@example.com").count() == 1
+
+    async def test_insert_race_recovers_to_winning_identity(self, mongo_db, monkeypatch):
+        """If a concurrent worker commits our identity first, the losing insert's
+        DuplicateKeyError is recovered to that winner row (idempotent first-login).
+
+        The DB is real; we only *inject* the race that ``asyncio.gather`` cannot
+        trigger deterministically — the fake insert commits the winner via the raw
+        collection, then raises the duplicate-key error our code must handle.
+        """
+        from pymongo.errors import DuplicateKeyError
+
+        from acemusic.api.models import User
+        from acemusic.api.models.common import utcnow
+
+        coll = User.get_pymongo_collection()
+
+        async def winner_then_collide(self):
+            await coll.insert_one(
+                {
+                    "email": "win@example.com",
+                    "name": "Winner",
+                    "display_name": "Winner",
+                    "oauth_provider": "google",
+                    "oauth_id": "g-win",
+                    "subscription_tier": "free",
+                    "handle": None,
+                    "bio": None,
+                    "style_tags": [],
+                    "avatar_url": None,
+                    "created_at": utcnow(),
+                    "updated_at": None,
+                }
+            )
+            raise DuplicateKeyError("E11000 duplicate key (simulated race)")
+
+        monkeypatch.setattr(User, "insert", winner_then_collide)
+        result = await user_service.get_or_create_user(
+            email="win@example.com", provider="google", oauth_id="g-win", name="Winner"
+        )
+        assert result.oauth_id == "g-win"
+        assert await User.find(User.email == "win@example.com").count() == 1
+
+    async def test_insert_race_on_foreign_email_raises_conflict(self, mongo_db, monkeypatch):
+        """If the insert collides but no row exists for our identity (a different
+        identity grabbed the email mid-flight), we surface the same 409 signal."""
+        from pymongo.errors import DuplicateKeyError
+
+        from acemusic.api.models import User
+
+        async def always_collide(self):
+            raise DuplicateKeyError("E11000 duplicate key (simulated race)")
+
+        monkeypatch.setattr(User, "insert", always_collide)
+        with pytest.raises(EmailAlreadyRegisteredError):
+            await user_service.get_or_create_user(
+                email="foreign@example.com", provider="google", oauth_id="g-foreign", name="Foreign"
             )
 
 
@@ -123,3 +201,10 @@ class TestGetUserById:
 
     async def test_returns_none_for_malformed_id(self, mongo_db):
         assert await user_service.get_user_by_id("not-an-object-id") is None
+
+    async def test_accepts_object_id_instance(self, mongo_db):
+        user = await user_service.get_or_create_user(
+            email="oid@example.com", provider="google", oauth_id="g-oid", name="Oid"
+        )
+        found = await user_service.get_user_by_id(user.id)  # pass the ObjectId directly
+        assert found is not None and found.id == user.id

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -1,0 +1,178 @@
+"""Integration tests for the user profile endpoints (US-8.4).
+
+Drives the real app with ``httpx.AsyncClient`` over ``ASGITransport`` against a
+local MongoDB (the ``mongo_db`` fixture), mirroring ``tests/test_auth_routes.py``.
+``AsyncClient`` (not Starlette's ``TestClient``) is required so requests run on
+the same event loop the Mongo client was initialised on.
+"""
+
+import httpx
+import pytest
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+
+pytestmark = pytest.mark.integration
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # mongo_db initialises Beanie against the isolated DB on this test's loop.
+    return mongo_settings.model_copy(update={"jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx"})
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str, name: str = "Test User"):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name=name)
+
+
+class TestGetProfile:
+    async def test_returns_full_profile(self, client, settings):
+        user = await _make_user("get-me@example.com", name="Getter")
+        resp = await client.get(f"{API_V1_PREFIX}/users/me", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["email"] == "get-me@example.com"
+        assert body["display_name"] == "Getter"
+        assert body["id"] == str(user.id)
+        assert "handle" in body and "bio" in body and "style_tags" in body and "avatar_url" in body
+
+    async def test_requires_authentication(self, client, settings):
+        resp = await client.get(f"{API_V1_PREFIX}/users/me")
+        assert resp.status_code == 401
+
+
+class TestUpdateProfile:
+    async def test_updates_fields_and_returns_updated_profile(self, client, settings):
+        user = await _make_user("patch-me@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"display_name": "Patched", "handle": "patched-one", "bio": "b", "style_tags": ["edm"]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["display_name"] == "Patched"
+        assert body["handle"] == "patched-one"
+        assert body["bio"] == "b"
+        assert body["style_tags"] == ["edm"]
+
+    async def test_invalid_handle_returns_422(self, client, settings):
+        user = await _make_user("bad-handle@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"handle": "no spaces"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        # Error mentions the format requirement, not a generic message.
+        detail = resp.json()["detail"]
+        assert any("letters" in str(d).lower() or "hyphen" in str(d).lower() for d in detail)
+
+    async def test_too_short_handle_returns_422(self, client, settings):
+        user = await _make_user("short-handle@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"handle": "ab"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_duplicate_handle_returns_409(self, client, settings):
+        owner = await _make_user("owner@example.com")
+        other = await _make_user("other@example.com")
+        first = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"handle": "the-one"},
+            headers=_auth_headers(owner, settings),
+        )
+        assert first.status_code == 200
+        clash = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"handle": "the-one"},
+            headers=_auth_headers(other, settings),
+        )
+        assert clash.status_code == 409
+
+    async def test_empty_body_returns_current_profile(self, client, settings):
+        user = await _make_user("noop@example.com", name="NoOp")
+        resp = await client.patch(f"{API_V1_PREFIX}/users/me", json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["display_name"] == "NoOp"
+
+    async def test_handle_can_be_cleared(self, client, settings):
+        user = await _make_user("clear@example.com")
+        await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"handle": "to-clear"},
+            headers=_auth_headers(user, settings),
+        )
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"handle": None},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["handle"] is None
+
+    async def test_unknown_field_rejected(self, client, settings):
+        user = await _make_user("strict@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"subscription_tier": "pro"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_requires_authentication(self, client, settings):
+        resp = await client.patch(f"{API_V1_PREFIX}/users/me", json={"bio": "x"})
+        assert resp.status_code == 401
+
+
+class TestMissingUser:
+    """Token valid, but the referenced user no longer exists (e.g. deleted)."""
+
+    def _orphan_headers(self, settings: ApiSettings) -> dict[str, str]:
+        from bson import ObjectId
+
+        token = create_access_token(
+            user_id=str(ObjectId()),
+            email="ghost@example.com",
+            subscription_tier="free",
+            settings=settings,
+        )
+        return {"Authorization": f"Bearer {token}"}
+
+    async def test_get_returns_404(self, client, settings):
+        resp = await client.get(f"{API_V1_PREFIX}/users/me", headers=self._orphan_headers(settings))
+        assert resp.status_code == 404
+
+    async def test_patch_returns_404(self, client, settings):
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"bio": "x"},
+            headers=self._orphan_headers(settings),
+        )
+        assert resp.status_code == 404

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -100,6 +100,24 @@ class TestUpdateProfile:
         )
         assert resp.status_code == 422
 
+    async def test_oversized_bio_returns_422(self, client, settings):
+        user = await _make_user("big-bio@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"bio": "x" * 501},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_too_many_style_tags_returns_422(self, client, settings):
+        user = await _make_user("many-tags@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"style_tags": [f"tag{i}" for i in range(21)]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
     async def test_duplicate_handle_returns_409(self, client, settings):
         owner = await _make_user("owner@example.com")
         other = await _make_user("other@example.com")

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -118,6 +118,59 @@ class TestUpdateProfile:
         )
         assert resp.status_code == 422
 
+    @pytest.mark.parametrize("handle", ["-lead", "trail-", "---"])
+    async def test_leading_or_trailing_hyphen_returns_422(self, client, settings, handle):
+        user = await _make_user(f"hyphen-{handle}@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"handle": handle},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_empty_display_name_returns_422(self, client, settings):
+        user = await _make_user("empty-name@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"display_name": ""},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_style_tags_are_stripped(self, client, settings):
+        user = await _make_user("strip-tags@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"style_tags": ["  lofi  ", "edm "]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["style_tags"] == ["lofi", "edm"]
+
+    async def test_blank_style_tag_returns_422(self, client, settings):
+        user = await _make_user("blank-tag@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"style_tags": ["ok", "   "]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_null_style_tags_clears_to_empty_list(self, client, settings):
+        user = await _make_user("null-tags@example.com")
+        await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"style_tags": ["lofi"]},
+            headers=_auth_headers(user, settings),
+        )
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"style_tags": None},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["style_tags"] == []
+
     async def test_duplicate_handle_returns_409(self, client, settings):
         owner = await _make_user("owner@example.com")
         other = await _make_user("other@example.com")


### PR DESCRIPTION
## Summary
Implements #72: User registration and profile CRUD.

- **User model** extended with `display_name`, `handle`, `bio`, `style_tags`, `avatar_url` and a **partial unique index** on `handle` (partial so the many users with a null handle don't collide — mirrors the existing OAuth-identity index).
- **`services/users.py`** (new service layer, mirroring `auth/services.py`):
  - `get_or_create_user(...)` — the canonical OAuth upsert; seeds `display_name` from the provider name on first login.
  - `update_user_profile(...)` — whitelists writable fields, translates `DuplicateKeyError` → `HandleConflictError`.
  - `get_user_by_id(...)` — `None` on unknown/malformed id.
  - `validate_handle(...)` — 3–30 chars, alphanumeric + hyphens, distinct message per failure mode.
- **`routers/users.py`** — `GET /api/v1/users/me` and `PATCH /api/v1/users/me`. Invalid handle → 422 (Pydantic); duplicate handle → 409. `display_name`/`bio`/`style_tags` are size-bounded.
- **OAuth callback refactor** — now delegates to `get_or_create_user`; cross-provider email collision still returns the same 409. All existing auth tests stay green.
- `HandleConflictError` → 409 mapped at the app level; new `exceptions.py` keeps the service layer HTTP-agnostic.

## Acceptance Criteria
- [x] First login creates a user record with data from the OAuth provider
- [x] `GET /api/v1/users/me` returns the full profile for the authenticated user
- [x] `PATCH /api/v1/users/me` updates fields and returns the updated profile
- [x] Duplicate handle returns 409 Conflict
- [x] Invalid handle format returns 422 with a descriptive error

## Test Plan
- [x] Tests written first (RED → GREEN); pure handle-validation unit tests + real-mongod integration tests (no mocking, per project standard)
- [x] All tests passing — default suite 990 passed; mongo integration 87 passed
- [x] Diff coverage 99% on changed lines (gate: ≥85%, new code only)
- [x] Linting clean (ruff + black)
- [x] Internal code review (advisory) completed — no Critical/Major
- [x] Cross-family review pass: **codex** — no actionable correctness issues
- [x] Test mutation sanity check completed (min-length + 409 mutations both fail the suite)

## Known Limitations / Intentionally Deferred
- **Avatar upload (`PUT /api/v1/users/me/avatar`)** — deferred to **US-8.5** (file storage). The `avatar_url` field exists on the model/response but there is no upload endpoint yet (confirmed with the issue owner). Functional requirement, not an acceptance criterion.
- **Handle uniqueness is case-sensitive** — `taken` and `Taken` are distinct handles. The literal AC (exact-duplicate → 409) is met; case-insensitive uniqueness (lowercasing or a case-insensitive collation on the index) to prevent look-alike impersonation is a follow-up.
- **Multi-identity account linking** — a verified email already registered under a different OAuth provider still returns 409 (single-identity model, unchanged from US-8.3).

## Implementation Notes
- CodeRabbit's issue plan assumed US-8.2 had delivered a complete `User` model; it had not, so this PR extends the model (Step 1) before adding the API surface.
- Schemas are defined inline in the router (matching the existing `auth` router convention) rather than a separate `schemas/` package.
- Tests use the codebase's `httpx.AsyncClient` + `mongo_db` integration pattern (real local MongoDB), not the plan's mocked-DB/`TestClient` approach.

Closes #72