### PR TITLE
feat(api): preset CRUD API (US-9.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ environment variables (see `.env.example`); cookie behavior is tuned via
 | `POST /api/v1/generate` | Submits a generation request and returns a `job_id` for async tracking (HTTP 202) |
 | `GET /api/v1/jobs/{id}/status` | Returns a job's current status; owner-scoped (404 for missing or other users' jobs) |
 
-The request body accepts the full creative parameter set: `prompt` (required), `style`, `lyrics`, `vocal_language`, `instrumental`, `bpm` (60–180 or `"auto"`), `key`, `time_signature`, `duration`, `seed`, `inference_steps`, `model`, `weirdness` (0–100), `style_influence` (0–100), `format` (`wav`/`flac`/`mp3`/`aac`/`opus`), `thinking`, `mode` (`song`|`sound`), and `sound_type` (`one-shot`|`loop`, required when `mode` is `sound`). The job is created with status `queued` and picked up by the async processor (US-9.2).
+The request body accepts the full creative parameter set: `prompt` (required), `style`, `lyrics`, `vocal_language`, `instrumental`, `bpm` (60–180 or `"auto"`), `key`, `time_signature`, `duration`, `seed`, `inference_steps`, `model`, `weirdness` (0–100), `style_influence` (0–100), `format` (`wav`/`flac`/`mp3`/`aac`/`opus`), `thinking`, `mode` (`song`|`sound`), `sound_type` (`one-shot`|`loop`, required when `mode` is `sound`), and the optional `preset_id`. When `preset_id` is supplied the saved preset's parameters serve as defaults; any field explicitly included in the request overrides the preset value. The job is created with status `queued` and picked up by the async processor (US-9.2).
 
 Invalid parameters return 422 with field-level errors. The create response includes `job_id`, `status: "queued"`, and `estimated_time_seconds`.
 
