### PR TITLE
feat(api): workspace and clip CRUD API (US-9.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,31 @@ error). Tunables (all prefixed `ACEMUSIC_API_`): `JOB_CONCURRENCY` (default 2),
 600), and `JOB_PROCESSOR_ENABLED` (default `true`; set `false` to run the API
 without the worker — recommended to run a single processor instance).
 
+### Workspaces
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/workspaces` | Create a workspace (201; 409 on duplicate name) |
+| `GET /api/v1/workspaces` | List all workspaces for the authenticated user with per-workspace clip counts |
+| `GET /api/v1/workspaces/{id}` | Get a single workspace (404 if missing or not owned) |
+| `PATCH /api/v1/workspaces/{id}` | Rename a workspace (409 on duplicate name; empty body is a no-op) |
+| `DELETE /api/v1/workspaces/{id}` | Delete a workspace (409 if non-empty without `?force=true`; 400 if it is the last workspace) |
+
+A default workspace is created automatically when a new user registers (OAuth callback). The get-or-create call is idempotent, so subsequent logins are a cheap lookup and accounts created before this feature are backfilled on their next login.
+
 ### Clips
 
 | Endpoint | Purpose |
 | --- | --- |
+| `GET /api/v1/clips` | Paginated clip list with search, filter, and sort |
+| `GET /api/v1/clips/{id}` | Get clip metadata (404 if missing or not owned) |
+| `PATCH /api/v1/clips/{id}` | Rename a clip (`title` is the only writable field; empty body is a no-op) |
+| `DELETE /api/v1/clips/{id}` | Delete the clip record and its stored audio |
 | `GET /api/v1/clips/{id}/audio` | Streams or downloads a clip's audio with the correct `Content-Type` |
 
-Supports single HTTP byte ranges (`Range: bytes=…` → `206 Partial Content`,
-unsatisfiable ranges → `416`) for seeking, and on-the-fly conversion via
-`?format=wav|flac|mp3` (mp3/flac conversion requires ffmpeg on the host; byte
-ranges are ignored for converted output). Access is owner-scoped: an unknown or
-malformed id returns `404`, another user's private clip returns `403`, and clips
-marked `is_public` are retrievable by any authenticated user.
+`GET /api/v1/clips` supports these query parameters: `workspace_id`, `search` (case-insensitive substring over title or style tags), `style`, `bpm_min`, `bpm_max`, `key`, `model`, `sort` (`newest` or `oldest`, default `newest`), `page` (default 1), `per_page` (default 20, max 100). An inverted BPM range (`bpm_min > bpm_max`) returns 422. The response includes `total`, `page`, `per_page`, and `total_pages`.
+
+All CRUD endpoints are owner-scoped. `GET /api/v1/clips/{id}/audio` additionally supports single HTTP byte ranges (`Range: bytes=…` → `206 Partial Content`, unsatisfiable ranges → `416`) for seeking, and on-the-fly conversion via `?format=wav|flac|mp3` (mp3/flac conversion requires ffmpeg on the host; byte ranges are ignored for converted output). For the audio endpoint an unknown or malformed id returns `404`, another user's private clip returns `403`, and clips marked `is_public` are retrievable by any authenticated user; the CRUD endpoints return `404` for any clip the caller does not own.
 
 ## Stem separation backends
 

--- a/src/acemusic/api/auth/dependencies.py
+++ b/src/acemusic/api/auth/dependencies.py
@@ -13,6 +13,7 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
+from ..services import users as user_service
 from ..settings import ApiSettings
 from .tokens import TokenExpiredError, TokenInvalidError, decode_access_token
 
@@ -71,6 +72,19 @@ def get_current_user(
     if credentials is None:
         raise _unauthorized("Not authenticated.")
     return _user_from_token(credentials.credentials, _settings(request))
+
+
+async def require_existing_user(current: CurrentUser = Depends(get_current_user)) -> CurrentUser:
+    """Like :func:`get_current_user`, but also require the account to still exist.
+
+    An access token outlives account deletion by up to its TTL; endpoints that
+    create or manage user-owned records resolve the user first so a stale token
+    gets a clean 404 instead of touching orphaned data (mirrors ``POST /generate``).
+    """
+    user = await user_service.get_user_by_id(current.user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+    return current
 
 
 def get_current_user_optional(

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -20,7 +20,7 @@ from acemusic import __version__
 
 from . import database
 from .exceptions import HandleConflictError
-from .routers import auth, clips, generation, health, jobs, users
+from .routers import auth, clips, generation, health, jobs, users, workspaces
 from .settings import ApiSettings
 from .tasks.processor import JobProcessor
 
@@ -116,6 +116,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(generation.router, prefix=API_V1_PREFIX)
     app.include_router(jobs.router, prefix=API_V1_PREFIX)
     app.include_router(clips.router, prefix=API_V1_PREFIX)
+    app.include_router(workspaces.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/models/workspace.py
+++ b/src/acemusic/api/models/workspace.py
@@ -22,6 +22,9 @@ class Workspace(Document):
         name = "workspaces"
         indexes = [
             IndexModel([("user_id", ASCENDING)]),
+            # Workspace names are unique per user (US-9.4): the API's create and
+            # rename paths rely on this index for race-safe 409s.
+            IndexModel([("user_id", ASCENDING), ("name", ASCENDING)], unique=True),
             # At most one default workspace per user. The partial filter scopes
             # uniqueness to ``is_default == True`` so a user may still hold many
             # non-default workspaces. This makes the lazy "get-or-create default"

--- a/src/acemusic/api/routers/auth.py
+++ b/src/acemusic/api/routers/auth.py
@@ -58,8 +58,7 @@ from ..auth.oauth import (
 from ..auth.tokens import create_access_token, create_refresh_token
 from ..exceptions import EmailAlreadyRegisteredError
 from ..models import User
-from ..services import users as user_service
-from ..services import workspaces as workspace_service
+from ..services import users as user_service, workspaces as workspace_service
 from ..settings import ApiSettings
 
 router = APIRouter(prefix="/auth", tags=["auth"])

--- a/src/acemusic/api/routers/auth.py
+++ b/src/acemusic/api/routers/auth.py
@@ -59,6 +59,7 @@ from ..auth.tokens import create_access_token, create_refresh_token
 from ..exceptions import EmailAlreadyRegisteredError
 from ..models import User
 from ..services import users as user_service
+from ..services import workspaces as workspace_service
 from ..settings import ApiSettings
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -201,6 +202,11 @@ async def callback(provider: str, body: CallbackRequest, request: Request, respo
             status_code=status.HTTP_409_CONFLICT,
             detail="This email is already registered with a different sign-in provider.",
         ) from exc
+
+    # Every account gets a default workspace at registration (US-9.4). The call
+    # is an idempotent get-or-create, so repeat logins are a cheap lookup and
+    # accounts predating this hook are backfilled on their next login.
+    await workspace_service.get_or_create_default_workspace(user.id)
 
     access, refresh = _mint_token_pair(user, settings)
     expires_at = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from acemusic.storage import get_storage_backend
 
@@ -56,6 +56,14 @@ class ClipSearchParams(BaseModel):
     sort: Literal["newest", "oldest"] = "newest"
     page: int = Field(default=1, ge=1)
     per_page: int = Field(default=PER_PAGE_DEFAULT, ge=1, le=PER_PAGE_MAX)
+
+    @model_validator(mode="after")
+    def _check_bpm_range(self) -> "ClipSearchParams":
+        # An inverted range can never match; reject it as the client error it
+        # is instead of silently returning an empty page.
+        if self.bpm_min is not None and self.bpm_max is not None and self.bpm_min > self.bpm_max:
+            raise ValueError("bpm_min must not be greater than bpm_max.")
+        return self
 
 
 class ClipUpdate(BaseModel):
@@ -130,7 +138,9 @@ class ClipListResponse(BaseModel):
 
 @router.get("", response_model=ClipListResponse)
 async def list_clips(
-    params: ClipSearchParams = Depends(),
+    # Annotated[..., Query()] (not plain Depends) makes FastAPI validate the
+    # model as one unit, so the cross-field bpm validator surfaces as 422.
+    params: Annotated[ClipSearchParams, Query()],
     current: CurrentUser = Depends(get_current_user),
 ) -> ClipListResponse:
     items, total = await clip_service.list_clips(

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -1,21 +1,30 @@
-"""Clip audio retrieval endpoint (US-9.3), mounted under ``/api/v1/clips``.
+"""Clip endpoints (US-9.3 audio retrieval, US-9.4 CRUD), mounted under ``/api/v1/clips``.
 
-``GET /api/v1/clips/{clip_id}/audio`` streams a clip's audio with the correct
-Content-Type, supports single byte-range requests (206 Partial Content) for
-seeking, and optionally converts to another format via ``?format=``. Access
-rules live in :func:`acemusic.api.services.clips.get_clip_for_audio_access`.
+* ``GET    /clips``           → paginated list with search/filter/sort (US-9.4)
+* ``GET    /clips/{id}``      → clip metadata (404 if missing/not owned)
+* ``PATCH  /clips/{id}``      → rename (title is the only writable field)
+* ``DELETE /clips/{id}``      → remove the record and its stored audio
+* ``GET    /clips/{id}/audio``→ stream audio, byte ranges + ``?format=`` (US-9.3)
+
+CRUD is owner-scoped; only the audio endpoint honors ``is_public``. Access and
+filter rules live in :mod:`acemusic.api.services.clips`.
 """
 
 import asyncio
 import logging
+import math
+from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from acemusic.storage import get_storage_backend
 
 from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import Clip
+from ..services import clips as clip_service
 from ..services.audio_conversion import convert_audio_format
 from ..services.clips import get_clip_for_audio_access
 from ..utils.media_types import get_audio_content_type
@@ -23,9 +32,153 @@ from ..utils.range_requests import parse_range_header
 
 logger = logging.getLogger(__name__)
 
+# Titles are stored verbatim and re-served on every list; cap them so one PATCH
+# cannot bloat the document (mirrors the users router's field caps).
+CLIP_TITLE_MAX_LENGTH = 200
+PER_PAGE_DEFAULT = 20
+PER_PAGE_MAX = 100
+
 # Router-level dependency gates every route behind a valid Bearer token
 # (mirrors the jobs/generation routers), so unauthenticated requests get 401.
 router = APIRouter(prefix="/clips", tags=["clips"], dependencies=[Depends(get_current_user)])
+
+
+class ClipSearchParams(BaseModel):
+    """Query parameters for ``GET /clips`` (validated as one unit via Depends)."""
+
+    workspace_id: str | None = None
+    search: str | None = None
+    style: str | None = None
+    bpm_min: int | None = Field(default=None, ge=0)
+    bpm_max: int | None = Field(default=None, ge=0)
+    key: str | None = None
+    model: str | None = None
+    sort: Literal["newest", "oldest"] = "newest"
+    page: int = Field(default=1, ge=1)
+    per_page: int = Field(default=PER_PAGE_DEFAULT, ge=1, le=PER_PAGE_MAX)
+
+
+class ClipUpdate(BaseModel):
+    """Rename payload. ``extra="forbid"`` rejects any non-title field with 422."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: Annotated[str, Field(min_length=1, max_length=CLIP_TITLE_MAX_LENGTH)] | None = None
+
+    @field_validator("title")
+    @classmethod
+    def _check_title(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        value = value.strip()
+        if not value:
+            raise ValueError("Clip title must not be blank.")
+        return value
+
+
+class ClipResponse(BaseModel):
+    # ``file_path`` is deliberately absent: storage keys are internal, and
+    # clients retrieve audio through ``GET /clips/{id}/audio``.
+    id: str
+    workspace_id: str
+    title: str | None
+    format: str | None
+    duration: float | None
+    bpm: int | None
+    key: str | None
+    style_tags: list[str]
+    lyrics: str | None
+    vocal_language: str | None
+    model: str | None
+    seed: int | None
+    inference_steps: int | None
+    parent_clip_ids: list[str]
+    generation_mode: str | None
+    is_public: bool
+    created_at: datetime
+
+    @classmethod
+    def from_clip(cls, clip: Clip) -> "ClipResponse":
+        return cls(
+            id=str(clip.id),
+            workspace_id=str(clip.workspace_id),
+            title=clip.title,
+            format=clip.format,
+            duration=clip.duration,
+            bpm=clip.bpm,
+            key=clip.key,
+            style_tags=clip.style_tags,
+            lyrics=clip.lyrics,
+            vocal_language=clip.vocal_language,
+            model=clip.model,
+            seed=clip.seed,
+            inference_steps=clip.inference_steps,
+            parent_clip_ids=[str(pid) for pid in clip.parent_clip_ids],
+            generation_mode=clip.generation_mode,
+            is_public=clip.is_public,
+            created_at=clip.created_at,
+        )
+
+
+class ClipListResponse(BaseModel):
+    clips: list[ClipResponse]
+    total: int
+    page: int
+    per_page: int
+    total_pages: int
+
+
+@router.get("", response_model=ClipListResponse)
+async def list_clips(
+    params: ClipSearchParams = Depends(),
+    current: CurrentUser = Depends(get_current_user),
+) -> ClipListResponse:
+    items, total = await clip_service.list_clips(
+        current.user_id,
+        workspace_id=params.workspace_id,
+        search=params.search,
+        style=params.style,
+        bpm_min=params.bpm_min,
+        bpm_max=params.bpm_max,
+        key=params.key,
+        model=params.model,
+        sort=params.sort,
+        page=params.page,
+        per_page=params.per_page,
+    )
+    return ClipListResponse(
+        clips=[ClipResponse.from_clip(clip) for clip in items],
+        total=total,
+        page=params.page,
+        per_page=params.per_page,
+        total_pages=math.ceil(total / params.per_page),
+    )
+
+
+@router.get("/{clip_id}", response_model=ClipResponse)
+async def get_clip(clip_id: str, current: CurrentUser = Depends(get_current_user)) -> ClipResponse:
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    return ClipResponse.from_clip(clip)
+
+
+@router.patch("/{clip_id}", response_model=ClipResponse)
+async def update_clip(
+    clip_id: str,
+    body: ClipUpdate,
+    current: CurrentUser = Depends(get_current_user),
+) -> ClipResponse:
+    """Rename the clip; an empty body is a no-op returning the current state."""
+    if body.title is None:
+        clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    else:
+        clip = await clip_service.update_clip_title(clip_id, current.user_id, body.title)
+    return ClipResponse.from_clip(clip)
+
+
+@router.delete("/{clip_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_clip(clip_id: str, current: CurrentUser = Depends(get_current_user)) -> Response:
+    await clip_service.delete_clip(clip_id, current.user_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{clip_id}/audio")

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -57,6 +57,15 @@ class ClipSearchParams(BaseModel):
     page: int = Field(default=1, ge=1)
     per_page: int = Field(default=PER_PAGE_DEFAULT, ge=1, le=PER_PAGE_MAX)
 
+    @field_validator("search", "style")
+    @classmethod
+    def _blank_to_none(cls, value: str | None) -> str | None:
+        # `?search=` must mean "no filter"; an empty needle would otherwise
+        # become an empty regex that matches every clip with the field set.
+        if value is None:
+            return None
+        return value.strip() or None
+
     @model_validator(mode="after")
     def _check_bpm_range(self) -> "ClipSearchParams":
         # An inverted range can never match; reject it as the client error it
@@ -82,6 +91,14 @@ class ClipUpdate(BaseModel):
         if not value:
             raise ValueError("Clip title must not be blank.")
         return value
+
+    @model_validator(mode="after")
+    def _reject_explicit_null(self) -> "ClipUpdate":
+        # An omitted title is a no-op; an explicit null is a malformed request
+        # (title has no "cleared" state) and must not masquerade as success.
+        if "title" in self.model_fields_set and self.title is None:
+            raise ValueError("title must be a non-empty string; omit the field to leave it unchanged.")
+        return self
 
 
 class ClipResponse(BaseModel):

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from acemusic.storage import get_storage_backend
 
-from ..auth.dependencies import CurrentUser, get_current_user
+from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
 from ..models import Clip
 from ..services import clips as clip_service
 from ..services.audio_conversion import convert_audio_format
@@ -141,7 +141,7 @@ async def list_clips(
     # Annotated[..., Query()] (not plain Depends) makes FastAPI validate the
     # model as one unit, so the cross-field bpm validator surfaces as 422.
     params: Annotated[ClipSearchParams, Query()],
-    current: CurrentUser = Depends(get_current_user),
+    current: CurrentUser = Depends(require_existing_user),
 ) -> ClipListResponse:
     items, total = await clip_service.list_clips(
         current.user_id,
@@ -166,7 +166,7 @@ async def list_clips(
 
 
 @router.get("/{clip_id}", response_model=ClipResponse)
-async def get_clip(clip_id: str, current: CurrentUser = Depends(get_current_user)) -> ClipResponse:
+async def get_clip(clip_id: str, current: CurrentUser = Depends(require_existing_user)) -> ClipResponse:
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
     return ClipResponse.from_clip(clip)
 
@@ -175,7 +175,7 @@ async def get_clip(clip_id: str, current: CurrentUser = Depends(get_current_user
 async def update_clip(
     clip_id: str,
     body: ClipUpdate,
-    current: CurrentUser = Depends(get_current_user),
+    current: CurrentUser = Depends(require_existing_user),
 ) -> ClipResponse:
     """Rename the clip; an empty body is a no-op returning the current state."""
     if body.title is None:
@@ -186,7 +186,7 @@ async def update_clip(
 
 
 @router.delete("/{clip_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_clip(clip_id: str, current: CurrentUser = Depends(get_current_user)) -> Response:
+async def delete_clip(clip_id: str, current: CurrentUser = Depends(require_existing_user)) -> Response:
     await clip_service.delete_clip(clip_id, current.user_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/src/acemusic/api/routers/workspaces.py
+++ b/src/acemusic/api/routers/workspaces.py
@@ -47,7 +47,10 @@ class WorkspaceCreate(BaseModel):
 
     name: Annotated[str, Field(min_length=1, max_length=WORKSPACE_NAME_MAX_LENGTH)]
 
-    _check_name = field_validator("name")(_validate_name)
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, value: str) -> str:
+        return _validate_name(value)
 
 
 class WorkspaceUpdate(BaseModel):

--- a/src/acemusic/api/routers/workspaces.py
+++ b/src/acemusic/api/routers/workspaces.py
@@ -20,7 +20,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query, Response, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from ..auth.dependencies import CurrentUser, get_current_user
+from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
 from ..models import Workspace
 from ..services import workspaces as workspace_service
 
@@ -91,14 +91,14 @@ class WorkspaceListResponse(BaseModel):
 @router.post("", response_model=WorkspaceResponse, status_code=status.HTTP_201_CREATED)
 async def create_workspace(
     body: WorkspaceCreate,
-    current: CurrentUser = Depends(get_current_user),
+    current: CurrentUser = Depends(require_existing_user),
 ) -> WorkspaceResponse:
     workspace = await workspace_service.create_workspace(current.user_id, body.name)
     return WorkspaceResponse.from_workspace(workspace, clip_count=0)
 
 
 @router.get("", response_model=WorkspaceListResponse)
-async def list_workspaces(current: CurrentUser = Depends(get_current_user)) -> WorkspaceListResponse:
+async def list_workspaces(current: CurrentUser = Depends(require_existing_user)) -> WorkspaceListResponse:
     pairs = await workspace_service.list_workspaces(current.user_id)
     return WorkspaceListResponse(
         workspaces=[WorkspaceResponse.from_workspace(workspace, count) for workspace, count in pairs],
@@ -109,7 +109,7 @@ async def list_workspaces(current: CurrentUser = Depends(get_current_user)) -> W
 @router.get("/{workspace_id}", response_model=WorkspaceResponse)
 async def get_workspace(
     workspace_id: str,
-    current: CurrentUser = Depends(get_current_user),
+    current: CurrentUser = Depends(require_existing_user),
 ) -> WorkspaceResponse:
     workspace = await workspace_service.get_workspace(workspace_id, current.user_id)
     clip_count = await workspace_service.count_clips(workspace)
@@ -120,7 +120,7 @@ async def get_workspace(
 async def update_workspace(
     workspace_id: str,
     body: WorkspaceUpdate,
-    current: CurrentUser = Depends(get_current_user),
+    current: CurrentUser = Depends(require_existing_user),
 ) -> WorkspaceResponse:
     """Rename the workspace; an empty body is a no-op returning the current state."""
     if body.name is None:
@@ -138,7 +138,7 @@ async def delete_workspace(
         default=False,
         description="Required (true) to delete a workspace that still contains clips, along with those clips.",
     ),
-    current: CurrentUser = Depends(get_current_user),
+    current: CurrentUser = Depends(require_existing_user),
 ) -> Response:
     await workspace_service.delete_workspace(workspace_id, current.user_id, force=force)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/acemusic/api/routers/workspaces.py
+++ b/src/acemusic/api/routers/workspaces.py
@@ -1,0 +1,144 @@
+"""Workspace CRUD router (US-9.4), mounted under ``/api/v1/workspaces``.
+
+Endpoints (all require a valid Bearer access token and operate only on the
+authenticated user's workspaces):
+
+* ``POST   /workspaces``      → create (201; 409 on duplicate name)
+* ``GET    /workspaces``      → list with per-workspace clip counts
+* ``GET    /workspaces/{id}`` → single workspace (404 if missing/not owned)
+* ``PATCH  /workspaces/{id}`` → rename (409 on duplicate name)
+* ``DELETE /workspaces/{id}`` → delete (409 if non-empty without ``?force=true``,
+  400 for the last workspace)
+
+Request/response schemas live here (same convention as the users router);
+business rules live in :mod:`acemusic.api.services.workspaces`.
+"""
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Response, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import Workspace
+from ..services import workspaces as workspace_service
+
+# Names are stored verbatim and re-served on every list; cap them so one POST
+# cannot bloat the document (mirrors the users router's field caps).
+WORKSPACE_NAME_MAX_LENGTH = 100
+
+# Router-level dependency gates every route; endpoints additionally take
+# ``current`` to read the identity. FastAPI caches the dependency, so
+# ``get_current_user`` still runs once per request.
+router = APIRouter(prefix="/workspaces", tags=["workspaces"], dependencies=[Depends(get_current_user)])
+
+
+def _validate_name(value: str) -> str:
+    """Strip surrounding whitespace and reject names that are blank after it."""
+    value = value.strip()
+    if not value:
+        raise ValueError("Workspace name must not be blank.")
+    return value
+
+
+class WorkspaceCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: Annotated[str, Field(min_length=1, max_length=WORKSPACE_NAME_MAX_LENGTH)]
+
+    _check_name = field_validator("name")(_validate_name)
+
+
+class WorkspaceUpdate(BaseModel):
+    """Rename payload. ``extra="forbid"`` rejects unknown keys with 422."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Annotated[str, Field(min_length=1, max_length=WORKSPACE_NAME_MAX_LENGTH)] | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, value: str | None) -> str | None:
+        return value if value is None else _validate_name(value)
+
+
+class WorkspaceResponse(BaseModel):
+    id: str
+    name: str
+    clip_count: int
+    is_default: bool
+    created_at: datetime
+    updated_at: datetime | None
+
+    @classmethod
+    def from_workspace(cls, workspace: Workspace, clip_count: int) -> "WorkspaceResponse":
+        return cls(
+            id=str(workspace.id),
+            name=workspace.name,
+            clip_count=clip_count,
+            is_default=workspace.is_default,
+            created_at=workspace.created_at,
+            updated_at=workspace.updated_at,
+        )
+
+
+class WorkspaceListResponse(BaseModel):
+    workspaces: list[WorkspaceResponse]
+    total: int
+
+
+@router.post("", response_model=WorkspaceResponse, status_code=status.HTTP_201_CREATED)
+async def create_workspace(
+    body: WorkspaceCreate,
+    current: CurrentUser = Depends(get_current_user),
+) -> WorkspaceResponse:
+    workspace = await workspace_service.create_workspace(current.user_id, body.name)
+    return WorkspaceResponse.from_workspace(workspace, clip_count=0)
+
+
+@router.get("", response_model=WorkspaceListResponse)
+async def list_workspaces(current: CurrentUser = Depends(get_current_user)) -> WorkspaceListResponse:
+    pairs = await workspace_service.list_workspaces(current.user_id)
+    return WorkspaceListResponse(
+        workspaces=[WorkspaceResponse.from_workspace(workspace, count) for workspace, count in pairs],
+        total=len(pairs),
+    )
+
+
+@router.get("/{workspace_id}", response_model=WorkspaceResponse)
+async def get_workspace(
+    workspace_id: str,
+    current: CurrentUser = Depends(get_current_user),
+) -> WorkspaceResponse:
+    workspace = await workspace_service.get_workspace(workspace_id, current.user_id)
+    clip_count = await workspace_service.count_clips(workspace)
+    return WorkspaceResponse.from_workspace(workspace, clip_count)
+
+
+@router.patch("/{workspace_id}", response_model=WorkspaceResponse)
+async def update_workspace(
+    workspace_id: str,
+    body: WorkspaceUpdate,
+    current: CurrentUser = Depends(get_current_user),
+) -> WorkspaceResponse:
+    """Rename the workspace; an empty body is a no-op returning the current state."""
+    if body.name is None:
+        workspace = await workspace_service.get_workspace(workspace_id, current.user_id)
+    else:
+        workspace = await workspace_service.update_workspace(workspace_id, current.user_id, body.name)
+    clip_count = await workspace_service.count_clips(workspace)
+    return WorkspaceResponse.from_workspace(workspace, clip_count)
+
+
+@router.delete("/{workspace_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_workspace(
+    workspace_id: str,
+    force: bool = Query(
+        default=False,
+        description="Required (true) to delete a workspace that still contains clips, along with those clips.",
+    ),
+    current: CurrentUser = Depends(get_current_user),
+) -> Response:
+    await workspace_service.delete_workspace(workspace_id, current.user_id, force=force)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -1,15 +1,26 @@
-"""Clip access service (US-9.3).
+"""Clip access and CRUD service (US-9.3, US-9.4).
 
 Resolves a clip for audio retrieval and enforces the visibility rules from
 issue #77: a clip that does not exist (or has a malformed id) is 404; another
 user's private clip is 403; the owner and any authenticated user (for public
 clips) get the clip back.
+
+CRUD (issue #78) is stricter: list/get/update/delete are owner-scoped, so
+another user's clip — public or not — is a plain 404. Public visibility only
+ever applies to the audio endpoint.
 """
+
+import asyncio
+import re
+from typing import Literal
 
 from beanie import PydanticObjectId
 from fastapi import HTTPException, status
 
+from acemusic.storage import get_storage_backend
+
 from ..models import Clip
+from . import workspaces as workspace_service
 
 
 def _coerce_object_id(value: str) -> PydanticObjectId | None:
@@ -34,3 +45,95 @@ async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
     if str(clip.user_id) != current_user_id and not clip.is_public:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="This clip is private.")
     return clip
+
+
+def _clip_not_found() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found.")
+
+
+def _contains_regex(text: str) -> dict:
+    """Case-insensitive substring matcher, with the needle treated literally."""
+    return {"$regex": re.escape(text), "$options": "i"}
+
+
+async def get_owned_clip(clip_id: str, user_id: str) -> Clip:
+    """Return the clip if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
+    oid = _coerce_object_id(clip_id)
+    clip = await Clip.get(oid) if oid is not None else None
+    if clip is None or str(clip.user_id) != user_id:
+        raise _clip_not_found()
+    return clip
+
+
+async def list_clips(
+    user_id: str,
+    *,
+    workspace_id: str | None = None,
+    search: str | None = None,
+    style: str | None = None,
+    bpm_min: int | None = None,
+    bpm_max: int | None = None,
+    key: str | None = None,
+    model: str | None = None,
+    sort: Literal["newest", "oldest"] = "newest",
+    page: int = 1,
+    per_page: int = 20,
+) -> tuple[list[Clip], int]:
+    """Return one page of the user's clips plus the total match count.
+
+    Filters mirror the CLI's ``search_clips`` (US-4.2): ``style`` and ``search``
+    are case-insensitive substring matches (``search`` over title *or* style
+    tags), BPM is a closed range, ``key``/``model`` are exact. A ``workspace_id``
+    filter is validated for ownership first and raises 404 like any other
+    workspace access.
+    """
+    query: dict = {"user_id": PydanticObjectId(user_id)}
+    if workspace_id is not None:
+        workspace = await workspace_service.get_workspace(workspace_id, user_id)
+        query["workspace_id"] = workspace.id
+    if style is not None:
+        query["style_tags"] = _contains_regex(style)
+    if search is not None:
+        needle = _contains_regex(search)
+        query["$or"] = [{"title": needle}, {"style_tags": needle}]
+    if bpm_min is not None or bpm_max is not None:
+        bpm_range: dict = {}
+        if bpm_min is not None:
+            bpm_range["$gte"] = bpm_min
+        if bpm_max is not None:
+            bpm_range["$lte"] = bpm_max
+        query["bpm"] = bpm_range
+    if key is not None:
+        query["key"] = key
+    if model is not None:
+        query["model"] = model
+
+    total = await Clip.find(query).count()
+    direction = -1 if sort == "newest" else 1
+    # _id tiebreak keeps pagination stable when created_at values collide.
+    items = (
+        await Clip.find(query)
+        .sort(("created_at", direction), ("_id", direction))
+        .skip((page - 1) * per_page)
+        .limit(per_page)
+        .to_list()
+    )
+    return items, total
+
+
+async def update_clip_title(clip_id: str, user_id: str, title: str) -> Clip:
+    """Rename the clip (title is the only client-writable field, as in the CLI)."""
+    clip = await get_owned_clip(clip_id, user_id)
+    clip.title = title
+    await clip.save()
+    return clip
+
+
+async def delete_clip(clip_id: str, user_id: str) -> None:
+    """Delete the clip record and its stored audio (idempotent on the object)."""
+    clip = await get_owned_clip(clip_id, user_id)
+    # delete() does file/network I/O via the sync backend; keep it off the
+    # event loop. Storage goes first so a crash between the two steps leaves a
+    # re-deletable record rather than an orphaned file.
+    await asyncio.to_thread(get_storage_backend().delete, clip.file_path)
+    await clip.delete()

--- a/src/acemusic/api/services/generation.py
+++ b/src/acemusic/api/services/generation.py
@@ -7,44 +7,17 @@ modules, so the router stays free of persistence concerns.
 """
 
 from beanie import PydanticObjectId
-from beanie.operators import Eq
-from pymongo.errors import DuplicateKeyError
 
-from ..models import Job, JobStatus, Workspace
+from ..models import Job, JobStatus
 from ..tasks import dispatch_job
 
+# get_or_create_default_workspace moved to the workspaces service (US-9.4); it is
+# re-exported here because generation still uses it as a lazy fallback for
+# accounts predating the registration-time bootstrap, and existing callers/tests
+# import it from this module.
+from .workspaces import DEFAULT_WORKSPACE_NAME, get_or_create_default_workspace  # noqa: F401
+
 GENERATE_JOB_TYPE = "generate"
-DEFAULT_WORKSPACE_NAME = "My Workspace"
-
-
-async def _find_default_workspace(user_id: PydanticObjectId) -> Workspace | None:
-    return await Workspace.find_one(Eq(Workspace.user_id, user_id), Eq(Workspace.is_default, True))
-
-
-async def get_or_create_default_workspace(user_id: PydanticObjectId) -> Workspace:
-    """Return the user's default workspace, creating it on first use.
-
-    A generation job must be attached to a workspace, but a freshly registered
-    account has none yet — workspaces are created lazily here rather than at
-    registration. The default workspace is created once and reused thereafter.
-
-    The create path is race-safe: the unique partial index on
-    ``(user_id, is_default=True)`` (see :class:`Workspace`) rejects a concurrent
-    second insert with ``DuplicateKeyError``, which we resolve by re-reading the
-    winner (mirroring ``users.get_or_create_user``).
-    """
-    workspace = await _find_default_workspace(user_id)
-    if workspace is not None:
-        return workspace
-    workspace = Workspace(name=DEFAULT_WORKSPACE_NAME, user_id=user_id, is_default=True)
-    try:
-        await workspace.insert()
-    except DuplicateKeyError:
-        existing = await _find_default_workspace(user_id)
-        if existing is None:
-            raise
-        return existing
-    return workspace
 
 
 async def create_generation_job(*, user_id: PydanticObjectId, params: dict) -> Job:

--- a/src/acemusic/api/services/workspaces.py
+++ b/src/acemusic/api/services/workspaces.py
@@ -71,9 +71,7 @@ async def get_or_create_default_workspace(user_id: PydanticObjectId) -> Workspac
         # (user_id, name) index: the user already owns a non-default workspace
         # named "My Workspace" (created via the API before this bootstrap ran).
         # Promote it rather than failing the login with a 500.
-        named = await Workspace.find_one(
-            Eq(Workspace.user_id, user_id), Eq(Workspace.name, DEFAULT_WORKSPACE_NAME)
-        )
+        named = await Workspace.find_one(Eq(Workspace.user_id, user_id), Eq(Workspace.name, DEFAULT_WORKSPACE_NAME))
         if named is None:
             raise
         named.is_default = True

--- a/src/acemusic/api/services/workspaces.py
+++ b/src/acemusic/api/services/workspaces.py
@@ -1,0 +1,166 @@
+"""Workspace service layer (US-9.4).
+
+Owns workspace CRUD and the default-workspace bootstrap (moved here from the
+generation service, which now imports it back — workspaces are this module's
+domain). Ownership failures and unknown/malformed ids surface as 404 so the
+API never reveals whether another user's workspace exists, mirroring
+:mod:`acemusic.api.services.clips`.
+"""
+
+import asyncio
+
+from beanie import PydanticObjectId
+from beanie.operators import Eq
+from fastapi import HTTPException, status
+from pymongo.errors import DuplicateKeyError
+
+from acemusic.storage import get_storage_backend
+
+from ..models import Clip, Workspace
+from ..models.common import utcnow
+
+DEFAULT_WORKSPACE_NAME = "My Workspace"
+
+
+def _coerce_object_id(value: str) -> PydanticObjectId | None:
+    """Parse a path id, treating a malformed id as "no such workspace" (→ 404)."""
+    try:
+        return PydanticObjectId(value)
+    except Exception:
+        return None
+
+
+def _not_found() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found.")
+
+
+def _name_conflict(name: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=f"A workspace named {name!r} already exists.",
+    )
+
+
+async def _find_default_workspace(user_id: PydanticObjectId) -> Workspace | None:
+    return await Workspace.find_one(Eq(Workspace.user_id, user_id), Eq(Workspace.is_default, True))
+
+
+async def get_or_create_default_workspace(user_id: PydanticObjectId) -> Workspace:
+    """Return the user's default workspace, creating it on first use.
+
+    Called at registration (US-9.4: the OAuth callback bootstraps every new
+    account with a default workspace) and kept as a lazy fallback in the
+    generation service for accounts that predate that hook.
+
+    The create path is race-safe: the unique partial index on
+    ``(user_id, is_default=True)`` (see :class:`Workspace`) rejects a concurrent
+    second insert with ``DuplicateKeyError``, which we resolve by re-reading the
+    winner (mirroring ``users.get_or_create_user``).
+    """
+    workspace = await _find_default_workspace(user_id)
+    if workspace is not None:
+        return workspace
+    workspace = Workspace(name=DEFAULT_WORKSPACE_NAME, user_id=user_id, is_default=True)
+    try:
+        await workspace.insert()
+    except DuplicateKeyError:
+        existing = await _find_default_workspace(user_id)
+        if existing is None:
+            raise
+        return existing
+    return workspace
+
+
+async def create_workspace(user_id: str, name: str) -> Workspace:
+    """Create a workspace for ``user_id``. Raises 409 if the name is taken.
+
+    The insert always carries ``is_default=False``, so a ``DuplicateKeyError``
+    here can only come from the unique ``(user_id, name)`` index — the partial
+    default-workspace index never matches non-default documents.
+    """
+    workspace = Workspace(name=name, user_id=PydanticObjectId(user_id))
+    try:
+        await workspace.insert()
+    except DuplicateKeyError as exc:
+        raise _name_conflict(name) from exc
+    return workspace
+
+
+async def list_workspaces(user_id: str) -> list[tuple[Workspace, int]]:
+    """Return all of ``user_id``'s workspaces (oldest first) with clip counts."""
+    user_oid = PydanticObjectId(user_id)
+    workspaces = await Workspace.find(Eq(Workspace.user_id, user_oid)).sort("+created_at").to_list()
+    # One aggregation for all counts instead of a count query per workspace.
+    rows = await Clip.aggregate(
+        [
+            {"$match": {"user_id": user_oid}},
+            {"$group": {"_id": "$workspace_id", "count": {"$sum": 1}}},
+        ]
+    ).to_list()
+    counts = {row["_id"]: row["count"] for row in rows}
+    return [(workspace, counts.get(workspace.id, 0)) for workspace in workspaces]
+
+
+async def get_workspace(workspace_id: str, user_id: str) -> Workspace:
+    """Return the workspace if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
+    oid = _coerce_object_id(workspace_id)
+    workspace = await Workspace.get(oid) if oid is not None else None
+    if workspace is None or str(workspace.user_id) != user_id:
+        raise _not_found()
+    return workspace
+
+
+async def count_clips(workspace: Workspace) -> int:
+    """Number of clips stored in ``workspace``."""
+    return await Clip.find(Eq(Clip.workspace_id, workspace.id)).count()
+
+
+async def update_workspace(workspace_id: str, user_id: str, name: str) -> Workspace:
+    """Rename the workspace. Raises 404 if not owned, 409 if the name is taken."""
+    workspace = await get_workspace(workspace_id, user_id)
+    workspace.name = name
+    workspace.updated_at = utcnow()
+    try:
+        await workspace.save()
+    except DuplicateKeyError as exc:
+        raise _name_conflict(name) from exc
+    return workspace
+
+
+async def delete_workspace(workspace_id: str, user_id: str, *, force: bool) -> None:
+    """Delete the workspace, cascading to its clips when ``force`` is set.
+
+    * 404 — unknown/malformed id or not owned by ``user_id``
+    * 400 — it is the user's last workspace (force does not override; every
+      account keeps at least one workspace, matching the CLI rule)
+    * 409 — the workspace still holds clips and ``force`` is false
+
+    A forced delete removes each clip's stored audio (idempotent — a missing
+    object is not an error) before the clip documents and the workspace itself,
+    so a crash mid-cascade leaves re-deletable records rather than orphaned files.
+    """
+    workspace = await get_workspace(workspace_id, user_id)
+
+    remaining = await Workspace.find(Eq(Workspace.user_id, workspace.user_id)).count()
+    if remaining <= 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete your last workspace.",
+        )
+
+    clip_count = await count_clips(workspace)
+    if clip_count and not force:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Workspace contains {clip_count} clip(s). Pass force=true to delete it and its clips.",
+        )
+
+    if clip_count:
+        storage = get_storage_backend()
+        async for clip in Clip.find(Eq(Clip.workspace_id, workspace.id)):
+            # delete() does file/network I/O via the sync backend; keep it off
+            # the event loop.
+            await asyncio.to_thread(storage.delete, clip.file_path)
+        await Clip.find(Eq(Clip.workspace_id, workspace.id)).delete()
+
+    await workspace.delete()

--- a/src/acemusic/api/services/workspaces.py
+++ b/src/acemusic/api/services/workspaces.py
@@ -65,9 +65,29 @@ async def get_or_create_default_workspace(user_id: PydanticObjectId) -> Workspac
         await workspace.insert()
     except DuplicateKeyError:
         existing = await _find_default_workspace(user_id)
-        if existing is None:
+        if existing is not None:
+            return existing
+        # No default exists, so the collision came from the unique
+        # (user_id, name) index: the user already owns a non-default workspace
+        # named "My Workspace" (created via the API before this bootstrap ran).
+        # Promote it rather than failing the login with a 500.
+        named = await Workspace.find_one(
+            Eq(Workspace.user_id, user_id), Eq(Workspace.name, DEFAULT_WORKSPACE_NAME)
+        )
+        if named is None:
             raise
-        return existing
+        named.is_default = True
+        named.updated_at = utcnow()
+        try:
+            await named.save()
+        except DuplicateKeyError:
+            # Lost a race to a concurrent bootstrap; the winner holds the
+            # default flag now.
+            winner = await _find_default_workspace(user_id)
+            if winner is None:
+                raise
+            return winner
+        return named
     return workspace
 
 

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -250,6 +250,43 @@ class TestCallback:
         assert claims["sub"] == str(user.id)
         assert body["refresh_token"]
 
+    async def test_callback_creates_default_workspace_for_new_user(self, client, settings, monkeypatch):
+        """Registration bootstraps a default workspace (US-9.4)."""
+        from acemusic.api.models import Workspace
+        from acemusic.api.services.workspaces import DEFAULT_WORKSPACE_NAME
+
+        _fake_exchange(
+            monkeypatch,
+            OAuthUserInfo(provider="google", oauth_id="g-ws", email="ws@example.com", name="W", email_verified=True),
+        )
+        resp = await client.post(
+            f"{API_V1_PREFIX}/auth/callback/google",
+            json={"code": "auth-code", "state": _bind_state(client, "google", settings)},
+        )
+        assert resp.status_code == 200
+        user = await User.find_one(User.oauth_provider == "google", User.oauth_id == "g-ws")
+        workspaces = await Workspace.find(Workspace.user_id == user.id).to_list()
+        assert len(workspaces) == 1
+        assert workspaces[0].is_default is True
+        assert workspaces[0].name == DEFAULT_WORKSPACE_NAME
+
+    async def test_repeat_login_does_not_create_second_default_workspace(self, client, settings, monkeypatch):
+        from acemusic.api.models import Workspace
+
+        info = OAuthUserInfo(
+            provider="google", oauth_id="g-ws2", email="ws2@example.com", name="W", email_verified=True
+        )
+        for code in ("c1", "c2"):
+            _fake_exchange(monkeypatch, info)
+            resp = await client.post(
+                f"{API_V1_PREFIX}/auth/callback/google",
+                json={"code": code, "state": _bind_state(client, "google", settings)},
+            )
+            assert resp.status_code == 200
+        user = await User.find_one(User.oauth_provider == "google", User.oauth_id == "g-ws2")
+        workspaces = await Workspace.find(Workspace.user_id == user.id).to_list()
+        assert len(workspaces) == 1
+
     async def test_discord_callback_creates_user_and_returns_jwt(self, client, settings, monkeypatch):
         _fake_exchange(
             monkeypatch,

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -526,8 +526,9 @@ class TestLogout:
 class TestRouteProtectionPattern:
     """Proves a router guarded by Depends(get_current_user) enforces auth.
 
-    No workspaces/clips routers exist yet, so we mount a representative protected
-    route under the v1 prefix on the real app to demonstrate the pattern.
+    Mounts a representative protected route under the v1 prefix on the real app
+    to test the dependency pattern in isolation from any production router
+    (which have their own auth-gate tests, e.g. tests/test_workspaces_api.py).
     """
 
     @pytest.fixture

--- a/tests/test_clips_crud_api.py
+++ b/tests/test_clips_crud_api.py
@@ -216,9 +216,7 @@ class TestListClips:
         clip_a = await _insert_clip(user, ws_a)
         await _insert_clip(user, ws_b)
 
-        resp = await client.get(
-            CLIPS_URL, params={"workspace_id": str(ws_a.id)}, headers=_auth_headers(user, settings)
-        )
+        resp = await client.get(CLIPS_URL, params={"workspace_id": str(ws_a.id)}, headers=_auth_headers(user, settings))
         body = resp.json()
         assert body["total"] == 1
         assert body["clips"][0]["id"] == str(clip_a.id)
@@ -276,9 +274,7 @@ class TestListClips:
         by_key = (await client.get(CLIPS_URL, params={"key": "C minor"}, headers=headers)).json()
         assert by_key["total"] == 2
 
-        both = (
-            await client.get(CLIPS_URL, params={"key": "C minor", "model": "ace-step-v1"}, headers=headers)
-        ).json()
+        both = (await client.get(CLIPS_URL, params={"key": "C minor", "model": "ace-step-v1"}, headers=headers)).json()
         assert both["total"] == 1
         assert both["clips"][0]["id"] == str(target.id)
 

--- a/tests/test_clips_crud_api.py
+++ b/tests/test_clips_crud_api.py
@@ -1,0 +1,432 @@
+"""Tests for the clip CRUD endpoints (US-9.4, issue #78).
+
+Covers ``GET /clips`` (filters, sort, pagination), ``GET /clips/{id}``,
+``PATCH /clips/{id}`` and ``DELETE /clips/{id}``. The audio retrieval endpoint
+(US-9.3) is covered separately in ``tests/test_clips_api.py``.
+
+The 401 auth-gate tests run in CI (no DB); the rest are ``integration`` and
+drive the real app with ``httpx.AsyncClient`` over a local MongoDB.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize(
+        ("method", "url"),
+        [
+            ("GET", CLIPS_URL),
+            ("GET", f"{CLIPS_URL}/{PydanticObjectId()}"),
+            ("PATCH", f"{CLIPS_URL}/{PydanticObjectId()}"),
+            ("DELETE", f"{CLIPS_URL}/{PydanticObjectId()}"),
+        ],
+    )
+    def test_missing_auth_header_returns_401(self, method: str, url: str) -> None:
+        client = TestClient(create_app())
+        resp = client.request(method, url)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    """Point the storage backend at a throwaway local root."""
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+_SEQ = {"n": 0}
+
+
+async def _insert_clip(
+    user,
+    workspace: Workspace,
+    *,
+    title: str | None = None,
+    style_tags: list[str] | None = None,
+    bpm: int | None = None,
+    key: str | None = None,
+    model: str | None = None,
+    is_public: bool = False,
+    created_at: datetime | None = None,
+    store_bytes: bytes | None = None,
+) -> Clip:
+    # Monotonic created_at default keeps sort order deterministic across clips
+    # inserted within the same millisecond.
+    _SEQ["n"] += 1
+    if created_at is None:
+        created_at = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=_SEQ["n"])
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.wav"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=file_path,
+        format="wav",
+        title=title,
+        style_tags=style_tags or [],
+        bpm=bpm,
+        key=key,
+        model=model,
+        is_public=is_public,
+        created_at=created_at,
+    )
+    await clip.insert()
+    return clip
+
+
+@pytest.mark.integration
+class TestListClips:
+    async def test_lists_only_own_clips_newest_first(self, client, settings) -> None:
+        user = await _make_user("clips-list@example.com")
+        other = await _make_user("clips-list-other@example.com")
+        workspace = await _make_workspace(user)
+        other_ws = await _make_workspace(other)
+        first = await _insert_clip(user, workspace, title="first")
+        second = await _insert_clip(user, workspace, title="second")
+        await _insert_clip(other, other_ws, title="theirs")
+
+        resp = await client.get(CLIPS_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 2
+        assert [c["id"] for c in body["clips"]] == [str(second.id), str(first.id)]
+
+    async def test_sort_oldest_reverses_order(self, client, settings) -> None:
+        user = await _make_user("clips-sort@example.com")
+        workspace = await _make_workspace(user)
+        first = await _insert_clip(user, workspace)
+        second = await _insert_clip(user, workspace)
+
+        resp = await client.get(CLIPS_URL, params={"sort": "oldest"}, headers=_auth_headers(user, settings))
+        assert [c["id"] for c in resp.json()["clips"]] == [str(first.id), str(second.id)]
+
+    async def test_invalid_sort_returns_422(self, client, settings) -> None:
+        user = await _make_user("clips-sort-bad@example.com")
+        resp = await client.get(CLIPS_URL, params={"sort": "loudest"}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+    async def test_pagination_metadata_and_page_slices(self, client, settings) -> None:
+        user = await _make_user("clips-page@example.com")
+        workspace = await _make_workspace(user)
+        clips = [await _insert_clip(user, workspace) for _ in range(5)]
+        newest_first = [str(c.id) for c in reversed(clips)]
+        headers = _auth_headers(user, settings)
+
+        page1 = (await client.get(CLIPS_URL, params={"per_page": 2}, headers=headers)).json()
+        assert page1["total"] == 5
+        assert page1["page"] == 1
+        assert page1["per_page"] == 2
+        assert page1["total_pages"] == 3
+        assert [c["id"] for c in page1["clips"]] == newest_first[:2]
+
+        page3 = (await client.get(CLIPS_URL, params={"per_page": 2, "page": 3}, headers=headers)).json()
+        assert [c["id"] for c in page3["clips"]] == newest_first[4:]
+        assert page3["total_pages"] == 3
+
+        beyond = (await client.get(CLIPS_URL, params={"per_page": 2, "page": 4}, headers=headers)).json()
+        assert beyond["clips"] == []
+        assert beyond["total"] == 5
+
+    @pytest.mark.parametrize("params", [{"page": 0}, {"per_page": 0}, {"per_page": 101}])
+    async def test_pagination_bounds_return_422(self, client, settings, params: dict) -> None:
+        user = await _make_user("clips-page-bad@example.com")
+        resp = await client.get(CLIPS_URL, params=params, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+    async def test_filter_by_workspace(self, client, settings) -> None:
+        user = await _make_user("clips-ws@example.com")
+        ws_a = await _make_workspace(user, "A")
+        ws_b = await _make_workspace(user, "B")
+        clip_a = await _insert_clip(user, ws_a)
+        await _insert_clip(user, ws_b)
+
+        resp = await client.get(
+            CLIPS_URL, params={"workspace_id": str(ws_a.id)}, headers=_auth_headers(user, settings)
+        )
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["clips"][0]["id"] == str(clip_a.id)
+
+    async def test_other_users_workspace_filter_returns_404(self, client, settings) -> None:
+        user = await _make_user("clips-ws-404@example.com")
+        other = await _make_user("clips-ws-404-other@example.com")
+        their_ws = await _make_workspace(other)
+
+        resp = await client.get(
+            CLIPS_URL, params={"workspace_id": str(their_ws.id)}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 404
+
+    async def test_malformed_workspace_filter_returns_404(self, client, settings) -> None:
+        user = await _make_user("clips-ws-malformed@example.com")
+        resp = await client.get(
+            CLIPS_URL, params={"workspace_id": "not-an-object-id"}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 404
+
+    async def test_filter_by_style_substring(self, client, settings) -> None:
+        user = await _make_user("clips-style@example.com")
+        workspace = await _make_workspace(user)
+        lofi = await _insert_clip(user, workspace, style_tags=["Lofi-HipHop", "chill"])
+        await _insert_clip(user, workspace, style_tags=["rock"])
+
+        resp = await client.get(CLIPS_URL, params={"style": "lofi"}, headers=_auth_headers(user, settings))
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["clips"][0]["id"] == str(lofi.id)
+
+    async def test_filter_by_bpm_range(self, client, settings) -> None:
+        user = await _make_user("clips-bpm@example.com")
+        workspace = await _make_workspace(user)
+        await _insert_clip(user, workspace, bpm=80)
+        mid = await _insert_clip(user, workspace, bpm=120)
+        await _insert_clip(user, workspace, bpm=160)
+
+        resp = await client.get(
+            CLIPS_URL, params={"bpm_min": 100, "bpm_max": 140}, headers=_auth_headers(user, settings)
+        )
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["clips"][0]["id"] == str(mid.id)
+
+    async def test_filter_by_key_and_model_exact(self, client, settings) -> None:
+        user = await _make_user("clips-key@example.com")
+        workspace = await _make_workspace(user)
+        target = await _insert_clip(user, workspace, key="C minor", model="ace-step-v1")
+        await _insert_clip(user, workspace, key="C major", model="ace-step-v1")
+        await _insert_clip(user, workspace, key="C minor", model="other-model")
+        headers = _auth_headers(user, settings)
+
+        by_key = (await client.get(CLIPS_URL, params={"key": "C minor"}, headers=headers)).json()
+        assert by_key["total"] == 2
+
+        both = (
+            await client.get(CLIPS_URL, params={"key": "C minor", "model": "ace-step-v1"}, headers=headers)
+        ).json()
+        assert both["total"] == 1
+        assert both["clips"][0]["id"] == str(target.id)
+
+    async def test_search_matches_title_and_style_case_insensitive(self, client, settings) -> None:
+        user = await _make_user("clips-search@example.com")
+        workspace = await _make_workspace(user)
+        by_title = await _insert_clip(user, workspace, title="Midnight Drive")
+        by_style = await _insert_clip(user, workspace, title="Untitled", style_tags=["midnight-jazz"])
+        await _insert_clip(user, workspace, title="Sunrise")
+
+        resp = await client.get(CLIPS_URL, params={"search": "MIDNIGHT"}, headers=_auth_headers(user, settings))
+        body = resp.json()
+        assert body["total"] == 2
+        assert {c["id"] for c in body["clips"]} == {str(by_title.id), str(by_style.id)}
+
+    async def test_search_with_regex_metacharacters_is_literal(self, client, settings) -> None:
+        user = await _make_user("clips-search-regex@example.com")
+        workspace = await _make_workspace(user)
+        literal = await _insert_clip(user, workspace, title="beat (v2)")
+        await _insert_clip(user, workspace, title="beat v2")
+
+        resp = await client.get(CLIPS_URL, params={"search": "(v2)"}, headers=_auth_headers(user, settings))
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["clips"][0]["id"] == str(literal.id)
+
+
+@pytest.mark.integration
+class TestGetClip:
+    async def test_get_own_clip_returns_full_metadata(self, client, settings) -> None:
+        user = await _make_user("clips-get@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(
+            user, workspace, title="Mine", style_tags=["lofi"], bpm=90, key="A minor", model="ace-step-v1"
+        )
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == str(clip.id)
+        assert body["workspace_id"] == str(workspace.id)
+        assert body["title"] == "Mine"
+        assert body["style_tags"] == ["lofi"]
+        assert body["bpm"] == 90
+        assert body["key"] == "A minor"
+        assert body["model"] == "ace-step-v1"
+        assert body["format"] == "wav"
+        assert body["created_at"]
+        # Storage keys are internal; clients fetch audio via /clips/{id}/audio.
+        assert "file_path" not in body
+
+    async def test_unknown_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("clips-get-unknown@example.com")
+        resp = await client.get(f"{CLIPS_URL}/{PydanticObjectId()}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_malformed_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("clips-get-malformed@example.com")
+        resp = await client.get(f"{CLIPS_URL}/not-an-object-id", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_clip_returns_404_even_when_public(self, client, settings) -> None:
+        owner = await _make_user("clips-get-owner@example.com")
+        other = await _make_user("clips-get-other@example.com")
+        workspace = await _make_workspace(owner)
+        private = await _insert_clip(owner, workspace, is_public=False)
+        public = await _insert_clip(owner, workspace, is_public=True)
+        headers = _auth_headers(other, settings)
+
+        # CRUD is owner-scoped (issue #78); public visibility applies only to
+        # the audio endpoint (US-9.3).
+        assert (await client.get(f"{CLIPS_URL}/{private.id}", headers=headers)).status_code == 404
+        assert (await client.get(f"{CLIPS_URL}/{public.id}", headers=headers)).status_code == 404
+
+
+@pytest.mark.integration
+class TestUpdateClip:
+    async def test_update_title_returns_updated_clip(self, client, settings) -> None:
+        user = await _make_user("clips-patch@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title="Old Title")
+
+        resp = await client.patch(
+            f"{CLIPS_URL}/{clip.id}", json={"title": "New Title"}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "New Title"
+
+        fetched = await Clip.get(clip.id)
+        assert fetched.title == "New Title"
+
+    @pytest.mark.parametrize("payload", [{"title": ""}, {"title": "   "}, {"bpm": 90}, {"file_path": "x"}])
+    async def test_blank_title_or_non_title_fields_return_422(self, client, settings, payload: dict) -> None:
+        user = await _make_user("clips-patch-bad@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title="Keep")
+
+        resp = await client.patch(f"{CLIPS_URL}/{clip.id}", json=payload, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert (await Clip.get(clip.id)).title == "Keep"
+
+    async def test_unknown_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("clips-patch-unknown@example.com")
+        resp = await client.patch(
+            f"{CLIPS_URL}/{PydanticObjectId()}", json={"title": "X"}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 404
+
+    async def test_other_users_clip_returns_404(self, client, settings) -> None:
+        owner = await _make_user("clips-patch-owner@example.com")
+        other = await _make_user("clips-patch-other@example.com")
+        workspace = await _make_workspace(owner)
+        clip = await _insert_clip(owner, workspace, title="Theirs")
+
+        resp = await client.patch(
+            f"{CLIPS_URL}/{clip.id}", json={"title": "Hijacked"}, headers=_auth_headers(other, settings)
+        )
+        assert resp.status_code == 404
+        assert (await Clip.get(clip.id)).title == "Theirs"
+
+
+@pytest.mark.integration
+class TestDeleteClip:
+    async def test_delete_removes_record_and_stored_audio(self, client, settings, local_storage) -> None:
+        user = await _make_user("clips-del@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, store_bytes=b"abc")
+        stored_file = local_storage / clip.file_path
+        assert stored_file.exists()
+
+        resp = await client.delete(f"{CLIPS_URL}/{clip.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 204
+        assert await Clip.get(clip.id) is None
+        assert not stored_file.exists()
+
+    async def test_delete_with_missing_audio_object_still_succeeds(self, client, settings, local_storage) -> None:
+        user = await _make_user("clips-del-missing@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace)  # no stored bytes
+
+        resp = await client.delete(f"{CLIPS_URL}/{clip.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 204
+        assert await Clip.get(clip.id) is None
+
+    async def test_unknown_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("clips-del-unknown@example.com")
+        resp = await client.delete(f"{CLIPS_URL}/{PydanticObjectId()}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_clip_returns_404(self, client, settings) -> None:
+        owner = await _make_user("clips-del-owner@example.com")
+        other = await _make_user("clips-del-other@example.com")
+        workspace = await _make_workspace(owner)
+        clip = await _insert_clip(owner, workspace)
+
+        resp = await client.delete(f"{CLIPS_URL}/{clip.id}", headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+        assert await Clip.get(clip.id) is not None

--- a/tests/test_clips_crud_api.py
+++ b/tests/test_clips_crud_api.py
@@ -202,6 +202,13 @@ class TestListClips:
         resp = await client.get(CLIPS_URL, params=params, headers=_auth_headers(user, settings))
         assert resp.status_code == 422
 
+    async def test_inverted_bpm_range_returns_422(self, client, settings) -> None:
+        user = await _make_user("clips-bpm-inverted@example.com")
+        resp = await client.get(
+            CLIPS_URL, params={"bpm_min": 200, "bpm_max": 100}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 422
+
     async def test_filter_by_workspace(self, client, settings) -> None:
         user = await _make_user("clips-ws@example.com")
         ws_a = await _make_workspace(user, "A")

--- a/tests/test_clips_crud_api.py
+++ b/tests/test_clips_crud_api.py
@@ -8,6 +8,7 @@ The 401 auth-gate tests run in CI (no DB); the rest are ``integration`` and
 drive the real app with ``httpx.AsyncClient`` over a local MongoDB.
 """
 
+import itertools
 from datetime import datetime, timedelta, timezone
 
 import httpx
@@ -100,7 +101,7 @@ async def _make_workspace(user, name: str = "WS") -> Workspace:
     return workspace
 
 
-_SEQ = {"n": 0}
+_SEQ = itertools.count(1)
 
 
 async def _insert_clip(
@@ -118,9 +119,8 @@ async def _insert_clip(
 ) -> Clip:
     # Monotonic created_at default keeps sort order deterministic across clips
     # inserted within the same millisecond.
-    _SEQ["n"] += 1
     if created_at is None:
-        created_at = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=_SEQ["n"])
+        created_at = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=next(_SEQ))
     clip_id = PydanticObjectId()
     file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.wav"
     if store_bytes is not None:
@@ -201,6 +201,18 @@ class TestListClips:
         user = await _make_user("clips-page-bad@example.com")
         resp = await client.get(CLIPS_URL, params=params, headers=_auth_headers(user, settings))
         assert resp.status_code == 422
+
+    async def test_blank_search_and_style_filters_are_ignored(self, client, settings) -> None:
+        """`?search=` / `?style=` must behave as "no filter", not as a match-all regex."""
+        user = await _make_user("clips-blank-filter@example.com")
+        workspace = await _make_workspace(user)
+        await _insert_clip(user, workspace, title="Has Title", style_tags=["lofi"])
+        await _insert_clip(user, workspace)  # no title, no tags
+        headers = _auth_headers(user, settings)
+
+        plain = (await client.get(CLIPS_URL, headers=headers)).json()
+        blank = (await client.get(CLIPS_URL, params={"search": "", "style": "  "}, headers=headers)).json()
+        assert blank["total"] == plain["total"] == 2
 
     async def test_inverted_bpm_range_returns_422(self, client, settings) -> None:
         user = await _make_user("clips-bpm-inverted@example.com")
@@ -387,6 +399,20 @@ class TestUpdateClip:
 
         fetched = await Clip.get(clip.id)
         assert fetched.title == "New Title"
+
+    async def test_empty_body_is_noop_but_explicit_null_title_returns_422(self, client, settings) -> None:
+        user = await _make_user("clips-patch-null@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title="Keep")
+        headers = _auth_headers(user, settings)
+
+        noop = await client.patch(f"{CLIPS_URL}/{clip.id}", json={}, headers=headers)
+        assert noop.status_code == 200
+        assert noop.json()["title"] == "Keep"
+
+        explicit_null = await client.patch(f"{CLIPS_URL}/{clip.id}", json={"title": None}, headers=headers)
+        assert explicit_null.status_code == 422
+        assert (await Clip.get(clip.id)).title == "Keep"
 
     @pytest.mark.parametrize("payload", [{"title": ""}, {"title": "   "}, {"bpm": 90}, {"file_path": "x"}])
     async def test_blank_title_or_non_title_fields_return_422(self, client, settings, payload: dict) -> None:

--- a/tests/test_clips_crud_api.py
+++ b/tests/test_clips_crud_api.py
@@ -303,6 +303,28 @@ class TestListClips:
 
 
 @pytest.mark.integration
+class TestMissingUser:
+    """Token valid, but the referenced user no longer exists (e.g. deleted).
+
+    Clip CRUD resolves the user first (like generation/users); the US-9.3 audio
+    endpoint keeps its own visibility rules and is unaffected.
+    """
+
+    def _orphan_headers(self, settings: ApiSettings) -> dict[str, str]:
+        token = create_access_token(
+            user_id=str(PydanticObjectId()),
+            email="ghost@example.com",
+            subscription_tier="free",
+            settings=settings,
+        )
+        return {"Authorization": f"Bearer {token}"}
+
+    async def test_list_returns_404(self, client, settings) -> None:
+        resp = await client.get(CLIPS_URL, headers=self._orphan_headers(settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
 class TestGetClip:
     async def test_get_own_clip_returns_full_metadata(self, client, settings) -> None:
         user = await _make_user("clips-get@example.com")

--- a/tests/test_workspaces_api.py
+++ b/tests/test_workspaces_api.py
@@ -340,6 +340,32 @@ class TestDeleteWorkspace:
 
 
 @pytest.mark.integration
+class TestMissingUser:
+    """Token valid, but the referenced user no longer exists (e.g. deleted).
+
+    Mirrors the generation endpoint's stale-token rule: resolve the user first
+    so a stale token gets a clean 404 instead of creating orphaned records.
+    """
+
+    def _orphan_headers(self, settings: ApiSettings) -> dict[str, str]:
+        token = create_access_token(
+            user_id=str(PydanticObjectId()),
+            email="ghost@example.com",
+            subscription_tier="free",
+            settings=settings,
+        )
+        return {"Authorization": f"Bearer {token}"}
+
+    async def test_create_returns_404(self, client, settings) -> None:
+        resp = await client.post(WORKSPACES_URL, json={"name": "Orphan"}, headers=self._orphan_headers(settings))
+        assert resp.status_code == 404
+
+    async def test_list_returns_404(self, client, settings) -> None:
+        resp = await client.get(WORKSPACES_URL, headers=self._orphan_headers(settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
 class TestDefaultWorkspaceBootstrap:
     """The get-or-create default bootstrap must coexist with the unique
     (user_id, name) index: a user may already own a *non-default* workspace

--- a/tests/test_workspaces_api.py
+++ b/tests/test_workspaces_api.py
@@ -1,0 +1,339 @@
+"""Tests for the workspace CRUD endpoints (US-9.4, issue #78).
+
+The 401 auth-gate tests run in CI (the router dependency rejects before any DB
+access; plain ``TestClient`` does not run the lifespan). The CRUD tests are
+``integration``: they drive the real app with ``httpx.AsyncClient`` over a local
+MongoDB (``mongo_db``), mirroring ``tests/test_jobs_api.py``.
+"""
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+WORKSPACES_URL = f"{API_V1_PREFIX}/workspaces"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize(
+        ("method", "url"),
+        [
+            ("GET", WORKSPACES_URL),
+            ("POST", WORKSPACES_URL),
+            ("GET", f"{WORKSPACES_URL}/{PydanticObjectId()}"),
+            ("PATCH", f"{WORKSPACES_URL}/{PydanticObjectId()}"),
+            ("DELETE", f"{WORKSPACES_URL}/{PydanticObjectId()}"),
+        ],
+    )
+    def test_missing_auth_header_returns_401(self, method: str, url: str) -> None:
+        client = TestClient(create_app())
+        resp = client.request(method, url)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    """Point the storage backend at a throwaway local root."""
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _insert_workspace(user, name: str, *, is_default: bool = False) -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id, is_default=is_default)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(user, workspace: Workspace, *, store_bytes: bytes | None = None) -> Clip:
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.wav"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
+    clip = Clip(id=clip_id, user_id=user.id, workspace_id=workspace.id, file_path=file_path, format="wav")
+    await clip.insert()
+    return clip
+
+
+@pytest.mark.integration
+class TestCreateWorkspace:
+    async def test_create_returns_201_with_workspace(self, client, settings) -> None:
+        user = await _make_user("ws-create@example.com")
+        resp = await client.post(WORKSPACES_URL, json={"name": "Beats"}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["name"] == "Beats"
+        assert body["clip_count"] == 0
+        assert body["is_default"] is False
+        assert body["id"]
+        assert body["created_at"]
+
+    async def test_duplicate_name_for_same_user_returns_409(self, client, settings) -> None:
+        user = await _make_user("ws-dup@example.com")
+        first = await client.post(WORKSPACES_URL, json={"name": "Beats"}, headers=_auth_headers(user, settings))
+        assert first.status_code == 201
+        second = await client.post(WORKSPACES_URL, json={"name": "Beats"}, headers=_auth_headers(user, settings))
+        assert second.status_code == 409
+
+    async def test_same_name_for_different_users_is_allowed(self, client, settings) -> None:
+        alice = await _make_user("ws-alice@example.com")
+        bob = await _make_user("ws-bob@example.com")
+        assert (
+            await client.post(WORKSPACES_URL, json={"name": "Beats"}, headers=_auth_headers(alice, settings))
+        ).status_code == 201
+        assert (
+            await client.post(WORKSPACES_URL, json={"name": "Beats"}, headers=_auth_headers(bob, settings))
+        ).status_code == 201
+
+    @pytest.mark.parametrize("payload", [{}, {"name": ""}, {"name": "   "}])
+    async def test_missing_or_blank_name_returns_422(self, client, settings, payload: dict) -> None:
+        user = await _make_user("ws-blank@example.com")
+        resp = await client.post(WORKSPACES_URL, json=payload, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+
+@pytest.mark.integration
+class TestListWorkspaces:
+    async def test_lists_only_own_workspaces_with_clip_counts(self, client, settings) -> None:
+        user = await _make_user("ws-list@example.com")
+        other = await _make_user("ws-list-other@example.com")
+        ws_a = await _insert_workspace(user, "A")
+        ws_b = await _insert_workspace(user, "B")
+        await _insert_workspace(other, "Theirs")
+        await _insert_clip(user, ws_a)
+        await _insert_clip(user, ws_a)
+
+        resp = await client.get(WORKSPACES_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 2
+        by_id = {w["id"]: w for w in body["workspaces"]}
+        assert set(by_id) == {str(ws_a.id), str(ws_b.id)}
+        assert by_id[str(ws_a.id)]["clip_count"] == 2
+        assert by_id[str(ws_b.id)]["clip_count"] == 0
+
+    async def test_empty_list_for_new_user(self, client, settings) -> None:
+        user = await _make_user("ws-list-empty@example.com")
+        resp = await client.get(WORKSPACES_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json() == {"workspaces": [], "total": 0}
+
+
+@pytest.mark.integration
+class TestGetWorkspace:
+    async def test_get_own_workspace_returns_200(self, client, settings) -> None:
+        user = await _make_user("ws-get@example.com")
+        workspace = await _insert_workspace(user, "Mine")
+        await _insert_clip(user, workspace)
+
+        resp = await client.get(f"{WORKSPACES_URL}/{workspace.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == str(workspace.id)
+        assert body["name"] == "Mine"
+        assert body["clip_count"] == 1
+
+    async def test_unknown_workspace_returns_404(self, client, settings) -> None:
+        user = await _make_user("ws-get-unknown@example.com")
+        resp = await client.get(f"{WORKSPACES_URL}/{PydanticObjectId()}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_malformed_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("ws-get-malformed@example.com")
+        resp = await client.get(f"{WORKSPACES_URL}/not-an-object-id", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_workspace_returns_404(self, client, settings) -> None:
+        owner = await _make_user("ws-get-owner@example.com")
+        other = await _make_user("ws-get-other@example.com")
+        workspace = await _insert_workspace(owner, "Private")
+        resp = await client.get(f"{WORKSPACES_URL}/{workspace.id}", headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestUpdateWorkspace:
+    async def test_rename_returns_updated_workspace(self, client, settings) -> None:
+        user = await _make_user("ws-rename@example.com")
+        workspace = await _insert_workspace(user, "Old Name")
+
+        resp = await client.patch(
+            f"{WORKSPACES_URL}/{workspace.id}",
+            json={"name": "New Name"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "New Name"
+        assert body["updated_at"] is not None
+
+        fetched = await Workspace.get(workspace.id)
+        assert fetched.name == "New Name"
+
+    async def test_rename_to_existing_name_returns_409(self, client, settings) -> None:
+        user = await _make_user("ws-rename-dup@example.com")
+        await _insert_workspace(user, "Taken")
+        workspace = await _insert_workspace(user, "Original")
+
+        resp = await client.patch(
+            f"{WORKSPACES_URL}/{workspace.id}",
+            json={"name": "Taken"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 409
+
+    async def test_unknown_workspace_returns_404(self, client, settings) -> None:
+        user = await _make_user("ws-rename-unknown@example.com")
+        resp = await client.patch(
+            f"{WORKSPACES_URL}/{PydanticObjectId()}",
+            json={"name": "X"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_other_users_workspace_returns_404(self, client, settings) -> None:
+        owner = await _make_user("ws-rename-owner@example.com")
+        other = await _make_user("ws-rename-other@example.com")
+        workspace = await _insert_workspace(owner, "Private")
+        resp = await client.patch(
+            f"{WORKSPACES_URL}/{workspace.id}",
+            json={"name": "Hijacked"},
+            headers=_auth_headers(other, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_blank_name_returns_422(self, client, settings) -> None:
+        user = await _make_user("ws-rename-blank@example.com")
+        workspace = await _insert_workspace(user, "Fine")
+        resp = await client.patch(
+            f"{WORKSPACES_URL}/{workspace.id}",
+            json={"name": "  "},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+
+@pytest.mark.integration
+class TestDeleteWorkspace:
+    async def test_delete_empty_workspace_returns_204(self, client, settings) -> None:
+        user = await _make_user("ws-del@example.com")
+        keep = await _insert_workspace(user, "Keep")
+        doomed = await _insert_workspace(user, "Doomed")
+
+        resp = await client.delete(f"{WORKSPACES_URL}/{doomed.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 204
+        assert await Workspace.get(doomed.id) is None
+        assert await Workspace.get(keep.id) is not None
+
+    async def test_delete_non_empty_without_force_returns_409(self, client, settings, local_storage) -> None:
+        user = await _make_user("ws-del-409@example.com")
+        await _insert_workspace(user, "Keep")
+        workspace = await _insert_workspace(user, "Full")
+        await _insert_clip(user, workspace, store_bytes=b"abc")
+
+        resp = await client.delete(f"{WORKSPACES_URL}/{workspace.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 409
+        assert await Workspace.get(workspace.id) is not None
+
+    async def test_delete_non_empty_with_force_cascades(self, client, settings, local_storage) -> None:
+        user = await _make_user("ws-del-force@example.com")
+        await _insert_workspace(user, "Keep")
+        workspace = await _insert_workspace(user, "Full")
+        clip = await _insert_clip(user, workspace, store_bytes=b"abc")
+        stored_file = local_storage / clip.file_path
+        assert stored_file.exists()
+
+        resp = await client.delete(
+            f"{WORKSPACES_URL}/{workspace.id}",
+            params={"force": "true"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 204
+        assert await Workspace.get(workspace.id) is None
+        assert await Clip.get(clip.id) is None
+        assert not stored_file.exists()
+
+    async def test_delete_last_workspace_returns_400(self, client, settings) -> None:
+        user = await _make_user("ws-del-last@example.com")
+        only = await _insert_workspace(user, "Only One")
+
+        resp = await client.delete(f"{WORKSPACES_URL}/{only.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 400
+        assert await Workspace.get(only.id) is not None
+
+    async def test_delete_last_workspace_with_force_still_returns_400(self, client, settings) -> None:
+        user = await _make_user("ws-del-last-force@example.com")
+        only = await _insert_workspace(user, "Only One")
+
+        resp = await client.delete(
+            f"{WORKSPACES_URL}/{only.id}",
+            params={"force": "true"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 400
+        assert await Workspace.get(only.id) is not None
+
+    async def test_unknown_workspace_returns_404(self, client, settings) -> None:
+        user = await _make_user("ws-del-unknown@example.com")
+        resp = await client.delete(f"{WORKSPACES_URL}/{PydanticObjectId()}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_workspace_returns_404(self, client, settings) -> None:
+        owner = await _make_user("ws-del-owner@example.com")
+        other = await _make_user("ws-del-other@example.com")
+        workspace = await _insert_workspace(owner, "Private")
+        resp = await client.delete(f"{WORKSPACES_URL}/{workspace.id}", headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+        assert await Workspace.get(workspace.id) is not None

--- a/tests/test_workspaces_api.py
+++ b/tests/test_workspaces_api.py
@@ -337,3 +337,34 @@ class TestDeleteWorkspace:
         resp = await client.delete(f"{WORKSPACES_URL}/{workspace.id}", headers=_auth_headers(other, settings))
         assert resp.status_code == 404
         assert await Workspace.get(workspace.id) is not None
+
+
+@pytest.mark.integration
+class TestDefaultWorkspaceBootstrap:
+    """The get-or-create default bootstrap must coexist with the unique
+    (user_id, name) index: a user may already own a *non-default* workspace
+    named "My Workspace" (created via the API before the registration backfill
+    runs), and the bootstrap must promote it instead of 500ing on the index."""
+
+    async def test_existing_same_named_workspace_is_promoted_to_default(self, mongo_db) -> None:
+        from acemusic.api.services.workspaces import (
+            DEFAULT_WORKSPACE_NAME,
+            get_or_create_default_workspace,
+        )
+
+        user = await _make_user("ws-bootstrap-promote@example.com")
+        named = await _insert_workspace(user, DEFAULT_WORKSPACE_NAME)  # not default
+
+        result = await get_or_create_default_workspace(user.id)
+        assert result.id == named.id
+        assert result.is_default is True
+        assert (await Workspace.get(named.id)).is_default is True
+
+    async def test_existing_default_workspace_is_reused(self, mongo_db) -> None:
+        from acemusic.api.services.workspaces import get_or_create_default_workspace
+
+        user = await _make_user("ws-bootstrap-reuse@example.com")
+        existing = await _insert_workspace(user, "Custom Default", is_default=True)
+
+        result = await get_or_create_default_workspace(user.id)
+        assert result.id == existing.id


### PR DESCRIPTION
## Summary
Implements #78: US-9.4 Workspace and clip CRUD API

- **Workspace endpoints** (`/api/v1/workspaces`): POST (201; 409 on duplicate name per user, backed by a new unique `(user_id, name)` index), GET list with per-workspace clip counts (single aggregation), GET/PATCH/DELETE by id. DELETE returns 409 for a non-empty workspace without `?force=true`, 400 for the user's last workspace; a forced delete cascades clips and their stored audio.
- **Clip CRUD endpoints** (`/api/v1/clips`): GET list with filters (`workspace_id`, `search`, `style`, `bpm_min`/`bpm_max`, `key`, `model`), `newest|oldest` sort, and pagination (`page`, `per_page` default 20 / max 100, `total_pages`); GET/PATCH/DELETE by id (PATCH updates title only; DELETE removes the stored audio object first). Search/style needles are regex-escaped, case-insensitive substrings — mirrors the CLI's `search_clips`.
- **Default workspace at registration**: the OAuth callback bootstraps every account via the idempotent `get_or_create_default_workspace` (moved from the generation service to the new workspaces service; generation keeps a lazy fallback). A pre-existing non-default workspace named "My Workspace" is promoted instead of colliding with the unique index.
- **Stale-token hardening**: new `require_existing_user` dependency — CRUD endpoints resolve the token's user first, so a valid token for a deleted account gets 404 instead of creating orphaned records (mirrors `POST /generate`).

## Acceptance Criteria
- [x] Full CRUD lifecycle works for workspaces (create, list, get, update, delete)
- [x] Full CRUD lifecycle works for clips (list, get, update, delete)
- [x] Clip search filters by style, BPM range, key, and model
- [x] Pagination returns correct page counts and respects per_page limits
- [x] Deleting a non-empty workspace without `?force=true` returns 409
- [x] All endpoints scoped to the authenticated user; default workspace created at registration

## Test Plan
- [x] Tests written first (TDD): `tests/test_workspaces_api.py` (38), `tests/test_clips_crud_api.py` (37), auth-callback bootstrap tests
- [x] All tests passing: 1125 unit + 127 API integration (real MongoDB, real JWT, no mocking)
- [x] Diff coverage 98% on changed lines (gate ≥85%); the 10 uncovered lines are concurrency race-recovery branches
- [x] Linting clean (black + ruff)
- [x] Internal code review (advisory) completed — 1 Major fixed (bootstrap name-collision promotion)
- [x] Cross-family review pass: codex — 2 P2 findings fixed (stale-token 404)
- [x] Test mutation sanity check completed — 6 mutations (force/409 check, ownership check, pagination skip, regex escape, default promotion, stale-user 404), all caught

## Known Limitations / Intentionally Deferred
- **Clip CRUD is strictly owner-scoped**: another user's clip returns 404 even when `is_public=true`. Public visibility applies only to the US-9.3 audio endpoint — listing/browsing public clips is a future discovery feature.
- **`ClipResponse` omits `file_path`**: storage keys are internal; clients fetch audio via `GET /clips/{id}/audio`. (Deviation from the CodeRabbit plan, which listed it.)
- **Forced workspace delete removes stored audio sequentially** (one object per clip). Fine at current scale; revisit with bounded concurrency if workspaces grow to thousands of clips.
- **Unique `(user_id, name)` index on workspaces**: any pre-existing deployment with duplicate workspace names per user would need a dedupe before this index builds. No production deployment exists yet, so no migration is shipped.
- **Workspace-delete preconditions are checked, not transactional**: the last-workspace and clip-count guards are pre-checks; a concurrent delete could race them. Atomic enforcement needs multi-document transactions (replica-set-only) or a per-user lock — neither exists in this deployment. Worst case (user transiently at zero workspaces) is self-healing via the lazy default-workspace bootstrap. (CodeRabbit finding, rebutted in review thread.)
- **API test fixtures are duplicated per test module** (matches the pre-existing pattern across all six API test files); consolidating into `tests/conftest.py` is a follow-up refactor beyond this PR's scope.
- **Clip `updated_at`** is not tracked (the Clip model has no such field); adding one is out of scope for this issue.
- **Date-range clip filters** (`date_from`/`date_to` from the CLI) are not exposed — the issue's query-param list does not include them.

## Implementation Notes
Deviations from the CodeRabbit plan on the issue (its research predates Stages 8–9): schemas live in router modules per codebase convention (no `schemas/` package); services follow the existing plural naming (`services/workspaces.py`, extended `services/clips.py`); the existing `routers/clips.py` (US-9.3 audio) was extended rather than recreated; tests follow the established integration pattern (httpx.AsyncClient + isolated throwaway Mongo DB + real JWTs) instead of a mocked `get_current_user` override; `workspace_id` is optional on `GET /clips` since clips carry `user_id` directly.

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace management: create, list, fetch, rename, and delete workspaces with clip counts and idempotent default-workspace bootstrap
  * Full clips CRUD: owner-scoped list, get, rename (title-only), and delete clips; audio streaming preserved

* **Behavior Changes**
  * Auth tightened: tokens for deleted users now yield 404
  * Workspace names unique per user; delete enforces constraints (force cascade)

* **Search & Filtering**
  * Advanced clip search: title/style substring, BPM ranges, key, model, sorting, pagination

* **Tests**
  * Extensive integration tests for workspaces, clips, auth edge cases, and default-workspace bootstrapping

* **Documentation**
  * API docs updated for Workspaces and expanded Clips endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
