### PR TITLE
feat: async job queue and processing (US-9.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,17 @@ ACEMUSIC_API_REFRESH_TOKEN_EXPIRE_DAYS=7
 ACEMUSIC_API_OAUTH_COOKIE_SECURE=true
 ACEMUSIC_API_OAUTH_COOKIE_SAMESITE=lax
 
+# Async job processor (US-9.2). A background task in the API process polls MongoDB
+# for queued generation jobs and runs them. JOB_CONCURRENCY bounds how many run at
+# once; JOB_POLL_INTERVAL is the idle sleep (seconds) between polls when the queue
+# is empty; JOB_POLL_TIMEOUT caps how long a single job waits for ACE-Step before
+# it is marked failed. Set JOB_PROCESSOR_ENABLED=false to run the API without the
+# worker (e.g. a separate worker deployment).
+ACEMUSIC_API_JOB_CONCURRENCY=2
+ACEMUSIC_API_JOB_POLL_INTERVAL=1.0
+ACEMUSIC_API_JOB_POLL_TIMEOUT=600.0
+ACEMUSIC_API_JOB_PROCESSOR_ENABLED=true
+
 # File storage abstraction (US-8.5). Selects how audio files are stored.
 # local = filesystem (development); s3 = S3-compatible bucket (production).
 ACEMUSIC_STORAGE_BACKEND=local

--- a/README.md
+++ b/README.md
@@ -75,10 +75,23 @@ environment variables (see `.env.example`); cookie behavior is tuned via
 | Endpoint | Purpose |
 | --- | --- |
 | `POST /api/v1/generate` | Submits a generation request and returns a `job_id` for async tracking (HTTP 202) |
+| `GET /api/v1/jobs/{id}/status` | Returns a job's current status; owner-scoped (404 for missing or other users' jobs) |
 
-The request body accepts the full creative parameter set: `prompt` (required), `style`, `lyrics`, `vocal_language`, `instrumental`, `bpm` (60–180 or `"auto"`), `key`, `time_signature`, `duration`, `seed`, `inference_steps`, `model`, `weirdness` (0–100), `style_influence` (0–100), `format` (`wav`/`flac`/`mp3`/`aac`/`opus`), `thinking`, `mode` (`song`|`sound`), and `sound_type` (`one-shot`|`loop`, required when `mode` is `sound`). The job is created with status `queued`; execution is handled asynchronously (US-9.2).
+The request body accepts the full creative parameter set: `prompt` (required), `style`, `lyrics`, `vocal_language`, `instrumental`, `bpm` (60–180 or `"auto"`), `key`, `time_signature`, `duration`, `seed`, `inference_steps`, `model`, `weirdness` (0–100), `style_influence` (0–100), `format` (`wav`/`flac`/`mp3`/`aac`/`opus`), `thinking`, `mode` (`song`|`sound`), and `sound_type` (`one-shot`|`loop`, required when `mode` is `sound`). The job is created with status `queued` and picked up by the async processor (US-9.2).
 
-Invalid parameters return 422 with field-level errors. The response includes `job_id`, `status: "queued"`, and `estimated_time_seconds`.
+Invalid parameters return 422 with field-level errors. The create response includes `job_id`, `status: "queued"`, and `estimated_time_seconds`.
+
+The status endpoint returns `job_id`, `status` (`queued`|`processing`|`completed`|`failed`), `created_at`, and `estimated_time_seconds`. Completed jobs additionally include `clip_ids` and `audio_urls`; failed jobs include an `error` message.
+
+#### Async job processor (US-9.2)
+
+A background processor runs inside the API process, polling MongoDB for `queued`
+jobs, forwarding them to ACE-Step, storing the audio via the storage abstraction,
+and creating clip records before marking the job `completed` (or `failed` with an
+error). Tunables (all prefixed `ACEMUSIC_API_`): `JOB_CONCURRENCY` (default 2),
+`JOB_POLL_INTERVAL` seconds (default 1.0), `JOB_POLL_TIMEOUT` seconds (default
+600), and `JOB_PROCESSOR_ENABLED` (default `true`; set `false` to run the API
+without the worker — recommended to run a single processor instance).
 
 ## Stem separation backends
 

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -20,8 +20,9 @@ from acemusic import __version__
 
 from . import database
 from .exceptions import HandleConflictError
-from .routers import auth, generation, health, users
+from .routers import auth, generation, health, jobs, users
 from .settings import ApiSettings
+from .tasks.processor import JobProcessor
 
 API_V1_PREFIX = "/api/v1"
 
@@ -61,9 +62,25 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     async def lifespan(app_: FastAPI):
         client = await database.init_db(settings)
         app_.state.mongo_client = client
+        # Start the background job processor (US-9.2) once the DB is up. It polls
+        # for queued jobs and runs them in-process; disable it (or run a
+        # processor-less API) via ACEMUSIC_API_JOB_PROCESSOR_ENABLED=false. The
+        # try/finally wraps processor start too, so a start() failure still closes
+        # the DB client rather than leaking it.
+        processor: JobProcessor | None = None
         try:
+            if settings.job_processor_enabled:
+                processor = JobProcessor(
+                    concurrency=settings.job_concurrency,
+                    poll_interval=settings.job_poll_interval,
+                    poll_timeout=settings.job_poll_timeout,
+                )
+                await processor.start()
+            app_.state.job_processor = processor
             yield
         finally:
