### PR TITLE
feat(api): clip audio retrieval with range streaming (US-9.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ Invalid parameters return 422 with field-level errors. The create response inclu
 
 The status endpoint returns `job_id`, `status` (`queued`|`processing`|`completed`|`failed`), `created_at`, and `estimated_time_seconds`. Completed jobs additionally include `clip_ids` and `audio_urls`; failed jobs include an `error` message.
 
+### Clips
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/v1/clips/{id}/audio` | Streams or downloads a clip's audio with the correct `Content-Type` |
+
+Supports single HTTP byte ranges (`Range: bytes=…` → `206 Partial Content`,
+unsatisfiable ranges → `416`) for seeking, and on-the-fly conversion via
+`?format=wav|flac|mp3` (mp3/flac conversion requires ffmpeg on the host; byte
+ranges are ignored for converted output). Access is owner-scoped: an unknown or
+malformed id returns `404`, another user's private clip returns `403`, and clips
+marked `is_public` are retrievable by any authenticated user.
+
 #### Async job processor (US-9.2)
 
 A background processor runs inside the API process, polling MongoDB for `queued`

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ Invalid parameters return 422 with field-level errors. The create response inclu
 
 The status endpoint returns `job_id`, `status` (`queued`|`processing`|`completed`|`failed`), `created_at`, and `estimated_time_seconds`. Completed jobs additionally include `clip_ids` and `audio_urls`; failed jobs include an `error` message.
 
+#### Async job processor (US-9.2)
+
+A background processor runs inside the API process, polling MongoDB for `queued`
+jobs, forwarding them to ACE-Step, storing the audio via the storage abstraction,
+and creating clip records before marking the job `completed` (or `failed` with an
+error). Tunables (all prefixed `ACEMUSIC_API_`): `JOB_CONCURRENCY` (default 2),
+`JOB_POLL_INTERVAL` seconds (default 1.0), `JOB_POLL_TIMEOUT` seconds (default
+600), and `JOB_PROCESSOR_ENABLED` (default `true`; set `false` to run the API
+without the worker — recommended to run a single processor instance).
+
 ### Clips
 
 | Endpoint | Purpose |
@@ -95,16 +105,6 @@ unsatisfiable ranges → `416`) for seeking, and on-the-fly conversion via
 ranges are ignored for converted output). Access is owner-scoped: an unknown or
 malformed id returns `404`, another user's private clip returns `403`, and clips
 marked `is_public` are retrievable by any authenticated user.
-
-#### Async job processor (US-9.2)
-
-A background processor runs inside the API process, polling MongoDB for `queued`
-jobs, forwarding them to ACE-Step, storing the audio via the storage abstraction,
-and creating clip records before marking the job `completed` (or `failed` with an
-error). Tunables (all prefixed `ACEMUSIC_API_`): `JOB_CONCURRENCY` (default 2),
-`JOB_POLL_INTERVAL` seconds (default 1.0), `JOB_POLL_TIMEOUT` seconds (default
-600), and `JOB_PROCESSOR_ENABLED` (default `true`; set `false` to run the API
-without the worker — recommended to run a single processor instance).
 
 ## Stem separation backends
 

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -20,7 +20,7 @@ from acemusic import __version__
 
 from . import database
 from .exceptions import HandleConflictError
-from .routers import auth, generation, health, jobs, users
+from .routers import auth, clips, generation, health, jobs, users
 from .settings import ApiSettings
 from .tasks.processor import JobProcessor
 
@@ -115,6 +115,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(users.router, prefix=API_V1_PREFIX)
     app.include_router(generation.router, prefix=API_V1_PREFIX)
     app.include_router(jobs.router, prefix=API_V1_PREFIX)
+    app.include_router(clips.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -32,10 +32,8 @@ class Clip(Document):
     inference_steps: int | None = None
     parent_clip_ids: list[PydanticObjectId] = Field(default_factory=list)
     generation_mode: str | None = None
-    # Visibility for cross-user audio access (US-9.3): private clips are only
-    # retrievable by their owner; public clips may be fetched by any
-    # authenticated user. Documents written before this field existed have no
-    # value stored and load as private.
+    # Cross-user audio access (US-9.3). Documents predating this field load as
+    # private.
     is_public: bool = False
     created_at: datetime = Field(default_factory=utcnow)
 

--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -32,9 +32,7 @@ class Clip(Document):
     inference_steps: int | None = None
     parent_clip_ids: list[PydanticObjectId] = Field(default_factory=list)
     generation_mode: str | None = None
-    # Cross-user audio access (US-9.3). Documents predating this field load as
-    # private.
-    is_public: bool = False
+    is_public: bool = False  # documents predating US-9.3 load as private
     created_at: datetime = Field(default_factory=utcnow)
 
     class Settings:

--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -32,6 +32,11 @@ class Clip(Document):
     inference_steps: int | None = None
     parent_clip_ids: list[PydanticObjectId] = Field(default_factory=list)
     generation_mode: str | None = None
+    # Visibility for cross-user audio access (US-9.3): private clips are only
+    # retrievable by their owner; public clips may be fetched by any
+    # authenticated user. Documents written before this field existed have no
+    # value stored and load as private.
+    is_public: bool = False
     created_at: datetime = Field(default_factory=utcnow)
 
     class Settings:

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -67,11 +67,12 @@ async def get_clip_audio(
         serve_format = format
         converted = True
 
-    headers = {"Accept-Ranges": "bytes"}
+    # Byte ranges address the stored representation; conversion produces a
+    # different byte layout, so Range (and the Accept-Ranges advertisement)
+    # only applies to unconverted responses.
+    headers = {} if converted else {"Accept-Ranges": "bytes"}
     media_type = get_audio_content_type(serve_format)
 
-    # Byte ranges address the stored representation; conversion produces a
-    # different byte layout, so Range only applies to unconverted responses.
     range_header = request.headers.get("range")
     if range_header is not None and not converted:
         byte_range = parse_range_header(range_header, len(audio))

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -1,0 +1,88 @@
+"""Clip audio retrieval endpoint (US-9.3), mounted under ``/api/v1/clips``.
+
+``GET /api/v1/clips/{clip_id}/audio`` streams a clip's audio with the correct
+Content-Type, supports single byte-range requests (206 Partial Content) for
+seeking, and optionally converts to another format via ``?format=``. Access
+rules live in :func:`acemusic.api.services.clips.get_clip_for_audio_access`.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+
+from acemusic.storage import get_storage_backend
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..services.audio_conversion import convert_audio_format
+from ..services.clips import get_clip_for_audio_access
+from ..utils.media_types import get_audio_content_type
+from ..utils.range_requests import parse_range_header
+
+logger = logging.getLogger(__name__)
+
+# Router-level dependency gates every route behind a valid Bearer token
+# (mirrors the jobs/generation routers), so unauthenticated requests get 401.
+router = APIRouter(prefix="/clips", tags=["clips"], dependencies=[Depends(get_current_user)])
+
+
+@router.get("/{clip_id}/audio")
+async def get_clip_audio(
+    clip_id: str,
+    request: Request,
+    format: Literal["wav", "flac", "mp3"] | None = Query(
+        default=None,
+        description="Convert to this format on the fly (default: the clip's stored format).",
+    ),
+    current: CurrentUser = Depends(get_current_user),
+) -> Response:
+    """Return the clip's audio — full (200) or a requested byte range (206)."""
+    clip = await get_clip_for_audio_access(clip_id, current.user_id)
+
+    storage = get_storage_backend()
+    try:
+        # download() does file/network I/O via the sync backend; keep it off
+        # the event loop.
+        audio = await asyncio.to_thread(storage.download, clip.file_path)
+    except FileNotFoundError:
+        # The clip document exists but its object is gone — a data integrity
+        # problem worth logging, surfaced to the client as a plain 404.
+        logger.warning("Clip %s exists but its audio object %r is missing", clip.id, clip.file_path)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio file not found.")
+
+    native_format = (clip.format or Path(clip.file_path).suffix.lstrip(".") or "wav").lower()
+    serve_format = native_format
+    converted = False
+    if format is not None and format != native_format:
+        try:
+            audio = await asyncio.to_thread(convert_audio_format, audio, native_format, format)
+        except Exception as exc:
+            logger.exception("Format conversion of clip %s (%s -> %s) failed", clip.id, native_format, format)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Could not convert audio to {format}.",
+            ) from exc
+        serve_format = format
+        converted = True
+
+    headers = {"Accept-Ranges": "bytes"}
+    media_type = get_audio_content_type(serve_format)
+
+    # Byte ranges address the stored representation; conversion produces a
+    # different byte layout, so Range only applies to unconverted responses.
+    range_header = request.headers.get("range")
+    if range_header is not None and not converted:
+        byte_range = parse_range_header(range_header, len(audio))
+        if byte_range is not None:
+            start, end = byte_range
+            headers["Content-Range"] = f"bytes {start}-{end}/{len(audio)}"
+            return Response(
+                content=audio[start : end + 1],
+                status_code=status.HTTP_206_PARTIAL_CONTENT,
+                media_type=media_type,
+                headers=headers,
+            )
+
+    return Response(content=audio, media_type=media_type, headers=headers)

--- a/src/acemusic/api/services/audio_conversion.py
+++ b/src/acemusic/api/services/audio_conversion.py
@@ -1,0 +1,37 @@
+"""In-memory audio format conversion for API responses (US-9.3).
+
+Buffer-based counterpart of :func:`acemusic.audio.export_audio` (US-7.1) with
+the same codec settings, so a clip downloaded as ``?format=mp3`` matches what
+the CLI's export command would produce. Conversion (other than wav decode)
+requires ffmpeg on the host.
+"""
+
+import io
+
+CONVERSION_FORMATS = ("wav", "flac", "mp3")
+
+
+def convert_audio_format(audio_bytes: bytes, source_format: str, target_format: str) -> bytes:
+    """Convert ``audio_bytes`` from ``source_format`` to ``target_format``.
+
+    Codec settings mirror ``export_audio``: wav is 48 kHz 24-bit PCM, flac is
+    lossless at the source rate, mp3 is 320 kbps CBR. Raises ``ValueError``
+    for an unsupported target format.
+    """
+    if target_format not in CONVERSION_FORMATS:
+        raise ValueError(f"Unsupported conversion format: {target_format!r}. Expected one of {CONVERSION_FORMATS}.")
+
+    from pydub import AudioSegment
+
+    # Always pass format= — detection would shell out to ffprobe, which is not
+    # installed everywhere (e.g. CI), and the clip's stored format is known.
+    segment = AudioSegment.from_file(io.BytesIO(audio_bytes), format=source_format)
+
+    buffer = io.BytesIO()
+    if target_format == "wav":
+        segment.export(buffer, format="wav", parameters=["-acodec", "pcm_s24le", "-ar", "48000"])
+    elif target_format == "flac":
+        segment.export(buffer, format="flac")
+    else:  # mp3
+        segment.export(buffer, format="mp3", bitrate="320k")
+    return buffer.getvalue()

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -1,0 +1,36 @@
+"""Clip access service (US-9.3).
+
+Resolves a clip for audio retrieval and enforces the visibility rules from
+issue #77: a clip that does not exist (or has a malformed id) is 404; another
+user's private clip is 403; the owner and any authenticated user (for public
+clips) get the clip back.
+"""
+
+from beanie import PydanticObjectId
+from fastapi import HTTPException, status
+
+from ..models import Clip
+
+
+def _coerce_object_id(value: str) -> PydanticObjectId | None:
+    """Parse a path id, treating a malformed id as "no such clip" (caller → 404)."""
+    try:
+        return PydanticObjectId(value)
+    except Exception:
+        return None
+
+
+async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
+    """Return ``clip_id``'s clip if ``current_user_id`` may retrieve its audio.
+
+    Raises 404 for malformed/unknown ids and 403 for another user's private
+    clip. Unlike jobs (which 404 to hide existence), clips deliberately
+    distinguish 403 so sharing flows can tell "ask the owner" from "gone".
+    """
+    oid = _coerce_object_id(clip_id)
+    clip = await Clip.get(oid) if oid is not None else None
+    if clip is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found.")
+    if str(clip.user_id) != current_user_id and not clip.is_public:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="This clip is private.")
+    return clip

--- a/src/acemusic/api/utils/__init__.py
+++ b/src/acemusic/api/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared HTTP-layer utilities for the platform API."""

--- a/src/acemusic/api/utils/media_types.py
+++ b/src/acemusic/api/utils/media_types.py
@@ -12,10 +12,13 @@ _AUDIO_CONTENT_TYPES = {
 DEFAULT_CONTENT_TYPE = "application/octet-stream"
 
 
-def get_audio_content_type(format: str) -> str:
+def get_audio_content_type(format: str | None) -> str:
     """Return the MIME type for an audio ``format`` name (case-insensitive).
 
-    Unknown formats fall back to ``application/octet-stream`` so the endpoint
-    can always serve bytes even for formats added to storage before this map.
+    Unknown, blank, or missing formats fall back to ``application/octet-stream``
+    so the endpoint can always serve bytes even for formats added to storage
+    before this map.
     """
-    return _AUDIO_CONTENT_TYPES.get(format.lower(), DEFAULT_CONTENT_TYPE)
+    if not format:
+        return DEFAULT_CONTENT_TYPE
+    return _AUDIO_CONTENT_TYPES.get(format.strip().lower(), DEFAULT_CONTENT_TYPE)

--- a/src/acemusic/api/utils/media_types.py
+++ b/src/acemusic/api/utils/media_types.py
@@ -1,0 +1,21 @@
+"""Audio format → MIME type mapping (US-9.3)."""
+
+_AUDIO_CONTENT_TYPES = {
+    "wav": "audio/wav",
+    "flac": "audio/flac",
+    "mp3": "audio/mpeg",
+    "ogg": "audio/ogg",
+    "aac": "audio/aac",
+    "opus": "audio/opus",
+}
+
+DEFAULT_CONTENT_TYPE = "application/octet-stream"
+
+
+def get_audio_content_type(format: str) -> str:
+    """Return the MIME type for an audio ``format`` name (case-insensitive).
+
+    Unknown formats fall back to ``application/octet-stream`` so the endpoint
+    can always serve bytes even for formats added to storage before this map.
+    """
+    return _AUDIO_CONTENT_TYPES.get(format.lower(), DEFAULT_CONTENT_TYPE)

--- a/src/acemusic/api/utils/range_requests.py
+++ b/src/acemusic/api/utils/range_requests.py
@@ -16,11 +16,12 @@ _RANGE_RE = re.compile(r"bytes=(\d*)-(\d*)$")
 
 def _unsatisfiable(content_length: int) -> HTTPException:
     # RFC 9110 §15.5.17: a 416 SHOULD carry the selected representation's
-    # length so the client can retry with a valid range.
+    # length so the client can retry with a valid range, and Accept-Ranges so
+    # it knows the bytes unit is understood (§14.3).
     return HTTPException(
         status_code=status.HTTP_416_RANGE_NOT_SATISFIABLE,
         detail="Requested range not satisfiable.",
-        headers={"Content-Range": f"bytes */{content_length}"},
+        headers={"Content-Range": f"bytes */{content_length}", "Accept-Ranges": "bytes"},
     )
 
 

--- a/src/acemusic/api/utils/range_requests.py
+++ b/src/acemusic/api/utils/range_requests.py
@@ -1,0 +1,60 @@
+"""HTTP Range header parsing for byte-range (206) responses (US-9.3).
+
+Implements the single-range subset of RFC 9110 §14: explicit (``bytes=0-99``),
+open-ended (``bytes=100-``), and suffix (``bytes=-100``) ranges. Multipart
+ranges and non-``bytes`` units are out of scope — per the RFC a server MAY
+ignore the Range header, so those serve the full body with 200.
+"""
+
+import re
+
+from fastapi import HTTPException, status
+
+# One range-spec in the bytes unit: "bytes=<start?>-<end?>".
+_RANGE_RE = re.compile(r"bytes=(\d*)-(\d*)$")
+
+
+def _unsatisfiable(content_length: int) -> HTTPException:
+    # RFC 9110 §15.5.17: a 416 SHOULD carry the selected representation's
+    # length so the client can retry with a valid range.
+    return HTTPException(
+        status_code=status.HTTP_416_RANGE_NOT_SATISFIABLE,
+        detail="Requested range not satisfiable.",
+        headers={"Content-Range": f"bytes */{content_length}"},
+    )
+
+
+def parse_range_header(range_header: str, content_length: int) -> tuple[int, int] | None:
+    """Parse a ``Range`` header into an inclusive ``(start, end)`` byte pair.
+
+    Returns ``None`` when the header is malformed, uses an unsupported unit,
+    or requests multiple ranges — the caller should ignore it and serve the
+    full body (RFC 9110 permits ignoring Range entirely). Raises a 416
+    :class:`HTTPException` when the header is well-formed but unsatisfiable
+    (start beyond the end of the representation, or an empty suffix).
+    """
+    if content_length <= 0:
+        return None
+
+    match = _RANGE_RE.match(range_header.strip())
+    if match is None:
+        return None
+    start_s, end_s = match.groups()
+
+    if not start_s and not end_s:  # "bytes=-"
+        return None
+
+    if not start_s:
+        # Suffix range: the last N bytes of the representation.
+        suffix = int(end_s)
+        if suffix == 0:
+            raise _unsatisfiable(content_length)
+        return max(0, content_length - suffix), content_length - 1
+
+    start = int(start_s)
+    if start >= content_length:
+        raise _unsatisfiable(content_length)
+    end = int(end_s) if end_s else content_length - 1
+    if end < start:  # "bytes=5-2" is syntactically invalid — ignore the header
+        return None
+    return start, min(end, content_length - 1)

--- a/tests/test_clips_api.py
+++ b/tests/test_clips_api.py
@@ -1,0 +1,348 @@
+"""Tests for the clip audio retrieval endpoint (US-9.3, issue #77).
+
+The utility tests and the 401 auth-gate test run in CI (no DB; plain
+``TestClient`` does not run the lifespan). The retrieval/authorization/range
+tests are ``integration``: they drive the real app with ``httpx.AsyncClient``
+over a local MongoDB (``mongo_db``) and real LocalStorage, mirroring
+``tests/test_jobs_api.py``. Format-conversion tests additionally require ffmpeg
+and skip when it is absent (CI does not install it).
+"""
+
+import shutil
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.api.utils.media_types import get_audio_content_type
+from acemusic.api.utils.range_requests import parse_range_header
+from acemusic.storage import get_storage_backend
+
+requires_ffmpeg = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="format conversion requires ffmpeg (not installed in CI)"
+)
+
+
+def _audio_url(clip_id: str) -> str:
+    return f"{API_V1_PREFIX}/clips/{clip_id}/audio"
+
+
+# ---------------------------------------------------------------------------
+# Media-type utility — runs in CI
+# ---------------------------------------------------------------------------
+
+
+class TestGetAudioContentType:
+    @pytest.mark.parametrize(
+        ("fmt", "expected"),
+        [
+            ("wav", "audio/wav"),
+            ("flac", "audio/flac"),
+            ("mp3", "audio/mpeg"),
+            ("ogg", "audio/ogg"),
+            ("aac", "audio/aac"),
+            ("opus", "audio/opus"),
+        ],
+    )
+    def test_known_formats_map_to_mime_types(self, fmt: str, expected: str) -> None:
+        assert get_audio_content_type(fmt) == expected
+
+    def test_lookup_is_case_insensitive(self) -> None:
+        assert get_audio_content_type("WAV") == "audio/wav"
+
+    def test_unknown_format_falls_back_to_octet_stream(self) -> None:
+        assert get_audio_content_type("xyz") == "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# Range header parser — runs in CI
+# ---------------------------------------------------------------------------
+
+
+class TestParseRangeHeader:
+    def test_explicit_range(self) -> None:
+        assert parse_range_header("bytes=0-99", 1000) == (0, 99)
+
+    def test_open_ended_range_runs_to_last_byte(self) -> None:
+        assert parse_range_header("bytes=100-", 1000) == (100, 999)
+
+    def test_suffix_range_returns_last_n_bytes(self) -> None:
+        assert parse_range_header("bytes=-100", 1000) == (900, 999)
+
+    def test_suffix_longer_than_content_clamps_to_full(self) -> None:
+        assert parse_range_header("bytes=-5000", 1000) == (0, 999)
+
+    def test_end_beyond_content_clamps_to_last_byte(self) -> None:
+        assert parse_range_header("bytes=500-9999", 1000) == (500, 999)
+
+    def test_start_at_or_past_length_raises_416(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            parse_range_header("bytes=1000-", 1000)
+        assert exc_info.value.status_code == 416
+        assert exc_info.value.headers["Content-Range"] == "bytes */1000"
+
+    def test_zero_suffix_raises_416(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            parse_range_header("bytes=-0", 1000)
+        assert exc_info.value.status_code == 416
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            "bytes=5-2",  # end before start: syntactically invalid per RFC 9110
+            "bytes=abc-def",
+            "bytes=0-99,200-299",  # multipart ranges unsupported — serve full body
+            "items=0-99",  # unknown unit
+            "bytes=",
+            "garbage",
+        ],
+    )
+    def test_invalid_or_unsupported_headers_are_ignored(self, header: str) -> None:
+        assert parse_range_header(header, 1000) is None
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_missing_auth_header_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.get(_audio_url(str(PydanticObjectId())))
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB + real LocalStorage
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    """Point the storage backend at a throwaway local root."""
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_clip(user, audio_bytes: bytes, *, fmt: str = "wav", is_public: bool = False, store: bool = True):
+    """Insert a clip owned by ``user`` and (optionally) store its audio bytes."""
+    clip_id = PydanticObjectId()
+    workspace_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace_id}/clips/{clip_id}.{fmt}"
+    if store:
+        get_storage_backend().upload(file_path, audio_bytes)
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace_id,
+        file_path=file_path,
+        format=fmt,
+        is_public=is_public,
+    )
+    await clip.insert()
+    return clip
+
+
+def _tone_bytes(write_tone, tmp_path_factory, duration_s: float = 1.0) -> bytes:
+    path = tmp_path_factory.mktemp("tone") / "tone.wav"
+    write_tone(path, duration_s=duration_s)
+    return path.read_bytes()
+
+
+@pytest.fixture
+def wav_bytes(write_tone, tmp_path_factory) -> bytes:
+    return _tone_bytes(write_tone, tmp_path_factory)
+
+
+@pytest.mark.integration
+class TestClipAudioRetrieval:
+    async def test_own_clip_returns_playable_audio_with_content_type(
+        self, client, settings, local_storage, wav_bytes
+    ) -> None:
+        user = await _make_user("clips-own@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        resp = await client.get(_audio_url(str(clip.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/wav"
+        assert resp.headers["accept-ranges"] == "bytes"
+        assert int(resp.headers["content-length"]) == len(wav_bytes)
+        assert resp.content == wav_bytes
+        assert resp.content[:4] == b"RIFF"  # playable WAV, not an error payload
+
+    async def test_nonexistent_clip_returns_404(self, client, settings, local_storage) -> None:
+        user = await _make_user("clips-missing@example.com")
+        resp = await client.get(_audio_url(str(PydanticObjectId())), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_malformed_clip_id_returns_404(self, client, settings, local_storage) -> None:
+        user = await _make_user("clips-malformed@example.com")
+        resp = await client.get(_audio_url("not-an-object-id"), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_private_clip_returns_403(self, client, settings, local_storage, wav_bytes) -> None:
+        owner = await _make_user("clips-owner@example.com")
+        other = await _make_user("clips-other@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=False)
+
+        resp = await client.get(_audio_url(str(clip.id)), headers=_auth_headers(other, settings))
+        assert resp.status_code == 403
+
+    async def test_other_users_public_clip_returns_200(self, client, settings, local_storage, wav_bytes) -> None:
+        owner = await _make_user("clips-pub-owner@example.com")
+        other = await _make_user("clips-pub-other@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        resp = await client.get(_audio_url(str(clip.id)), headers=_auth_headers(other, settings))
+        assert resp.status_code == 200
+        assert resp.content == wav_bytes
+
+    async def test_clip_with_missing_audio_file_returns_404(self, client, settings, local_storage) -> None:
+        user = await _make_user("clips-nofile@example.com")
+        clip = await _make_clip(user, b"", store=False)
+
+        resp = await client.get(_audio_url(str(clip.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestClipAudioRangeRequests:
+    async def test_first_100_bytes(self, client, settings, local_storage, wav_bytes) -> None:
+        user = await _make_user("clips-range1@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        headers = {**_auth_headers(user, settings), "Range": "bytes=0-99"}
+        resp = await client.get(_audio_url(str(clip.id)), headers=headers)
+        assert resp.status_code == 206
+        assert resp.content == wav_bytes[:100]
+        assert resp.headers["content-range"] == f"bytes 0-99/{len(wav_bytes)}"
+        assert int(resp.headers["content-length"]) == 100
+
+    async def test_last_100_bytes_via_suffix_range(self, client, settings, local_storage, wav_bytes) -> None:
+        user = await _make_user("clips-range2@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        headers = {**_auth_headers(user, settings), "Range": "bytes=-100"}
+        resp = await client.get(_audio_url(str(clip.id)), headers=headers)
+        assert resp.status_code == 206
+        assert resp.content == wav_bytes[-100:]
+        total = len(wav_bytes)
+        assert resp.headers["content-range"] == f"bytes {total - 100}-{total - 1}/{total}"
+
+    async def test_open_ended_range_returns_tail(self, client, settings, local_storage, wav_bytes) -> None:
+        user = await _make_user("clips-range3@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        headers = {**_auth_headers(user, settings), "Range": "bytes=1000-"}
+        resp = await client.get(_audio_url(str(clip.id)), headers=headers)
+        assert resp.status_code == 206
+        assert resp.content == wav_bytes[1000:]
+
+    async def test_unsatisfiable_range_returns_416(self, client, settings, local_storage, wav_bytes) -> None:
+        user = await _make_user("clips-range4@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        headers = {**_auth_headers(user, settings), "Range": f"bytes={len(wav_bytes)}-"}
+        resp = await client.get(_audio_url(str(clip.id)), headers=headers)
+        assert resp.status_code == 416
+        assert resp.headers["content-range"] == f"bytes */{len(wav_bytes)}"
+
+    async def test_invalid_range_header_serves_full_content(self, client, settings, local_storage, wav_bytes) -> None:
+        user = await _make_user("clips-range5@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        headers = {**_auth_headers(user, settings), "Range": "bytes=5-2"}
+        resp = await client.get(_audio_url(str(clip.id)), headers=headers)
+        assert resp.status_code == 200
+        assert resp.content == wav_bytes
+
+
+@pytest.mark.integration
+class TestClipAudioFormatConversion:
+    @requires_ffmpeg
+    async def test_format_mp3_returns_mpeg_audio(self, client, settings, local_storage, wav_bytes) -> None:
+        user = await _make_user("clips-conv1@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        resp = await client.get(_audio_url(str(clip.id)) + "?format=mp3", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/mpeg"
+        # MP3 bitstream: either an ID3 tag or an MPEG frame-sync header.
+        assert resp.content[:3] == b"ID3" or resp.content[0] == 0xFF
+        assert int(resp.headers["content-length"]) == len(resp.content)
+
+    async def test_same_format_as_native_serves_bytes_unchanged(
+        self, client, settings, local_storage, wav_bytes
+    ) -> None:
+        user = await _make_user("clips-conv2@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        resp = await client.get(_audio_url(str(clip.id)) + "?format=wav", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/wav"
+        assert resp.content == wav_bytes
+
+    async def test_unsupported_format_returns_422(self, client, settings, local_storage, wav_bytes) -> None:
+        user = await _make_user("clips-conv3@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        resp = await client.get(_audio_url(str(clip.id)) + "?format=xm", headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+    @requires_ffmpeg
+    async def test_range_header_is_ignored_for_converted_content(
+        self, client, settings, local_storage, wav_bytes
+    ) -> None:
+        # Conversion changes the byte layout, so byte ranges against the native
+        # file are meaningless — the endpoint serves the full converted body.
+        user = await _make_user("clips-conv4@example.com")
+        clip = await _make_clip(user, wav_bytes)
+
+        headers = {**_auth_headers(user, settings), "Range": "bytes=0-99"}
+        resp = await client.get(_audio_url(str(clip.id)) + "?format=mp3", headers=headers)
+        assert resp.status_code == 200
+        assert len(resp.content) > 100

--- a/tests/test_clips_api.py
+++ b/tests/test_clips_api.py
@@ -321,6 +321,7 @@ class TestClipAudioRangeRequests:
         resp = await client.get(_audio_url(str(clip.id)), headers=headers)
         assert resp.status_code == 416
         assert resp.headers["content-range"] == f"bytes */{len(wav_bytes)}"
+        assert resp.headers["accept-ranges"] == "bytes"
 
     async def test_invalid_range_header_serves_full_content(self, client, settings, local_storage, wav_bytes) -> None:
         user = await _make_user("clips-range5@example.com")

--- a/tests/test_clips_api.py
+++ b/tests/test_clips_api.py
@@ -20,6 +20,7 @@ from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Clip
 from acemusic.api.services import users as user_service
+from acemusic.api.services.audio_conversion import convert_audio_format
 from acemusic.api.settings import ApiSettings
 from acemusic.api.utils.media_types import get_audio_content_type
 from acemusic.api.utils.range_requests import parse_range_header
@@ -101,11 +102,41 @@ class TestParseRangeHeader:
             "bytes=0-99,200-299",  # multipart ranges unsupported — serve full body
             "items=0-99",  # unknown unit
             "bytes=",
+            "bytes=-",
             "garbage",
         ],
     )
     def test_invalid_or_unsupported_headers_are_ignored(self, header: str) -> None:
         assert parse_range_header(header, 1000) is None
+
+    def test_empty_content_is_never_range_served(self) -> None:
+        assert parse_range_header("bytes=0-99", 0) is None
+
+
+# ---------------------------------------------------------------------------
+# Conversion service — runs in CI except where ffmpeg is required
+# ---------------------------------------------------------------------------
+
+
+class TestConvertAudioFormat:
+    def test_unsupported_target_format_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported conversion format"):
+            convert_audio_format(b"\x00", "wav", "xm")
+
+    @requires_ffmpeg
+    def test_wav_to_flac_round_trip_preserves_duration(self, write_tone, tmp_path) -> None:
+        from pydub import AudioSegment
+
+        path = tmp_path / "tone.wav"
+        write_tone(path, duration_s=1.0)
+        flac_bytes = convert_audio_format(path.read_bytes(), "wav", "flac")
+        assert flac_bytes[:4] == b"fLaC"
+
+        wav_bytes = convert_audio_format(flac_bytes, "flac", "wav")
+        import io
+
+        segment = AudioSegment.from_file(io.BytesIO(wav_bytes), format="wav")
+        assert segment.duration_seconds == pytest.approx(1.0, abs=0.05)
 
 
 # ---------------------------------------------------------------------------
@@ -332,6 +363,15 @@ class TestClipAudioFormatConversion:
 
         resp = await client.get(_audio_url(str(clip.id)) + "?format=xm", headers=_auth_headers(user, settings))
         assert resp.status_code == 422
+
+    @requires_ffmpeg
+    async def test_undecodable_audio_returns_500(self, client, settings, local_storage) -> None:
+        user = await _make_user("clips-conv5@example.com")
+        clip = await _make_clip(user, b"this is not audio data", fmt="wav")
+
+        resp = await client.get(_audio_url(str(clip.id)) + "?format=mp3", headers=_auth_headers(user, settings))
+        assert resp.status_code == 500
+        assert "convert" in resp.json()["detail"].lower()
 
     @requires_ffmpeg
     async def test_range_header_is_ignored_for_converted_content(

--- a/tests/test_clips_api.py
+++ b/tests/test_clips_api.py
@@ -61,6 +61,10 @@ class TestGetAudioContentType:
     def test_unknown_format_falls_back_to_octet_stream(self) -> None:
         assert get_audio_content_type("xyz") == "application/octet-stream"
 
+    @pytest.mark.parametrize("fmt", [None, "", "   "])
+    def test_missing_or_blank_format_falls_back_to_octet_stream(self, fmt: str | None) -> None:
+        assert get_audio_content_type(fmt) == "application/octet-stream"
+
 
 # ---------------------------------------------------------------------------
 # Range header parser — runs in CI
@@ -346,6 +350,9 @@ class TestClipAudioFormatConversion:
         # MP3 bitstream: either an ID3 tag or an MPEG frame-sync header.
         assert resp.content[:3] == b"ID3" or resp.content[0] == 0xFF
         assert int(resp.headers["content-length"]) == len(resp.content)
+        # Converted output does not honor byte ranges, so it must not
+        # advertise range support.
+        assert "accept-ranges" not in resp.headers
 
     async def test_same_format_as_native_serves_bytes_unchanged(
         self, client, settings, local_storage, wav_bytes


### PR DESCRIPTION
## Summary
Implements #77: US-9.3 Clip audio retrieval (streaming)

- New `GET /api/v1/clips/{clip_id}/audio` endpoint serving stored clip audio with correct Content-Type and `Accept-Ranges: bytes`
- Single byte-range support per RFC 9110: explicit (`bytes=0-99`), open-ended (`bytes=100-`) and suffix (`bytes=-100`) ranges → 206 Partial Content with `Content-Range`; unsatisfiable ranges → 416; malformed/multipart ranges ignored (200 full body)
- Access rules in a new clips service: 404 for unknown/malformed ids, 403 for another user's private clip, public clips retrievable by any authenticated user (new `Clip.is_public` field, defaults to private so pre-existing documents stay private)
- Optional on-the-fly conversion via `?format=wav|flac|mp3` with codec settings mirroring the CLI's `export_audio` (US-7.1); conversion uses in-memory pydub I/O with explicit `format=` (no ffprobe dependency); invalid format values → 422
- Router is auth-gated at router level (401 without a Bearer token), mirroring the jobs/generation routers

## Acceptance Criteria
- [x] `GET /api/v1/clips/{id}/audio` returns a playable audio file with correct Content-Type
- [x] Range request returns 206 Partial Content with the requested byte range
- [x] Requesting another user's private clip returns 403
- [x] Requesting a non-existent clip returns 404

## Test Plan
- [x] Unit tests written (TDD approach) — 42 tests in `tests/test_clips_api.py` (utils + auth gate run in CI; retrieval/range/conversion are integration tests against real MongoDB + LocalStorage)
- [x] All tests passing (1113 unit; API-layer integration suite green locally)
- [x] Diff coverage 100% on changed lines (gate: ≥85%)
- [x] Linting clean (black + ruff)
- [x] Internal code review (advisory) completed — no Critical/Major findings
- [x] Cross-family review pass: codex — no findings
- [x] Test mutation sanity check completed — 5 mutations (privacy inversion, suffix-range math, 206→200, MIME map, 404 status) all caught by tests

## Known Limitations / Intentionally Deferred
- Range requests reduce the response size but not the storage fetch: the endpoint downloads the full object before slicing (matches the existing `jobs.py` storage pattern; fine for short clips, revisit if large stems are served)
- Storage failures other than missing-file (e.g. transient S3 errors) surface as FastAPI's generic 500 — no stack trace is leaked; a dedicated 502 mapping was deemed out of scope
- Multipart ranges (`bytes=0-1,5-9`) are not supported and are deliberately ignored per RFC 9110 (full body served)
- Conversion to mp3/flac requires ffmpeg on the host; the conversion tests skip when ffmpeg is absent (CI does not install it)
- No `If-Range`/`ETag` conditional-range support — not requested in US-9.3

## Implementation Notes
- The issue's FR text "404 if clip does not belong to the authenticated user" conflicts with its own AC "another user's private clip returns 403" — the AC checklist wins (403), unlike jobs which 404 to hide existence; the distinction enables future sharing flows
- Original CodeRabbit plan targeted a new `src/acemusic_api/` package; the API layer already exists at `src/acemusic/api/` so all paths were adapted

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clip audio streaming endpoint with seeking support via HTTP byte-range requests
  * Enabled on-the-fly audio format conversion (WAV, FLAC, MP3)
  * Implemented clip visibility controls: private clips owner-only, public clips accessible to authenticated users

* **Documentation**
  * Updated README with clip audio endpoint details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->