### PR TITLE
feat(api): audio editing endpoints — crop, speed, remaster (US-10.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AI-powered music generation platform built on **ACE-Step-1.5** (fork: `github.co
 3. **Layer 3 — Web UI** (Stages 15–21): Next.js frontend
 4. **Layer 4 — Advanced Integrations** (Stages 22–28): VST3 plugin, music video, voice models, credits, moderation
 
-**Current progress:** Stages 1–4 complete; Stage 6 in progress (US-6.1 extend, US-6.2 cover, US-6.3 repaint, US-6.4 mashup, US-6.5 sample, US-6.6 add-vocal/replace, and US-6.7 full-song implemented). CLI entry point, health check, basic generation, musical parameters, quality/speed tradeoffs, model selection, sound modes, workspace management, clip extension, cover-mode restyle, section repaint with crossfade blending, two-clip mashup with BPM alignment, loop sampling, vocal layering, section replacement, and full-song auto-extend all implemented.
+**Current progress:** Stages 1–9 complete on `main`; Stage 10 in progress (US-10.1 audio editing endpoints implemented). CLI foundation (Stages 1–7): generation, workspace management, audio processing, DAW export. Platform API (Stages 8–9): FastAPI with OAuth2 auth, async job queue, clip audio streaming, workspace/clip/preset CRUD, credit deduction. Audio editing API (US-10.1): crop, speed-adjust, and remaster endpoints enqueue async jobs that create derived clips with lineage tracking.
 
 ## Commands
 
@@ -112,7 +112,7 @@ src/acemusic/
     settings.py     # ApiSettings (pydantic-settings, ACEMUSIC_API_ prefix)
     database.py     # MongoDB connect/close (Beanie + pymongo async), fail-fast ping
     models/         # Beanie ODM documents: User, Workspace, Clip, Job, Preset, CreditTransaction
-    routers/        # Versioned routers mounted under /api/v1 (health, ...)
+    routers/        # Versioned routers mounted under /api/v1 (health, auth, users, generation, jobs, clips, editing, workspaces, presets)
   backends.py       # Backend selector: resolve_backend (auto|ace-step|elevenlabs) + capability map
   cli.py            # Typer CLI app (health, generate, compose, sounds, models, workspace commands)
   client.py         # AceStepClient — HTTP client for ACE-Step REST API

--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ Invalid parameters return 422 with field-level errors. If the user has insuffici
 
 The status endpoint returns `job_id`, `status` (`queued`|`processing`|`completed`|`failed`), `created_at`, and `estimated_time_seconds`. Completed jobs additionally include `clip_ids` and `audio_urls`; failed jobs include an `error` message.
 
-#### Async job processor (US-9.2)
+#### Async job processor (US-9.2, US-10.1)
 
 A background processor runs inside the API process, polling MongoDB for `queued`
-jobs, forwarding them to ACE-Step, storing the audio via the storage abstraction,
-and creating clip records before marking the job `completed` (or `failed` with an
+jobs and dispatching them to the handler registered for their `job_type`. Generation
+jobs (`generate`) forward to ACE-Step, store the audio, and create clip records.
+Editing jobs (`crop`, `speed`, `remaster`) run local CPU operations via the audio
+processing library. All handlers mark the job `completed` (or `failed` with an
 error). Tunables (all prefixed `ACEMUSIC_API_`): `JOB_CONCURRENCY` (default 2),
 `JOB_POLL_INTERVAL` seconds (default 1.0), `JOB_POLL_TIMEOUT` seconds (default
 600), and `JOB_PROCESSOR_ENABLED` (default `true`; set `false` to run the API
@@ -119,6 +121,16 @@ A default workspace is created automatically when a new user registers (OAuth ca
 `GET /api/v1/clips` supports these query parameters: `workspace_id`, `search` (case-insensitive substring over title or style tags), `style`, `bpm_min`, `bpm_max`, `key`, `model`, `sort` (`newest` or `oldest`, default `newest`), `page` (default 1), `per_page` (default 20, max 100). An inverted BPM range (`bpm_min > bpm_max`) returns 422. The response includes `total`, `page`, `per_page`, and `total_pages`.
 
 All CRUD endpoints are owner-scoped. `GET /api/v1/clips/{id}/audio` additionally supports single HTTP byte ranges (`Range: bytes=…` → `206 Partial Content`, unsatisfiable ranges → `416`) for seeking, and on-the-fly conversion via `?format=wav|flac|mp3` (mp3/flac conversion requires ffmpeg on the host; byte ranges are ignored for converted output). For the audio endpoint an unknown or malformed id returns `404`, another user's private clip returns `403`, and clips marked `is_public` are retrievable by any authenticated user; the CRUD endpoints return `404` for any clip the caller does not own.
+
+### Audio Editing (US-10.1)
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/clips/{id}/crop` | Trim a clip to `[start, end]` with optional fades and beat-snap; returns 202 + `job_id` |
+| `POST /api/v1/clips/{id}/speed` | Time-stretch a clip by a `multiplier` (0.5–2.0) or to a `target_bpm`; returns 202 + `job_id` |
+| `POST /api/v1/clips/{id}/remaster` | Loudness-normalise a clip to a `target_lufs` (default −14 LUFS); returns 202 + `job_id` |
+
+All three editing endpoints are non-destructive: the original clip is never modified. Each operation creates a new clip with `parent_clip_ids` and `generation_mode` set for lineage tracking, and tracks progress via `GET /api/v1/jobs/{id}/status`. Only `wav` source clips are accepted (422 otherwise). No credits are deducted — editing is local CPU work. Time parameters use human-readable strings (`"10s"`, `"1m30s"`, `"5"`). The `speed` endpoint accepts either `multiplier` (direct rate) or `target_bpm` (requires BPM metadata on the source clip); exactly one must be provided.
 
 ### Presets
 

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -20,7 +20,7 @@ from acemusic import __version__
 
 from . import database
 from .exceptions import HandleConflictError
-from .routers import auth, clips, generation, health, jobs, presets, users, workspaces
+from .routers import auth, clips, editing, generation, health, jobs, presets, users, workspaces
 from .settings import ApiSettings
 from .tasks.processor import JobProcessor
 
@@ -116,6 +116,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(generation.router, prefix=API_V1_PREFIX)
     app.include_router(jobs.router, prefix=API_V1_PREFIX)
     app.include_router(clips.router, prefix=API_V1_PREFIX)
+    app.include_router(editing.router, prefix=API_V1_PREFIX)
     app.include_router(workspaces.router, prefix=API_V1_PREFIX)
     app.include_router(presets.router, prefix=API_V1_PREFIX)
 

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -14,7 +14,6 @@ import asyncio
 import logging
 import math
 from datetime import datetime
-from pathlib import Path
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
@@ -232,7 +231,7 @@ async def get_clip_audio(
         logger.warning("Clip %s exists but its audio object %r is missing", clip.id, clip.file_path)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio file not found.")
 
-    native_format = (clip.format or Path(clip.file_path).suffix.lstrip(".") or "wav").lower()
+    native_format = clip_service.native_format(clip)
     serve_format = native_format
     converted = False
     if format is not None and format != native_format:

--- a/src/acemusic/api/routers/editing.py
+++ b/src/acemusic/api/routers/editing.py
@@ -93,6 +93,19 @@ class EditJobResponse(BaseModel):
     status: Literal["queued"] = "queued"
 
 
+def _require_wav(clip: Clip) -> None:
+    """422 unless the clip's audio is wav.
+
+    The editing pipeline can only round-trip wav: ``soundfile`` cannot write
+    PCM_16 mp3/aac/opus and pydub needs ffmpeg (absent on the server) for
+    compressed formats, so a non-wav job would only fail later in the worker
+    with an opaque library error.
+    """
+    fmt = clip_service.native_format(clip)
+    if fmt != "wav":
+        raise _unprocessable(f"unsupported format {fmt!r} for editing; currently only wav is supported.")
+
+
 def _require_duration_ms(clip: Clip) -> int:
     """The clip's duration in milliseconds, or 422 if the metadata is missing."""
     if clip.duration is None:
@@ -118,6 +131,7 @@ async def crop_clip(
 ) -> EditJobResponse:
     """Enqueue a crop of ``clip_id`` to ``[start, end]``; the original is preserved."""
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    _require_wav(clip)
     duration_ms = _require_duration_ms(clip)
 
     start_ms = parse_time_string(request.start)
@@ -157,6 +171,7 @@ async def speed_clip(
 ) -> EditJobResponse:
     """Enqueue a pitch-preserving time-stretch of ``clip_id``; the original is preserved."""
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    _require_wav(clip)
     # The derived clip's duration is source / multiplier, so the metadata must exist.
     _require_duration_ms(clip)
 
@@ -195,8 +210,6 @@ async def remaster_clip(
 ) -> EditJobResponse:
     """Enqueue a remaster of ``clip_id`` to ``target_lufs``; the original is preserved."""
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
-    fmt = (clip.format or "").lower()
-    if fmt != "wav":
-        raise _unprocessable(f"unsupported format {fmt!r} for remastering; currently only wav is supported.")
+    _require_wav(clip)
 
     return await _enqueue(clip, editing_service.REMASTER_JOB_TYPE, {"target_lufs": request.target_lufs})

--- a/src/acemusic/api/routers/editing.py
+++ b/src/acemusic/api/routers/editing.py
@@ -83,7 +83,9 @@ class RemasterRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    target_lufs: float = -14.0
+    # Real-world targets run from broadcast (-23/-24) to loud masters (~-9);
+    # anything above -5 or below -70 is a client error, not a master.
+    target_lufs: float = Field(default=-14.0, ge=-70.0, le=-5.0)
 
 
 class EditJobResponse(BaseModel):

--- a/src/acemusic/api/routers/editing.py
+++ b/src/acemusic/api/routers/editing.py
@@ -1,0 +1,202 @@
+"""Audio editing endpoints (US-10.1), mounted under ``/api/v1/clips``.
+
+* ``POST /clips/{id}/crop``     → trim to a time range (optional fades / beat-snap)
+* ``POST /clips/{id}/speed``    → time-stretch by a multiplier or to a target BPM
+* ``POST /clips/{id}/remaster`` → loudness-normalise to a target LUFS
+
+Each endpoint validates the request against the source clip, persists a queued
+:class:`~acemusic.api.models.job.Job` and returns 202 with a job id trackable
+via ``GET /api/v1/jobs/{id}/status`` (mirrors ``POST /generate``). Editing is
+non-generative local CPU work, so no credits are deducted.
+
+Time parameters are human-readable strings ("10s", "1m30s", "5") parsed with
+:func:`acemusic.utils.parse_time_string`, matching the CLI commands.
+"""
+
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from acemusic.audio import calculate_speed_multiplier
+from acemusic.utils import parse_time_string, snap_to_beat
+
+from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..models import Clip
+from ..services import clips as clip_service, editing as editing_service
+
+logger = logging.getLogger(__name__)
+
+# Time-stretch quality degrades sharply outside this window (mirrors the CLI).
+SPEED_MULTIPLIER_MIN = 0.5
+SPEED_MULTIPLIER_MAX = 2.0
+
+# Router-level dependency gates every route behind a valid Bearer token
+# (mirrors the clips/generation routers), so unauthenticated requests get 401.
+router = APIRouter(prefix="/clips", tags=["editing"], dependencies=[Depends(get_current_user)])
+
+
+def _unprocessable(detail: str) -> HTTPException:
+    """Clip-dependent validation failure (the body itself parsed fine)."""
+    return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail)
+
+
+class CropRequest(BaseModel):
+    """Trim spec. Times are strings ("10s", "1m30s", "5") like the CLI flags."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    start: str
+    end: str
+    fade_in: str = "0s"
+    fade_out: str = "0s"
+    snap_to_beat: bool = False
+
+    @field_validator("start", "end", "fade_in", "fade_out")
+    @classmethod
+    def _check_time_string(cls, value: str) -> str:
+        # Surface unparseable values as field-level 422s; the handler re-parses
+        # the (now guaranteed-valid) strings into milliseconds.
+        parse_time_string(value)
+        return value
+
+
+class SpeedRequest(BaseModel):
+    """Time-stretch spec: exactly one of ``multiplier`` or ``target_bpm``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    multiplier: float | None = Field(default=None, ge=SPEED_MULTIPLIER_MIN, le=SPEED_MULTIPLIER_MAX)
+    target_bpm: float | None = Field(default=None, gt=0)
+    preserve_pitch: bool = True
+
+    @model_validator(mode="after")
+    def _check_exactly_one(self) -> "SpeedRequest":
+        if (self.multiplier is None) == (self.target_bpm is None):
+            raise ValueError("provide either multiplier or target_bpm, not both")
+        return self
+
+
+class RemasterRequest(BaseModel):
+    """Loudness-normalisation spec (defaults to the -14 LUFS streaming target)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_lufs: float = -14.0
+
+
+class EditJobResponse(BaseModel):
+    """The accepted-job acknowledgement returned with HTTP 202."""
+
+    job_id: str
+    status: Literal["queued"] = "queued"
+
+
+def _require_duration_ms(clip: Clip) -> int:
+    """The clip's duration in milliseconds, or 422 if the metadata is missing."""
+    if clip.duration is None:
+        raise _unprocessable(f"Clip {clip.id} has no duration metadata; cannot validate the edit.")
+    return int(round(clip.duration * 1000))
+
+
+async def _enqueue(clip: Clip, job_type: str, params: dict) -> EditJobResponse:
+    job = await editing_service.create_edit_job(
+        user_id=clip.user_id,
+        workspace_id=clip.workspace_id,
+        job_type=job_type,
+        params={"clip_id": str(clip.id), **params},
+    )
+    return EditJobResponse(job_id=str(job.id))
+
+
+@router.post("/{clip_id}/crop", response_model=EditJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def crop_clip(
+    clip_id: str,
+    request: CropRequest,
+    current: CurrentUser = Depends(require_existing_user),
+) -> EditJobResponse:
+    """Enqueue a crop of ``clip_id`` to ``[start, end]``; the original is preserved."""
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    duration_ms = _require_duration_ms(clip)
+
+    start_ms = parse_time_string(request.start)
+    end_ms = parse_time_string(request.end)
+    if request.snap_to_beat:
+        if clip.bpm is None:
+            raise _unprocessable(f"snap_to_beat requires BPM metadata on clip {clip.id}, but none is set.")
+        start_ms = snap_to_beat(start_ms, clip.bpm)
+        end_ms = snap_to_beat(end_ms, clip.bpm)
+
+    if start_ms >= end_ms:
+        if request.snap_to_beat:
+            raise _unprocessable(
+                f"after beat-snapping, start ({start_ms / 1000:.3f}s) is not less than end ({end_ms / 1000:.3f}s)."
+            )
+        raise _unprocessable(f"start ({request.start}) must be less than end ({request.end}).")
+    if end_ms > duration_ms:
+        raise _unprocessable(f"end ({request.end}) exceeds clip duration ({clip.duration:.1f}s).")
+
+    return await _enqueue(
+        clip,
+        editing_service.CROP_JOB_TYPE,
+        {
+            "start_ms": start_ms,
+            "end_ms": end_ms,
+            "fade_in_ms": parse_time_string(request.fade_in),
+            "fade_out_ms": parse_time_string(request.fade_out),
+        },
+    )
+
+
+@router.post("/{clip_id}/speed", response_model=EditJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def speed_clip(
+    clip_id: str,
+    request: SpeedRequest,
+    current: CurrentUser = Depends(require_existing_user),
+) -> EditJobResponse:
+    """Enqueue a pitch-preserving time-stretch of ``clip_id``; the original is preserved."""
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    # The derived clip's duration is source / multiplier, so the metadata must exist.
+    _require_duration_ms(clip)
+
+    if request.target_bpm is not None:
+        if clip.bpm is None:
+            raise _unprocessable(f"target_bpm requires BPM metadata on clip {clip.id}, but none is set.")
+        multiplier = calculate_speed_multiplier(clip.bpm, request.target_bpm)
+        if not (SPEED_MULTIPLIER_MIN <= multiplier <= SPEED_MULTIPLIER_MAX):
+            raise _unprocessable(
+                f"target BPM of {request.target_bpm} would require a rate of {multiplier:.4g}x, "
+                f"which is outside the allowed range {SPEED_MULTIPLIER_MIN}-{SPEED_MULTIPLIER_MAX}."
+            )
+    else:
+        multiplier = request.multiplier
+
+    if not request.preserve_pitch:
+        # The librosa phase vocoder always preserves pitch; the flag is accepted
+        # for API-shape compatibility but cannot change the behaviour.
+        logger.warning(
+            "preserve_pitch=false requested for clip %s, but time-stretching always preserves pitch; ignoring.",
+            clip.id,
+        )
+
+    return await _enqueue(
+        clip,
+        editing_service.SPEED_JOB_TYPE,
+        {"multiplier": multiplier, "preserve_pitch": request.preserve_pitch},
+    )
+
+
+@router.post("/{clip_id}/remaster", response_model=EditJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def remaster_clip(
+    clip_id: str,
+    request: RemasterRequest,
+    current: CurrentUser = Depends(require_existing_user),
+) -> EditJobResponse:
+    """Enqueue a remaster of ``clip_id`` to ``target_lufs``; the original is preserved."""
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    fmt = (clip.format or "").lower()
+    if fmt != "wav":
+        raise _unprocessable(f"unsupported format {fmt!r} for remastering; currently only wav is supported.")
+
+    return await _enqueue(clip, editing_service.REMASTER_JOB_TYPE, {"target_lufs": request.target_lufs})

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -18,9 +18,14 @@ from acemusic.storage import get_storage_backend
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import Clip, Job, JobStatus
 from ..services.common import coerce_object_id
+from ..services.editing import EDIT_JOB_TYPES
 from .generation import GenerationRequest, estimate_seconds
 
 logger = logging.getLogger(__name__)
+
+# Editing jobs (crop/speed/remaster, US-10.1) are quick local CPU work, so a
+# small flat estimate replaces the duration-scaled generation heuristic.
+_EDIT_ESTIMATE_SECONDS = 5
 
 # Router-level dependency gates every route behind a valid Bearer token (mirrors
 # the generation router), so an unauthenticated request is rejected with 401.
@@ -45,12 +50,17 @@ class JobStatusResponse(BaseModel):
 
 
 def _estimate_for(job: Job) -> int:
-    """Re-derive the advisory estimate from the persisted request snapshot.
+    """Advisory estimate per job type.
 
-    Reuses the generation router's heuristic so the status and create responses
-    agree. A snapshot that no longer validates (e.g. a schema change) falls back
-    to 0 rather than failing the status read.
+    Editing jobs get a flat per-type constant — their ``input_params`` are an
+    edit spec, not a :class:`GenerationRequest`, so the generation heuristic
+    would (mis)report them as 0. Generation jobs reuse the generation router's
+    heuristic so the status and create responses agree; a snapshot that no
+    longer validates (e.g. a schema change) falls back to 0 rather than failing
+    the status read.
     """
+    if job.job_type in EDIT_JOB_TYPES:
+        return _EDIT_ESTIMATE_SECONDS
     try:
         return estimate_seconds(GenerationRequest(**job.input_params))
     except Exception:

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -12,6 +12,7 @@ ever applies to the audio endpoint.
 
 import asyncio
 import re
+from pathlib import Path
 from typing import Literal
 
 from beanie import PydanticObjectId
@@ -42,6 +43,13 @@ async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
 
 def _clip_not_found() -> HTTPException:
     return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found.")
+
+
+def native_format(clip: Clip) -> str:
+    """The clip's stored audio format: the ``format`` field, falling back to
+    the ``file_path`` suffix (legacy/imported documents may lack the field),
+    then to wav."""
+    return (clip.format or Path(clip.file_path).suffix.lstrip(".") or "wav").lower()
 
 
 def _contains_regex(text: str) -> dict:

--- a/src/acemusic/api/services/editing.py
+++ b/src/acemusic/api/services/editing.py
@@ -1,0 +1,55 @@
+"""Editing service layer (US-10.1).
+
+Persists queued editing jobs (crop, speed, remaster) for the audio editing
+endpoints, mirroring :func:`acemusic.api.services.generation.create_generation_job`.
+Kept transport-agnostic (plain exceptions, never ``HTTPException``) like the
+other service modules.
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import Job, JobStatus
+from ..tasks import dispatch_job
+
+CROP_JOB_TYPE = "crop"
+SPEED_JOB_TYPE = "speed"
+REMASTER_JOB_TYPE = "remaster"
+
+EDIT_JOB_TYPES = (CROP_JOB_TYPE, SPEED_JOB_TYPE, REMASTER_JOB_TYPE)
+
+
+async def create_edit_job(
+    *,
+    user_id: PydanticObjectId,
+    workspace_id: PydanticObjectId,
+    job_type: str,
+    params: dict,
+) -> Job:
+    """Persist a queued editing job and dispatch it.
+
+    ``params`` holds the *resolved* edit spec (millisecond bounds, final
+    multiplier, …) plus the source ``clip_id``, so the worker (Step 3) never
+    re-derives anything from the request strings. ``workspace_id`` is the source
+    clip's workspace — the derived clip lands next to its parent. Returns the
+    saved :class:`Job` (with its id).
+    """
+    if job_type not in EDIT_JOB_TYPES:
+        raise ValueError(f"Unknown edit job type: {job_type!r}")
+    job = Job(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        job_type=job_type,
+        status=JobStatus.QUEUED,
+        input_params=params,
+    )
+    await job.insert()
+    try:
+        await dispatch_job(str(job.id))
+    except BaseException:
+        # Don't leave the job behind: the processor polls for QUEUED documents,
+        # so an orphan would still run even though the caller saw a failure.
+        # BaseException (not Exception) on purpose: asyncio.CancelledError must
+        # also clean up (mirrors create_generation_job).
+        await job.delete()
+        raise
+    return job

--- a/src/acemusic/api/services/users.py
+++ b/src/acemusic/api/services/users.py
@@ -91,7 +91,14 @@ async def get_or_create_user(*, email: str, provider: str, oauth_id: str, name: 
             await user.save()
         return user
 
-    if await User.find_one(User.email == email) is not None:
+    email_owner = await User.find_one(User.email == email)
+    if email_owner is not None:
+        # A concurrent first-login for the *same* identity may have inserted
+        # this row between the identity lookup above and here — that's the
+        # idempotent case, not a conflict (mirrors the DuplicateKeyError
+        # recovery below). Only a different identity owning the email is a 409.
+        if email_owner.oauth_provider == provider and email_owner.oauth_id == oauth_id:
+            return email_owner
         raise EmailAlreadyRegisteredError(email)
 
     user = User(

--- a/src/acemusic/api/tasks/editing.py
+++ b/src/acemusic/api/tasks/editing.py
@@ -28,6 +28,7 @@ from acemusic.storage import StorageBackend
 
 from ..models import Clip, Job
 from ..services.clips import native_format
+from ..services.editing import CROP_JOB_TYPE, REMASTER_JOB_TYPE, SPEED_JOB_TYPE
 
 logger = logging.getLogger(__name__)
 
@@ -202,7 +203,7 @@ async def process_remaster_job(job: Job, storage: StorageBackend) -> dict[str, A
 
 
 EDIT_JOB_HANDLERS = {
-    "crop": process_crop_job,
-    "speed": process_speed_job,
-    "remaster": process_remaster_job,
+    CROP_JOB_TYPE: process_crop_job,
+    SPEED_JOB_TYPE: process_speed_job,
+    REMASTER_JOB_TYPE: process_remaster_job,
 }

--- a/src/acemusic/api/tasks/editing.py
+++ b/src/acemusic/api/tasks/editing.py
@@ -27,16 +27,13 @@ from acemusic.audio import crop_audio, remaster_audio, time_stretch_audio
 from acemusic.storage import StorageBackend
 
 from ..models import Clip, Job
+from ..services.clips import native_format
 
 logger = logging.getLogger(__name__)
 
 
 class EditProcessingError(Exception):
     """An editing job could not be processed (missing source, audio failure)."""
-
-
-def _clip_format(clip: Clip) -> str:
-    return (clip.format or Path(clip.file_path).suffix.lstrip(".") or "wav").lower()
 
 
 async def _load_source_clip(job: Job) -> Clip:
@@ -71,7 +68,7 @@ async def _store_derived_clip(
     An insert failure deletes the just-uploaded object so a failed job never
     leaves an orphaned file behind (mirrors the generate path's rollback).
     """
-    fmt = _clip_format(source)
+    fmt = native_format(source)
     clip_id = PydanticObjectId()
     path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
     await asyncio.to_thread(storage.upload, path, data)
@@ -121,7 +118,7 @@ async def process_crop_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
     start_ms, end_ms = params["start_ms"], params["end_ms"]
 
     with tempfile.TemporaryDirectory(prefix="acemusic-crop-") as tmp_dir:
-        workspace = _EditWorkspace(tmp_dir, _clip_format(source))
+        workspace = _EditWorkspace(tmp_dir, native_format(source))
         await _download_source(storage, source, workspace)
         await asyncio.to_thread(
             crop_audio,
@@ -151,7 +148,7 @@ async def process_speed_job(job: Job, storage: StorageBackend) -> dict[str, Any]
     multiplier = job.input_params["multiplier"]
 
     with tempfile.TemporaryDirectory(prefix="acemusic-speed-") as tmp_dir:
-        workspace = _EditWorkspace(tmp_dir, _clip_format(source))
+        workspace = _EditWorkspace(tmp_dir, native_format(source))
         await _download_source(storage, source, workspace)
         await asyncio.to_thread(
             time_stretch_audio,
@@ -178,7 +175,7 @@ async def process_remaster_job(job: Job, storage: StorageBackend) -> dict[str, A
     target_lufs = job.input_params["target_lufs"]
 
     with tempfile.TemporaryDirectory(prefix="acemusic-remaster-") as tmp_dir:
-        workspace = _EditWorkspace(tmp_dir, _clip_format(source))
+        workspace = _EditWorkspace(tmp_dir, native_format(source))
         await _download_source(storage, source, workspace)
         measurements = await asyncio.to_thread(
             remaster_audio,

--- a/src/acemusic/api/tasks/editing.py
+++ b/src/acemusic/api/tasks/editing.py
@@ -204,7 +204,6 @@ async def process_remaster_job(job: Job, storage: StorageBackend) -> dict[str, A
     }
 
 
-# Registered by JobProcessor as the default handlers for editing job types.
 EDIT_JOB_HANDLERS = {
     "crop": process_crop_job,
     "speed": process_speed_job,

--- a/src/acemusic/api/tasks/editing.py
+++ b/src/acemusic/api/tasks/editing.py
@@ -1,0 +1,212 @@
+"""Editing job handlers (US-10.1): crop, speed and remaster workers.
+
+Each handler runs one claimed editing :class:`~acemusic.api.models.job.Job`:
+download the source clip's audio from storage into a temp file, run the
+corresponding CPU-bound function from :mod:`acemusic.audio` in a worker thread,
+upload the result under the standard clip key, and insert the derived
+:class:`~acemusic.api.models.clip.Clip` with lineage (``parent_clip_ids``,
+``generation_mode``) and derived metadata. The source clip — bytes and
+document — is never modified.
+
+Handlers receive the storage backend from the :class:`JobProcessor` (which owns
+the factory seam) and return the dict persisted as ``job.result``; exceptions
+propagate and the processor marks the job failed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from beanie import PydanticObjectId
+
+from acemusic.audio import crop_audio, remaster_audio, time_stretch_audio
+from acemusic.storage import StorageBackend
+
+from ..models import Clip, Job
+
+logger = logging.getLogger(__name__)
+
+
+class EditProcessingError(Exception):
+    """An editing job could not be processed (missing source, audio failure)."""
+
+
+def _clip_format(clip: Clip) -> str:
+    return (clip.format or Path(clip.file_path).suffix.lstrip(".") or "wav").lower()
+
+
+async def _load_source_clip(job: Job) -> Clip:
+    """Resolve the job's source clip, or fail the job with a clear error.
+
+    The clip may legitimately vanish between enqueue and processing (the owner
+    can DELETE it while the job is queued), so a miss is a job failure, not a
+    crash.
+    """
+    clip_id = (job.input_params or {}).get("clip_id")
+    try:
+        oid = PydanticObjectId(clip_id)
+    except Exception as exc:
+        raise EditProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
+    clip = await Clip.get(oid)
+    if clip is None:
+        raise EditProcessingError(f"Source clip {clip_id} no longer exists")
+    return clip
+
+
+async def _store_derived_clip(
+    job: Job,
+    source: Clip,
+    storage: StorageBackend,
+    data: bytes,
+    *,
+    duration: float | None,
+    bpm: int | None,
+) -> Clip:
+    """Upload the edited audio and insert its Clip record (id matches the key).
+
+    An insert failure deletes the just-uploaded object so a failed job never
+    leaves an orphaned file behind (mirrors the generate path's rollback).
+    """
+    fmt = _clip_format(source)
+    clip_id = PydanticObjectId()
+    path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
+    await asyncio.to_thread(storage.upload, path, data)
+    clip = Clip(
+        id=clip_id,
+        user_id=job.user_id,
+        workspace_id=job.workspace_id,
+        file_path=path,
+        format=fmt,
+        duration=duration,
+        bpm=bpm,
+        key=source.key,
+        parent_clip_ids=[source.id],
+        generation_mode=job.job_type,
+    )
+    try:
+        await clip.insert()
+    except BaseException:
+        try:
+            await asyncio.to_thread(storage.delete, path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned storage object %s during rollback", path)
+        raise
+    return clip
+
+
+class _EditWorkspace:
+    """Temp-dir scaffold for one edit: the downloaded source and the output slot."""
+
+    def __init__(self, tmp_dir: str, fmt: str) -> None:
+        self.input_path = Path(tmp_dir) / f"source.{fmt}"
+        self.output_path = Path(tmp_dir) / f"output.{fmt}"
+
+
+async def _download_source(storage: StorageBackend, source: Clip, workspace: _EditWorkspace) -> None:
+    try:
+        data = await asyncio.to_thread(storage.download, source.file_path)
+    except FileNotFoundError as exc:
+        raise EditProcessingError(f"Source clip {source.id} audio object {source.file_path!r} is missing") from exc
+    workspace.input_path.write_bytes(data)
+
+
+async def process_crop_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
+    """Trim the source to ``[start_ms, end_ms]`` (with optional fades)."""
+    source = await _load_source_clip(job)
+    params = job.input_params
+    start_ms, end_ms = params["start_ms"], params["end_ms"]
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-crop-") as tmp_dir:
+        workspace = _EditWorkspace(tmp_dir, _clip_format(source))
+        await _download_source(storage, source, workspace)
+        await asyncio.to_thread(
+            crop_audio,
+            input_path=str(workspace.input_path),
+            output_path=str(workspace.output_path),
+            start_ms=start_ms,
+            end_ms=end_ms,
+            fade_in_ms=params.get("fade_in_ms", 0),
+            fade_out_ms=params.get("fade_out_ms", 0),
+        )
+        output = workspace.output_path.read_bytes()
+
+    clip = await _store_derived_clip(
+        job,
+        source,
+        storage,
+        output,
+        duration=(end_ms - start_ms) / 1000.0,
+        bpm=source.bpm,
+    )
+    return {"clip_ids": [str(clip.id)]}
+
+
+async def process_speed_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
+    """Time-stretch the source by the resolved ``multiplier`` (pitch preserved)."""
+    source = await _load_source_clip(job)
+    multiplier = job.input_params["multiplier"]
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-speed-") as tmp_dir:
+        workspace = _EditWorkspace(tmp_dir, _clip_format(source))
+        await _download_source(storage, source, workspace)
+        await asyncio.to_thread(
+            time_stretch_audio,
+            input_path=str(workspace.input_path),
+            output_path=str(workspace.output_path),
+            rate=multiplier,
+        )
+        output = workspace.output_path.read_bytes()
+
+    clip = await _store_derived_clip(
+        job,
+        source,
+        storage,
+        output,
+        duration=source.duration / multiplier if source.duration is not None else None,
+        bpm=round(source.bpm * multiplier) if source.bpm is not None else None,
+    )
+    return {"clip_ids": [str(clip.id)]}
+
+
+async def process_remaster_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
+    """Loudness-normalise the source to ``target_lufs`` (full remaster pipeline)."""
+    source = await _load_source_clip(job)
+    target_lufs = job.input_params["target_lufs"]
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-remaster-") as tmp_dir:
+        workspace = _EditWorkspace(tmp_dir, _clip_format(source))
+        await _download_source(storage, source, workspace)
+        measurements = await asyncio.to_thread(
+            remaster_audio,
+            workspace.input_path,
+            workspace.output_path,
+            target_lufs=target_lufs,
+        )
+        output = workspace.output_path.read_bytes()
+
+    clip = await _store_derived_clip(
+        job,
+        source,
+        storage,
+        output,
+        duration=source.duration,
+        bpm=source.bpm,
+    )
+    return {
+        "clip_ids": [str(clip.id)],
+        # measure_lufs returns numpy float64; cast so the result is BSON-safe.
+        "before_lufs": float(measurements["before_lufs"]),
+        "after_lufs": float(measurements["after_lufs"]),
+    }
+
+
+# Registered by JobProcessor as the default handlers for editing job types.
+EDIT_JOB_HANDLERS = {
+    "crop": process_crop_job,
+    "speed": process_speed_job,
+    "remaster": process_remaster_job,
+}

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -34,6 +34,7 @@ from acemusic.storage import StorageBackend, get_storage_backend
 from .. import database
 from ..models import Clip, Job, JobStatus
 from ..models.common import utcnow
+from .editing import EDIT_JOB_HANDLERS
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,8 @@ class JobProcessor:
         # (and re-queued when stale), so jobs another deployment owns are left
         # alone. ``handlers`` lets callers add or override entries.
         self._handlers: dict[str, JobHandler] = {"generate": self._handle_generate}
+        for job_type, edit_handler in EDIT_JOB_HANDLERS.items():
+            self._handlers[job_type] = partial(self._run_edit_handler, edit_handler)
         if handlers:
             self._handlers.update(handlers)
         self._running = False
@@ -262,6 +265,10 @@ class JobProcessor:
         except Exception as exc:  # noqa: BLE001 - any failure must land on the job record
             logger.exception("Job %s failed", job.id)
             await self._mark_failed(job, str(exc))
+
+    async def _run_edit_handler(self, edit_handler: Any, job: Job) -> dict[str, Any]:
+        """Adapt an editing handler ``(job, storage) -> result`` to the registry."""
+        return await edit_handler(job, self._storage_factory())
 
     async def _handle_generate(self, job: Job) -> dict[str, Any]:
         """Run an ACE-Step generation job: submit, poll, store clips."""

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -67,8 +67,6 @@ class JobProcessingError(Exception):
     """A job could not be processed (ACE-Step failure, timeout, or no output)."""
 
 
-# A handler runs one claimed job end-to-end and returns the dict stored as
-# ``job.result`` on success; any exception marks the job failed.
 JobHandler = Callable[[Job], Awaitable[dict[str, Any]]]
 
 

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -1,10 +1,11 @@
-"""Async job processor (US-9.2).
+"""Async job processor (US-9.2, generalised for multiple job types in US-10.1).
 
-A background worker that drives queued generation jobs to completion inside the
-FastAPI process. It polls MongoDB for ``status=queued`` jobs — a stateless,
+A background worker that drives queued jobs to completion inside the FastAPI
+process. It polls MongoDB for ``status=queued`` jobs — a stateless,
 restart-safe design that mirrors how a future Celery/Redis swap would behave —
-atomically claims each, runs the ACE-Step generation, stores the audio via the
-storage abstraction, creates :class:`Clip` records, and transitions the job
+atomically claims each, dispatches it to the handler registered for its
+``job_type`` (generation runs ACE-Step and stores the audio; editing handlers
+live in :mod:`acemusic.api.tasks.editing`), and transitions the job
 ``queued -> processing -> completed | failed``.
 
 The ACE-Step client and storage backend are synchronous, so their blocking calls
@@ -18,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from functools import partial
 from typing import Any
@@ -65,6 +66,11 @@ class JobProcessingError(Exception):
     """A job could not be processed (ACE-Step failure, timeout, or no output)."""
 
 
+# A handler runs one claimed job end-to-end and returns the dict stored as
+# ``job.result`` on success; any exception marks the job failed.
+JobHandler = Callable[[Job], Awaitable[dict[str, Any]]]
+
+
 def _default_client_factory() -> AceStepClient:
     """Build an ACE-Step client from the CLI config (env > .env > config.yaml)."""
     config = load_config()
@@ -74,11 +80,13 @@ def _default_client_factory() -> AceStepClient:
 
 
 class JobProcessor:
-    """Background worker pool that processes queued generation jobs.
+    """Background worker pool that processes queued jobs by ``job_type``.
 
-    The ACE-Step client and storage backend are obtained through factories so
-    tests can inject in-process doubles; production uses the real config-driven
-    client and the configured storage backend.
+    Each registered job_type maps to a handler; the built-in ``generate``
+    handler runs ACE-Step generations. The ACE-Step client and storage backend
+    are obtained through factories so tests can inject in-process doubles;
+    production uses the real config-driven client and the configured storage
+    backend.
     """
 
     def __init__(
@@ -89,9 +97,9 @@ class JobProcessor:
         poll_timeout: float = 600.0,
         ace_poll_interval: float = 2.0,
         stale_after: float | None = None,
-        job_type: str = "generate",
         client_factory: Callable[[], AceStepClient] | None = None,
         storage_factory: Callable[[], StorageBackend] | None = None,
+        handlers: dict[str, JobHandler] | None = None,
     ) -> None:
         self._concurrency = concurrency
         self._semaphore = asyncio.Semaphore(concurrency)
@@ -103,9 +111,14 @@ class JobProcessor:
         # window plus a margin, so a startup sweep never reclaims a job a live
         # sibling process is still working — see _requeue_stale_jobs.
         self._stale_after = stale_after if stale_after is not None else poll_timeout + 300.0
-        self._job_type = job_type
         self._client_factory = client_factory or _default_client_factory
         self._storage_factory = storage_factory or get_storage_backend
+        # Handler registry keyed by job_type: only registered types are claimed
+        # (and re-queued when stale), so jobs another deployment owns are left
+        # alone. ``handlers`` lets callers add or override entries.
+        self._handlers: dict[str, JobHandler] = {"generate": self._handle_generate}
+        if handlers:
+            self._handlers.update(handlers)
         self._running = False
         self._worker_task: asyncio.Task[None] | None = None
         self._active: set[asyncio.Task[None]] = set()
@@ -191,7 +204,7 @@ class JobProcessor:
         """
         collection = database.get_database()[Job.Settings.name]
         doc = await collection.find_one_and_update(
-            {"status": JobStatus.QUEUED.value, "job_type": self._job_type},
+            {"status": JobStatus.QUEUED.value, "job_type": {"$in": list(self._handlers)}},
             {"$set": {"status": JobStatus.PROCESSING.value, "started_at": utcnow()}},
             sort=[("created_at", ASCENDING)],
             return_document=ReturnDocument.AFTER,
@@ -221,7 +234,7 @@ class JobProcessor:
         result = await collection.update_many(
             {
                 "status": JobStatus.PROCESSING.value,
-                "job_type": self._job_type,
+                "job_type": {"$in": list(self._handlers)},
                 # ``started_at`` missing/None means a legacy/partial claim — also stale.
                 "$or": [{"started_at": {"$lt": cutoff}}, {"started_at": None}],
             },
@@ -233,32 +246,39 @@ class JobProcessor:
     # -- single-job processing --------------------------------------------
 
     async def _process_job(self, job: Job) -> None:
-        """Run one claimed job end-to-end, recording success or failure.
+        """Dispatch one claimed job to its handler, recording success or failure.
 
         Cancellation (graceful shutdown) is re-raised, leaving the job in
         ``processing`` so the next startup re-queues it. Any other error is
-        captured on the job as ``failed`` with its message.
+        captured on the job as ``failed`` with its message. The claim query
+        filters on registered types, so the handler lookup cannot miss.
         """
         try:
-            client = self._client_factory()
-            params = dict(job.input_params or {})
-
-            task_id = await asyncio.to_thread(partial(client.submit_task, **self._build_submit_kwargs(params)))
-            result = await self._poll_until_complete(client, task_id)
-            if result.get("status") == "failed":
-                raise JobProcessingError(result.get("error") or "ACE-Step generation failed")
-
-            audio_urls = result.get("audio_urls") or []
-            if not audio_urls:
-                raise JobProcessingError("ACE-Step completed but returned no audio")
-
-            clip_ids = await self._store_clips(job, params, client, audio_urls)
-            await self._mark_completed(job, clip_ids)
+            handler = self._handlers[job.job_type]
+            result = await handler(job)
+            await self._mark_completed(job, result)
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001 - any failure must land on the job record
             logger.exception("Job %s failed", job.id)
             await self._mark_failed(job, str(exc))
+
+    async def _handle_generate(self, job: Job) -> dict[str, Any]:
+        """Run an ACE-Step generation job: submit, poll, store clips."""
+        client = self._client_factory()
+        params = dict(job.input_params or {})
+
+        task_id = await asyncio.to_thread(partial(client.submit_task, **self._build_submit_kwargs(params)))
+        result = await self._poll_until_complete(client, task_id)
+        if result.get("status") == "failed":
+            raise JobProcessingError(result.get("error") or "ACE-Step generation failed")
+
+        audio_urls = result.get("audio_urls") or []
+        if not audio_urls:
+            raise JobProcessingError("ACE-Step completed but returned no audio")
+
+        clip_ids = await self._store_clips(job, params, client, audio_urls)
+        return {"clip_ids": clip_ids}
 
     async def _poll_until_complete(self, client: AceStepClient, task_id: str) -> dict[str, Any]:
         """Poll query_result until the task reaches a terminal state or times out."""
@@ -365,11 +385,11 @@ class JobProcessor:
 
     # -- status transitions ------------------------------------------------
 
-    async def _mark_completed(self, job: Job, clip_ids: list[str]) -> None:
+    async def _mark_completed(self, job: Job, result: dict[str, Any]) -> None:
         await job.set(
             {
                 Job.status: JobStatus.COMPLETED,
-                Job.result: {"clip_ids": clip_ids},
+                Job.result: result,
                 Job.completed_at: utcnow(),
             }
         )

--- a/tests/test_clips_edit_api.py
+++ b/tests/test_clips_edit_api.py
@@ -107,11 +107,13 @@ async def _insert_clip(
     duration: float | None = 10.0,
     bpm: int | None = None,
     key: str | None = None,
-    fmt: str = "wav",
+    fmt: str | None = "wav",
     store_bytes: bytes | None = None,
 ) -> Clip:
     clip_id = PydanticObjectId()
-    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt}"
+    # A None ``fmt`` exercises clips with no format metadata; the stored file
+    # is still a wav so the suffix fallback resolves it.
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt or 'wav'}"
     if store_bytes is not None:
         get_storage_backend().upload(file_path, store_bytes)
     clip = Clip(
@@ -290,13 +292,40 @@ class TestSpeedValidation:
 
 
 @pytest.mark.integration
-class TestRemasterValidation:
-    async def test_non_wav_clip_returns_422(self, client, settings) -> None:
-        user, _, clip = await _user_with_clip("edit-remaster-mp3@example.com", fmt="mp3")
-        resp = await client.post(_edit_url(clip.id, "remaster"), json={}, headers=_auth_headers(user, settings))
+class TestFormatGate:
+    """All three operations only process wav sources (soundfile can't write
+    PCM_16 mp3/aac/opus and pydub needs ffmpeg for compressed formats), so a
+    non-wav clip must be rejected at request time, not fail in the worker."""
+
+    @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
+    @pytest.mark.parametrize("fmt", ["mp3", "aac", "opus", "flac"])
+    async def test_non_wav_clip_returns_422(self, client, settings, operation: str, fmt: str) -> None:
+        user, _, clip = await _user_with_clip(f"edit-fmt-{operation}-{fmt}@example.com", fmt=fmt, bpm=120)
+        resp = await client.post(
+            _edit_url(clip.id, operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
         assert resp.status_code == 422
+        assert fmt in resp.json()["detail"]
         assert await Job.count() == 0
 
+    @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
+    async def test_missing_format_falls_back_to_wav_suffix(self, client, settings, operation: str) -> None:
+        # Legacy/imported clip documents may have format=None while file_path
+        # still ends in .wav — the gate must use the suffix fallback, not 422.
+        user, _, clip = await _user_with_clip(f"edit-fmt-none-{operation}@example.com", fmt=None, bpm=120)
+        resp = await client.post(
+            _edit_url(clip.id, operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert await Job.count() == 1
+
+
+@pytest.mark.integration
+class TestRemasterValidation:
     async def test_extra_field_returns_422(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("edit-remaster-extra@example.com")
         resp = await client.post(

--- a/tests/test_clips_edit_api.py
+++ b/tests/test_clips_edit_api.py
@@ -1,0 +1,445 @@
+"""Tests for the audio editing endpoints (US-10.1, issue #81).
+
+Covers ``POST /clips/{id}/crop``, ``POST /clips/{id}/speed`` and
+``POST /clips/{id}/remaster``: each validates against the source clip, enqueues
+an editing job and returns 202 with a trackable job id.
+
+The 401 auth-gate tests run in CI (no DB); the rest are ``integration`` and
+drive the real app with ``httpx.AsyncClient`` over a local MongoDB.
+"""
+
+import logging
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Job, JobStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+
+# Minimal valid bodies, used where the test target is not the payload itself.
+VALID_BODIES = {
+    "crop": {"start": "0s", "end": "1s"},
+    "speed": {"multiplier": 1.5},
+    "remaster": {},
+}
+
+
+def _edit_url(clip_id, operation: str) -> str:
+    return f"{CLIPS_URL}/{clip_id}/{operation}"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB; plain TestClient does not run the lifespan)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
+    def test_missing_auth_header_returns_401(self, operation: str) -> None:
+        client = TestClient(create_app())
+        resp = client.post(_edit_url(PydanticObjectId(), operation), json=VALID_BODIES[operation])
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # Disable the background processor: these tests assert on the queued job
+    # record and do not want a worker claiming it out from under them.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(
+    user,
+    workspace: Workspace,
+    *,
+    duration: float | None = 10.0,
+    bpm: int | None = None,
+    key: str | None = None,
+    fmt: str = "wav",
+) -> Clip:
+    clip_id = PydanticObjectId()
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt}",
+        format=fmt,
+        duration=duration,
+        bpm=bpm,
+        key=key,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _user_with_clip(email: str, **clip_kwargs):
+    user = await _make_user(email)
+    workspace = await _make_workspace(user)
+    clip = await _insert_clip(user, workspace, **clip_kwargs)
+    return user, workspace, clip
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown / malformed / other-user clip ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestClipNotFound:
+    @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
+    async def test_unknown_clip_returns_404(self, client, settings, operation: str) -> None:
+        user = await _make_user(f"edit-404-{operation}@example.com")
+        resp = await client.post(
+            _edit_url(PydanticObjectId(), operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
+    async def test_malformed_id_returns_404(self, client, settings, operation: str) -> None:
+        user = await _make_user(f"edit-malformed-{operation}@example.com")
+        resp = await client.post(
+            _edit_url("not-an-object-id", operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
+    async def test_other_users_clip_returns_404(self, client, settings, operation: str) -> None:
+        owner, _, clip = await _user_with_clip(f"edit-owner-{operation}@example.com")
+        other = await _make_user(f"edit-other-{operation}@example.com")
+
+        resp = await client.post(
+            _edit_url(clip.id, operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(other, settings),
+        )
+        assert resp.status_code == 404
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 422 — validation matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestCropValidation:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"start": "abc", "end": "5s"},  # unparseable start
+            {"start": "1s", "end": "later"},  # unparseable end
+            {"start": "1s", "end": "5s", "fade_in": "x"},  # unparseable fade
+            {"end": "5s"},  # missing start
+            {"start": "1s"},  # missing end
+            {"start": "5s", "end": "5s"},  # start == end
+            {"start": "6s", "end": "5s"},  # start > end
+            {"start": "1s", "end": "11s"},  # end beyond clip duration (10s)
+            {"start": "1s", "end": "5s", "bogus": True},  # extra="forbid"
+        ],
+    )
+    async def test_invalid_request_returns_422(self, client, settings, body: dict) -> None:
+        user, _, clip = await _user_with_clip("edit-crop-422@example.com", duration=10.0)
+        resp = await client.post(_edit_url(clip.id, "crop"), json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_snap_to_beat_without_bpm_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("edit-crop-snap-nobpm@example.com", duration=10.0, bpm=None)
+        resp = await client.post(
+            _edit_url(clip.id, "crop"),
+            json={"start": "1s", "end": "5s", "snap_to_beat": True},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_snap_collapsing_range_returns_422(self, client, settings) -> None:
+        # bpm=120 → beat every 500ms; both 0.1s and 0.2s snap to 0ms.
+        user, _, clip = await _user_with_clip("edit-crop-snap-collapse@example.com", duration=10.0, bpm=120)
+        resp = await client.post(
+            _edit_url(clip.id, "crop"),
+            json={"start": "0.1s", "end": "0.2s", "snap_to_beat": True},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_clip_without_duration_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("edit-crop-nodur@example.com", duration=None)
+        resp = await client.post(
+            _edit_url(clip.id, "crop"),
+            json={"start": "1s", "end": "5s"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+
+@pytest.mark.integration
+class TestSpeedValidation:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},  # neither multiplier nor target_bpm
+            {"multiplier": 1.2, "target_bpm": 100},  # both
+            {"multiplier": 0.4},  # below range
+            {"multiplier": 2.5},  # above range
+            {"multiplier": 0},  # not positive
+            {"multiplier": 1.2, "bogus": True},  # extra="forbid"
+            {"target_bpm": 0},  # not positive
+        ],
+    )
+    async def test_invalid_request_returns_422(self, client, settings, body: dict) -> None:
+        user, _, clip = await _user_with_clip("edit-speed-422@example.com", duration=10.0, bpm=120)
+        resp = await client.post(_edit_url(clip.id, "speed"), json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_target_bpm_without_source_bpm_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("edit-speed-nobpm@example.com", duration=10.0, bpm=None)
+        resp = await client.post(
+            _edit_url(clip.id, "speed"),
+            json={"target_bpm": 100},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_target_bpm_yielding_out_of_range_rate_returns_422(self, client, settings) -> None:
+        # 120 → 30 BPM needs rate 0.25, below the allowed 0.5–2.0 window.
+        user, _, clip = await _user_with_clip("edit-speed-range@example.com", duration=10.0, bpm=120)
+        resp = await client.post(
+            _edit_url(clip.id, "speed"),
+            json={"target_bpm": 30},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        # The error must name the offending BPM (mirrors the CLI message).
+        assert "30" in str(resp.json()["detail"])
+        assert await Job.count() == 0
+
+    async def test_clip_without_duration_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("edit-speed-nodur@example.com", duration=None)
+        resp = await client.post(
+            _edit_url(clip.id, "speed"),
+            json={"multiplier": 1.5},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+
+@pytest.mark.integration
+class TestRemasterValidation:
+    async def test_non_wav_clip_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("edit-remaster-mp3@example.com", fmt="mp3")
+        resp = await client.post(_edit_url(clip.id, "remaster"), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_extra_field_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("edit-remaster-extra@example.com")
+        resp = await client.post(
+            _edit_url(clip.id, "remaster"),
+            json={"bogus": True},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 202 — job creation
+# ---------------------------------------------------------------------------
+
+
+async def _get_only_job() -> Job:
+    jobs = await Job.find_all().to_list()
+    assert len(jobs) == 1
+    return jobs[0]
+
+
+@pytest.mark.integration
+class TestCropEnqueue:
+    async def test_returns_202_and_persists_resolved_params(self, client, settings) -> None:
+        user, workspace, clip = await _user_with_clip("edit-crop-202@example.com", duration=10.0)
+
+        resp = await client.post(
+            _edit_url(clip.id, "crop"),
+            json={"start": "1s", "end": "2.5s", "fade_out": "0.5s"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+
+        job = await _get_only_job()
+        assert str(job.id) == body["job_id"]
+        assert job.job_type == "crop"
+        assert job.status == JobStatus.QUEUED
+        assert job.user_id == user.id
+        assert job.workspace_id == workspace.id
+        assert job.input_params == {
+            "clip_id": str(clip.id),
+            "start_ms": 1000,
+            "end_ms": 2500,
+            "fade_in_ms": 0,
+            "fade_out_ms": 500,
+        }
+
+    async def test_snap_to_beat_resolves_snapped_bounds(self, client, settings) -> None:
+        # bpm=120 → beat every 500ms; 0.6s snaps to 500ms, 1.7s to 1500ms.
+        user, _, clip = await _user_with_clip("edit-crop-snap@example.com", duration=10.0, bpm=120)
+
+        resp = await client.post(
+            _edit_url(clip.id, "crop"),
+            json={"start": "0.6s", "end": "1.7s", "snap_to_beat": True},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+
+        job = await _get_only_job()
+        assert job.input_params["start_ms"] == 500
+        assert job.input_params["end_ms"] == 1500
+
+
+@pytest.mark.integration
+class TestSpeedEnqueue:
+    async def test_multiplier_returns_202_and_persists_params(self, client, settings) -> None:
+        user, workspace, clip = await _user_with_clip("edit-speed-202@example.com", duration=10.0)
+
+        resp = await client.post(
+            _edit_url(clip.id, "speed"),
+            json={"multiplier": 1.5},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+
+        job = await _get_only_job()
+        assert str(job.id) == body["job_id"]
+        assert job.job_type == "speed"
+        assert job.status == JobStatus.QUEUED
+        assert job.workspace_id == workspace.id
+        assert job.input_params == {
+            "clip_id": str(clip.id),
+            "multiplier": 1.5,
+            "preserve_pitch": True,
+        }
+
+    async def test_target_bpm_resolves_final_multiplier(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("edit-speed-bpm@example.com", duration=10.0, bpm=100)
+
+        resp = await client.post(
+            _edit_url(clip.id, "speed"),
+            json={"target_bpm": 150},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+
+        job = await _get_only_job()
+        assert job.input_params["multiplier"] == pytest.approx(1.5)
+
+    async def test_preserve_pitch_false_logs_warning(self, client, settings, caplog, monkeypatch) -> None:
+        user, _, clip = await _user_with_clip("edit-speed-pitch@example.com", duration=10.0)
+
+        # The app pins acemusic logs to its own handler (propagate=False in
+        # _ensure_app_logging); caplog listens on the root logger, so re-enable
+        # propagation for this assertion (mirrors test_credits_api).
+        monkeypatch.setattr(logging.getLogger("acemusic"), "propagate", True)
+
+        with caplog.at_level(logging.WARNING, logger="acemusic.api.routers.editing"):
+            resp = await client.post(
+                _edit_url(clip.id, "speed"),
+                json={"multiplier": 1.5, "preserve_pitch": False},
+                headers=_auth_headers(user, settings),
+            )
+        assert resp.status_code == 202
+        assert any("preserve_pitch" in record.getMessage() for record in caplog.records)
+
+        job = await _get_only_job()
+        assert job.input_params["preserve_pitch"] is False
+
+
+@pytest.mark.integration
+class TestRemasterEnqueue:
+    async def test_returns_202_with_default_target_lufs(self, client, settings) -> None:
+        user, workspace, clip = await _user_with_clip("edit-remaster-202@example.com")
+
+        resp = await client.post(_edit_url(clip.id, "remaster"), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+
+        job = await _get_only_job()
+        assert str(job.id) == body["job_id"]
+        assert job.job_type == "remaster"
+        assert job.status == JobStatus.QUEUED
+        assert job.workspace_id == workspace.id
+        assert job.input_params == {"clip_id": str(clip.id), "target_lufs": -14.0}
+
+    async def test_custom_target_lufs_is_persisted(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("edit-remaster-lufs@example.com")
+
+        resp = await client.post(
+            _edit_url(clip.id, "remaster"),
+            json={"target_lufs": -16.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+
+        job = await _get_only_job()
+        assert job.input_params["target_lufs"] == -16.0

--- a/tests/test_clips_edit_api.py
+++ b/tests/test_clips_edit_api.py
@@ -8,7 +8,9 @@ The 401 auth-gate tests run in CI (no DB); the rest are ``integration`` and
 drive the real app with ``httpx.AsyncClient`` over a local MongoDB.
 """
 
+import asyncio
 import logging
+import time
 
 import httpx
 import pytest
@@ -20,8 +22,10 @@ from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Clip, Job, JobStatus, Workspace
 from acemusic.api.services import users as user_service
 from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
 
 CLIPS_URL = f"{API_V1_PREFIX}/clips"
+JOBS_URL = f"{API_V1_PREFIX}/jobs"
 
 # Minimal valid bodies, used where the test target is not the payload itself.
 VALID_BODIES = {
@@ -104,13 +108,17 @@ async def _insert_clip(
     bpm: int | None = None,
     key: str | None = None,
     fmt: str = "wav",
+    store_bytes: bytes | None = None,
 ) -> Clip:
     clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt}"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
     clip = Clip(
         id=clip_id,
         user_id=user.id,
         workspace_id=workspace.id,
-        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt}",
+        file_path=file_path,
         format=fmt,
         duration=duration,
         bpm=bpm,
@@ -443,3 +451,99 @@ class TestRemasterEnqueue:
 
         job = await _get_only_job()
         assert job.input_params["target_lufs"] == -16.0
+
+
+# ---------------------------------------------------------------------------
+# Job status compatibility + end-to-end lifecycle (Step 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestEditJobStatus:
+    @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
+    async def test_status_reports_positive_estimate_for_edit_jobs(self, client, settings, operation: str) -> None:
+        """GET /jobs/{id}/status must not choke on (or zero out) editing jobs."""
+        user, _, clip = await _user_with_clip(f"edit-status-{operation}@example.com", duration=10.0, bpm=120)
+
+        bodies = {"crop": {"start": "1s", "end": "5s"}, "speed": {"multiplier": 1.5}, "remaster": {}}
+        accepted = await client.post(
+            _edit_url(clip.id, operation), json=bodies[operation], headers=_auth_headers(user, settings)
+        )
+        assert accepted.status_code == 202
+        job_id = accepted.json()["job_id"]
+
+        resp = await client.get(f"{JOBS_URL}/{job_id}/status", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "queued"
+        assert isinstance(body["estimated_time_seconds"], int)
+        # Editing is quick but not free; the estimate must be a real per-type
+        # value, not the generation heuristic's broken-snapshot fallback of 0.
+        assert body["estimated_time_seconds"] > 0
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    """Point the storage backend at a throwaway local root."""
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path / "storage"))
+    return tmp_path
+
+
+@pytest.mark.integration
+class TestEditLifecycleEndToEnd:
+    """AC4: each operation's job is trackable queued → completed via the API.
+
+    ``httpx.ASGITransport`` does not run the app lifespan, so the production
+    :class:`JobProcessor` is started directly with its default (env-driven)
+    storage backend — the same worker the lifespan would launch.
+    """
+
+    @pytest.mark.parametrize(
+        ("operation", "body", "expected_duration"),
+        [
+            ("crop", {"start": "0.5s", "end": "1.5s"}, 1.0),
+            ("speed", {"multiplier": 2.0}, 1.0),
+            ("remaster", {}, 2.0),
+        ],
+    )
+    async def test_edit_runs_to_completed_via_status_endpoint(
+        self, client, settings, local_storage, write_tone, operation: str, body: dict, expected_duration: float
+    ) -> None:
+        from acemusic.api.tasks.processor import JobProcessor
+
+        user = await _make_user(f"edit-e2e-{operation}@example.com")
+        workspace = await _make_workspace(user)
+        tone_path = local_storage / "tone.wav"
+        write_tone(tone_path, duration_s=2.0)
+        clip = await _insert_clip(user, workspace, duration=2.0, bpm=120, store_bytes=tone_path.read_bytes())
+        headers = _auth_headers(user, settings)
+
+        accepted = await client.post(_edit_url(clip.id, operation), json=body, headers=headers)
+        assert accepted.status_code == 202
+        assert accepted.json()["status"] == "queued"
+        job_id = accepted.json()["job_id"]
+
+        processor = JobProcessor(concurrency=1, poll_interval=0.05)
+        await processor.start()
+        try:
+            status_body = None
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                resp = await client.get(f"{JOBS_URL}/{job_id}/status", headers=headers)
+                assert resp.status_code == 200
+                status_body = resp.json()
+                assert status_body["status"] in {"queued", "processing", "completed"}, status_body.get("error")
+                if status_body["status"] == "completed":
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            await processor.stop()
+        assert status_body is not None and status_body["status"] == "completed", "job never completed"
+
+        assert len(status_body["clip_ids"]) == 1
+        assert len(status_body["audio_urls"]) == 1
+        new_clip = await Clip.get(PydanticObjectId(status_body["clip_ids"][0]))
+        assert new_clip.duration == pytest.approx(expected_duration)
+        assert new_clip.parent_clip_ids == [clip.id]
+        assert new_clip.generation_mode == operation

--- a/tests/test_clips_edit_api.py
+++ b/tests/test_clips_edit_api.py
@@ -326,6 +326,29 @@ class TestFormatGate:
 
 @pytest.mark.integration
 class TestRemasterValidation:
+    @pytest.mark.parametrize("target_lufs", [5.0, 0.0, -4.9, -70.1, -200.0])
+    async def test_out_of_range_target_lufs_returns_422(self, client, settings, target_lufs: float) -> None:
+        # Positive (or near-zero) loudness targets are physically nonsensical
+        # and would only drive the pipeline into the true-peak limiter.
+        user, _, clip = await _user_with_clip(f"edit-remaster-lufs-{target_lufs}@example.com")
+        resp = await client.post(
+            _edit_url(clip.id, "remaster"),
+            json={"target_lufs": target_lufs},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    @pytest.mark.parametrize("target_lufs", [-5.0, -14.0, -70.0])
+    async def test_in_range_target_lufs_is_accepted(self, client, settings, target_lufs: float) -> None:
+        user, _, clip = await _user_with_clip(f"edit-remaster-lufs-ok-{target_lufs}@example.com")
+        resp = await client.post(
+            _edit_url(clip.id, "remaster"),
+            json={"target_lufs": target_lufs},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+
     async def test_extra_field_returns_422(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("edit-remaster-extra@example.com")
         resp = await client.post(

--- a/tests/test_editing_processor.py
+++ b/tests/test_editing_processor.py
@@ -1,0 +1,315 @@
+"""Tests for the editing job handlers (US-10.1, Step 3).
+
+Integration tests drive the real :class:`JobProcessor` against a local MongoDB
+and :class:`LocalStorage`, with real sine-wave WAVs (``write_tone``) — no
+ACE-Step involvement, so they run in CI. They prove the issue's acceptance
+criteria at the worker level: crop duration = end − start, speed ×2 halves the
+duration, remaster lands on the target LUFS, and originals are never touched.
+"""
+
+import asyncio
+import io
+import os
+import time
+
+import pytest
+import soundfile as sf
+from beanie import PydanticObjectId
+
+from acemusic.api.models import Clip, Job, JobStatus
+from acemusic.api.tasks.processor import JobProcessor
+from acemusic.audio import measure_lufs
+from acemusic.storage import LocalStorage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_processor(storage) -> JobProcessor:
+    # client_factory would only run for "generate" jobs, which these tests never
+    # enqueue; a crashing factory proves editing never touches ACE-Step.
+    def _no_client():  # pragma: no cover - would only run on a routing bug
+        raise AssertionError("editing jobs must not build an ACE-Step client")
+
+    return JobProcessor(
+        concurrency=1,
+        poll_interval=0.01,
+        poll_timeout=30.0,
+        ace_poll_interval=0.01,
+        stale_after=3600.0,
+        client_factory=_no_client,
+        storage_factory=lambda: storage,
+    )
+
+
+@pytest.fixture
+def storage(tmp_path) -> LocalStorage:
+    root = tmp_path / "storage"
+    root.mkdir()
+    return LocalStorage(root_dir=root)
+
+
+async def _insert_source_clip(
+    storage: LocalStorage,
+    tmp_path,
+    write_tone,
+    *,
+    duration_s: float = 2.0,
+    bpm: int | None = None,
+    key: str | None = None,
+    amplitude: float = 0.3,
+) -> Clip:
+    """Write a real tone, upload it to storage and insert its Clip document."""
+    user_id = PydanticObjectId()
+    workspace_id = PydanticObjectId()
+    clip_id = PydanticObjectId()
+
+    scratch = tmp_path / "scratch"
+    scratch.mkdir(exist_ok=True)
+    tone_path = scratch / f"{clip_id}.wav"
+    write_tone(tone_path, duration_s=duration_s, amplitude=amplitude)
+
+    file_path = f"{user_id}/{workspace_id}/clips/{clip_id}.wav"
+    storage.upload(file_path, tone_path.read_bytes())
+    clip = Clip(
+        id=clip_id,
+        user_id=user_id,
+        workspace_id=workspace_id,
+        file_path=file_path,
+        format="wav",
+        duration=duration_s,
+        bpm=bpm,
+        key=key,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _enqueue_edit(source: Clip, job_type: str, params: dict) -> Job:
+    job = Job(
+        user_id=source.user_id,
+        workspace_id=source.workspace_id,
+        job_type=job_type,
+        status=JobStatus.QUEUED,
+        input_params={"clip_id": str(source.id), **params},
+    )
+    await job.insert()
+    return job
+
+
+async def _run_to_terminal(storage: LocalStorage, job: Job, *, timeout: float = 30.0) -> Job:
+    """Start a processor, wait until ``job`` reaches a terminal state, stop it."""
+    proc = _make_processor(storage)
+    await proc.start()
+    try:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            refreshed = await Job.get(job.id)
+            if refreshed.status in (JobStatus.COMPLETED, JobStatus.FAILED):
+                return refreshed
+            await asyncio.sleep(0.02)
+    finally:
+        await proc.stop()
+    pytest.fail(f"job {job.id} did not reach a terminal state within {timeout}s")
+
+
+def _audio_duration_seconds(data: bytes) -> float:
+    samples, sample_rate = sf.read(io.BytesIO(data))
+    return len(samples) / sample_rate
+
+
+async def _result_clip(job: Job) -> Clip:
+    clip_ids = job.result["clip_ids"]
+    assert len(clip_ids) == 1
+    clip = await Clip.get(PydanticObjectId(clip_ids[0]))
+    assert clip is not None
+    return clip
+
+
+def _storage_files(storage: LocalStorage) -> set[str]:
+    return {
+        os.path.relpath(os.path.join(root, name), storage.root_dir)
+        for root, _dirs, files in os.walk(storage.root_dir)
+        for name in files
+    }
+
+
+# ---------------------------------------------------------------------------
+# Handlers are registered by default
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultRegistry:
+    def test_editing_job_types_are_registered(self, tmp_path) -> None:
+        proc = JobProcessor(storage_factory=lambda: LocalStorage(root_dir=tmp_path))
+        assert {"generate", "crop", "speed", "remaster"} <= set(proc._handlers)
+
+
+# ---------------------------------------------------------------------------
+# Crop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestCropJob:
+    async def test_crop_creates_clip_with_duration_end_minus_start(
+        self, mongo_db, storage, tmp_path, write_tone
+    ) -> None:
+        source = await _insert_source_clip(storage, tmp_path, write_tone, duration_s=2.0, bpm=120, key="C major")
+        original_bytes = storage.download(source.file_path)
+        # Snapshot via a DB round-trip so datetime precision matches the later read.
+        original_doc = (await Clip.get(source.id)).model_dump()
+
+        job = await _enqueue_edit(source, "crop", {"start_ms": 500, "end_ms": 1500, "fade_in_ms": 0, "fade_out_ms": 0})
+        finished = await _run_to_terminal(storage, job)
+
+        assert finished.status == JobStatus.COMPLETED
+        new_clip = await _result_clip(finished)
+        assert new_clip.duration == pytest.approx(1.0)
+        # The stored audio really is one second long, not just the metadata.
+        assert _audio_duration_seconds(storage.download(new_clip.file_path)) == pytest.approx(1.0, abs=0.05)
+
+        # Lineage and inherited metadata.
+        assert new_clip.parent_clip_ids == [source.id]
+        assert new_clip.generation_mode == "crop"
+        assert new_clip.user_id == source.user_id
+        assert new_clip.workspace_id == source.workspace_id
+        assert new_clip.key == "C major"
+        assert new_clip.format == "wav"
+        assert new_clip.bpm == 120
+        assert new_clip.file_path == f"{source.user_id}/{source.workspace_id}/clips/{new_clip.id}.wav"
+
+        # The original is untouched: stored bytes and document both unchanged.
+        assert storage.download(source.file_path) == original_bytes
+        assert (await Clip.get(source.id)).model_dump() == original_doc
+
+    async def test_crop_applies_fades_without_changing_duration(self, mongo_db, storage, tmp_path, write_tone) -> None:
+        source = await _insert_source_clip(storage, tmp_path, write_tone, duration_s=2.0)
+        job = await _enqueue_edit(
+            source, "crop", {"start_ms": 0, "end_ms": 1000, "fade_in_ms": 100, "fade_out_ms": 100}
+        )
+        finished = await _run_to_terminal(storage, job)
+
+        assert finished.status == JobStatus.COMPLETED
+        new_clip = await _result_clip(finished)
+        data = storage.download(new_clip.file_path)
+        assert _audio_duration_seconds(data) == pytest.approx(1.0, abs=0.05)
+        # Fade-in tames the first samples relative to the (constant-amplitude) middle.
+        samples, _sr = sf.read(io.BytesIO(data))
+        head = abs(samples[: len(samples) // 100]).max()
+        middle = abs(samples[len(samples) // 2 :]).max()
+        assert head < middle
+
+
+# ---------------------------------------------------------------------------
+# Speed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestSpeedJob:
+    async def test_multiplier_two_halves_duration_and_scales_bpm(self, mongo_db, storage, tmp_path, write_tone) -> None:
+        source = await _insert_source_clip(storage, tmp_path, write_tone, duration_s=2.0, bpm=100, key="A minor")
+        original_bytes = storage.download(source.file_path)
+
+        job = await _enqueue_edit(source, "speed", {"multiplier": 2.0, "preserve_pitch": True})
+        finished = await _run_to_terminal(storage, job)
+
+        assert finished.status == JobStatus.COMPLETED
+        new_clip = await _result_clip(finished)
+        assert new_clip.duration == pytest.approx(1.0)
+        assert _audio_duration_seconds(storage.download(new_clip.file_path)) == pytest.approx(1.0, abs=0.1)
+        assert new_clip.bpm == 200
+        assert new_clip.key == "A minor"
+        assert new_clip.parent_clip_ids == [source.id]
+        assert new_clip.generation_mode == "speed"
+
+        assert storage.download(source.file_path) == original_bytes
+
+    async def test_bpm_stays_unset_when_source_has_none(self, mongo_db, storage, tmp_path, write_tone) -> None:
+        source = await _insert_source_clip(storage, tmp_path, write_tone, duration_s=2.0, bpm=None)
+        job = await _enqueue_edit(source, "speed", {"multiplier": 1.5, "preserve_pitch": True})
+        finished = await _run_to_terminal(storage, job)
+
+        assert finished.status == JobStatus.COMPLETED
+        new_clip = await _result_clip(finished)
+        assert new_clip.bpm is None
+        assert new_clip.duration == pytest.approx(2.0 / 1.5)
+
+
+# ---------------------------------------------------------------------------
+# Remaster
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestRemasterJob:
+    async def test_remaster_hits_target_lufs(self, mongo_db, storage, tmp_path, write_tone) -> None:
+        # A quiet source (~-29 LUFS) so the normalisation has real work to do.
+        source = await _insert_source_clip(
+            storage, tmp_path, write_tone, duration_s=3.0, bpm=90, key="D major", amplitude=0.05
+        )
+        original_bytes = storage.download(source.file_path)
+
+        job = await _enqueue_edit(source, "remaster", {"target_lufs": -14.0})
+        finished = await _run_to_terminal(storage, job)
+
+        assert finished.status == JobStatus.COMPLETED
+        new_clip = await _result_clip(finished)
+
+        samples, sample_rate = sf.read(io.BytesIO(storage.download(new_clip.file_path)))
+        assert measure_lufs(samples, sample_rate) == pytest.approx(-14.0, abs=1.5)
+
+        # Before/after measurements land on the job result for the client.
+        assert finished.result["before_lufs"] == pytest.approx(-29.0, abs=3.0)
+        assert finished.result["after_lufs"] == pytest.approx(-14.0, abs=1.5)
+
+        # Remaster inherits duration/bpm/key; lineage points at the source.
+        assert new_clip.duration == pytest.approx(3.0)
+        assert new_clip.bpm == 90
+        assert new_clip.key == "D major"
+        assert new_clip.parent_clip_ids == [source.id]
+        assert new_clip.generation_mode == "remaster"
+
+        assert storage.download(source.file_path) == original_bytes
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestEditFailures:
+    async def test_missing_source_clip_fails_job_without_orphans(self, mongo_db, storage) -> None:
+        ghost_id = PydanticObjectId()
+        job = Job(
+            user_id=PydanticObjectId(),
+            workspace_id=PydanticObjectId(),
+            job_type="crop",
+            status=JobStatus.QUEUED,
+            input_params={"clip_id": str(ghost_id), "start_ms": 0, "end_ms": 1000, "fade_in_ms": 0, "fade_out_ms": 0},
+        )
+        await job.insert()
+
+        finished = await _run_to_terminal(storage, job)
+
+        assert finished.status == JobStatus.FAILED
+        assert str(ghost_id) in (finished.error or "")
+        assert await Clip.count() == 0
+        assert _storage_files(storage) == set()
+
+    async def test_missing_source_audio_fails_job_without_orphans(
+        self, mongo_db, storage, tmp_path, write_tone
+    ) -> None:
+        source = await _insert_source_clip(storage, tmp_path, write_tone, duration_s=2.0)
+        storage.delete(source.file_path)  # the record exists but its object is gone
+
+        job = await _enqueue_edit(source, "speed", {"multiplier": 1.5, "preserve_pitch": True})
+        finished = await _run_to_terminal(storage, job)
+
+        assert finished.status == JobStatus.FAILED
+        assert finished.error
+        assert await Clip.count() == 1, "no derived clip may be recorded for a failed edit"
+        assert _storage_files(storage) == set(), "no partial output may be left behind"

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -92,11 +92,11 @@ class _FakeAceClient:
         return self._audio
 
 
-async def _enqueue(input_params: dict | None = None) -> Job:
+async def _enqueue(input_params: dict | None = None, *, job_type: str = "generate") -> Job:
     job = Job(
         user_id=PydanticObjectId(),
         workspace_id=PydanticObjectId(),
-        job_type="generate",
+        job_type=job_type,
         status=JobStatus.QUEUED,
         input_params=input_params or {"prompt": "a calm piano ballad", "format": "wav"},
     )
@@ -113,7 +113,7 @@ async def _wait_until(predicate, *, timeout: float = 5.0, interval: float = 0.02
     return False
 
 
-def _make_processor(fake, storage, *, concurrency: int = 2, stale_after: float = 0.0) -> JobProcessor:
+def _make_processor(fake, storage, *, concurrency: int = 2, stale_after: float = 0.0, handlers=None) -> JobProcessor:
     # stale_after=0.0: any `processing` job is treated as immediately orphaned, so
     # the requeue-on-startup test is deterministic (production uses a real window).
     return JobProcessor(
@@ -124,6 +124,7 @@ def _make_processor(fake, storage, *, concurrency: int = 2, stale_after: float =
         stale_after=stale_after,
         client_factory=lambda: fake,
         storage_factory=lambda: storage,
+        handlers=handlers,
     )
 
 
@@ -417,6 +418,135 @@ class TestShutdownAndRequeue:
         refreshed = await Job.get(job.id)
         assert refreshed.status == JobStatus.QUEUED
         assert refreshed.started_at is None
+
+
+# ---------------------------------------------------------------------------
+# Handler registry — dispatch by job_type (US-10.1, Step 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestHandlerRegistry:
+    async def test_custom_handler_processes_its_job_type(self, mongo_db, tmp_path) -> None:
+        seen: list[str] = []
+
+        async def echo_handler(job: Job) -> dict:
+            seen.append(job.job_type)
+            return {"echo": job.input_params["value"]}
+
+        proc = _make_processor(
+            _FakeAceClient(),
+            LocalStorage(root_dir=tmp_path),
+            handlers={"echo": echo_handler},
+        )
+        job = await _enqueue({"value": 42}, job_type="echo")
+
+        await proc.start()
+        try:
+            done = await _wait_until(lambda: _is_status(job.id, JobStatus.COMPLETED))
+        finally:
+            await proc.stop()
+
+        assert done, "custom-typed job did not complete"
+        refreshed = await Job.get(job.id)
+        assert refreshed.result == {"echo": 42}
+        assert seen == ["echo"]
+
+    async def test_generate_jobs_still_route_to_generate_handler(self, mongo_db, tmp_path) -> None:
+        # The registry must not change generate behaviour: a generate job and a
+        # custom-typed job each reach their own handler.
+        async def noop_handler(job: Job) -> dict:
+            return {"handled": True}
+
+        storage = LocalStorage(root_dir=tmp_path)
+        fake = _FakeAceClient(audio_urls=["http://ace/a.wav"])
+        proc = _make_processor(fake, storage, handlers={"noop": noop_handler})
+        gen_job = await _enqueue()
+        noop_job = await _enqueue({"x": 1}, job_type="noop")
+
+        await proc.start()
+        try:
+            done = await _wait_until(lambda: _all_status([gen_job.id, noop_job.id], JobStatus.COMPLETED))
+        finally:
+            await proc.stop()
+
+        assert done, "jobs did not complete"
+        refreshed_gen = await Job.get(gen_job.id)
+        assert refreshed_gen.result["clip_ids"], "generate handler did not produce clips"
+        refreshed_noop = await Job.get(noop_job.id)
+        assert refreshed_noop.result == {"handled": True}
+
+    async def test_unregistered_job_type_is_never_claimed(self, mongo_db, tmp_path) -> None:
+        proc = _make_processor(_FakeAceClient(), LocalStorage(root_dir=tmp_path))
+        job = await _enqueue({"x": 1}, job_type="mystery")
+
+        await proc.start()
+        try:
+            claimed = await _wait_until(lambda: _is_status(job.id, JobStatus.PROCESSING), timeout=0.3)
+        finally:
+            await proc.stop()
+
+        assert not claimed, "a job with no registered handler was claimed"
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.QUEUED
+
+    async def test_handler_exception_marks_job_failed(self, mongo_db, tmp_path) -> None:
+        async def boom_handler(job: Job) -> dict:
+            raise RuntimeError("edit boom")
+
+        proc = _make_processor(
+            _FakeAceClient(),
+            LocalStorage(root_dir=tmp_path),
+            handlers={"boom": boom_handler},
+        )
+        job = await _enqueue({"x": 1}, job_type="boom")
+
+        await proc.start()
+        try:
+            done = await _wait_until(lambda: _is_status(job.id, JobStatus.FAILED))
+        finally:
+            await proc.stop()
+
+        assert done, "failing handler did not mark the job failed"
+        refreshed = await Job.get(job.id)
+        assert refreshed.error == "edit boom"
+
+    async def test_stale_requeue_covers_all_registered_types(self, mongo_db, tmp_path) -> None:
+        from acemusic.api.models.common import utcnow
+
+        async def noop_handler(job: Job) -> dict:  # pragma: no cover - never runs
+            return {}
+
+        proc = _make_processor(
+            _FakeAceClient(),
+            LocalStorage(root_dir=tmp_path),
+            stale_after=0.0,
+            handlers={"noop": noop_handler},
+        )
+        stale = Job(
+            user_id=PydanticObjectId(),
+            workspace_id=PydanticObjectId(),
+            job_type="noop",
+            status=JobStatus.PROCESSING,
+            started_at=utcnow(),
+            input_params={"x": 1},
+        )
+        await stale.insert()
+        unknown = Job(
+            user_id=PydanticObjectId(),
+            workspace_id=PydanticObjectId(),
+            job_type="mystery",
+            status=JobStatus.PROCESSING,
+            started_at=utcnow(),
+            input_params={"x": 1},
+        )
+        await unknown.insert()
+
+        await proc._requeue_stale_jobs()
+
+        assert (await Job.get(stale.id)).status == JobStatus.QUEUED
+        # A type this processor cannot run is left alone for whoever owns it.
+        assert (await Job.get(unknown.id)).status == JobStatus.PROCESSING
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements #81: US-10.1 — Audio editing endpoints (crop, speed, remaster)

- `POST /api/v1/clips/{id}/crop` (`start`/`end`/`fade_in`/`fade_out` as CLI-style time strings, optional `snap_to_beat`), `POST /api/v1/clips/{id}/speed` (exactly one of `multiplier` ∈ [0.5, 2.0] or `target_bpm`; `preserve_pitch` accepted, warning logged when false), `POST /api/v1/clips/{id}/remaster` (`target_lufs`, default −14) — all return **202** with `{job_id, status: "queued"}`, mirroring `POST /generate`
- `JobProcessor` generalized from a hardcoded `job_type="generate"` to a **handler registry** keyed by job_type; claim and stale-requeue queries scope to registered types only, so unrelated deployments' jobs are never claimed; generate behavior unchanged
- New editing workers (`tasks/editing.py`) download the source from the storage backend, run the existing `crop_audio`/`time_stretch_audio`/`remaster_audio`, upload the result, and insert a derived `Clip` with `parent_clip_ids=[source]`, `generation_mode` ∈ {crop, speed, remaster}, derived duration/BPM; remaster results carry before/after LUFS
- Originals are never modified: workers operate on temp copies and insert new documents; insert failure rolls back the uploaded object
- `GET /api/v1/jobs/{id}/status` now produces a per-job-type `estimated_time_seconds` (previously it parsed `input_params` as a `GenerationRequest`, which would misreport editing jobs)
- All three endpoints share a wav gate with a file-suffix fallback (`clip_service.native_format()`), returning an upfront 422 for formats the pipeline cannot round-trip (review finding, see notes)

## Acceptance Criteria
- [x] Crop creates a new clip with the correct duration (end − start) — `test_crop_creates_clip_with_duration_end_minus_start`
- [x] Speed `multiplier: 2.0` produces a clip half the original duration — `test_multiplier_two_halves_duration_and_scales_bpm`
- [x] Remaster produces a clip with loudness ≈ target LUFS (±1.5) — `test_remaster_hits_target_lufs`
- [x] All operations return job IDs; status trackable via `GET /api/v1/jobs/{id}/status` — `test_edit_runs_to_completed_via_status_endpoint` (full E2E through the real `JobProcessor`)
- [x] Original clips unchanged after any operation — source bytes and document asserted identical in `tests/test_editing_processor.py`

## Test Plan
- [x] Unit + integration tests written first (TDD; real MongoDB, real sine-wave WAVs, no mocks)
- [x] Full suite green: **1479 passed, 5 skipped** (skips are external-service auto-skips)
- [x] Diff coverage **95%** on changed lines (gate: ≥85%)
- [x] Linting clean (black + ruff)
- [x] Internal code review (advisory) completed — 1 Major finding fixed (format gate)
- [x] Cross-family review pass: **codex** (2 P2 findings, both fixed: suffix fallback for missing `format`, upfront rejection of non-wav sources)
- [x] Mutation sanity check: 7/7 mutations killed

## Known Limitations / Intentionally Deferred
- **wav-only editing**: crop/speed/remaster reject non-wav sources with 422. `soundfile` cannot write PCM_16 mp3/aac/opus and the server cannot rely on ffmpeg for pydub; transcoding support is a possible follow-up.
- **`preserve_pitch=false` is accepted but not honored** (warning logged): the librosa phase vocoder always preserves pitch. Per the plan's design choice for API-shape compatibility.
- **No credit deduction** for editing operations — non-generative local CPU work; confirmed product decision during plan approval.
- **Single-parent lineage only**: `parent_clip_ids` always has exactly one element here; multi-parent (mashup) is separate work.

## Implementation Notes
- The CodeRabbit plan on the issue predates Stage 9; the layout was adapted to the actual `routers/{feature}.py` + `services/` convention, and lineage uses the API model's plural `parent_clip_ids` (the plan's singular field only exists on the CLI SQLite model).
- Includes one out-of-scope bug fix (own commit, `e93c388`): a pre-existing concurrent first-login race in `get_or_create_user` that `test_concurrent_first_login_is_idempotent` reproduces consistently against a fresh mongod. Fixed under the repo's bug-ownership rule.

Closes #81
