### PR TITLE
feat(api): credit deduction (US-9.6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ src/acemusic/
     main.py         # create_app() factory + ASGI app (uvicorn target); DB lifespan
     settings.py     # ApiSettings (pydantic-settings, ACEMUSIC_API_ prefix)
     database.py     # MongoDB connect/close (Beanie + pymongo async), fail-fast ping
-    models/         # Beanie ODM documents: User, Workspace, Clip, Job
+    models/         # Beanie ODM documents: User, Workspace, Clip, Job, Preset, CreditTransaction
     routers/        # Versioned routers mounted under /api/v1 (health, ...)
   backends.py       # Backend selector: resolve_backend (auto|ace-step|elevenlabs) + capability map
   cli.py            # Typer CLI app (health, generate, compose, sounds, models, workspace commands)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ token plus a rotating, single-use refresh token. All `/api/v1` routes except
 | --- | --- |
 | `GET /api/v1/users/me` | Returns the authenticated user's full profile |
 | `PATCH /api/v1/users/me` | Partially updates the profile (`display_name`, `handle`, `bio`, `style_tags`); unset fields are left unchanged |
+| `GET /api/v1/users/me/credits` | Returns the authenticated user's current credit balance, subscription tier, and recent usage history (newest first, up to 50 entries) |
 
 Profile fields: `display_name` (user-editable name, 1–100 chars), `handle` (unique public identifier — alphanumeric + hyphens, 3–30 chars, must start and end with a letter or number; currently case-sensitive), `bio` (up to 500 chars), `style_tags` (up to 20 tags, 30 chars each). A duplicate handle returns `409 Conflict`; an invalid handle or unknown PATCH key returns `422`.
 
@@ -79,7 +80,7 @@ environment variables (see `.env.example`); cookie behavior is tuned via
 
 The request body accepts the full creative parameter set: `prompt` (required), `style`, `lyrics`, `vocal_language`, `instrumental`, `bpm` (60–180 or `"auto"`), `key`, `time_signature`, `duration`, `seed`, `inference_steps`, `model`, `weirdness` (0–100), `style_influence` (0–100), `format` (`wav`/`flac`/`mp3`/`aac`/`opus`), `thinking`, `mode` (`song`|`sound`), `sound_type` (`one-shot`|`loop`, required when `mode` is `sound`), and the optional `preset_id`. When `preset_id` is supplied the saved preset's parameters serve as defaults; any field explicitly included in the request overrides the preset value. The job is created with status `queued` and picked up by the async processor (US-9.2).
 
-Invalid parameters return 422 with field-level errors. The create response includes `job_id`, `status: "queued"`, and `estimated_time_seconds`.
+Invalid parameters return 422 with field-level errors. If the user has insufficient credits for the requested mode (song costs 1.0 credit, sound costs 0.5), the request is rejected with `402 Payment Required` and a JSON body of `{"detail": {"error": "insufficient_credits", "balance": <current>, "required": <cost>}}`. New accounts start with 10.0 credits. The create response includes `job_id`, `status: "queued"`, and `estimated_time_seconds`.
 
 The status endpoint returns `job_id`, `status` (`queued`|`processing`|`completed`|`failed`), `created_at`, and `estimated_time_seconds`. Completed jobs additionally include `clip_ids` and `audio_urls`; failed jobs include an `error` message.
 

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -4,18 +4,20 @@
 """
 
 from .clip import Clip
+from .credit_transaction import CreditTransaction
 from .job import Job, JobStatus
 from .preset import PRESET_PARAM_FIELDS, Preset
 from .refresh_token import RefreshToken
 from .user import User
 from .workspace import Workspace
 
-ALL_MODELS = [User, Workspace, Clip, Job, RefreshToken, Preset]
+ALL_MODELS = [User, Workspace, Clip, Job, RefreshToken, Preset, CreditTransaction]
 
 __all__ = [
     "User",
     "Workspace",
     "Clip",
+    "CreditTransaction",
     "Job",
     "JobStatus",
     "RefreshToken",

--- a/src/acemusic/api/models/credit_transaction.py
+++ b/src/acemusic/api/models/credit_transaction.py
@@ -1,0 +1,36 @@
+"""Credit transaction document model (US-9.6).
+
+An append-only ledger of credit movements. Each successful deduction at
+job-queue time writes one row; the credits endpoint serves usage history from
+it. ``amount`` is signed (negative for deductions) so future credit grants and
+refunds fit the same shape without a schema change.
+"""
+
+from datetime import datetime
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, DESCENDING, IndexModel
+
+from .common import utcnow
+
+
+class CreditTransaction(Document):
+    """One credit movement on a user's balance."""
+
+    user_id: PydanticObjectId
+    amount: float
+    action_type: str
+    job_id: str
+    # Balance immediately after this movement, denormalised from the atomic
+    # update so history rows are self-describing without replaying the ledger.
+    balance_after: float
+    created_at: datetime = Field(default_factory=utcnow)
+
+    class Settings:
+        name = "credit_transactions"
+        indexes = [
+            # Serves the "this user's history, newest first" query entirely
+            # from the index (same pattern as Clip's workspace listing).
+            IndexModel([("user_id", ASCENDING), ("created_at", DESCENDING)]),
+        ]

--- a/src/acemusic/api/models/user.py
+++ b/src/acemusic/api/models/user.py
@@ -8,6 +8,11 @@ from pymongo import ASCENDING, IndexModel
 
 from .common import utcnow
 
+# Starting balance for new accounts (US-9.6). No product spec exists yet — the
+# purchase/subscription flow is Layer 4 (Stage 26) — so this is a provisional
+# free allowance: enough for 10 songs or 20 sounds.
+DEFAULT_CREDITS_BALANCE = 10.0
+
 
 class User(Document):
     """A platform user. ``email`` is validated and uniquely indexed.
@@ -22,6 +27,9 @@ class User(Document):
     oauth_provider: str | None = None
     oauth_id: str | None = None
     subscription_tier: str = "free"
+    # US-9.6: deducted atomically at job-queue time (see services/credits.py).
+    # Documents predating the field load with the default starting balance.
+    credits_balance: float = DEFAULT_CREDITS_BALANCE
     # Profile fields (US-8.4). All optional so existing/OAuth-created users remain
     # valid; ``handle`` stays null until the user claims one.
     display_name: str | None = None

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -36,7 +36,12 @@ from acemusic.constants import (
 
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import PRESET_PARAM_FIELDS, Preset
-from ..services import generation as generation_service, presets as preset_service, users as user_service
+from ..services import (
+    credits as credits_service,
+    generation as generation_service,
+    presets as preset_service,
+    users as user_service,
+)
 from ._validators import validate_format, validate_model, validate_time_signature
 
 # Estimate heuristic (seconds): a song's wall-clock scales with its duration; a
@@ -177,8 +182,37 @@ async def create_generation(
         # 404 for unknown/malformed/not-owned ids (never reveals other users' presets).
         preset = await preset_service.get_preset(request.preset_id, current.user_id)
         request = _apply_preset(request, preset)
-    job = await generation_service.create_generation_job(
+    # US-9.6: credits are deducted atomically at queue time. Cost is judged on
+    # the merged request, since a preset may supply the mode. The atomic
+    # balance-conditioned deduction is the concurrency guard — two requests
+    # racing over the last credit cannot both pass.
+    cost = credits_service.get_cost(request.mode)
+    balance_after = await credits_service.deduct_credits(user.id, cost)
+    if balance_after is None:
+        # Re-read the balance for the error payload: the copy on ``user`` was
+        # loaded before the deduction attempt and may be stale under
+        # concurrent requests.
+        fresh = await user_service.get_user_by_id(user.id)
+        balance = fresh.credits_balance if fresh is not None else 0.0
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"error": "insufficient_credits", "balance": balance, "required": cost},
+        )
+    try:
+        job = await generation_service.create_generation_job(
+            user_id=user.id,
+            params=request.model_dump(exclude_none=True, exclude={"preset_id"}),
+        )
+    except BaseException:
+        # The deduction already landed but no job exists — give the credit back
+        # rather than charging for work that will never run.
+        await credits_service.refund_credits(user.id, cost)
+        raise
+    await credits_service.record_transaction(
         user_id=user.id,
-        params=request.model_dump(exclude_none=True, exclude={"preset_id"}),
+        amount=-cost,
+        action_type=request.mode,
+        job_id=str(job.id),
+        balance_after=balance_after,
     )
     return GenerationResponse(job_id=str(job.id), estimated_time_seconds=estimate_seconds(request))

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -208,7 +208,8 @@ async def create_generation(
         )
     except BaseException:
         # The deduction already landed but no job exists — give the credit back
-        # rather than charging for work that will never run.
+        # rather than charging for work that will never run. BaseException (not
+        # Exception) on purpose: asyncio.CancelledError must also compensate.
         await credits_service.refund_credits(user.id, cost)
         raise
     try:

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -10,6 +10,7 @@ bounds and enumerations come from :mod:`acemusic.constants` so CLI and API
 validation share one source of truth.
 """
 
+import logging
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -43,6 +44,8 @@ from ..services import (
     users as user_service,
 )
 from ._validators import validate_format, validate_model, validate_time_signature
+
+logger = logging.getLogger(__name__)
 
 # Estimate heuristic (seconds): a song's wall-clock scales with its duration; a
 # short sound is roughly fixed. These are advisory hints returned to the client.
@@ -208,11 +211,18 @@ async def create_generation(
         # rather than charging for work that will never run.
         await credits_service.refund_credits(user.id, cost)
         raise
-    await credits_service.record_transaction(
-        user_id=user.id,
-        amount=-cost,
-        action_type=request.mode,
-        job_id=str(job.id),
-        balance_after=balance_after,
-    )
+    try:
+        await credits_service.record_transaction(
+            user_id=user.id,
+            amount=-cost,
+            action_type=request.mode,
+            job_id=str(job.id),
+            balance_after=balance_after,
+        )
+    except Exception:
+        # The charge is taken and the job is dispatched (possibly already
+        # claimed by the processor), so failing the request here would invite a
+        # retry that charges the user twice for work that is already running.
+        # The ledger row is best-effort history — log loudly and keep the 202.
+        logger.exception("Credit ledger write failed for job %s (user %s)", job.id, user.id)
     return GenerationResponse(job_id=str(job.id), estimated_time_seconds=estimate_seconds(request))

--- a/src/acemusic/api/routers/users.py
+++ b/src/acemusic/api/routers/users.py
@@ -19,8 +19,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ..auth.dependencies import CurrentUser, get_current_user
-from ..models import User
-from ..services import users as user_service
+from ..models import CreditTransaction, User
+from ..services import credits as credits_service, users as user_service
 
 # Free-text profile fields are stored verbatim and re-served on every
 # GET /users/me, so cap them: one PATCH must not be able to bloat the document
@@ -112,6 +112,34 @@ class UserProfileUpdate(BaseModel):
         return cleaned
 
 
+class CreditTransactionEntry(BaseModel):
+    """One usage-history row (US-9.6)."""
+
+    amount: float
+    action_type: str
+    job_id: str
+    balance_after: float
+    created_at: datetime
+
+    @classmethod
+    def from_transaction(cls, txn: CreditTransaction) -> "CreditTransactionEntry":
+        return cls(
+            amount=txn.amount,
+            action_type=txn.action_type,
+            job_id=txn.job_id,
+            balance_after=txn.balance_after,
+            created_at=txn.created_at,
+        )
+
+
+class CreditsResponse(BaseModel):
+    """Current balance plus recent usage history, newest first (US-9.6)."""
+
+    balance: float
+    tier: str
+    history: list[CreditTransactionEntry]
+
+
 def _not_found() -> HTTPException:
     # An authenticated token whose user no longer exists (e.g. deleted account).
     return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
@@ -123,6 +151,24 @@ async def get_me(current: CurrentUser = Depends(get_current_user)) -> UserProfil
     if user is None:
         raise _not_found()
     return UserProfileResponse.from_user(user)
+
+
+@router.get("/me/credits", response_model=CreditsResponse)
+async def get_my_credits(current: CurrentUser = Depends(get_current_user)) -> CreditsResponse:
+    """The authenticated user's credit balance and recent usage history.
+
+    Balance and tier come from the user document (not the token claims), so the
+    response reflects deductions made since the token was issued.
+    """
+    user = await user_service.get_user_by_id(current.user_id)
+    if user is None:
+        raise _not_found()
+    transactions = await credits_service.get_recent_transactions(user.id)
+    return CreditsResponse(
+        balance=user.credits_balance,
+        tier=user.subscription_tier,
+        history=[CreditTransactionEntry.from_transaction(txn) for txn in transactions],
+    )
 
 
 @router.patch("/me", response_model=UserProfileResponse)

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -51,12 +51,15 @@ async def deduct_credits(user_id: PydanticObjectId, cost: float) -> float | None
         # (Pydantic-level) default. Materialise the default and retry once.
         # Concurrent backfills are harmless: $set of the same constant, gated
         # on the field still being absent, is idempotent.
-        backfill = await collection.update_one(
+        await collection.update_one(
             {"_id": user_id, "credits_balance": {"$exists": False}},
             {"$set": {"credits_balance": DEFAULT_CREDITS_BALANCE}},
         )
-        if backfill.modified_count:
-            doc = await collection.find_one_and_update(*update, return_document=ReturnDocument.AFTER)
+        # Retry unconditionally: a concurrent request may have won the backfill
+        # (our update matched nothing), yet the now-present balance can still
+        # cover this deduction. A genuinely insufficient balance just fails the
+        # retry the same way it failed the first attempt.
+        doc = await collection.find_one_and_update(*update, return_document=ReturnDocument.AFTER)
     if doc is None:
         return None
     return doc["credits_balance"]

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -38,6 +38,10 @@ async def deduct_credits(user_id: PydanticObjectId, cost: float) -> float | None
     Returns the balance *after* deduction, or ``None`` if the balance was
     insufficient (or the user does not exist).
     """
+    # A non-positive cost would invert the operation: the $gte filter always
+    # matches and the $inc would *grant* credits. Reject at the boundary.
+    if cost <= 0:
+        raise ValueError("cost must be positive")
     collection = User.get_pymongo_collection()
     update = (
         {"_id": user_id, "credits_balance": {"$gte": cost}},
@@ -67,6 +71,9 @@ async def deduct_credits(user_id: PydanticObjectId, cost: float) -> float | None
 
 async def refund_credits(user_id: PydanticObjectId, cost: float) -> None:
     """Compensating credit for a deduction whose job never got queued."""
+    # Symmetric guard: a non-positive "refund" would silently deduct.
+    if cost <= 0:
+        raise ValueError("cost must be positive")
     await User.get_pymongo_collection().update_one(
         {"_id": user_id},
         {"$inc": {"credits_balance": cost}},

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -76,10 +76,14 @@ async def record_transaction(
 
 
 async def get_recent_transactions(user_id: PydanticObjectId, limit: int = HISTORY_LIMIT) -> list[CreditTransaction]:
-    """The user's most recent credit movements, newest first."""
+    """The user's most recent credit movements, newest first.
+
+    ``_id`` breaks ties: BSON datetimes have millisecond resolution, so two
+    movements in the same millisecond would otherwise sort unstably.
+    """
     return (
         await CreditTransaction.find(CreditTransaction.user_id == user_id)
-        .sort([("created_at", DESCENDING)])
+        .sort([("created_at", DESCENDING), ("_id", DESCENDING)])
         .limit(limit)
         .to_list()
     )

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -10,6 +10,7 @@ from beanie import PydanticObjectId
 from pymongo import DESCENDING, ReturnDocument
 
 from ..models import CreditTransaction, User
+from ..models.user import DEFAULT_CREDITS_BALANCE
 
 SONG_COST = 1.0
 SOUND_COST = 0.5
@@ -37,11 +38,25 @@ async def deduct_credits(user_id: PydanticObjectId, cost: float) -> float | None
     Returns the balance *after* deduction, or ``None`` if the balance was
     insufficient (or the user does not exist).
     """
-    doc = await User.get_pymongo_collection().find_one_and_update(
+    collection = User.get_pymongo_collection()
+    update = (
         {"_id": user_id, "credits_balance": {"$gte": cost}},
         {"$inc": {"credits_balance": -cost}},
-        return_document=ReturnDocument.AFTER,
     )
+    doc = await collection.find_one_and_update(*update, return_document=ReturnDocument.AFTER)
+    if doc is None:
+        # Documents predating US-9.6 have no credits_balance field, and a $gte
+        # range filter never matches an absent field — without a backfill every
+        # legacy account would be rejected while /users/me/credits shows the
+        # (Pydantic-level) default. Materialise the default and retry once.
+        # Concurrent backfills are harmless: $set of the same constant, gated
+        # on the field still being absent, is idempotent.
+        backfill = await collection.update_one(
+            {"_id": user_id, "credits_balance": {"$exists": False}},
+            {"$set": {"credits_balance": DEFAULT_CREDITS_BALANCE}},
+        )
+        if backfill.modified_count:
+            doc = await collection.find_one_and_update(*update, return_document=ReturnDocument.AFTER)
     if doc is None:
         return None
     return doc["credits_balance"]

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -1,0 +1,85 @@
+"""Credits service layer (US-9.6).
+
+Module-level async functions (matching the other service modules) for the
+credit cost table, atomic balance deduction, and the transaction ledger. The
+layer raises plain exceptions, never ``HTTPException``, so it stays
+transport-agnostic.
+"""
+
+from beanie import PydanticObjectId
+from pymongo import DESCENDING, ReturnDocument
+
+from ..models import CreditTransaction, User
+
+SONG_COST = 1.0
+SOUND_COST = 0.5
+
+_COSTS = {"song": SONG_COST, "sound": SOUND_COST}
+
+# History page size for GET /users/me/credits.
+HISTORY_LIMIT = 50
+
+
+def get_cost(mode: str) -> float:
+    """Credit cost of one generation in ``mode``. Raises for unknown modes."""
+    try:
+        return _COSTS[mode]
+    except KeyError:
+        raise ValueError(f"Unknown generation mode: {mode!r}") from None
+
+
+async def deduct_credits(user_id: PydanticObjectId, cost: float) -> float | None:
+    """Atomically deduct ``cost`` from the user's balance.
+
+    A single ``find_one_and_update`` filtered on ``credits_balance >= cost``,
+    so two concurrent requests racing over the last credit are serialised by
+    MongoDB — exactly one matches and decrements; the loser matches nothing.
+    Returns the balance *after* deduction, or ``None`` if the balance was
+    insufficient (or the user does not exist).
+    """
+    doc = await User.get_pymongo_collection().find_one_and_update(
+        {"_id": user_id, "credits_balance": {"$gte": cost}},
+        {"$inc": {"credits_balance": -cost}},
+        return_document=ReturnDocument.AFTER,
+    )
+    if doc is None:
+        return None
+    return doc["credits_balance"]
+
+
+async def refund_credits(user_id: PydanticObjectId, cost: float) -> None:
+    """Compensating credit for a deduction whose job never got queued."""
+    await User.get_pymongo_collection().update_one(
+        {"_id": user_id},
+        {"$inc": {"credits_balance": cost}},
+    )
+
+
+async def record_transaction(
+    *,
+    user_id: PydanticObjectId,
+    amount: float,
+    action_type: str,
+    job_id: str,
+    balance_after: float,
+) -> CreditTransaction:
+    """Append one movement to the credit ledger."""
+    txn = CreditTransaction(
+        user_id=user_id,
+        amount=amount,
+        action_type=action_type,
+        job_id=job_id,
+        balance_after=balance_after,
+    )
+    await txn.insert()
+    return txn
+
+
+async def get_recent_transactions(user_id: PydanticObjectId, limit: int = HISTORY_LIMIT) -> list[CreditTransaction]:
+    """The user's most recent credit movements, newest first."""
+    return (
+        await CreditTransaction.find(CreditTransaction.user_id == user_id)
+        .sort([("created_at", DESCENDING)])
+        .limit(limit)
+        .to_list()
+    )

--- a/src/acemusic/api/services/generation.py
+++ b/src/acemusic/api/services/generation.py
@@ -36,5 +36,12 @@ async def create_generation_job(*, user_id: PydanticObjectId, params: dict) -> J
         input_params=params,
     )
     await job.insert()
-    await dispatch_job(str(job.id))
+    try:
+        await dispatch_job(str(job.id))
+    except BaseException:
+        # Don't leave the job behind: the processor polls for QUEUED documents,
+        # so an orphan would still run even though the caller saw a failure
+        # (and, for generation, refunded the credits — US-9.6).
+        await job.delete()
+        raise
     return job

--- a/src/acemusic/api/services/generation.py
+++ b/src/acemusic/api/services/generation.py
@@ -41,7 +41,8 @@ async def create_generation_job(*, user_id: PydanticObjectId, params: dict) -> J
     except BaseException:
         # Don't leave the job behind: the processor polls for QUEUED documents,
         # so an orphan would still run even though the caller saw a failure
-        # (and, for generation, refunded the credits — US-9.6).
+        # (and, for generation, refunded the credits — US-9.6). BaseException
+        # (not Exception) on purpose: asyncio.CancelledError must also clean up.
         await job.delete()
         raise
     return job

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -204,6 +204,9 @@ class TestRefundOnJobCreationFailure:
 
         monkeypatch.setattr("acemusic.api.services.generation.create_generation_job", _boom)
         user = await _make_user("credits-refund@example.com", balance=10.0)
+        # ASGITransport re-raises unhandled server exceptions into the test
+        # (real clients would see a 500); the contract under test is the
+        # compensating refund, not the status code.
         with pytest.raises(RuntimeError):
             await client.post(
                 GENERATE_URL,
@@ -222,6 +225,9 @@ class TestRefundOnJobCreationFailure:
 
         monkeypatch.setattr("acemusic.api.services.generation.dispatch_job", _boom)
         user = await _make_user("credits-dispatch@example.com", balance=10.0)
+        # ASGITransport re-raises unhandled server exceptions into the test
+        # (real clients would see a 500); the contract under test is the
+        # cleanup, not the status code.
         with pytest.raises(RuntimeError):
             await client.post(
                 GENERATE_URL,

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -14,6 +14,7 @@ import logging
 
 import httpx
 import pytest
+from beanie import PydanticObjectId
 from fastapi.testclient import TestClient
 
 from acemusic.api.auth.tokens import create_access_token
@@ -47,6 +48,22 @@ class TestGetCost:
     def test_unknown_mode_raises(self) -> None:
         with pytest.raises(ValueError):
             credits_service.get_cost("video")
+
+
+class TestNonPositiveCostGuard:
+    """Runs in CI (no DB): the guards raise before any database access. A
+    negative cost would otherwise mint credits ($inc of a positive amount
+    behind an always-true $gte filter) or silently deduct on refund."""
+
+    @pytest.mark.parametrize("cost", [0.0, -1.0])
+    async def test_deduct_rejects_non_positive_cost(self, cost: float) -> None:
+        with pytest.raises(ValueError):
+            await credits_service.deduct_credits(PydanticObjectId(), cost)
+
+    @pytest.mark.parametrize("cost", [0.0, -1.0])
+    async def test_refund_rejects_non_positive_cost(self, cost: float) -> None:
+        with pytest.raises(ValueError):
+            await credits_service.refund_credits(PydanticObjectId(), cost)
 
 
 def _async_client(app) -> httpx.AsyncClient:

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -212,6 +212,25 @@ class TestRefundOnJobCreationFailure:
         assert (await _reload(user)).credits_balance == 10.0
         assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0
 
+    async def test_no_orphaned_job_when_dispatch_fails_after_insert(self, client, settings, monkeypatch):
+        # Failure AFTER the job document is persisted: the job must not be left
+        # behind as QUEUED (the US-9.2 processor polls the collection and would
+        # run it for free once the refund lands).
+        async def _boom(_job_id):
+            raise RuntimeError("dispatch exploded")
+
+        monkeypatch.setattr("acemusic.api.services.generation.dispatch_job", _boom)
+        user = await _make_user("credits-dispatch@example.com", balance=10.0)
+        with pytest.raises(RuntimeError):
+            await client.post(
+                GENERATE_URL,
+                json={"prompt": "a calm piano ballad"},
+                headers=_auth_headers(user, settings),
+            )
+        assert (await _reload(user)).credits_balance == 10.0
+        assert await Job.find(Job.user_id == user.id).count() == 0
+        assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0
+
 
 @pytest.mark.integration
 class TestCreditsEndpoint:

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -10,6 +10,7 @@ under concurrent requests, refund on job-creation failure, and the
 """
 
 import asyncio
+import logging
 
 import httpx
 import pytest
@@ -334,3 +335,65 @@ class TestLegacyUserWithoutBalanceField:
         second = await client.post(GENERATE_URL, json={"prompt": "ballad"}, headers=headers)
         assert second.status_code == 402
         assert second.json()["detail"]["balance"] == 0.75
+
+    async def test_backfill_race_loser_still_deducts(self, client, settings, monkeypatch):
+        # A request can lose the backfill race: its own $exists backfill
+        # matches nothing because a concurrent winner already materialised the
+        # field. It must then retry the deduction against the now-present
+        # balance instead of reporting 402 with 10 credits available. The race
+        # is simulated deterministically by materialising the field just
+        # before this request's backfill update runs.
+        user = await _make_user("credits-legacy-race@example.com")
+        await self._strip_balance_field(user)
+
+        collection_cls = type(User.get_pymongo_collection())
+        real_update_one = collection_cls.update_one
+
+        async def race_winner_first(coll_self, filt, update, *args, **kwargs):
+            is_backfill = isinstance(filt.get("credits_balance"), dict) and "$exists" in filt["credits_balance"]
+            if is_backfill:
+                await real_update_one(
+                    coll_self,
+                    {"_id": user.id, "credits_balance": {"$exists": False}},
+                    {"$set": {"credits_balance": 10.0}},
+                )
+            return await real_update_one(coll_self, filt, update, *args, **kwargs)
+
+        monkeypatch.setattr(collection_cls, "update_one", race_winner_first)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "a calm piano ballad"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload(user)).credits_balance == 9.0
+
+
+@pytest.mark.integration
+class TestLedgerWriteFailure:
+    async def test_202_still_returned_when_ledger_insert_fails(self, client, settings, monkeypatch, caplog):
+        # The charge is taken and the job is queued (and possibly already
+        # claimed by the processor) before the ledger insert. A transient
+        # ledger failure must not surface as a 500 — the client would retry
+        # and be charged twice for work that is already running. The row is
+        # best-effort: log loudly, keep the 202 truthful.
+        async def _boom(**_kwargs):
+            raise RuntimeError("ledger exploded")
+
+        monkeypatch.setattr("acemusic.api.services.credits.record_transaction", _boom)
+        # The app pins acemusic logs to its own handler (propagate=False in
+        # _ensure_app_logging); caplog listens on the root logger, so re-enable
+        # propagation for this test only.
+        monkeypatch.setattr(logging.getLogger("acemusic"), "propagate", True)
+        user = await _make_user("credits-ledger-fail@example.com", balance=10.0)
+        with caplog.at_level(logging.ERROR, logger="acemusic.api.routers.generation"):
+            resp = await client.post(
+                GENERATE_URL,
+                json={"prompt": "a calm piano ballad"},
+                headers=_auth_headers(user, settings),
+            )
+        assert resp.status_code == 202
+        assert (await _reload(user)).credits_balance == 9.0
+        assert await Job.find(Job.user_id == user.id).count() == 1
+        assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0
+        assert any("ledger" in rec.getMessage().lower() for rec in caplog.records if rec.levelno >= logging.ERROR)

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -1,0 +1,285 @@
+"""Tests for credit deduction (US-9.6).
+
+CI-safe classes (no DB): the 401 auth gate for the credits endpoint and unit
+tests for the cost table. ``@pytest.mark.integration`` classes drive the real
+app with ``httpx.AsyncClient`` over ``ASGITransport`` against a local MongoDB
+(the ``mongo_db`` fixture), mirroring ``tests/test_generation_api.py``. Covers
+balance deduction per mode, the 402 insufficient-credits contract, atomicity
+under concurrent requests, refund on job-creation failure, and the
+``GET /users/me/credits`` balance/history surface.
+"""
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import CreditTransaction, Job, User
+from acemusic.api.services import credits as credits_service, users as user_service
+from acemusic.api.settings import ApiSettings
+
+GENERATE_URL = f"{API_V1_PREFIX}/generate"
+CREDITS_URL = f"{API_V1_PREFIX}/users/me/credits"
+
+
+class TestAuthGate:
+    """Runs in CI (no DB): the route must reject anonymous requests outright."""
+
+    def test_missing_auth_header_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.get(CREDITS_URL)
+        assert resp.status_code == 401
+
+
+class TestGetCost:
+    """Runs in CI (no DB): the cost table is pure logic."""
+
+    def test_song_costs_one_credit(self) -> None:
+        assert credits_service.get_cost("song") == 1.0
+
+    def test_sound_costs_half_credit(self) -> None:
+        assert credits_service.get_cost("sound") == 0.5
+
+    def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(ValueError):
+            credits_service.get_cost("video")
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # mongo_db initialises Beanie against the isolated DB on this test's loop.
+    # Disable the background processor (US-9.2) so queued jobs stay queued.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str, *, balance: float | None = None):
+    user = await user_service.get_or_create_user(
+        email=email, provider="google", oauth_id=f"g-{email}", name="Test User"
+    )
+    if balance is not None:
+        user.credits_balance = balance
+        await user.save()
+    return user
+
+
+async def _reload(user) -> User:
+    return await User.get(user.id)
+
+
+@pytest.mark.integration
+class TestGenerationDeductsCredits:
+    async def test_song_deducts_one_credit(self, client, settings):
+        user = await _make_user("credits-song@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "a calm piano ballad"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload(user)).credits_balance == 9.0
+
+    async def test_sound_deducts_half_credit(self, client, settings):
+        user = await _make_user("credits-sound@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "punchy kick", "mode": "sound", "sound_type": "one-shot"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload(user)).credits_balance == 9.5
+
+    async def test_deduction_recorded_as_transaction(self, client, settings):
+        user = await _make_user("credits-txn@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "a calm piano ballad"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+        txns = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        assert len(txns) == 1
+        txn = txns[0]
+        assert txn.amount == -1.0
+        assert txn.action_type == "song"
+        assert txn.job_id == job_id
+        assert txn.balance_after == 9.0
+
+
+@pytest.mark.integration
+class TestInsufficientCredits:
+    async def test_returns_402_with_balance_payload(self, client, settings):
+        user = await _make_user("credits-poor@example.com", balance=0.25)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "a calm piano ballad"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 402
+        detail = resp.json()["detail"]
+        assert detail["error"] == "insufficient_credits"
+        assert detail["balance"] == 0.25
+        assert detail["required"] == 1.0
+
+    async def test_balance_unchanged_and_no_job_created(self, client, settings):
+        user = await _make_user("credits-nojob@example.com", balance=0.25)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "a calm piano ballad"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 402
+        assert (await _reload(user)).credits_balance == 0.25
+        assert await Job.find(Job.user_id == user.id).count() == 0
+        assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0
+
+    async def test_sound_allowed_when_song_is_not(self, client, settings):
+        # 0.5 ≤ balance < 1.0: enough for a sound, not for a song.
+        user = await _make_user("credits-half@example.com", balance=0.5)
+        headers = _auth_headers(user, settings)
+        song = await client.post(GENERATE_URL, json={"prompt": "ballad"}, headers=headers)
+        assert song.status_code == 402
+        sound = await client.post(
+            GENERATE_URL,
+            json={"prompt": "kick", "mode": "sound", "sound_type": "one-shot"},
+            headers=headers,
+        )
+        assert sound.status_code == 202
+        assert (await _reload(user)).credits_balance == 0.0
+
+
+@pytest.mark.integration
+class TestConcurrentDeduction:
+    async def test_no_double_deduction_when_budget_covers_one(self, client, settings):
+        # Budget for exactly one song: of two concurrent requests, exactly one
+        # may win the atomic deduction; the loser gets 402 and no job.
+        user = await _make_user("credits-race@example.com", balance=1.0)
+        headers = _auth_headers(user, settings)
+        body = {"prompt": "a calm piano ballad"}
+        first, second = await asyncio.gather(
+            client.post(GENERATE_URL, json=body, headers=headers),
+            client.post(GENERATE_URL, json=body, headers=headers),
+        )
+        assert sorted([first.status_code, second.status_code]) == [202, 402]
+        assert (await _reload(user)).credits_balance == 0.0
+        assert await Job.find(Job.user_id == user.id).count() == 1
+        assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 1
+
+
+@pytest.mark.integration
+class TestRefundOnJobCreationFailure:
+    async def test_balance_restored_when_queueing_fails(self, client, settings, monkeypatch):
+        async def _boom(**_kwargs):
+            raise RuntimeError("queue exploded")
+
+        monkeypatch.setattr("acemusic.api.services.generation.create_generation_job", _boom)
+        user = await _make_user("credits-refund@example.com", balance=10.0)
+        with pytest.raises(RuntimeError):
+            await client.post(
+                GENERATE_URL,
+                json={"prompt": "a calm piano ballad"},
+                headers=_auth_headers(user, settings),
+            )
+        assert (await _reload(user)).credits_balance == 10.0
+        assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0
+
+
+@pytest.mark.integration
+class TestCreditsEndpoint:
+    async def test_returns_balance_and_tier(self, client, settings):
+        user = await _make_user("credits-view@example.com", balance=7.5)
+        resp = await client.get(CREDITS_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["balance"] == 7.5
+        assert body["tier"] == "free"
+        assert body["history"] == []
+
+    async def test_history_lists_transactions_newest_first(self, client, settings):
+        user = await _make_user("credits-history@example.com", balance=10.0)
+        headers = _auth_headers(user, settings)
+        song = await client.post(GENERATE_URL, json={"prompt": "ballad"}, headers=headers)
+        sound = await client.post(
+            GENERATE_URL,
+            json={"prompt": "kick", "mode": "sound", "sound_type": "one-shot"},
+            headers=headers,
+        )
+        assert song.status_code == 202 and sound.status_code == 202
+
+        resp = await client.get(CREDITS_URL, headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["balance"] == 8.5
+        history = body["history"]
+        assert len(history) == 2
+        # Newest first: the sound came second.
+        assert history[0]["action_type"] == "sound"
+        assert history[0]["amount"] == -0.5
+        assert history[0]["balance_after"] == 8.5
+        assert history[0]["job_id"] == sound.json()["job_id"]
+        assert history[1]["action_type"] == "song"
+        assert history[1]["amount"] == -1.0
+        assert history[1]["balance_after"] == 9.0
+        assert "created_at" in history[0]
+
+    async def test_history_is_capped_at_50_entries(self, client, settings):
+        user = await _make_user("credits-cap@example.com", balance=100.0)
+        for i in range(55):
+            await credits_service.record_transaction(
+                user_id=user.id,
+                amount=-1.0,
+                action_type="song",
+                job_id=f"job-{i}",
+                balance_after=float(100 - i - 1),
+            )
+        resp = await client.get(CREDITS_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        history = resp.json()["history"]
+        assert len(history) == 50
+        # Newest first: the last-recorded transaction leads.
+        assert history[0]["job_id"] == "job-54"
+
+    async def test_stale_token_for_deleted_user_returns_404(self, client, settings):
+        user = await _make_user("credits-deleted@example.com")
+        headers = _auth_headers(user, settings)
+        await user.delete()
+        resp = await client.get(CREDITS_URL, headers=headers)
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestNewUserDefaultBalance:
+    async def test_new_user_starts_with_default_credits(self, client, settings):
+        user = await _make_user("credits-fresh@example.com")
+        resp = await client.get(CREDITS_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["balance"] == 10.0

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -302,3 +302,35 @@ class TestNewUserDefaultBalance:
         resp = await client.get(CREDITS_URL, headers=_auth_headers(user, settings))
         assert resp.status_code == 200
         assert resp.json()["balance"] == 10.0
+
+
+@pytest.mark.integration
+class TestLegacyUserWithoutBalanceField:
+    async def _strip_balance_field(self, user) -> None:
+        # Simulate a document created before US-9.6: no credits_balance field
+        # exists in MongoDB (Beanie only supplies the default at load time).
+        await User.get_pymongo_collection().update_one({"_id": user.id}, {"$unset": {"credits_balance": ""}})
+
+    async def test_generation_succeeds_and_deducts_from_default(self, client, settings):
+        user = await _make_user("credits-legacy@example.com")
+        await self._strip_balance_field(user)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"prompt": "a calm piano ballad"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload(user)).credits_balance == 9.0
+
+    async def test_insufficient_path_still_402_after_backfill_spend(self, client, settings):
+        user = await _make_user("credits-legacy-poor@example.com")
+        await self._strip_balance_field(user)
+        headers = _auth_headers(user, settings)
+        first = await client.post(GENERATE_URL, json={"prompt": "ballad"}, headers=headers)
+        assert first.status_code == 202
+        # Force the balance below a song's cost, then verify the normal 402 path.
+        user.credits_balance = 0.75
+        await user.save()
+        second = await client.post(GENERATE_URL, json={"prompt": "ballad"}, headers=headers)
+        assert second.status_code == 402
+        assert second.json()["detail"]["balance"] == 0.75


### PR DESCRIPTION
## Summary

Implements #80: US-9.6 Credit deduction.

- `User.credits_balance` field (default starting balance 10.0; documents predating the field are lazily backfilled at first deduction)
- `CreditTransaction` append-only ledger document, indexed `(user_id, created_at desc)`
- Credits service: cost table (song = 1.0, sound = 0.5), atomic balance-conditioned `find_one_and_update` deduction, compensating refund, recent-history query with `_id` tiebreaker
- `POST /api/v1/generate` deducts at queue time (cost judged on the preset-merged request); insufficient credits → 402 with `{"error": "insufficient_credits", "balance": X, "required": Y}`; job-creation failure after deduction refunds; dispatch failure after insert deletes the job so the processor can't run unpaid work
- `GET /api/v1/users/me/credits` returns balance, tier, and the last 50 ledger rows newest-first

## Adapted Plan

The CodeRabbit plan on the issue (2026-05-31) predates Stages 8–9 and proposed building the FastAPI/Mongo/JWT foundation from scratch. All of that exists from US-8.x/9.1–9.5, so this PR implements only the credit-specific work, reusing the existing routers, service-module conventions, and auth dependencies.

## Acceptance Criteria

- [x] Generation with sufficient credits succeeds and reduces the balance (`TestGenerationDeductsCredits`)
- [x] Generation with insufficient credits returns 402 (`TestInsufficientCredits`)
- [x] Credit balance is visible via `GET /api/v1/users/me/credits` (`TestCreditsEndpoint`)
- [x] Concurrent generation requests do not cause double-deduction (`TestConcurrentDeduction`, atomic `$gte`-conditioned update)

## Test Plan

- [x] Tests written first (TDD): 22 tests in `tests/test_credits_api.py` (4 CI-safe, 18 integration against real local MongoDB)
- [x] Full unit suite passing (1135) and API integration suite passing (257+ incl. new tests)
- [x] Diff coverage 100% on changed lines (target ≥85%)
- [x] Linting clean (black + ruff)
- [x] Internal code review (advisory): 1 Major found and fixed (orphaned-QUEUED-job free-work path on dispatch failure)
- [x] Cross-family review pass: codex (2 rounds). Round 1 P1 fixed (legacy documents without `credits_balance` were rejected by the `$gte` filter). Round 2 P2s fixed (backfill race-loser wrong 402; ledger-insert failure surfacing as 500 inviting retry double-charge)
- [x] Mutation sanity check: 7 mutations (drop `$gte` condition, wrong cost, flipped sort, removed refund, removed orphan delete, removed backfill retry, narrowed ledger exception handling) — all caught by tests

## Known Limitations / Intentionally Deferred

- **Default starting balance of 10.0 credits is an assumption** — no product spec exists; the purchase/subscription flow is Layer 4 (Stage 26). The constant lives in one place (`DEFAULT_CREDITS_BALANCE`).
- **Ledger writes are best-effort**: if the `CreditTransaction` insert fails after the charge is taken and the job dispatched, the API logs at error level and still returns 202 (failing would invite a retry double-charge). Balance is always authoritative; history may rarely omit a row.
- **No credit grant/purchase endpoints** — Layer 4 (Stage 26).
- **History pagination beyond the latest 50 rows** not implemented — not required by the issue.
- **No idempotency key on `POST /generate`** — a client retry after a successful-but-lost response creates (and charges for) a second job. Pre-existing endpoint behavior, unchanged by this PR.

## Implementation Notes

- Deduct-then-queue ordering follows the issue requirement ("checks balance before queuing"); the refund + job-delete compensations close the failure windows between the two writes (Mongo multi-document transactions were not introduced — the singular atomic deduction is the only correctness-critical step per the AC).
- `float` is used rather than `Decimal`: both costs (1.0, 0.5) are exactly representable doubles, consistent with codebase style.

Closes #80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generation requests now require credits (songs: 1 credit, sounds: 0.5 credits).
  * View credit balance and transaction history via new user credits endpoint.
  * HTTP 402 response when insufficient credits; automatic refunds on job failures.
  * New users receive 10 free credits.

* **Tests**
  * Added comprehensive credit system test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->