+            if processor is not None:
+                await processor.stop()
             await database.close_db(client)
 
     app = FastAPI(
@@ -97,6 +114,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(auth.router, prefix=API_V1_PREFIX)
     app.include_router(users.router, prefix=API_V1_PREFIX)
     app.include_router(generation.router, prefix=API_V1_PREFIX)
+    app.include_router(jobs.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/models/job.py
+++ b/src/acemusic/api/models/job.py
@@ -40,5 +40,9 @@ class Job(Document):
         name = "jobs"
         indexes = [
             IndexModel([("user_id", ASCENDING)]),
-            IndexModel([("status", ASCENDING)]),
+            # Serves the processor's claim/requeue queries (US-9.2): filter by
+            # (status, job_type) and sort by created_at, so a worker claims the
+            # oldest queued job from the index rather than scanning the
+            # collection. The (status) prefix also covers plain status lookups.
+            IndexModel([("status", ASCENDING), ("job_type", ASCENDING), ("created_at", ASCENDING)]),
         ]

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -1,0 +1,103 @@
+"""Job status endpoint (US-9.2), mounted under ``/api/v1/jobs``.
+
+``GET /api/v1/jobs/{job_id}/status`` returns a job's current lifecycle state so a
+client can poll while generation runs asynchronously. The route is owner-scoped:
+a job that does not exist *or* belongs to another user yields 404, so the
+endpoint never reveals the existence of another user's jobs.
+"""
+
+import asyncio
+from datetime import datetime
+
+from beanie import PydanticObjectId
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from acemusic.storage import get_storage_backend
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import Clip, Job, JobStatus
+from .generation import GenerationRequest, estimate_seconds
+
+# Router-level dependency gates every route behind a valid Bearer token (mirrors
+# the generation router), so an unauthenticated request is rejected with 401.
+router = APIRouter(prefix="/jobs", tags=["jobs"], dependencies=[Depends(get_current_user)])
+
+
+class JobStatusResponse(BaseModel):
+    """A job's current state. Result fields are populated by lifecycle phase.
+
+    ``response_model_exclude_none`` drops the optional fields until they apply:
+    ``clip_ids``/``audio_urls`` appear only when completed, ``error`` only when
+    failed.
+    """
+
+    job_id: str
+    status: JobStatus
+    created_at: datetime
+    estimated_time_seconds: int
+    clip_ids: list[str] | None = None
+    audio_urls: list[str] | None = None
+    error: str | None = None
+
+
+def _coerce_object_id(value: str) -> PydanticObjectId | None:
+    """Parse a path id, treating a malformed id as "no such job" (caller → 404)."""
+    try:
+        return PydanticObjectId(value)
+    except Exception:
+        return None
+
+
+def _estimate_for(job: Job) -> int:
+    """Re-derive the advisory estimate from the persisted request snapshot.
+
+    Reuses the generation router's heuristic so the status and create responses
+    agree. A snapshot that no longer validates (e.g. a schema change) falls back
+    to 0 rather than failing the status read.
+    """
+    try:
+        return estimate_seconds(GenerationRequest(**job.input_params))
+    except Exception:
+        return 0
+
+
+async def _resolve_audio_urls(clip_ids: list[str]) -> list[str]:
+    """Map a completed job's clip ids to retrievable audio URLs via storage."""
+    if not clip_ids:
+        return []
+    storage = get_storage_backend()
+    urls: list[str] = []
+    for clip_id in clip_ids:
+        clip = await Clip.get(clip_id)
+        if clip is None:
+            continue
+        # get_url may hit the network (S3 presign), so keep it off the event loop.
+        urls.append(await asyncio.to_thread(storage.get_url, clip.file_path))
+    return urls
+
+
+@router.get("/{job_id}/status", response_model=JobStatusResponse, response_model_exclude_none=True)
+async def get_job_status(
+    job_id: str,
+    current: CurrentUser = Depends(get_current_user),
+) -> JobStatusResponse:
+    """Return the current status of ``job_id`` for its owner (404 otherwise)."""
+    oid = _coerce_object_id(job_id)
+    job = await Job.get(oid) if oid is not None else None
+    if job is None or str(job.user_id) != current.user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found.")
+
+    response = JobStatusResponse(
+        job_id=str(job.id),
+        status=job.status,
+        created_at=job.created_at,
+        estimated_time_seconds=_estimate_for(job),
+    )
+    if job.status == JobStatus.COMPLETED:
+        clip_ids = list((job.result or {}).get("clip_ids", []))
+        response.clip_ids = clip_ids
+        response.audio_urls = await _resolve_audio_urls(clip_ids)
+    elif job.status == JobStatus.FAILED:
+        response.error = job.error
+    return response

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -7,6 +7,7 @@ endpoint never reveals the existence of another user's jobs.
 """
 
 import asyncio
+import logging
 from datetime import datetime
 
 from beanie import PydanticObjectId
@@ -18,6 +19,8 @@ from acemusic.storage import get_storage_backend
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import Clip, Job, JobStatus
 from .generation import GenerationRequest, estimate_seconds
+
+logger = logging.getLogger(__name__)
 
 # Router-level dependency gates every route behind a valid Bearer token (mirrors
 # the generation router), so an unauthenticated request is rejected with 401.
@@ -71,6 +74,9 @@ async def _resolve_audio_urls(clip_ids: list[str]) -> list[str]:
     for clip_id in clip_ids:
         clip = await Clip.get(clip_id)
         if clip is None:
+            # The processor inserts clips atomically with the job result, so a
+            # missing one signals a data inconsistency worth surfacing.
+            logger.warning("Clip %s referenced by a completed job is missing", clip_id)
             continue
         # get_url may hit the network (S3 presign), so keep it off the event loop.
         urls.append(await asyncio.to_thread(storage.get_url, clip.file_path))

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -78,7 +78,7 @@ class ApiSettings(BaseSettings):
     job_concurrency: int = Field(default=2, ge=1)
     job_poll_interval: float = Field(default=1.0, gt=0)
     job_poll_timeout: float = Field(default=600.0, gt=0)
-    job_processor_enabled: bool = True
+    job_processor_enabled: bool = Field(default=True)
 
     # OAuth ``state`` cookie policy (issue #110, login-CSRF binding). The login
     # flow sets a per-client nonce cookie that the callback requires.

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -69,6 +69,17 @@ class ApiSettings(BaseSettings):
     access_token_expire_minutes: int = Field(default=15, ge=1)
     refresh_token_expire_days: int = Field(default=7, ge=1)
 
+    # Async job processor (US-9.2). The processor runs as a background task inside
+    # the API process, polling MongoDB for queued jobs. ``job_concurrency`` bounds
+    # how many run at once; ``job_poll_interval`` is the idle sleep between polls
+    # when the queue is empty; ``job_poll_timeout`` caps how long a single job
+    # waits for ACE-Step before it is failed. ``job_processor_enabled`` lets a
+    # deployment (or a test) run the API without the background worker.
+    job_concurrency: int = Field(default=2, ge=1)
+    job_poll_interval: float = Field(default=1.0, gt=0)
+    job_poll_timeout: float = Field(default=600.0, gt=0)
+    job_processor_enabled: bool = True
+
     # OAuth ``state`` cookie policy (issue #110, login-CSRF binding). The login
     # flow sets a per-client nonce cookie that the callback requires.
     # ``oauth_cookie_secure`` marks it Secure (HTTPS-only); keep True in

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -275,19 +275,43 @@ class JobProcessor:
         client: AceStepClient,
         audio_urls: list[str],
     ) -> list[str]:
-        """Download each result, store it, and create its Clip record."""
+        """Download each result, store it, and create its Clip record.
+
+        A failure partway through (download/upload/insert error on a later clip)
+        rolls back the clips and files already written, so a job that ends up
+        ``failed`` never leaves orphaned ``Clip`` rows or storage objects behind.
+        """
         storage = self._storage_factory()
         fmt = params.get("format") or "wav"
         clip_ids: list[str] = []
-        for url in audio_urls:
-            data = await asyncio.to_thread(client.download_audio, url)
-            clip_id = PydanticObjectId()
-            path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
-            await asyncio.to_thread(storage.upload, path, data)
-            clip = self._build_clip(job, params, clip_id, path, fmt)
-            await clip.insert()
-            clip_ids.append(str(clip_id))
+        stored: list[tuple[Clip, str]] = []
+        try:
+            for url in audio_urls:
+                data = await asyncio.to_thread(client.download_audio, url)
+                clip_id = PydanticObjectId()
+                path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
+                await asyncio.to_thread(storage.upload, path, data)
+                clip = self._build_clip(job, params, clip_id, path, fmt)
+                await clip.insert()
+                stored.append((clip, path))
+                clip_ids.append(str(clip_id))
+        except Exception:
+            await self._rollback_clips(storage, stored)
+            raise
         return clip_ids
+
+    @staticmethod
+    async def _rollback_clips(storage: StorageBackend, stored: list[tuple[Clip, str]]) -> None:
+        """Best-effort cleanup of clips/files written before a mid-batch failure."""
+        for clip, path in stored:
+            try:
+                await clip.delete()
+            except Exception:  # pragma: no cover - cleanup is best-effort
+                logger.exception("Failed to delete orphaned clip %s during rollback", clip.id)
+            try:
+                await asyncio.to_thread(storage.delete, path)
+            except Exception:  # pragma: no cover - cleanup is best-effort
+                logger.exception("Failed to delete orphaned storage object %s during rollback", path)
 
     @staticmethod
     def _build_submit_kwargs(params: dict[str, Any]) -> dict[str, Any]:
@@ -311,6 +335,8 @@ class JobProcessor:
         fmt: str,
     ) -> Clip:
         """Construct a Clip from a job's params (id pre-assigned to match the path)."""
+        # ``duration`` is the *requested* duration from the job params (ACE-Step
+        # honours it); we store it as the clip's duration metadata.
         # bpm may be the literal "auto"; Clip.bpm is an int, so persist only ints.
         bpm = params.get("bpm")
         style = params.get("style")

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -1,0 +1,356 @@
+"""Async job processor (US-9.2).
+
+A background worker that drives queued generation jobs to completion inside the
+FastAPI process. It polls MongoDB for ``status=queued`` jobs — a stateless,
+restart-safe design that mirrors how a future Celery/Redis swap would behave —
+atomically claims each, runs the ACE-Step generation, stores the audio via the
+storage abstraction, creates :class:`Clip` records, and transitions the job
+``queued -> processing -> completed | failed``.
+
+The ACE-Step client and storage backend are synchronous, so their blocking calls
+run in a worker thread (:func:`asyncio.to_thread`) to keep the event loop
+responsive. Concurrency is bounded by an :class:`asyncio.Semaphore`; :meth:`stop`
+cancels in-flight work for a graceful shutdown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable
+from datetime import timedelta
+from functools import partial
+from typing import Any
+
+from beanie import PydanticObjectId
+from pymongo import ASCENDING, ReturnDocument
+
+from acemusic.client import AceStepClient
+from acemusic.config import load_config
+from acemusic.storage import StorageBackend, get_storage_backend
+
+from .. import database
+from ..models import Clip, Job, JobStatus
+from ..models.common import utcnow
+
+logger = logging.getLogger(__name__)
+
+# query_result already normalises ACE-Step's integer status codes to these.
+_TERMINAL_STATES = {"completed", "failed"}
+
+# input_params is the verbatim GenerationRequest snapshot. submit_task accepts a
+# focused subset; anything else (API-only fields) is ignored. prompt/duration/
+# format are mapped explicitly below.
+_SUBMIT_FIELDS = (
+    "style",
+    "lyrics",
+    "vocal_language",
+    "instrumental",
+    "bpm",
+    "key",
+    "time_signature",
+    "seed",
+    "inference_steps",
+    "weirdness",
+    "style_influence",
+    "thinking",
+    "model",
+    "mode",
+    "sound_type",
+)
+
+
+class JobProcessingError(Exception):
+    """A job could not be processed (ACE-Step failure, timeout, or no output)."""
+
+
+def _default_client_factory() -> AceStepClient:
+    """Build an ACE-Step client from the CLI config (env > .env > config.yaml)."""
+    config = load_config()
+    if not config.api_url:
+        raise JobProcessingError("ACE-Step base URL is not configured (set ACEMUSIC_BASE_URL).")
+    return AceStepClient(base_url=config.api_url, api_key=config.api_key)
+
+
+class JobProcessor:
+    """Background worker pool that processes queued generation jobs.
+
+    The ACE-Step client and storage backend are obtained through factories so
+    tests can inject in-process doubles; production uses the real config-driven
+    client and the configured storage backend.
+    """
+
+    def __init__(
+        self,
+        *,
+        concurrency: int = 2,
+        poll_interval: float = 1.0,
+        poll_timeout: float = 600.0,
+        ace_poll_interval: float = 2.0,
+        stale_after: float | None = None,
+        job_type: str = "generate",
+        client_factory: Callable[[], AceStepClient] | None = None,
+        storage_factory: Callable[[], StorageBackend] | None = None,
+    ) -> None:
+        self._concurrency = concurrency
+        self._semaphore = asyncio.Semaphore(concurrency)
+        self._poll_interval = poll_interval
+        self._poll_timeout = poll_timeout
+        self._ace_poll_interval = ace_poll_interval
+        # A job legitimately stays in `processing` for at most poll_timeout (its
+        # own worker fails it after that). Only re-queue jobs older than that
+        # window plus a margin, so a startup sweep never reclaims a job a live
+        # sibling process is still working — see _requeue_stale_jobs.
+        self._stale_after = stale_after if stale_after is not None else poll_timeout + 300.0
+        self._job_type = job_type
+        self._client_factory = client_factory or _default_client_factory
+        self._storage_factory = storage_factory or get_storage_backend
+        self._running = False
+        self._worker_task: asyncio.Task[None] | None = None
+        self._active: set[asyncio.Task[None]] = set()
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def start(self) -> None:
+        """Re-queue stale jobs, then launch the polling worker. Idempotent."""
+        if self._running:
+            return
+        self._running = True
+        await self._requeue_stale_jobs()
+        self._worker_task = asyncio.create_task(self._run_worker())
+        logger.info("Job processor started (concurrency=%d)", self._concurrency)
+
+    async def stop(self) -> None:
+        """Stop polling and cancel any in-flight jobs, awaiting their unwind."""
+        self._running = False
+        if self._worker_task is not None:
+            self._worker_task.cancel()
+            try:
+                await self._worker_task
+            except asyncio.CancelledError:
+                pass
+            self._worker_task = None
+        active = list(self._active)
+        for task in active:
+            task.cancel()
+        if active:
+            await asyncio.gather(*active, return_exceptions=True)
+        self._active.clear()
+        logger.info("Job processor stopped")
+
+    # -- worker loop -------------------------------------------------------
+
+    async def _run_worker(self) -> None:
+        """Continuously claim and dispatch jobs, bounded by the semaphore."""
+        while self._running:
+            # Acquire a slot *before* claiming: the claim flips status to
+            # processing, so over-claiming would strand jobs with no worker.
+            await self._semaphore.acquire()
+            if not self._running:
+                self._semaphore.release()
+                break
+            try:
+                job = await self._claim_next_job()
+            except asyncio.CancelledError:
+                # Shutdown cancelled us mid-claim: release the slot we hold (the
+                # instance is discarded after stop(), but stay leak-free) and exit.
+                self._semaphore.release()
+                raise
+            except Exception:  # pragma: no cover - defensive: keep the loop alive
+                logger.exception("Failed to claim next job")
+                self._semaphore.release()
+                await asyncio.sleep(self._poll_interval)
+                continue
+            if job is None:
+                self._semaphore.release()
+                await asyncio.sleep(self._poll_interval)
+                continue
+            task = asyncio.create_task(self._process_and_release(job))
+            self._active.add(task)
+            task.add_done_callback(self._active.discard)
+
+    async def _process_and_release(self, job: Job) -> None:
+        try:
+            await self._process_job(job)
+        finally:
+            self._semaphore.release()
+
+    # -- job discovery -----------------------------------------------------
+
+    async def _claim_next_job(self) -> Job | None:
+        """Atomically claim the oldest queued job, or return None if there are none.
+
+        ``find_one_and_update`` is atomic at the document level, so two workers
+        racing for the same job are serialised by MongoDB — exactly one wins.
+        """
+        collection = database.get_database()[Job.Settings.name]
+        doc = await collection.find_one_and_update(
+            {"status": JobStatus.QUEUED.value, "job_type": self._job_type},
+            {"$set": {"status": JobStatus.PROCESSING.value, "started_at": utcnow()}},
+            sort=[("created_at", ASCENDING)],
+            return_document=ReturnDocument.AFTER,
+        )
+        if doc is None:
+            return None
+        # Re-load through Beanie so the rest of the pipeline works with a typed
+        # Job (and its update helpers) rather than a raw BSON dict.
+        job = await Job.get(doc["_id"])
+        if job is None:  # pragma: no cover - claimed doc deleted out from under us
+            logger.error("Claimed job %s vanished before reload; skipping", doc["_id"])
+        return job
+
+    async def _requeue_stale_jobs(self) -> None:
+        """Reset *stale* ``processing`` jobs back to ``queued`` on startup.
+
+        A job left in ``processing`` longer than ``stale_after`` is orphaned: its
+        worker either crashed or was cancelled mid-generation, since a live worker
+        fails a job after ``poll_timeout``. Re-queue only those so they are retried
+        rather than stranded. Bounding by ``started_at`` keeps this safe when more
+        than one API process runs — a job a sibling is actively working (started
+        recently) is never reclaimed. (Running a single processor instance is still
+        the recommended deployment; this is the safety net.)
+        """
+        collection = database.get_database()[Job.Settings.name]
+        cutoff = utcnow() - timedelta(seconds=self._stale_after)
+        result = await collection.update_many(
+            {
+                "status": JobStatus.PROCESSING.value,
+                "job_type": self._job_type,
+                # ``started_at`` missing/None means a legacy/partial claim — also stale.
+                "$or": [{"started_at": {"$lt": cutoff}}, {"started_at": None}],
+            },
+            {"$set": {"status": JobStatus.QUEUED.value, "started_at": None}},
+        )
+        if result.modified_count:
+            logger.info("Re-queued %d stale processing job(s)", result.modified_count)
+
+    # -- single-job processing --------------------------------------------
+
+    async def _process_job(self, job: Job) -> None:
+        """Run one claimed job end-to-end, recording success or failure.
+
+        Cancellation (graceful shutdown) is re-raised, leaving the job in
+        ``processing`` so the next startup re-queues it. Any other error is
+        captured on the job as ``failed`` with its message.
+        """
+        try:
+            client = self._client_factory()
+            params = dict(job.input_params or {})
+
+            task_id = await asyncio.to_thread(partial(client.submit_task, **self._build_submit_kwargs(params)))
+            result = await self._poll_until_complete(client, task_id)
+            if result.get("status") == "failed":
+                raise JobProcessingError(result.get("error") or "ACE-Step generation failed")
+
+            audio_urls = result.get("audio_urls") or []
+            if not audio_urls:
+                raise JobProcessingError("ACE-Step completed but returned no audio")
+
+            clip_ids = await self._store_clips(job, params, client, audio_urls)
+            await self._mark_completed(job, clip_ids)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - any failure must land on the job record
+            logger.exception("Job %s failed", job.id)
+            await self._mark_failed(job, str(exc))
+
+    async def _poll_until_complete(self, client: AceStepClient, task_id: str) -> dict[str, Any]:
+        """Poll query_result until the task reaches a terminal state or times out."""
+        start = time.monotonic()
+        while True:
+            result = await asyncio.to_thread(client.query_result, task_id)
+            if result.get("status") in _TERMINAL_STATES:
+                return result
+            if time.monotonic() - start > self._poll_timeout:
+                raise JobProcessingError(
+                    f"Timed out after {self._poll_timeout:.0f}s waiting for ACE-Step task {task_id}"
+                )
+            await asyncio.sleep(self._ace_poll_interval)
+
+    async def _store_clips(
+        self,
+        job: Job,
+        params: dict[str, Any],
+        client: AceStepClient,
+        audio_urls: list[str],
+    ) -> list[str]:
+        """Download each result, store it, and create its Clip record."""
+        storage = self._storage_factory()
+        fmt = params.get("format") or "wav"
+        clip_ids: list[str] = []
+        for url in audio_urls:
+            data = await asyncio.to_thread(client.download_audio, url)
+            clip_id = PydanticObjectId()
+            path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
+            await asyncio.to_thread(storage.upload, path, data)
+            clip = self._build_clip(job, params, clip_id, path, fmt)
+            await clip.insert()
+            clip_ids.append(str(clip_id))
+        return clip_ids
+
+    @staticmethod
+    def _build_submit_kwargs(params: dict[str, Any]) -> dict[str, Any]:
+        """Map persisted job params onto ``AceStepClient.submit_task`` kwargs."""
+        kwargs: dict[str, Any] = {"prompt": params.get("prompt", "")}
+        if params.get("duration") is not None:
+            kwargs["audio_duration"] = params["duration"]
+        if params.get("format") is not None:
+            kwargs["format"] = params["format"]
+        for field in _SUBMIT_FIELDS:
+            if field in params:
+                kwargs[field] = params[field]
+        return kwargs
+
+    @staticmethod
+    def _build_clip(
+        job: Job,
+        params: dict[str, Any],
+        clip_id: PydanticObjectId,
+        path: str,
+        fmt: str,
+    ) -> Clip:
+        """Construct a Clip from a job's params (id pre-assigned to match the path)."""
+        # bpm may be the literal "auto"; Clip.bpm is an int, so persist only ints.
+        bpm = params.get("bpm")
+        style = params.get("style")
+        return Clip(
+            id=clip_id,
+            user_id=job.user_id,
+            workspace_id=job.workspace_id,
+            file_path=path,
+            format=fmt,
+            duration=params.get("duration"),
+            bpm=bpm if isinstance(bpm, int) else None,
+            key=params.get("key"),
+            style_tags=[style] if isinstance(style, str) and style else [],
+            lyrics=params.get("lyrics"),
+            vocal_language=params.get("vocal_language"),
+            model=params.get("model"),
+            seed=params.get("seed"),
+            inference_steps=params.get("inference_steps"),
+            generation_mode=params.get("mode"),
+        )
+
+    # -- status transitions ------------------------------------------------
+
+    async def _mark_completed(self, job: Job, clip_ids: list[str]) -> None:
+        await job.set(
+            {
+                Job.status: JobStatus.COMPLETED,
+                Job.result: {"clip_ids": clip_ids},
+                Job.completed_at: utcnow(),
+            }
+        )
+
+    async def _mark_failed(self, job: Job, error: str) -> None:
+        try:
+            await job.set(
+                {
+                    Job.status: JobStatus.FAILED,
+                    Job.error: error,
+                    Job.completed_at: utcnow(),
+                }
+            )
+        except Exception:  # pragma: no cover - last-ditch; never crash the worker
+            logger.exception("Failed to record failure for job %s", job.id)

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -146,29 +146,34 @@ class JobProcessor:
         while self._running:
             # Acquire a slot *before* claiming: the claim flips status to
             # processing, so over-claiming would strand jobs with no worker.
+            # acquire() returns holding a permit, or raises (e.g. on cancellation)
+            # holding none — so a raise here leaks nothing. The path from here to
+            # the try below is synchronous, so the permit is never held across an
+            # unguarded suspension point; the finally then releases it on every
+            # path that doesn't hand it to a job task.
             await self._semaphore.acquire()
-            if not self._running:
-                self._semaphore.release()
-                break
+            slot_held = True
             try:
-                job = await self._claim_next_job()
-            except asyncio.CancelledError:
-                # Shutdown cancelled us mid-claim: release the slot we hold (the
-                # instance is discarded after stop(), but stay leak-free) and exit.
-                self._semaphore.release()
-                raise
-            except Exception:  # pragma: no cover - defensive: keep the loop alive
-                logger.exception("Failed to claim next job")
-                self._semaphore.release()
-                await asyncio.sleep(self._poll_interval)
-                continue
-            if job is None:
-                self._semaphore.release()
-                await asyncio.sleep(self._poll_interval)
-                continue
-            task = asyncio.create_task(self._process_and_release(job))
-            self._active.add(task)
-            task.add_done_callback(self._active.discard)
+                if not self._running:
+                    break
+                try:
+                    job = await self._claim_next_job()
+                except Exception:  # pragma: no cover - defensive: keep the loop alive
+                    logger.exception("Failed to claim next job")
+                    job = None
+                if job is None:
+                    # Release before the idle backoff so a freed slot stays usable.
+                    self._semaphore.release()
+                    slot_held = False
+                    await asyncio.sleep(self._poll_interval)
+                    continue
+                task = asyncio.create_task(self._process_and_release(job))
+                self._active.add(task)
+                task.add_done_callback(self._active.discard)
+                slot_held = False  # ownership of the permit passes to the job task
+            finally:
+                if slot_held:
+                    self._semaphore.release()
 
     async def _process_and_release(self, job: Job) -> None:
         try:

--- a/tests/test_generation_api.py
+++ b/tests/test_generation_api.py
@@ -28,7 +28,14 @@ def _async_client(app) -> httpx.AsyncClient:
 @pytest.fixture
 def settings(mongo_db, mongo_settings) -> ApiSettings:
     # mongo_db initialises Beanie against the isolated DB on this test's loop.
-    return mongo_settings.model_copy(update={"jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx"})
+    # Disable the background processor (US-9.2): these tests assert jobs stay
+    # ``queued``, so a worker claiming them mid-test would make them flaky.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
 
 
 @pytest.fixture

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -54,6 +54,7 @@ class _FakeAceClient:
         error: str | None = None,
         pending_forever: bool = False,
         track: _ConcurrencyTracker | None = None,
+        fail_download_after: int | None = None,
     ) -> None:
         self._audio_urls = ["http://ace/a.wav", "http://ace/b.wav"] if audio_urls is None else audio_urls
         self._audio = audio
@@ -61,6 +62,8 @@ class _FakeAceClient:
         self._error = error
         self._pending_forever = pending_forever
         self._track = track
+        self._fail_download_after = fail_download_after
+        self._downloads = 0
         self.submitted: list[dict] = []
 
     def submit_task(self, **kwargs) -> str:
@@ -82,6 +85,9 @@ class _FakeAceClient:
                 self._track.exit()
 
     def download_audio(self, url: str, timeout: float = 120.0) -> bytes:
+        self._downloads += 1
+        if self._fail_download_after is not None and self._downloads > self._fail_download_after:
+            raise RuntimeError("download boom")
         return self._audio
 
 
@@ -266,6 +272,28 @@ class TestLifecycle:
         refreshed = await Job.get(job.id)
         assert refreshed.status == JobStatus.FAILED
         assert "no audio" in (refreshed.error or "").lower()
+
+    async def test_partial_failure_rolls_back_stored_clips(self, mongo_db, tmp_path) -> None:
+        # Second download fails after the first clip is already stored — the job
+        # fails and the first clip's record AND file must be rolled back.
+        import os
+
+        storage = LocalStorage(root_dir=tmp_path)
+        fake = _FakeAceClient(audio_urls=["http://ace/a.wav", "http://ace/b.wav"], fail_download_after=1)
+        proc = _make_processor(fake, storage)
+        job = await _enqueue()
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.FAILED))
+        finally:
+            await proc.stop()
+
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.FAILED
+        assert await Clip.count() == 0, "orphaned clip record not rolled back"
+        leftover = [f for _root, _dirs, files in os.walk(tmp_path) for f in files]
+        assert leftover == [], "orphaned storage file not rolled back"
 
     async def test_two_concurrent_jobs_complete_without_corruption(self, mongo_db, tmp_path) -> None:
         storage = LocalStorage(root_dir=tmp_path)

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -1,0 +1,407 @@
+"""Tests for the async job processor (US-9.2).
+
+Pure helper tests run in CI (no services). The lifecycle/claim/shutdown tests are
+marked ``integration``: they run against a real local MongoDB (``mongo_db``) and a
+real :class:`LocalStorage` backend, with only the external, account-gated ACE-Step
+HTTP client replaced by an in-process double (mirrors ``tests/test_generate.py``).
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+from beanie import PydanticObjectId
+
+from acemusic.api.models import Clip, Job, JobStatus
+from acemusic.api.tasks.processor import JobProcessor
+from acemusic.storage import LocalStorage
+
+# ---------------------------------------------------------------------------
+# In-process ACE-Step double + helpers
+# ---------------------------------------------------------------------------
+
+
+class _ConcurrencyTracker:
+    """Records the peak number of overlapping ``query_result`` calls (real threads)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.current = 0
+        self.max = 0
+
+    def enter(self) -> None:
+        with self._lock:
+            self.current += 1
+            self.max = max(self.max, self.current)
+        # Hold the slot briefly so genuine overlap is observable.
+        time.sleep(0.05)
+
+    def exit(self) -> None:
+        with self._lock:
+            self.current -= 1
+
+
+class _FakeAceClient:
+    """Synchronous ACE-Step stand-in driven by canned results."""
+
+    def __init__(
+        self,
+        *,
+        audio_urls=None,
+        audio: bytes = b"FAKE-WAV-BYTES",
+        status: str = "completed",
+        error: str | None = None,
+        pending_forever: bool = False,
+        track: _ConcurrencyTracker | None = None,
+    ) -> None:
+        self._audio_urls = ["http://ace/a.wav", "http://ace/b.wav"] if audio_urls is None else audio_urls
+        self._audio = audio
+        self._status = status
+        self._error = error
+        self._pending_forever = pending_forever
+        self._track = track
+        self.submitted: list[dict] = []
+
+    def submit_task(self, **kwargs) -> str:
+        self.submitted.append(kwargs)
+        return "task-123"
+
+    def query_result(self, task_id: str, timeout: float = 10.0) -> dict:
+        if self._track is not None:
+            self._track.enter()
+        try:
+            if self._pending_forever:
+                time.sleep(0.02)
+                return {"status": "pending", "audio_urls": [], "error": None}
+            if self._status == "failed":
+                return {"status": "failed", "audio_urls": [], "error": self._error or "boom"}
+            return {"status": "completed", "audio_urls": list(self._audio_urls), "error": None}
+        finally:
+            if self._track is not None:
+                self._track.exit()
+
+    def download_audio(self, url: str, timeout: float = 120.0) -> bytes:
+        return self._audio
+
+
+async def _enqueue(input_params: dict | None = None) -> Job:
+    job = Job(
+        user_id=PydanticObjectId(),
+        workspace_id=PydanticObjectId(),
+        job_type="generate",
+        status=JobStatus.QUEUED,
+        input_params=input_params or {"prompt": "a calm piano ballad", "format": "wav"},
+    )
+    await job.insert()
+    return job
+
+
+async def _wait_until(predicate, *, timeout: float = 5.0, interval: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if await predicate():
+            return True
+        await asyncio.sleep(interval)
+    return False
+
+
+def _make_processor(fake, storage, *, concurrency: int = 2, stale_after: float = 0.0) -> JobProcessor:
+    # stale_after=0.0: any `processing` job is treated as immediately orphaned, so
+    # the requeue-on-startup test is deterministic (production uses a real window).
+    return JobProcessor(
+        concurrency=concurrency,
+        poll_interval=0.01,
+        poll_timeout=5.0,
+        ace_poll_interval=0.01,
+        stale_after=stale_after,
+        client_factory=lambda: fake,
+        storage_factory=lambda: storage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no services) — run in CI
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSubmitKwargs:
+    def test_maps_known_fields(self) -> None:
+        params = {
+            "prompt": "epic orchestral",
+            "duration": 90.0,
+            "format": "flac",
+            "style": "cinematic",
+            "bpm": 120,
+            "mode": "song",
+            "weirdness": 70,
+            # An API-only field the client does not accept must be dropped.
+            "weirdness_unknown": "ignored",
+        }
+        kwargs = JobProcessor._build_submit_kwargs(params)
+        assert kwargs["prompt"] == "epic orchestral"
+        assert kwargs["audio_duration"] == 90.0
+        assert kwargs["format"] == "flac"
+        assert kwargs["style"] == "cinematic"
+        assert kwargs["bpm"] == 120
+        assert kwargs["mode"] == "song"
+        assert kwargs["weirdness"] == 70
+        assert "weirdness_unknown" not in kwargs
+        assert "duration" not in kwargs  # renamed to audio_duration
+
+    def test_minimal_params(self) -> None:
+        kwargs = JobProcessor._build_submit_kwargs({"prompt": "lofi"})
+        assert kwargs == {"prompt": "lofi"}
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle / claim / shutdown — integration (real MongoDB + LocalStorage)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLifecycle:
+    async def test_queued_job_runs_to_completed(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        fake = _FakeAceClient(audio_urls=["http://ace/a.wav", "http://ace/b.wav"])
+        proc = _make_processor(fake, storage)
+        job = await _enqueue()
+
+        await proc.start()
+        try:
+            done = await _wait_until(lambda: _is_status(job.id, JobStatus.COMPLETED))
+        finally:
+            await proc.stop()
+
+        assert done, "job did not reach completed"
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.COMPLETED
+        assert refreshed.started_at is not None
+        assert refreshed.completed_at is not None
+        clip_ids = refreshed.result["clip_ids"]
+        assert len(clip_ids) == 2
+
+        clips = await Clip.find(Clip.user_id == job.user_id).to_list()
+        assert len(clips) == 2
+        for clip in clips:
+            assert storage.download(clip.file_path) == b"FAKE-WAV-BYTES"
+            assert clip.workspace_id == job.workspace_id
+
+    async def test_clip_metadata_persisted_from_params(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        fake = _FakeAceClient(audio_urls=["http://ace/only.wav"])
+        proc = _make_processor(fake, storage, concurrency=1)
+        job = await _enqueue(
+            {
+                "prompt": "house loop",
+                "format": "wav",
+                "style": "deep house",
+                "bpm": 124,
+                "key": "A minor",
+                "model": "turbo",
+                "seed": 7,
+                "mode": "sound",
+            }
+        )
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.COMPLETED))
+        finally:
+            await proc.stop()
+
+        clip = (await Clip.find(Clip.user_id == job.user_id).to_list())[0]
+        assert clip.format == "wav"
+        assert clip.style_tags == ["deep house"]
+        assert clip.bpm == 124
+        assert clip.key == "A minor"
+        assert clip.model == "turbo"
+        assert clip.seed == 7
+        assert clip.generation_mode == "sound"
+
+    async def test_bpm_auto_is_not_persisted_as_int(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        fake = _FakeAceClient(audio_urls=["http://ace/only.wav"])
+        proc = _make_processor(fake, storage, concurrency=1)
+        job = await _enqueue({"prompt": "x", "format": "wav", "bpm": "auto"})
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.COMPLETED))
+        finally:
+            await proc.stop()
+
+        clip = (await Clip.find(Clip.user_id == job.user_id).to_list())[0]
+        assert clip.bpm is None
+
+    async def test_failed_generation_records_error(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        fake = _FakeAceClient(status="failed", error="model overloaded")
+        proc = _make_processor(fake, storage)
+        job = await _enqueue()
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.FAILED))
+        finally:
+            await proc.stop()
+
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.FAILED
+        assert refreshed.error == "model overloaded"
+        assert await Clip.find(Clip.user_id == job.user_id).to_list() == []
+
+    async def test_completed_without_audio_marks_failed(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        fake = _FakeAceClient(audio_urls=[])  # completed but empty
+        proc = _make_processor(fake, storage)
+        job = await _enqueue()
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.FAILED))
+        finally:
+            await proc.stop()
+
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.FAILED
+        assert "no audio" in (refreshed.error or "").lower()
+
+    async def test_two_concurrent_jobs_complete_without_corruption(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        tracker = _ConcurrencyTracker()
+        fake = _FakeAceClient(audio_urls=["http://ace/a.wav", "http://ace/b.wav"], track=tracker)
+        proc = _make_processor(fake, storage, concurrency=2)
+        job_a = await _enqueue({"prompt": "first", "format": "wav"})
+        job_b = await _enqueue({"prompt": "second", "format": "wav"})
+
+        await proc.start()
+        try:
+            done = await _wait_until(
+                lambda: _all_status([job_a.id, job_b.id], JobStatus.COMPLETED),
+                timeout=8.0,
+            )
+        finally:
+            await proc.stop()
+
+        assert done, "both jobs did not complete"
+        assert tracker.max >= 2, "jobs did not actually run concurrently"
+
+        refreshed_a = await Job.get(job_a.id)
+        refreshed_b = await Job.get(job_b.id)
+        ids_a = set(refreshed_a.result["clip_ids"])
+        ids_b = set(refreshed_b.result["clip_ids"])
+        assert len(ids_a) == 2 and len(ids_b) == 2
+        assert ids_a.isdisjoint(ids_b), "clip ids leaked between jobs"
+        assert await Clip.count() == 4
+
+
+@pytest.mark.integration
+class TestClaim:
+    async def test_claim_returns_none_when_empty(self, mongo_db, tmp_path) -> None:
+        proc = _make_processor(_FakeAceClient(), LocalStorage(root_dir=tmp_path))
+        assert await proc._claim_next_job() is None
+
+    async def test_claim_is_exclusive(self, mongo_db, tmp_path) -> None:
+        proc = _make_processor(_FakeAceClient(), LocalStorage(root_dir=tmp_path))
+        job = await _enqueue()
+
+        first = await proc._claim_next_job()
+        second = await proc._claim_next_job()
+
+        assert first is not None and str(first.id) == str(job.id)
+        assert first.status == JobStatus.PROCESSING
+        assert second is None
+
+
+@pytest.mark.integration
+class TestShutdownAndRequeue:
+    async def test_stop_cancels_in_flight_then_restart_requeues(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        # A job that never finishes: it sits in `processing` until the worker stops.
+        stuck = _FakeAceClient(pending_forever=True)
+        proc = _make_processor(stuck, storage, concurrency=1)
+        job = await _enqueue()
+
+        await proc.start()
+        claimed = await _wait_until(lambda: _is_status(job.id, JobStatus.PROCESSING))
+        await proc.stop()
+        assert claimed, "job was never claimed"
+
+        # Shutdown left it processing (not failed): it is re-runnable.
+        mid = await Job.get(job.id)
+        assert mid.status == JobStatus.PROCESSING
+
+        # A fresh processor re-queues the stale job on startup and finishes it.
+        good = _FakeAceClient(audio_urls=["http://ace/a.wav"])
+        proc2 = _make_processor(good, storage, concurrency=1)
+        await proc2.start()
+        try:
+            done = await _wait_until(lambda: _is_status(job.id, JobStatus.COMPLETED))
+        finally:
+            await proc2.stop()
+
+        assert done, "stale job was not re-queued and completed"
+        final = await Job.get(job.id)
+        assert final.status == JobStatus.COMPLETED
+        assert len(final.result["clip_ids"]) == 1
+
+    async def test_recently_started_job_is_not_requeued(self, mongo_db, tmp_path) -> None:
+        # A job a live sibling process started moments ago must survive the startup
+        # sweep — only jobs older than stale_after are reclaimed (multi-worker safety).
+        from acemusic.api.models.common import utcnow
+
+        proc = _make_processor(_FakeAceClient(), LocalStorage(root_dir=tmp_path), stale_after=3600.0)
+        job = Job(
+            user_id=PydanticObjectId(),
+            workspace_id=PydanticObjectId(),
+            job_type="generate",
+            status=JobStatus.PROCESSING,
+            started_at=utcnow(),
+            input_params={"prompt": "x"},
+        )
+        await job.insert()
+
+        await proc._requeue_stale_jobs()
+
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.PROCESSING
+
+    async def test_stale_processing_job_is_requeued(self, mongo_db, tmp_path) -> None:
+        from datetime import timedelta
+
+        from acemusic.api.models.common import utcnow
+
+        proc = _make_processor(_FakeAceClient(), LocalStorage(root_dir=tmp_path), stale_after=60.0)
+        job = Job(
+            user_id=PydanticObjectId(),
+            workspace_id=PydanticObjectId(),
+            job_type="generate",
+            status=JobStatus.PROCESSING,
+            started_at=utcnow() - timedelta(seconds=120),
+            input_params={"prompt": "x"},
+        )
+        await job.insert()
+
+        await proc._requeue_stale_jobs()
+
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.QUEUED
+        assert refreshed.started_at is None
+
+
+# ---------------------------------------------------------------------------
+# Status predicates (used by _wait_until)
+# ---------------------------------------------------------------------------
+
+
+async def _is_status(job_id, expected: JobStatus) -> bool:
+    job = await Job.get(job_id)
+    return job is not None and job.status == expected
+
+
+async def _all_status(job_ids, expected: JobStatus) -> bool:
+    for job_id in job_ids:
+        if not await _is_status(job_id, expected):
+            return False
+    return True

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -7,6 +7,7 @@ HTTP client replaced by an in-process double (mirrors ``tests/test_generate.py``
 """
 
 import asyncio
+import os
 import threading
 import time
 
@@ -276,8 +277,6 @@ class TestLifecycle:
     async def test_partial_failure_rolls_back_stored_clips(self, mongo_db, tmp_path) -> None:
         # Second download fails after the first clip is already stored — the job
         # fails and the first clip's record AND file must be rolled back.
-        import os
-
         storage = LocalStorage(root_dir=tmp_path)
         fake = _FakeAceClient(audio_urls=["http://ace/a.wav", "http://ace/b.wav"], fail_download_after=1)
         proc = _make_processor(fake, storage)

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -334,12 +334,14 @@ class TestClaim:
         proc = _make_processor(_FakeAceClient(), LocalStorage(root_dir=tmp_path))
         job = await _enqueue()
 
-        first = await proc._claim_next_job()
-        second = await proc._claim_next_job()
+        # Two workers race for the same single queued job; the atomic
+        # find_one_and_update must hand it to exactly one of them.
+        first, second = await asyncio.gather(proc._claim_next_job(), proc._claim_next_job())
 
-        assert first is not None and str(first.id) == str(job.id)
-        assert first.status == JobStatus.PROCESSING
-        assert second is None
+        claimed = [r for r in (first, second) if r is not None]
+        assert len(claimed) == 1, "the same job was claimed by two workers"
+        assert str(claimed[0].id) == str(job.id)
+        assert claimed[0].status == JobStatus.PROCESSING
 
 
 @pytest.mark.integration

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -112,7 +112,12 @@ class TestStatusLifecycle:
 
         resp = await client.get(_status_url(str(job.id)), headers=_auth_headers(user, settings))
         assert resp.status_code == 200
-        assert resp.json()["status"] == "processing"
+        body = resp.json()
+        assert body["status"] == "processing"
+        # Result fields apply only once terminal; they must be absent here.
+        assert "clip_ids" not in body
+        assert "audio_urls" not in body
+        assert "error" not in body
 
     async def test_completed_job_includes_clip_ids_and_audio_urls(
         self, client, settings, monkeypatch, tmp_path
@@ -154,6 +159,7 @@ class TestStatusLifecycle:
         assert body["status"] == "failed"
         assert body["error"] == "model overloaded"
         assert "clip_ids" not in body
+        assert "audio_urls" not in body
 
 
 @pytest.mark.integration

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1,0 +1,177 @@
+"""Tests for the job status endpoint (US-9.2).
+
+The 401 auth-gate test runs in CI (the router dependency rejects before any DB
+access). The lifecycle/ownership tests are ``integration``: they drive the real
+app with ``httpx.AsyncClient`` over a local MongoDB (``mongo_db``), mirroring
+``tests/test_generation_api.py``.
+"""
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Job, JobStatus
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+
+
+def _status_url(job_id: str) -> str:
+    return f"{API_V1_PREFIX}/jobs/{job_id}/status"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB; plain TestClient does not run the lifespan)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_missing_auth_header_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.get(_status_url(str(PydanticObjectId())))
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # Disable the background processor: these tests drive job state directly and
+    # do not want a worker claiming their fixtures out from under them.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _insert_job(user, *, status=JobStatus.QUEUED, result=None, error=None, params=None) -> Job:
+    job = Job(
+        user_id=user.id,
+        workspace_id=PydanticObjectId(),
+        job_type="generate",
+        status=status,
+        input_params=params or {"prompt": "a calm piano ballad"},
+        result=result,
+        error=error,
+    )
+    await job.insert()
+    return job
+
+
+@pytest.mark.integration
+class TestStatusLifecycle:
+    async def test_queued_job_reports_queued(self, client, settings) -> None:
+        user = await _make_user("jobs-queued@example.com")
+        job = await _insert_job(user, status=JobStatus.QUEUED)
+
+        resp = await client.get(_status_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["job_id"] == str(job.id)
+        assert body["status"] == "queued"
+        assert isinstance(body["estimated_time_seconds"], int)
+        assert "clip_ids" not in body
+        assert "audio_urls" not in body
+        assert "error" not in body
+
+    async def test_processing_job_reports_processing(self, client, settings) -> None:
+        user = await _make_user("jobs-processing@example.com")
+        job = await _insert_job(user, status=JobStatus.PROCESSING)
+
+        resp = await client.get(_status_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "processing"
+
+    async def test_completed_job_includes_clip_ids_and_audio_urls(
+        self, client, settings, monkeypatch, tmp_path
+    ) -> None:
+        # Point storage at a throwaway root so get_url() resolves cleanly.
+        monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+        monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+
+        user = await _make_user("jobs-done@example.com")
+        workspace_id = PydanticObjectId()
+        clip_ids = []
+        for name in ("a", "b"):
+            clip = Clip(
+                user_id=user.id,
+                workspace_id=workspace_id,
+                file_path=f"{user.id}/{workspace_id}/clips/{name}.wav",
+                format="wav",
+            )
+            await clip.insert()
+            clip_ids.append(str(clip.id))
+
+        job = await _insert_job(user, status=JobStatus.COMPLETED, result={"clip_ids": clip_ids})
+
+        resp = await client.get(_status_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "completed"
+        assert body["clip_ids"] == clip_ids
+        assert len(body["audio_urls"]) == 2
+        assert "error" not in body
+
+    async def test_failed_job_includes_error(self, client, settings) -> None:
+        user = await _make_user("jobs-failed@example.com")
+        job = await _insert_job(user, status=JobStatus.FAILED, error="model overloaded")
+
+        resp = await client.get(_status_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "failed"
+        assert body["error"] == "model overloaded"
+        assert "clip_ids" not in body
+
+
+@pytest.mark.integration
+class TestStatusNotFound:
+    async def test_unknown_job_returns_404(self, client, settings) -> None:
+        user = await _make_user("jobs-unknown@example.com")
+        resp = await client.get(_status_url(str(PydanticObjectId())), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_malformed_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("jobs-malformed@example.com")
+        resp = await client.get(_status_url("not-an-object-id"), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_job_returns_404(self, client, settings) -> None:
+        owner = await _make_user("jobs-owner@example.com")
+        other = await _make_user("jobs-other@example.com")
+        job = await _insert_job(owner, status=JobStatus.COMPLETED, result={"clip_ids": []})
+
+        resp = await client.get(_status_url(str(job.id)), headers=_auth_headers(other, settings))
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Implements **US-9.2** (closes #76): an async background job processor so generation requests are handled off the request path with status tracking.

A `JobProcessor` runs as a background task inside the FastAPI process. It **polls MongoDB** for `status=queued` jobs (stateless, restart-safe, mirrors a future Celery/Redis swap), atomically claims each via `find_one_and_update`, runs the ACE-Step generation, stores the audio through the storage abstraction, creates `Clip` records, and drives the job `queued → processing → completed | failed`. A new `GET /api/v1/jobs/{id}/status` endpoint exposes state. Concurrency is bounded by an `asyncio.Semaphore`.

## What's included

- **`src/acemusic/api/tasks/processor.py`** — `JobProcessor`: `start()/stop()` lifecycle, semaphore-bounded poll loop, atomic claim, per-job ACE-Step run → storage upload → `Clip` creation, status transitions, graceful shutdown that cancels in-flight work, and stale-job re-queue on startup.
- **`src/acemusic/api/routers/jobs.py`** — `GET /api/v1/jobs/{id}/status`, auth-protected and **owner-scoped** (404 for missing *or* other users' jobs). Completed → `clip_ids` + `audio_urls`; failed → `error`.
- **`src/acemusic/api/main.py`** — starts/stops the processor in the lifespan handler (guarded by `job_processor_enabled`), with the DB client always closed even if startup fails.
- **`src/acemusic/api/settings.py` / `.env.example`** — `ACEMUSIC_API_JOB_{CONCURRENCY,POLL_INTERVAL,POLL_TIMEOUT,PROCESSOR_ENABLED}`.

## Design notes / deviations from the issue's draft plan

- Module lives in the existing `tasks/` package (which already owns `dispatch_job`) rather than a new top-level `job_processor.py`.
- Concurrency env var is `ACEMUSIC_API_JOB_CONCURRENCY` (a field on `ApiSettings`), matching the established `ACEMUSIC_API_` prefix.
- `AceStepClient` and `StorageBackend` are **synchronous**, so their blocking calls run via `asyncio.to_thread` to keep the event loop responsive.
- `dispatch_job` stays a log — the polling design is the pickup mechanism, honouring its US-9.2 contract note.

## Testing

- **Unit (CI):** `submit_task` kwarg mapping; status-endpoint 401 gate.
- **Integration (real MongoDB + real `LocalStorage`, stubbed ACE-Step HTTP — the live service is account-gated):** full lifecycle to `completed`; clip metadata persistence; failure + no-audio → `failed`; **two concurrent jobs without corruption** (verified peak concurrency ≥ 2); atomic-claim exclusivity; graceful-shutdown cancellation; stale-job re-queue **and** the multi-worker safety bound (recent jobs are *not* re-queued).
- Full suite green; no regressions (existing generation API tests now disable the processor to avoid a worker racing their `queued` assertions).

## Known limitations

- **Single-processor deployment recommended.** Startup re-queue only reclaims jobs older than `poll_timeout + margin`, so a sibling process's recently-started job is never stolen — but running one processor instance (or `ACEMUSIC_API_JOB_PROCESSOR_ENABLED=false` on all but one) remains the recommended setup until a lease/heartbeat is added.
- **No automatic retry** of a failed generation (the job is marked `failed` with its error; re-submission is a client concern).
- In-process worker only (asyncio), as specified — Redis/Celery migration is future work; the polling/claim contract is designed to carry over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background job processor for queued generation requests with configurable concurrency, poll interval, timeout, and enable/disable flag
  * Job status API to monitor progress, see lifecycle state, estimated time, clip IDs, audio URLs, and errors

* **Configuration**
  * Example environment variables added to control the job processor

* **Tests**
  * New unit and integration tests covering processor behavior, lifecycle, error handling, rollback, and status endpoint
<!-- end of auto-generated comment: release notes by coderabbit.ai -->