@@ -118,6 +118,18 @@ A default workspace is created automatically when a new user registers (OAuth ca
 `GET /api/v1/clips` supports these query parameters: `workspace_id`, `search` (case-insensitive substring over title or style tags), `style`, `bpm_min`, `bpm_max`, `key`, `model`, `sort` (`newest` or `oldest`, default `newest`), `page` (default 1), `per_page` (default 20, max 100). An inverted BPM range (`bpm_min > bpm_max`) returns 422. The response includes `total`, `page`, `per_page`, and `total_pages`.
 
 All CRUD endpoints are owner-scoped. `GET /api/v1/clips/{id}/audio` additionally supports single HTTP byte ranges (`Range: bytes=…` → `206 Partial Content`, unsatisfiable ranges → `416`) for seeking, and on-the-fly conversion via `?format=wav|flac|mp3` (mp3/flac conversion requires ffmpeg on the host; byte ranges are ignored for converted output). For the audio endpoint an unknown or malformed id returns `404`, another user's private clip returns `403`, and clips marked `is_public` are retrievable by any authenticated user; the CRUD endpoints return `404` for any clip the caller does not own.
+
+### Presets
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/presets` | Create a preset (201; 409 on duplicate name) |
+| `GET /api/v1/presets` | List all presets for the authenticated user |
+| `GET /api/v1/presets/{id}` | Get a single preset (404 if missing or not owned) |
+| `PATCH /api/v1/presets/{id}` | Partially update a preset; sending `null` for a parameter clears it (409 on duplicate name; empty body is a no-op) |
+| `DELETE /api/v1/presets/{id}` | Delete a preset (204) |
+
+A preset is a named snapshot of generation parameters. Every creative field accepted by `POST /api/v1/generate` (except `prompt` and `preset_id`) can be saved in a preset; all fields are optional — a preset pins down only what the user chooses to fix. Preset names are unique per user. All endpoints are owner-scoped (404 for missing or another user's preset).
 
 ## Stem separation backends
 

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -20,7 +20,7 @@ from acemusic import __version__
 
 from . import database
 from .exceptions import HandleConflictError
-from .routers import auth, clips, generation, health, jobs, users, workspaces
+from .routers import auth, clips, generation, health, jobs, presets, users, workspaces
 from .settings import ApiSettings
 from .tasks.processor import JobProcessor
 
@@ -117,6 +117,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(jobs.router, prefix=API_V1_PREFIX)
     app.include_router(clips.router, prefix=API_V1_PREFIX)
     app.include_router(workspaces.router, prefix=API_V1_PREFIX)
+    app.include_router(presets.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -5,10 +5,21 @@
 
 from .clip import Clip
 from .job import Job, JobStatus
+from .preset import PRESET_PARAM_FIELDS, Preset
 from .refresh_token import RefreshToken
 from .user import User
 from .workspace import Workspace
 
-ALL_MODELS = [User, Workspace, Clip, Job, RefreshToken]
+ALL_MODELS = [User, Workspace, Clip, Job, RefreshToken, Preset]
 
-__all__ = ["User", "Workspace", "Clip", "Job", "JobStatus", "RefreshToken", "ALL_MODELS"]
+__all__ = [
+    "User",
+    "Workspace",
+    "Clip",
+    "Job",
+    "JobStatus",
+    "RefreshToken",
+    "Preset",
+    "PRESET_PARAM_FIELDS",
+    "ALL_MODELS",
+]

--- a/src/acemusic/api/models/preset.py
+++ b/src/acemusic/api/models/preset.py
@@ -1,0 +1,79 @@
+"""Preset document model (US-9.5).
+
+A preset is a user-owned, named snapshot of generation parameters. The
+parameter fields mirror :class:`~acemusic.api.routers.generation.GenerationRequest`
+(every creative knob the generate endpoint accepts) and are all optional — a
+preset stores only what the user chose to pin down. Applying a preset to a
+generation request happens in the generation router (preset values as
+defaults, explicitly-sent request values win).
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+
+class Preset(Document):
+    """A user-owned generation parameter snapshot."""
+
+    name: str
+    user_id: PydanticObjectId
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime | None = None
+
+    # Generation parameters — same names and shapes as GenerationRequest.
+    style: str | None = None
+    lyrics: str | None = None
+    vocal_language: str | None = None
+    instrumental: bool | None = None
+    bpm: int | Literal["auto"] | None = None
+    key: str | None = None
+    time_signature: str | None = None
+    duration: float | None = None
+    seed: int | None = None
+    inference_steps: int | None = None
+    model: str | None = None
+    weirdness: int | None = None
+    style_influence: int | None = None
+    format: str | None = None
+    thinking: bool | None = None
+    mode: Literal["song", "sound"] | None = None
+    sound_type: Literal["one-shot", "loop"] | None = None
+
+    class Settings:
+        name = "presets"
+        indexes = [
+            IndexModel([("user_id", ASCENDING)]),
+            # Preset names are unique per user: create and rename rely on this
+            # index for race-safe 409s (same pattern as Workspace).
+            IndexModel([("user_id", ASCENDING), ("name", ASCENDING)], unique=True),
+        ]
+
+
+# The parameter fields a preset can contribute to a generation request, i.e.
+# every field above except identity/bookkeeping. The generation router uses
+# this to build the merge base.
+PRESET_PARAM_FIELDS: tuple[str, ...] = (
+    "style",
+    "lyrics",
+    "vocal_language",
+    "instrumental",
+    "bpm",
+    "key",
+    "time_signature",
+    "duration",
+    "seed",
+    "inference_steps",
+    "model",
+    "weirdness",
+    "style_influence",
+    "format",
+    "thinking",
+    "mode",
+    "sound_type",
+)

--- a/src/acemusic/api/routers/_validators.py
+++ b/src/acemusic/api/routers/_validators.py
@@ -1,0 +1,27 @@
+"""Field-validator helpers shared by the generation and preset schemas.
+
+Both ``GenerationRequest`` and ``_PresetParams`` validate the same enum-like
+fields against :mod:`acemusic.constants`; delegating to these functions keeps
+the two schemas from drifting. ``None`` passes through so the same helper
+serves required fields (generation's ``format``) and nullable preset fields.
+"""
+
+from acemusic.constants import VALID_FORMATS, VALID_MODELS, VALID_TIME_SIGNATURES
+
+
+def validate_format(value: str | None) -> str | None:
+    if value is not None and value not in VALID_FORMATS:
+        raise ValueError(f"format must be one of {sorted(VALID_FORMATS)}")
+    return value
+
+
+def validate_model(value: str | None) -> str | None:
+    if value is not None and value not in VALID_MODELS:
+        raise ValueError(f"model must be one of {sorted(VALID_MODELS)}")
+    return value
+
+
+def validate_time_signature(value: str | None) -> str | None:
+    if value is not None and value not in VALID_TIME_SIGNATURES:
+        raise ValueError(f"time_signature must be one of {sorted(VALID_TIME_SIGNATURES)}")
+    return value

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -29,9 +29,6 @@ from acemusic.constants import (
     STYLE_INFLUENCE_MAX,
     STYLE_INFLUENCE_MIN,
     STYLE_MAX_LENGTH,
-    VALID_FORMATS,
-    VALID_MODELS,
-    VALID_TIME_SIGNATURES,
     VOCAL_LANGUAGE_MAX_LENGTH,
     WEIRDNESS_MAX,
     WEIRDNESS_MIN,
@@ -40,6 +37,7 @@ from acemusic.constants import (
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import PRESET_PARAM_FIELDS, Preset
 from ..services import generation as generation_service, presets as preset_service, users as user_service
+from ._validators import validate_format, validate_model, validate_time_signature
 
 # Estimate heuristic (seconds): a song's wall-clock scales with its duration; a
 # short sound is roughly fixed. These are advisory hints returned to the client.
@@ -89,23 +87,17 @@ class GenerationRequest(BaseModel):
     @field_validator("format")
     @classmethod
     def _check_format(cls, value: str) -> str:
-        if value not in VALID_FORMATS:
-            raise ValueError(f"format must be one of {sorted(VALID_FORMATS)}")
-        return value
+        return validate_format(value)
 
     @field_validator("model")
     @classmethod
     def _check_model(cls, value: str | None) -> str | None:
-        if value is not None and value not in VALID_MODELS:
-            raise ValueError(f"model must be one of {sorted(VALID_MODELS)}")
-        return value
+        return validate_model(value)
 
     @field_validator("time_signature")
     @classmethod
     def _check_time_signature(cls, value: str | None) -> str | None:
-        if value is not None and value not in VALID_TIME_SIGNATURES:
-            raise ValueError(f"time_signature must be one of {sorted(VALID_TIME_SIGNATURES)}")
-        return value
+        return validate_time_signature(value)
 
     @model_validator(mode="after")
     def _check_mode_constraints(self) -> "GenerationRequest":

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -21,20 +21,21 @@ from acemusic.constants import (
     DURATION_MAX,
     DURATION_MIN,
     INFERENCE_STEPS_MAX,
+    KEY_MAX_LENGTH,
+    LYRICS_MAX_LENGTH,
+    PROMPT_MAX_LENGTH,
+    SEED_MAX,
+    SEED_MIN,
     STYLE_INFLUENCE_MAX,
     STYLE_INFLUENCE_MIN,
+    STYLE_MAX_LENGTH,
     VALID_FORMATS,
     VALID_MODELS,
     VALID_TIME_SIGNATURES,
+    VOCAL_LANGUAGE_MAX_LENGTH,
     WEIRDNESS_MAX,
     WEIRDNESS_MIN,
 )
-
-# Seeds are opaque values forwarded to the backend; bound them to MongoDB's
-# signed 64-bit integer range so an oversized value is a clean 422 rather than a
-# BSON-encoding 500 when the job is persisted.
-_SEED_MIN = -(2**63)
-_SEED_MAX = 2**63 - 1
 
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import PRESET_PARAM_FIELDS, Preset
@@ -44,17 +45,6 @@ from ..services import generation as generation_service, presets as preset_servi
 # short sound is roughly fixed. These are advisory hints returned to the client.
 _SONG_BASE_SECONDS = 30
 _SOUND_BASE_SECONDS = 15
-
-# Free-text fields are persisted verbatim in ``Job.input_params`` and re-read by
-# the worker, so cap them: a single request must not be able to bloat the jobs
-# document (or approach MongoDB's 16MB cap) and turn into a 500 (same rationale
-# as the profile caps in the users router). Lyrics get the most headroom since a
-# full song's words are legitimately long.
-_PROMPT_MAX_LENGTH = 2000
-_STYLE_MAX_LENGTH = 1000
-_LYRICS_MAX_LENGTH = 5000
-_VOCAL_LANGUAGE_MAX_LENGTH = 100
-_KEY_MAX_LENGTH = 50
 
 # Router-level dependency gates every route behind a valid Bearer token, so an
 # unauthenticated request is rejected with 401 before any handler runs.
@@ -75,18 +65,18 @@ class GenerationRequest(BaseModel):
     # request fields override preset values. Never forwarded to the job.
     preset_id: str | None = None
 
-    prompt: Annotated[str, Field(min_length=1, max_length=_PROMPT_MAX_LENGTH)]
-    style: Annotated[str, Field(max_length=_STYLE_MAX_LENGTH)] | None = None
-    lyrics: Annotated[str, Field(max_length=_LYRICS_MAX_LENGTH)] | None = None
-    vocal_language: Annotated[str, Field(max_length=_VOCAL_LANGUAGE_MAX_LENGTH)] | None = None
+    prompt: Annotated[str, Field(min_length=1, max_length=PROMPT_MAX_LENGTH)]
+    style: Annotated[str, Field(max_length=STYLE_MAX_LENGTH)] | None = None
+    lyrics: Annotated[str, Field(max_length=LYRICS_MAX_LENGTH)] | None = None
+    vocal_language: Annotated[str, Field(max_length=VOCAL_LANGUAGE_MAX_LENGTH)] | None = None
     instrumental: bool = False
     bpm: Annotated[int, Field(ge=BPM_MIN, le=BPM_MAX)] | Literal["auto"] | None = None
-    key: Annotated[str, Field(max_length=_KEY_MAX_LENGTH)] | None = None
+    key: Annotated[str, Field(max_length=KEY_MAX_LENGTH)] | None = None
     time_signature: str | None = None
     # Upper bound and positivity hold for every mode; the 30s song floor is
     # enforced mode-aware below so short sounds (one-shots, loops) are allowed.
     duration: Annotated[float, Field(gt=0, le=DURATION_MAX)] | None = None
-    seed: Annotated[int, Field(ge=_SEED_MIN, le=_SEED_MAX)] | None = None
+    seed: Annotated[int, Field(ge=SEED_MIN, le=SEED_MAX)] | None = None
     inference_steps: Annotated[int, Field(gt=0, le=INFERENCE_STEPS_MAX)] | None = None
     model: str | None = None
     weirdness: Annotated[int, Field(ge=WEIRDNESS_MIN, le=WEIRDNESS_MAX)] = 50

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -13,7 +13,7 @@ validation share one source of truth.
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from acemusic.constants import (
     BPM_MAX,
@@ -37,7 +37,8 @@ _SEED_MIN = -(2**63)
 _SEED_MAX = 2**63 - 1
 
 from ..auth.dependencies import CurrentUser, get_current_user
-from ..services import generation as generation_service, users as user_service
+from ..models import PRESET_PARAM_FIELDS, Preset
+from ..services import generation as generation_service, presets as preset_service, users as user_service
 
 # Estimate heuristic (seconds): a song's wall-clock scales with its duration; a
 # short sound is roughly fixed. These are advisory hints returned to the client.
@@ -69,6 +70,10 @@ class GenerationRequest(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    # US-9.5: apply a saved preset as parameter defaults; explicitly-sent
+    # request fields override preset values. Never forwarded to the job.
+    preset_id: str | None = None
 
     prompt: Annotated[str, Field(min_length=1, max_length=_PROMPT_MAX_LENGTH)]
     style: Annotated[str, Field(max_length=_STYLE_MAX_LENGTH)] | None = None
@@ -114,6 +119,12 @@ class GenerationRequest(BaseModel):
 
     @model_validator(mode="after")
     def _check_mode_constraints(self) -> "GenerationRequest":
+        # With a preset in play the cross-field rules can only be judged on the
+        # MERGED parameter set (the preset may supply sound_type, duration, …),
+        # so they are deferred to _apply_preset's re-validation, where the
+        # merged model carries preset_id=None and these checks run.
+        if self.preset_id is not None:
+            return self
         # sound_type and mode are coupled: it is required for sounds and
         # meaningless for songs.
         if self.mode == "sound" and self.sound_type is None:
@@ -146,6 +157,24 @@ def estimate_seconds(request: GenerationRequest) -> int:
     return _SONG_BASE_SECONDS + int(duration)
 
 
+def _apply_preset(request: GenerationRequest, preset: Preset) -> GenerationRequest:
+    """Merge ``preset`` into ``request``: preset values are the base, fields the
+    client explicitly sent win (``model_fields_set``, so an explicit value equal
+    to a schema default still overrides). The merged set is re-validated as a
+    plain request (preset_id absent), which enforces the deferred cross-field
+    rules; a conflict surfaces as 422 just like any other invalid body.
+    """
+    base = {field: getattr(preset, field) for field in PRESET_PARAM_FIELDS if getattr(preset, field) is not None}
+    explicit = {field: getattr(request, field) for field in request.model_fields_set if field != "preset_id"}
+    try:
+        return GenerationRequest.model_validate({**base, **explicit})
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=[{"loc": list(error["loc"]), "msg": error["msg"], "type": error["type"]} for error in exc.errors()],
+        ) from exc
+
+
 @router.post("", response_model=GenerationResponse, status_code=status.HTTP_202_ACCEPTED)
 async def create_generation(
     request: GenerationRequest,
@@ -162,8 +191,12 @@ async def create_generation(
     user = await user_service.get_user_by_id(current.user_id)
     if user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+    if request.preset_id is not None:
+        # 404 for unknown/malformed/not-owned ids (never reveals other users' presets).
+        preset = await preset_service.get_preset(request.preset_id, current.user_id)
+        request = _apply_preset(request, preset)
     job = await generation_service.create_generation_job(
         user_id=user.id,
-        params=request.model_dump(exclude_none=True),
+        params=request.model_dump(exclude_none=True, exclude={"preset_id"}),
     )
     return GenerationResponse(job_id=str(job.id), estimated_time_seconds=estimate_seconds(request))

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -10,7 +10,6 @@ import asyncio
 import logging
 from datetime import datetime
 
-from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
@@ -18,6 +17,7 @@ from acemusic.storage import get_storage_backend
 
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import Clip, Job, JobStatus
+from ..services.common import coerce_object_id
 from .generation import GenerationRequest, estimate_seconds
 
 logger = logging.getLogger(__name__)
@@ -42,14 +42,6 @@ class JobStatusResponse(BaseModel):
     clip_ids: list[str] | None = None
     audio_urls: list[str] | None = None
     error: str | None = None
-
-
-def _coerce_object_id(value: str) -> PydanticObjectId | None:
-    """Parse a path id, treating a malformed id as "no such job" (caller → 404)."""
-    try:
-        return PydanticObjectId(value)
-    except Exception:
-        return None
 
 
 def _estimate_for(job: Job) -> int:
@@ -89,7 +81,7 @@ async def get_job_status(
     current: CurrentUser = Depends(get_current_user),
 ) -> JobStatusResponse:
     """Return the current status of ``job_id`` for its owner (404 otherwise)."""
-    oid = _coerce_object_id(job_id)
+    oid = coerce_object_id(job_id)
     job = await Job.get(oid) if oid is not None else None
     if job is None or str(job.user_id) != current.user_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found.")

--- a/src/acemusic/api/routers/presets.py
+++ b/src/acemusic/api/routers/presets.py
@@ -37,9 +37,6 @@ from acemusic.constants import (
     STYLE_INFLUENCE_MAX,
     STYLE_INFLUENCE_MIN,
     STYLE_MAX_LENGTH,
-    VALID_FORMATS,
-    VALID_MODELS,
-    VALID_TIME_SIGNATURES,
     VOCAL_LANGUAGE_MAX_LENGTH,
     WEIRDNESS_MAX,
     WEIRDNESS_MIN,
@@ -48,6 +45,7 @@ from acemusic.constants import (
 from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
 from ..models import PRESET_PARAM_FIELDS, Preset
 from ..services import presets as preset_service
+from ._validators import validate_format, validate_model, validate_time_signature
 
 PRESET_NAME_MAX_LENGTH = 100
 
@@ -95,23 +93,17 @@ class _PresetParams(BaseModel):
     @field_validator("format")
     @classmethod
     def _check_format(cls, value: str | None) -> str | None:
-        if value is not None and value not in VALID_FORMATS:
-            raise ValueError(f"format must be one of {sorted(VALID_FORMATS)}")
-        return value
+        return validate_format(value)
 
     @field_validator("model")
     @classmethod
     def _check_model(cls, value: str | None) -> str | None:
-        if value is not None and value not in VALID_MODELS:
-            raise ValueError(f"model must be one of {sorted(VALID_MODELS)}")
-        return value
+        return validate_model(value)
 
     @field_validator("time_signature")
     @classmethod
     def _check_time_signature(cls, value: str | None) -> str | None:
-        if value is not None and value not in VALID_TIME_SIGNATURES:
-            raise ValueError(f"time_signature must be one of {sorted(VALID_TIME_SIGNATURES)}")
-        return value
+        return validate_time_signature(value)
 
 
 class PresetCreate(_PresetParams):

--- a/src/acemusic/api/routers/presets.py
+++ b/src/acemusic/api/routers/presets.py
@@ -30,11 +30,17 @@ from acemusic.constants import (
     BPM_MIN,
     DURATION_MAX,
     INFERENCE_STEPS_MAX,
+    KEY_MAX_LENGTH,
+    LYRICS_MAX_LENGTH,
+    SEED_MAX,
+    SEED_MIN,
     STYLE_INFLUENCE_MAX,
     STYLE_INFLUENCE_MIN,
+    STYLE_MAX_LENGTH,
     VALID_FORMATS,
     VALID_MODELS,
     VALID_TIME_SIGNATURES,
+    VOCAL_LANGUAGE_MAX_LENGTH,
     WEIRDNESS_MAX,
     WEIRDNESS_MIN,
 )
@@ -42,14 +48,6 @@ from acemusic.constants import (
 from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
 from ..models import PRESET_PARAM_FIELDS, Preset
 from ..services import presets as preset_service
-from .generation import (
-    _KEY_MAX_LENGTH,
-    _LYRICS_MAX_LENGTH,
-    _SEED_MAX,
-    _SEED_MIN,
-    _STYLE_MAX_LENGTH,
-    _VOCAL_LANGUAGE_MAX_LENGTH,
-)
 
 PRESET_NAME_MAX_LENGTH = 100
 
@@ -76,15 +74,15 @@ class _PresetParams(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    style: Annotated[str, Field(max_length=_STYLE_MAX_LENGTH)] | None = None
-    lyrics: Annotated[str, Field(max_length=_LYRICS_MAX_LENGTH)] | None = None
-    vocal_language: Annotated[str, Field(max_length=_VOCAL_LANGUAGE_MAX_LENGTH)] | None = None
+    style: Annotated[str, Field(max_length=STYLE_MAX_LENGTH)] | None = None
+    lyrics: Annotated[str, Field(max_length=LYRICS_MAX_LENGTH)] | None = None
+    vocal_language: Annotated[str, Field(max_length=VOCAL_LANGUAGE_MAX_LENGTH)] | None = None
     instrumental: bool | None = None
     bpm: Annotated[int, Field(ge=BPM_MIN, le=BPM_MAX)] | Literal["auto"] | None = None
-    key: Annotated[str, Field(max_length=_KEY_MAX_LENGTH)] | None = None
+    key: Annotated[str, Field(max_length=KEY_MAX_LENGTH)] | None = None
     time_signature: str | None = None
     duration: Annotated[float, Field(gt=0, le=DURATION_MAX)] | None = None
-    seed: Annotated[int, Field(ge=_SEED_MIN, le=_SEED_MAX)] | None = None
+    seed: Annotated[int, Field(ge=SEED_MIN, le=SEED_MAX)] | None = None
     inference_steps: Annotated[int, Field(gt=0, le=INFERENCE_STEPS_MAX)] | None = None
     model: str | None = None
     weirdness: Annotated[int, Field(ge=WEIRDNESS_MIN, le=WEIRDNESS_MAX)] | None = None

--- a/src/acemusic/api/routers/presets.py
+++ b/src/acemusic/api/routers/presets.py
@@ -1,0 +1,231 @@
+"""Preset CRUD router (US-9.5), mounted under ``/api/v1/presets``.
+
+Endpoints (all require a valid Bearer access token and operate only on the
+authenticated user's presets):
+
+* ``POST   /presets``      → create (201; 409 on duplicate name)
+* ``GET    /presets``      → list the user's presets
+* ``GET    /presets/{id}`` → single preset (404 if missing/not owned)
+* ``PATCH  /presets/{id}`` → partial update; an explicit ``null`` clears a
+  parameter (409 on duplicate name)
+* ``DELETE /presets/{id}`` → delete (204)
+
+Request/response schemas live here (same convention as the workspaces router);
+persistence lives in :mod:`acemusic.api.services.presets`. Parameter fields and
+bounds mirror :class:`~acemusic.api.routers.generation.GenerationRequest` — a
+preset may only store values the generate endpoint would accept — except the
+cross-field rules (mode/sound_type coupling, the song duration floor), which
+are enforced when the preset is applied to a request, since they depend on the
+final merged parameter set.
+"""
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Response, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from acemusic.constants import (
+    BPM_MAX,
+    BPM_MIN,
+    DURATION_MAX,
+    INFERENCE_STEPS_MAX,
+    STYLE_INFLUENCE_MAX,
+    STYLE_INFLUENCE_MIN,
+    VALID_FORMATS,
+    VALID_MODELS,
+    VALID_TIME_SIGNATURES,
+    WEIRDNESS_MAX,
+    WEIRDNESS_MIN,
+)
+
+from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..models import PRESET_PARAM_FIELDS, Preset
+from ..services import presets as preset_service
+from .generation import (
+    _KEY_MAX_LENGTH,
+    _LYRICS_MAX_LENGTH,
+    _SEED_MAX,
+    _SEED_MIN,
+    _STYLE_MAX_LENGTH,
+    _VOCAL_LANGUAGE_MAX_LENGTH,
+)
+
+PRESET_NAME_MAX_LENGTH = 100
+
+# Router-level dependency gates every route; endpoints additionally take
+# ``current`` to read the identity.
+router = APIRouter(prefix="/presets", tags=["presets"], dependencies=[Depends(get_current_user)])
+
+
+def _validate_name(value: str) -> str:
+    """Strip surrounding whitespace and reject names that are blank after it."""
+    value = value.strip()
+    if not value:
+        raise ValueError("Preset name must not be blank.")
+    return value
+
+
+class _PresetParams(BaseModel):
+    """The optional generation parameter snapshot shared by create and update.
+
+    Field shapes and bounds mirror ``GenerationRequest`` so a stored preset is
+    always applicable; every field is nullable because a preset pins down only
+    what the user chose to save.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    style: Annotated[str, Field(max_length=_STYLE_MAX_LENGTH)] | None = None
+    lyrics: Annotated[str, Field(max_length=_LYRICS_MAX_LENGTH)] | None = None
+    vocal_language: Annotated[str, Field(max_length=_VOCAL_LANGUAGE_MAX_LENGTH)] | None = None
+    instrumental: bool | None = None
+    bpm: Annotated[int, Field(ge=BPM_MIN, le=BPM_MAX)] | Literal["auto"] | None = None
+    key: Annotated[str, Field(max_length=_KEY_MAX_LENGTH)] | None = None
+    time_signature: str | None = None
+    duration: Annotated[float, Field(gt=0, le=DURATION_MAX)] | None = None
+    seed: Annotated[int, Field(ge=_SEED_MIN, le=_SEED_MAX)] | None = None
+    inference_steps: Annotated[int, Field(gt=0, le=INFERENCE_STEPS_MAX)] | None = None
+    model: str | None = None
+    weirdness: Annotated[int, Field(ge=WEIRDNESS_MIN, le=WEIRDNESS_MAX)] | None = None
+    style_influence: Annotated[int, Field(ge=STYLE_INFLUENCE_MIN, le=STYLE_INFLUENCE_MAX)] | None = None
+    format: str | None = None
+    thinking: bool | None = None
+    mode: Literal["song", "sound"] | None = None
+    sound_type: Literal["one-shot", "loop"] | None = None
+
+    @field_validator("format")
+    @classmethod
+    def _check_format(cls, value: str | None) -> str | None:
+        if value is not None and value not in VALID_FORMATS:
+            raise ValueError(f"format must be one of {sorted(VALID_FORMATS)}")
+        return value
+
+    @field_validator("model")
+    @classmethod
+    def _check_model(cls, value: str | None) -> str | None:
+        if value is not None and value not in VALID_MODELS:
+            raise ValueError(f"model must be one of {sorted(VALID_MODELS)}")
+        return value
+
+    @field_validator("time_signature")
+    @classmethod
+    def _check_time_signature(cls, value: str | None) -> str | None:
+        if value is not None and value not in VALID_TIME_SIGNATURES:
+            raise ValueError(f"time_signature must be one of {sorted(VALID_TIME_SIGNATURES)}")
+        return value
+
+
+class PresetCreate(_PresetParams):
+    name: Annotated[str, Field(min_length=1, max_length=PRESET_NAME_MAX_LENGTH)]
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, value: str) -> str:
+        return _validate_name(value)
+
+
+class PresetUpdate(_PresetParams):
+    """Partial update. Only explicitly-sent fields are applied; sending
+    ``null`` for a parameter clears it. The name cannot be cleared."""
+
+    name: Annotated[str, Field(min_length=1, max_length=PRESET_NAME_MAX_LENGTH)] | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, value: str | None) -> str | None:
+        return value if value is None else _validate_name(value)
+
+    @model_validator(mode="after")
+    def _reject_null_name(self) -> "PresetUpdate":
+        if "name" in self.model_fields_set and self.name is None:
+            raise ValueError("Preset name cannot be cleared.")
+        return self
+
+
+class PresetResponse(BaseModel):
+    id: str
+    name: str
+    created_at: datetime
+    updated_at: datetime | None
+
+    style: str | None
+    lyrics: str | None
+    vocal_language: str | None
+    instrumental: bool | None
+    bpm: int | Literal["auto"] | None
+    key: str | None
+    time_signature: str | None
+    duration: float | None
+    seed: int | None
+    inference_steps: int | None
+    model: str | None
+    weirdness: int | None
+    style_influence: int | None
+    format: str | None
+    thinking: bool | None
+    mode: Literal["song", "sound"] | None
+    sound_type: Literal["one-shot", "loop"] | None
+
+    @classmethod
+    def from_preset(cls, preset: Preset) -> "PresetResponse":
+        return cls(
+            id=str(preset.id),
+            name=preset.name,
+            created_at=preset.created_at,
+            updated_at=preset.updated_at,
+            **{field: getattr(preset, field) for field in PRESET_PARAM_FIELDS},
+        )
+
+
+class PresetListResponse(BaseModel):
+    presets: list[PresetResponse]
+    total: int
+
+
+@router.post("", response_model=PresetResponse, status_code=status.HTTP_201_CREATED)
+async def create_preset(
+    body: PresetCreate,
+    current: CurrentUser = Depends(require_existing_user),
+) -> PresetResponse:
+    params = body.model_dump(exclude={"name"})
+    preset = await preset_service.create_preset(current.user_id, body.name, params)
+    return PresetResponse.from_preset(preset)
+
+
+@router.get("", response_model=PresetListResponse)
+async def list_presets(current: CurrentUser = Depends(require_existing_user)) -> PresetListResponse:
+    presets = await preset_service.list_presets(current.user_id)
+    return PresetListResponse(presets=[PresetResponse.from_preset(p) for p in presets], total=len(presets))
+
+
+@router.get("/{preset_id}", response_model=PresetResponse)
+async def get_preset(
+    preset_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> PresetResponse:
+    preset = await preset_service.get_preset(preset_id, current.user_id)
+    return PresetResponse.from_preset(preset)
+
+
+@router.patch("/{preset_id}", response_model=PresetResponse)
+async def update_preset(
+    preset_id: str,
+    body: PresetUpdate,
+    current: CurrentUser = Depends(require_existing_user),
+) -> PresetResponse:
+    updates = body.model_dump(exclude_unset=True)
+    if not updates:
+        preset = await preset_service.get_preset(preset_id, current.user_id)
+    else:
+        preset = await preset_service.update_preset(preset_id, current.user_id, updates)
+    return PresetResponse.from_preset(preset)
+
+
+@router.delete("/{preset_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_preset(
+    preset_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> Response:
+    await preset_service.delete_preset(preset_id, current.user_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -21,14 +21,7 @@ from acemusic.storage import get_storage_backend
 
 from ..models import Clip
 from . import workspaces as workspace_service
-
-
-def _coerce_object_id(value: str) -> PydanticObjectId | None:
-    """Parse a path id, treating a malformed id as "no such clip" (caller → 404)."""
-    try:
-        return PydanticObjectId(value)
-    except Exception:
-        return None
+from .common import coerce_object_id
 
 
 async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
@@ -38,7 +31,7 @@ async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
     clip. Unlike jobs (which 404 to hide existence), clips deliberately
     distinguish 403 so sharing flows can tell "ask the owner" from "gone".
     """
-    oid = _coerce_object_id(clip_id)
+    oid = coerce_object_id(clip_id)
     clip = await Clip.get(oid) if oid is not None else None
     if clip is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found.")
@@ -58,7 +51,7 @@ def _contains_regex(text: str) -> dict:
 
 async def get_owned_clip(clip_id: str, user_id: str) -> Clip:
     """Return the clip if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
-    oid = _coerce_object_id(clip_id)
+    oid = coerce_object_id(clip_id)
     clip = await Clip.get(oid) if oid is not None else None
     if clip is None or str(clip.user_id) != user_id:
         raise _clip_not_found()

--- a/src/acemusic/api/services/common.py
+++ b/src/acemusic/api/services/common.py
@@ -1,0 +1,15 @@
+"""Helpers shared across the API service modules."""
+
+from beanie import PydanticObjectId
+
+
+def coerce_object_id(value: str) -> PydanticObjectId | None:
+    """Parse a path id, treating a malformed id as "no such document" (→ 404).
+
+    Used by the ownership-checked lookups (clips, workspaces, presets) so a
+    malformed id is indistinguishable from a missing or not-owned one.
+    """
+    try:
+        return PydanticObjectId(value)
+    except Exception:
+        return None

--- a/src/acemusic/api/services/presets.py
+++ b/src/acemusic/api/services/presets.py
@@ -1,0 +1,81 @@
+"""Preset service layer (US-9.5).
+
+Owns user-scoped preset CRUD. Ownership failures and unknown/malformed ids
+surface as 404 so the API never reveals whether another user's preset exists,
+mirroring :mod:`acemusic.api.services.workspaces`.
+"""
+
+from beanie import PydanticObjectId
+from beanie.operators import Eq
+from fastapi import HTTPException, status
+from pymongo.errors import DuplicateKeyError
+
+from ..models import Preset
+from ..models.common import utcnow
+
+
+def _coerce_object_id(value: str) -> PydanticObjectId | None:
+    """Parse a path id, treating a malformed id as "no such preset" (→ 404)."""
+    try:
+        return PydanticObjectId(value)
+    except Exception:
+        return None
+
+
+def _not_found() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Preset not found.")
+
+
+def _name_conflict(name: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=f"A preset named {name!r} already exists.",
+    )
+
+
+async def create_preset(user_id: str, name: str, params: dict) -> Preset:
+    """Create a preset for ``user_id``. Raises 409 if the name is taken.
+
+    ``params`` holds only generation parameter fields (the router validates
+    and dumps them), so identity fields cannot be injected through it.
+    """
+    preset = Preset(name=name, user_id=PydanticObjectId(user_id), **params)
+    try:
+        await preset.insert()
+    except DuplicateKeyError as exc:
+        raise _name_conflict(name) from exc
+    return preset
+
+
+async def list_presets(user_id: str) -> list[Preset]:
+    """Return all of ``user_id``'s presets, oldest first."""
+    return await Preset.find(Eq(Preset.user_id, PydanticObjectId(user_id))).sort("+created_at").to_list()
+
+
+async def get_preset(preset_id: str, user_id: str) -> Preset:
+    """Return the preset if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
+    oid = _coerce_object_id(preset_id)
+    preset = await Preset.get(oid) if oid is not None else None
+    if preset is None or str(preset.user_id) != user_id:
+        raise _not_found()
+    return preset
+
+
+async def update_preset(preset_id: str, user_id: str, updates: dict) -> Preset:
+    """Apply ``updates`` (explicitly-sent fields only, may include ``None`` to
+    clear a parameter). Raises 404 if not owned, 409 on a name collision."""
+    preset = await get_preset(preset_id, user_id)
+    for field, value in updates.items():
+        setattr(preset, field, value)
+    preset.updated_at = utcnow()
+    try:
+        await preset.save()
+    except DuplicateKeyError as exc:
+        raise _name_conflict(preset.name) from exc
+    return preset
+
+
+async def delete_preset(preset_id: str, user_id: str) -> None:
+    """Delete the preset. Raises 404 for unknown/malformed/not-owned ids."""
+    preset = await get_preset(preset_id, user_id)
+    await preset.delete()

--- a/src/acemusic/api/services/presets.py
+++ b/src/acemusic/api/services/presets.py
@@ -12,14 +12,7 @@ from pymongo.errors import DuplicateKeyError
 
 from ..models import Preset
 from ..models.common import utcnow
-
-
-def _coerce_object_id(value: str) -> PydanticObjectId | None:
-    """Parse a path id, treating a malformed id as "no such preset" (→ 404)."""
-    try:
-        return PydanticObjectId(value)
-    except Exception:
-        return None
+from .common import coerce_object_id
 
 
 def _not_found() -> HTTPException:
@@ -54,7 +47,7 @@ async def list_presets(user_id: str) -> list[Preset]:
 
 async def get_preset(preset_id: str, user_id: str) -> Preset:
     """Return the preset if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
-    oid = _coerce_object_id(preset_id)
+    oid = coerce_object_id(preset_id)
     preset = await Preset.get(oid) if oid is not None else None
     if preset is None or str(preset.user_id) != user_id:
         raise _not_found()

--- a/src/acemusic/api/services/presets.py
+++ b/src/acemusic/api/services/presets.py
@@ -63,7 +63,12 @@ async def get_preset(preset_id: str, user_id: str) -> Preset:
 
 async def update_preset(preset_id: str, user_id: str, updates: dict) -> Preset:
     """Apply ``updates`` (explicitly-sent fields only, may include ``None`` to
-    clear a parameter). Raises 404 if not owned, 409 on a name collision."""
+    clear a parameter). Raises 404 if not owned, 409 on a name collision.
+
+    ``updates`` must come from a validated ``PresetUpdate`` dump — the setattr
+    loop trusts its keys, so a raw dict could reassign identity fields like
+    ``user_id`` (same contract as ``create_preset``).
+    """
     preset = await get_preset(preset_id, user_id)
     for field, value in updates.items():
         setattr(preset, field, value)

--- a/src/acemusic/api/services/workspaces.py
+++ b/src/acemusic/api/services/workspaces.py
@@ -18,16 +18,9 @@ from acemusic.storage import get_storage_backend
 
 from ..models import Clip, Workspace
 from ..models.common import utcnow
+from .common import coerce_object_id
 
 DEFAULT_WORKSPACE_NAME = "My Workspace"
-
-
-def _coerce_object_id(value: str) -> PydanticObjectId | None:
-    """Parse a path id, treating a malformed id as "no such workspace" (→ 404)."""
-    try:
-        return PydanticObjectId(value)
-    except Exception:
-        return None
 
 
 def _not_found() -> HTTPException:
@@ -121,7 +114,7 @@ async def list_workspaces(user_id: str) -> list[tuple[Workspace, int]]:
 
 async def get_workspace(workspace_id: str, user_id: str) -> Workspace:
     """Return the workspace if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
-    oid = _coerce_object_id(workspace_id)
+    oid = coerce_object_id(workspace_id)
     workspace = await Workspace.get(oid) if oid is not None else None
     if workspace is None or str(workspace.user_id) != user_id:
         raise _not_found()

--- a/src/acemusic/constants.py
+++ b/src/acemusic/constants.py
@@ -77,3 +77,20 @@ INFERENCE_STEPS_MAX = 500
 # Creation modes and the sound sub-types valid when ``mode == "sound"``.
 VALID_MODES: frozenset[str] = frozenset({"song", "sound"})
 VALID_SOUND_TYPES: frozenset[str] = frozenset({"one-shot", "loop"})
+
+# Free-text field caps, shared by the API's generation and preset schemas.
+# These fields are persisted verbatim (``Job.input_params``, preset documents)
+# and re-read by the worker, so cap them: a single request must not be able to
+# bloat a MongoDB document (16MB cap) and turn into a 500. Lyrics get the most
+# headroom since a full song's words are legitimately long.
+PROMPT_MAX_LENGTH = 2000
+STYLE_MAX_LENGTH = 1000
+LYRICS_MAX_LENGTH = 5000
+VOCAL_LANGUAGE_MAX_LENGTH = 100
+KEY_MAX_LENGTH = 50
+
+# Seeds are opaque values forwarded to the backend; bound them to MongoDB's
+# signed 64-bit integer range so an oversized value is a clean 422 rather than
+# a BSON-encoding 500 when persisted.
+SEED_MIN = -(2**63)
+SEED_MAX = 2**63 - 1

--- a/tests/test_presets_api.py
+++ b/tests/test_presets_api.py
@@ -42,6 +42,22 @@ FULL_PARAMS = {
 
 
 # ---------------------------------------------------------------------------
+# Model contract — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestPresetParamFieldsParity:
+    def test_param_fields_cover_every_non_identity_model_field(self) -> None:
+        """PRESET_PARAM_FIELDS drives the merge base, PresetResponse, and the
+        service dump; a Preset field missing from it would be silently ignored
+        at generation time. Lock the tuple to the model."""
+        from acemusic.api.models import PRESET_PARAM_FIELDS
+
+        identity_fields = {"id", "name", "user_id", "created_at", "updated_at", "revision_id"}
+        assert set(PRESET_PARAM_FIELDS) == set(Preset.model_fields) - identity_fields
+
+
+# ---------------------------------------------------------------------------
 # Auth gate — runs in CI (no DB)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_presets_api.py
+++ b/tests/test_presets_api.py
@@ -1,0 +1,505 @@
+"""Tests for the preset CRUD endpoints and preset-aware generation (US-9.5, issue #79).
+
+The 401 auth-gate tests run in CI (the router dependency rejects before any DB
+access; plain ``TestClient`` does not run the lifespan). The CRUD and generate
+tests are ``integration``: they drive the real app with ``httpx.AsyncClient``
+over a local MongoDB (``mongo_db``), mirroring ``tests/test_workspaces_api.py``.
+"""
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Job, Preset
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+
+PRESETS_URL = f"{API_V1_PREFIX}/presets"
+GENERATE_URL = f"{API_V1_PREFIX}/generate"
+
+# A representative full parameter snapshot used across tests.
+FULL_PARAMS = {
+    "style": "lofi hip hop",
+    "lyrics": "la la la",
+    "vocal_language": "en",
+    "instrumental": True,
+    "bpm": 90,
+    "key": "C minor",
+    "time_signature": "4/4",
+    "duration": 60.0,
+    "seed": 1234,
+    "inference_steps": 32,
+    "weirdness": 80,
+    "style_influence": 20,
+    "format": "flac",
+    "thinking": True,
+    "mode": "song",
+}
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize(
+        ("method", "url"),
+        [
+            ("GET", PRESETS_URL),
+            ("POST", PRESETS_URL),
+            ("GET", f"{PRESETS_URL}/{PydanticObjectId()}"),
+            ("PATCH", f"{PRESETS_URL}/{PydanticObjectId()}"),
+            ("DELETE", f"{PRESETS_URL}/{PydanticObjectId()}"),
+        ],
+    )
+    def test_missing_auth_header_returns_401(self, method: str, url: str) -> None:
+        client = TestClient(create_app())
+        resp = client.request(method, url)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _insert_preset(user, name: str = "Default", **params) -> Preset:
+    preset = Preset(user_id=user.id, name=name, **params)
+    await preset.insert()
+    return preset
+
+
+async def _get_job(job_id: str) -> Job:
+    job = await Job.get(PydanticObjectId(job_id))
+    assert job is not None
+    return job
+
+
+@pytest.mark.integration
+class TestCreatePreset:
+    async def test_create_with_full_params_returns_201_and_echoes_all(self, client, settings) -> None:
+        user = await _make_user("preset-create@example.com")
+        resp = await client.post(
+            PRESETS_URL,
+            json={"name": "My Lofi", **FULL_PARAMS},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["id"]
+        assert body["name"] == "My Lofi"
+        assert body["created_at"]
+        for field, value in FULL_PARAMS.items():
+            assert body[field] == value, f"field {field!r}: {body[field]!r} != {value!r}"
+
+    async def test_create_minimal_returns_201_with_null_params(self, client, settings) -> None:
+        user = await _make_user("preset-create-min@example.com")
+        resp = await client.post(PRESETS_URL, json={"name": "Bare"}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["name"] == "Bare"
+        assert body["style"] is None
+        assert body["bpm"] is None
+        assert body["instrumental"] is None
+
+    async def test_bpm_auto_is_accepted(self, client, settings) -> None:
+        user = await _make_user("preset-create-auto@example.com")
+        resp = await client.post(
+            PRESETS_URL, json={"name": "Auto", "bpm": "auto"}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 201
+        assert resp.json()["bpm"] == "auto"
+
+    async def test_duplicate_name_for_same_user_returns_409(self, client, settings) -> None:
+        user = await _make_user("preset-dup@example.com")
+        headers = _auth_headers(user, settings)
+        assert (await client.post(PRESETS_URL, json={"name": "Beats"}, headers=headers)).status_code == 201
+        assert (await client.post(PRESETS_URL, json={"name": "Beats"}, headers=headers)).status_code == 409
+
+    async def test_same_name_for_different_users_is_allowed(self, client, settings) -> None:
+        alice = await _make_user("preset-alice@example.com")
+        bob = await _make_user("preset-bob@example.com")
+        assert (
+            await client.post(PRESETS_URL, json={"name": "Beats"}, headers=_auth_headers(alice, settings))
+        ).status_code == 201
+        assert (
+            await client.post(PRESETS_URL, json={"name": "Beats"}, headers=_auth_headers(bob, settings))
+        ).status_code == 201
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},  # missing name
+            {"name": ""},
+            {"name": "   "},
+            {"name": "X", "bpm": 300},  # out of range
+            {"name": "X", "weirdness": 101},
+            {"name": "X", "format": "ogg"},  # not a valid format
+            {"name": "X", "time_signature": "13/8"},
+            {"name": "X", "nope": True},  # unknown field
+        ],
+    )
+    async def test_invalid_payload_returns_422(self, client, settings, payload: dict) -> None:
+        user = await _make_user("preset-invalid@example.com")
+        resp = await client.post(PRESETS_URL, json=payload, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+
+@pytest.mark.integration
+class TestListPresets:
+    async def test_lists_only_own_presets(self, client, settings) -> None:
+        user = await _make_user("preset-list@example.com")
+        other = await _make_user("preset-list-other@example.com")
+        mine_a = await _insert_preset(user, "A", style="ambient")
+        mine_b = await _insert_preset(user, "B")
+        await _insert_preset(other, "Theirs")
+
+        resp = await client.get(PRESETS_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 2
+        by_id = {p["id"]: p for p in body["presets"]}
+        assert set(by_id) == {str(mine_a.id), str(mine_b.id)}
+        assert by_id[str(mine_a.id)]["style"] == "ambient"
+
+    async def test_empty_list_for_new_user(self, client, settings) -> None:
+        user = await _make_user("preset-list-empty@example.com")
+        resp = await client.get(PRESETS_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json() == {"presets": [], "total": 0}
+
+
+@pytest.mark.integration
+class TestGetPreset:
+    async def test_get_own_preset_returns_all_saved_params(self, client, settings) -> None:
+        user = await _make_user("preset-get@example.com")
+        preset = await _insert_preset(user, "Mine", **FULL_PARAMS)
+
+        resp = await client.get(f"{PRESETS_URL}/{preset.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == str(preset.id)
+        assert body["name"] == "Mine"
+        for field, value in FULL_PARAMS.items():
+            assert body[field] == value, f"field {field!r}: {body[field]!r} != {value!r}"
+
+    async def test_unknown_preset_returns_404(self, client, settings) -> None:
+        user = await _make_user("preset-get-unknown@example.com")
+        resp = await client.get(f"{PRESETS_URL}/{PydanticObjectId()}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_malformed_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("preset-get-malformed@example.com")
+        resp = await client.get(f"{PRESETS_URL}/not-an-object-id", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_preset_returns_404(self, client, settings) -> None:
+        owner = await _make_user("preset-get-owner@example.com")
+        other = await _make_user("preset-get-other@example.com")
+        preset = await _insert_preset(owner, "Private")
+        resp = await client.get(f"{PRESETS_URL}/{preset.id}", headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestUpdatePreset:
+    async def test_partial_update_changes_only_sent_fields(self, client, settings) -> None:
+        user = await _make_user("preset-patch@example.com")
+        preset = await _insert_preset(user, "Mine", style="lofi", bpm=90, weirdness=80)
+
+        resp = await client.patch(
+            f"{PRESETS_URL}/{preset.id}",
+            json={"bpm": 120},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["bpm"] == 120
+        assert body["style"] == "lofi"
+        assert body["weirdness"] == 80
+        assert body["updated_at"] is not None
+
+        fetched = await Preset.get(preset.id)
+        assert fetched.bpm == 120
+        assert fetched.style == "lofi"
+
+    async def test_explicit_null_clears_a_param(self, client, settings) -> None:
+        user = await _make_user("preset-patch-null@example.com")
+        preset = await _insert_preset(user, "Mine", style="lofi", bpm=90)
+
+        resp = await client.patch(
+            f"{PRESETS_URL}/{preset.id}",
+            json={"style": None},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["style"] is None
+        assert body["bpm"] == 90
+
+    async def test_rename_returns_updated_preset(self, client, settings) -> None:
+        user = await _make_user("preset-rename@example.com")
+        preset = await _insert_preset(user, "Old")
+        resp = await client.patch(
+            f"{PRESETS_URL}/{preset.id}",
+            json={"name": "New"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "New"
+
+    async def test_rename_to_existing_name_returns_409(self, client, settings) -> None:
+        user = await _make_user("preset-rename-dup@example.com")
+        await _insert_preset(user, "Taken")
+        preset = await _insert_preset(user, "Original")
+        resp = await client.patch(
+            f"{PRESETS_URL}/{preset.id}",
+            json={"name": "Taken"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 409
+
+    async def test_null_name_returns_422(self, client, settings) -> None:
+        user = await _make_user("preset-rename-null@example.com")
+        preset = await _insert_preset(user, "Mine")
+        resp = await client.patch(
+            f"{PRESETS_URL}/{preset.id}",
+            json={"name": None},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_other_users_preset_returns_404(self, client, settings) -> None:
+        owner = await _make_user("preset-patch-owner@example.com")
+        other = await _make_user("preset-patch-other@example.com")
+        preset = await _insert_preset(owner, "Private")
+        resp = await client.patch(
+            f"{PRESETS_URL}/{preset.id}",
+            json={"bpm": 100},
+            headers=_auth_headers(other, settings),
+        )
+        assert resp.status_code == 404
+        assert (await Preset.get(preset.id)).bpm is None
+
+
+@pytest.mark.integration
+class TestDeletePreset:
+    async def test_delete_returns_204_and_preset_is_gone(self, client, settings) -> None:
+        user = await _make_user("preset-del@example.com")
+        preset = await _insert_preset(user, "Doomed")
+        headers = _auth_headers(user, settings)
+
+        resp = await client.delete(f"{PRESETS_URL}/{preset.id}", headers=headers)
+        assert resp.status_code == 204
+        assert await Preset.get(preset.id) is None
+        assert (await client.get(f"{PRESETS_URL}/{preset.id}", headers=headers)).status_code == 404
+
+    async def test_unknown_preset_returns_404(self, client, settings) -> None:
+        user = await _make_user("preset-del-unknown@example.com")
+        resp = await client.delete(f"{PRESETS_URL}/{PydanticObjectId()}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_preset_returns_404(self, client, settings) -> None:
+        owner = await _make_user("preset-del-owner@example.com")
+        other = await _make_user("preset-del-other@example.com")
+        preset = await _insert_preset(owner, "Private")
+        resp = await client.delete(f"{PRESETS_URL}/{preset.id}", headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+        assert await Preset.get(preset.id) is not None
+
+
+@pytest.mark.integration
+class TestMissingUser:
+    """Token valid, but the referenced user no longer exists (stale token)."""
+
+    def _orphan_headers(self, settings: ApiSettings) -> dict[str, str]:
+        token = create_access_token(
+            user_id=str(PydanticObjectId()),
+            email="ghost@example.com",
+            subscription_tier="free",
+            settings=settings,
+        )
+        return {"Authorization": f"Bearer {token}"}
+
+    async def test_create_returns_404(self, client, settings) -> None:
+        resp = await client.post(PRESETS_URL, json={"name": "Orphan"}, headers=self._orphan_headers(settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestGenerateWithPreset:
+    """`POST /api/v1/generate` with `preset_id` (US-9.5 acceptance criteria 2+3)."""
+
+    async def test_preset_params_are_applied_to_job(self, client, settings) -> None:
+        user = await _make_user("gen-preset@example.com")
+        preset = await _insert_preset(user, "Lofi", style="lofi hip hop", bpm=90, weirdness=80, instrumental=True)
+
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "rainy evening", "preset_id": str(preset.id)},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await _get_job(resp.json()["job_id"])
+        assert job.input_params["prompt"] == "rainy evening"
+        assert job.input_params["style"] == "lofi hip hop"
+        assert job.input_params["bpm"] == 90
+        assert job.input_params["weirdness"] == 80
+        assert job.input_params["instrumental"] is True
+        # The preset reference itself is not a generation parameter.
+        assert "preset_id" not in job.input_params
+
+    async def test_explicit_params_override_preset_values(self, client, settings) -> None:
+        user = await _make_user("gen-preset-override@example.com")
+        preset = await _insert_preset(user, "Lofi", style="lofi hip hop", bpm=90, weirdness=80)
+
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "x", "preset_id": str(preset.id), "bpm": 140, "style": "drum and bass"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await _get_job(resp.json()["job_id"])
+        assert job.input_params["bpm"] == 140
+        assert job.input_params["style"] == "drum and bass"
+        assert job.input_params["weirdness"] == 80  # untouched preset value still applies
+
+    async def test_explicitly_sent_default_value_overrides_preset(self, client, settings) -> None:
+        # weirdness=50 equals the schema default; because the client SENT it,
+        # it must beat the preset's 80 (model_fields_set semantics, not
+        # truthiness/None checks).
+        user = await _make_user("gen-preset-default@example.com")
+        preset = await _insert_preset(user, "Weird", weirdness=80, instrumental=True)
+
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "x", "preset_id": str(preset.id), "weirdness": 50, "instrumental": False},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await _get_job(resp.json()["job_id"])
+        assert job.input_params["weirdness"] == 50
+        assert job.input_params.get("instrumental", False) is False
+
+    async def test_omitted_default_field_does_not_override_preset(self, client, settings) -> None:
+        # The client did NOT send weirdness, so the schema default (50) must
+        # not clobber the preset's snapshot.
+        user = await _make_user("gen-preset-omitted@example.com")
+        preset = await _insert_preset(user, "Weird", weirdness=80)
+
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "x", "preset_id": str(preset.id)},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await _get_job(resp.json()["job_id"])
+        assert job.input_params["weirdness"] == 80
+
+    async def test_preset_supplying_sound_mode_passes_deferred_validation(self, client, settings) -> None:
+        # mode/sound_type coupling is validated after the merge, so a preset
+        # may carry the whole sound configuration.
+        user = await _make_user("gen-preset-sound@example.com")
+        preset = await _insert_preset(user, "Loop", mode="sound", sound_type="loop", bpm=124)
+
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "house loop", "preset_id": str(preset.id)},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await _get_job(resp.json()["job_id"])
+        assert job.input_params["mode"] == "sound"
+        assert job.input_params["sound_type"] == "loop"
+
+    async def test_invalid_merged_params_return_422(self, client, settings) -> None:
+        # Preset bpm + explicit one-shot request: the merged result violates
+        # the "no bpm for one-shot sounds" rule and must be rejected.
+        user = await _make_user("gen-preset-merge-invalid@example.com")
+        preset = await _insert_preset(user, "Tempo", bpm=120)
+
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "kick", "preset_id": str(preset.id), "mode": "sound", "sound_type": "one-shot"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_unknown_preset_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("gen-preset-unknown@example.com")
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "x", "preset_id": str(PydanticObjectId())},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_malformed_preset_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("gen-preset-malformed@example.com")
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "x", "preset_id": "not-an-object-id"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_other_users_preset_id_returns_404(self, client, settings) -> None:
+        owner = await _make_user("gen-preset-owner@example.com")
+        other = await _make_user("gen-preset-other@example.com")
+        preset = await _insert_preset(owner, "Private", bpm=100)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "x", "preset_id": str(preset.id)},
+            headers=_auth_headers(other, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_generate_without_preset_id_is_unchanged(self, client, settings) -> None:
+        user = await _make_user("gen-no-preset@example.com")
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "a calm piano ballad"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await _get_job(resp.json()["job_id"])
+        assert "preset_id" not in job.input_params

--- a/tests/test_presets_api.py
+++ b/tests/test_presets_api.py
@@ -32,6 +32,7 @@ FULL_PARAMS = {
     "duration": 60.0,
     "seed": 1234,
     "inference_steps": 32,
+    "model": "xl-base",
     "weirdness": 80,
     "style_influence": 20,
     "format": "flac",
@@ -174,6 +175,7 @@ class TestCreatePreset:
             {"name": "X", "bpm": 300},  # out of range
             {"name": "X", "weirdness": 101},
             {"name": "X", "format": "ogg"},  # not a valid format
+            {"name": "X", "model": "not-a-model"},
             {"name": "X", "time_signature": "13/8"},
             {"name": "X", "nope": True},  # unknown field
         ],
@@ -275,6 +277,16 @@ class TestUpdatePreset:
         body = resp.json()
         assert body["style"] is None
         assert body["bpm"] == 90
+
+    async def test_empty_body_is_noop_returning_current_state(self, client, settings) -> None:
+        user = await _make_user("preset-patch-empty@example.com")
+        preset = await _insert_preset(user, "Mine", bpm=90)
+        resp = await client.patch(f"{PRESETS_URL}/{preset.id}", json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "Mine"
+        assert body["bpm"] == 90
+        assert body["updated_at"] is None
 
     async def test_rename_returns_updated_preset(self, client, settings) -> None:
         user = await _make_user("preset-rename@example.com")
@@ -450,6 +462,20 @@ class TestGenerateWithPreset:
         job = await _get_job(resp.json()["job_id"])
         assert job.input_params["mode"] == "sound"
         assert job.input_params["sound_type"] == "loop"
+
+    async def test_preset_with_incomplete_sound_config_returns_422(self, client, settings) -> None:
+        # A preset may legally store mode="sound" without sound_type (cross-field
+        # rules are deferred to application time); a bare generate against it
+        # must then fail the merged validation.
+        user = await _make_user("gen-preset-incomplete@example.com")
+        preset = await _insert_preset(user, "SoundOnly", mode="sound")
+
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "x", "preset_id": str(preset.id)},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
 
     async def test_invalid_merged_params_return_422(self, client, settings) -> None:
         # Preset bpm + explicit one-shot request: the merged result violates


### PR DESCRIPTION
## Summary
Implements #79: US-9.5 Preset CRUD API

- `Preset` Beanie document, user-scoped with a unique `(user_id, name)` index; parameter fields mirror `GenerationRequest` so every stored value is applicable at generate time
- `services/presets.py`: CRUD with ownership hiding (404 for unknown/malformed/not-owned ids) and race-safe 409 on name conflicts, following the workspaces service pattern
- `routers/presets.py`: `POST`/`GET`/`GET {id}`/`PATCH`/`DELETE` under `/api/v1/presets`; PATCH applies only explicitly-sent fields, and an explicit `null` clears a parameter
- `POST /api/v1/generate` accepts an optional `preset_id`: preset values serve as defaults, explicitly-sent request fields override (via `model_fields_set`, so an explicit value equal to a schema default still wins); cross-field rules (mode/sound_type coupling, song duration floor) are re-validated on the merged parameter set

## Acceptance Criteria
- [x] Creating and retrieving a preset returns all saved parameters
- [x] Generating with a preset_id applies the preset's parameters
- [x] Explicit parameters in the generate request override preset values
- [x] Presets are scoped to the authenticated user (no cross-user access)

## Test Plan
- [x] Tests written first (TDD): 47 tests in `tests/test_presets_api.py` (auth gate, CRUD, cross-user scoping, preset-aware generation incl. merge-override edge cases)
- [x] All tests passing: 1130 unit (CI scope) + 355 targeted API integration against local MongoDB
- [x] Diff coverage 100% on changed lines (gate: ≥85%)
- [x] Linting clean (black + ruff)
- [x] Internal code review (advisory) completed — no Critical/Major; both suggestions applied
- [x] Cross-family review pass: codex (`codex review --base main`) — no findings
- [x] Test mutation sanity check: 3 mutations (ownership check, merge precedence, fields_set semantics) all killed by tests

## Known Limitations / Intentionally Deferred
- Presets are **user-scoped, not workspace-scoped** — per this issue's acceptance criteria; the CLI's workspace-scoped presets (US-4.3) remain separate and unmodified
- CLI-only preset fields `quality` and `exclude_style` are **not** stored — the API generate endpoint rejects them (`extra="forbid"`), so storing them would be dead, un-appliable data
- No pagination on `GET /presets` — matches the workspaces list endpoint; revisit if preset counts grow
- A preset may store an incomplete sound configuration (e.g. `mode="sound"` without `sound_type`); cross-field rules are deliberately enforced at application time (covered by tests)

## Implementation Notes
The CodeRabbit plan on the issue predates Stages 8–9 (it proposed building FastAPI from scratch on SQLite with API-key auth). This implementation reuses the existing FastAPI/Beanie/JWT infrastructure from US-9.1–9.4 instead; see the deviation list in the first commit message.

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add full preset support: create, list, get, update, delete per user.
  * Apply presets to generation requests; explicit request fields override preset defaults.
  * Enforce per-user unique preset names and validated preset parameter fields.

* **Bug Fixes / Chores**
  * Consistent handling of malformed IDs as “not found” across endpoints.
  * Centralized shared limits for text fields and seed bounds used in validation.

* **Tests**
  * New integration tests covering preset CRUD, generation-with-preset behavior, and auth gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->