### PR TITLE
US-10.2: Stems and MIDI extraction endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AI-powered music generation platform built on **ACE-Step-1.5** (fork: `github.co
 3. **Layer 3 — Web UI** (Stages 15–21): Next.js frontend
 4. **Layer 4 — Advanced Integrations** (Stages 22–28): VST3 plugin, music video, voice models, credits, moderation
 
-**Current progress:** Stages 1–9 complete on `main`; Stage 10 in progress (US-10.1 audio editing endpoints implemented). CLI foundation (Stages 1–7): generation, workspace management, audio processing, DAW export. Platform API (Stages 8–9): FastAPI with OAuth2 auth, async job queue, clip audio streaming, workspace/clip/preset CRUD, credit deduction. Audio editing API (US-10.1): crop, speed-adjust, and remaster endpoints enqueue async jobs that create derived clips with lineage tracking.
+**Current progress:** Stages 1–9 complete on `main`; Stage 10 in progress (US-10.1 audio editing, US-10.2 stems/MIDI extraction endpoints implemented). CLI foundation (Stages 1–7): generation, workspace management, audio processing, DAW export. Platform API (Stages 8–9): FastAPI with OAuth2 auth, async job queue, clip audio streaming, workspace/clip/preset CRUD, credit deduction. Audio editing API (US-10.1): crop, speed-adjust, and remaster endpoints enqueue async jobs that create derived clips with lineage tracking. Stems/MIDI extraction API (US-10.2): stem separation (4 child clips) and MIDI extraction (files referenced via `Clip.midi_paths`) run as cache-first, idempotent async jobs.
 
 ## Commands
 
@@ -112,7 +112,7 @@ src/acemusic/
     settings.py     # ApiSettings (pydantic-settings, ACEMUSIC_API_ prefix)
     database.py     # MongoDB connect/close (Beanie + pymongo async), fail-fast ping
     models/         # Beanie ODM documents: User, Workspace, Clip, Job, Preset, CreditTransaction
-    routers/        # Versioned routers mounted under /api/v1 (health, auth, users, generation, jobs, clips, editing, workspaces, presets)
+    routers/        # Versioned routers mounted under /api/v1 (health, auth, users, generation, jobs, clips, editing, extraction, workspaces, presets)
   backends.py       # Backend selector: resolve_backend (auto|ace-step|elevenlabs) + capability map
   cli.py            # Typer CLI app (health, generate, compose, sounds, models, workspace commands)
   client.py         # AceStepClient — HTTP client for ACE-Step REST API

--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ All CRUD endpoints are owner-scoped. `GET /api/v1/clips/{id}/audio` additionally
 
 All three editing endpoints are non-destructive: the original clip is never modified. Each operation creates a new clip with `parent_clip_ids` and `generation_mode` set for lineage tracking, and tracks progress via `GET /api/v1/jobs/{id}/status`. Only `wav` source clips are accepted (422 otherwise). No credits are deducted — editing is local CPU work. Time parameters use human-readable strings (`"10s"`, `"1m30s"`, `"5"`). The `speed` endpoint accepts either `multiplier` (direct rate) or `target_bpm` (requires BPM metadata on the source clip); exactly one must be provided.
 
+### Stems & MIDI Extraction (US-10.2)
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/clips/{id}/stems` | Separate a clip into `vocals`/`drums`/`bass`/`other`; returns 202 + `job_id` (or 200 with the existing stems on a cache hit) |
+| `GET /api/v1/clips/{id}/stems` | The 4 stem clip ids and labels once separated (404 until the full set exists) |
+| `POST /api/v1/clips/{id}/midi` | Extract `melody`/`chords`/`bass`/`drums` MIDI; returns 202 + `job_id` (or 200 with the existing files on a cache hit) |
+| `GET /api/v1/clips/{id}/midi` | Download URLs for the extracted `.mid` files (404 until extracted) |
+
+Both operations run as background jobs and are tracked via `GET /api/v1/jobs/{id}/status` — completed stems jobs surface `clip_ids`/`audio_urls`, completed MIDI jobs surface `midi_download_urls`. Stems become **four child clips** linked to the parent (`generation_mode="stems"`, same duration as the source); MIDI files are stored as objects (not clip records) and referenced from the parent clip's `midi_paths`. Requests are cache-first and idempotent per clip: re-requesting returns the existing results, and a second request while a job is in flight rides the existing job rather than enqueuing a duplicate. Only `wav` source clips are accepted (422 otherwise); no credits are deducted.
+
 ### Presets
 
 | Endpoint | Purpose |

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -20,7 +20,7 @@ from acemusic import __version__
 
 from . import database
 from .exceptions import HandleConflictError
-from .routers import auth, clips, editing, generation, health, jobs, presets, users, workspaces
+from .routers import auth, clips, editing, extraction, generation, health, jobs, presets, users, workspaces
 from .settings import ApiSettings
 from .tasks.processor import JobProcessor
 
@@ -117,6 +117,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(jobs.router, prefix=API_V1_PREFIX)
     app.include_router(clips.router, prefix=API_V1_PREFIX)
     app.include_router(editing.router, prefix=API_V1_PREFIX)
+    app.include_router(extraction.router, prefix=API_V1_PREFIX)
     app.include_router(workspaces.router, prefix=API_V1_PREFIX)
     app.include_router(presets.router, prefix=API_V1_PREFIX)
 

--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -32,6 +32,11 @@ class Clip(Document):
     inference_steps: int | None = None
     parent_clip_ids: list[PydanticObjectId] = Field(default_factory=list)
     generation_mode: str | None = None
+    # Extracted MIDI artifacts (US-10.2), keyed label -> storage key. MIDI files
+    # are not clips, so the parent clip records them here; this is the cache and
+    # retrieval source (the storage backend offers no list/exists). None until a
+    # MIDI extraction job completes for this clip.
+    midi_paths: dict[str, str] | None = None
     is_public: bool = False  # documents predating US-9.3 load as private
     created_at: datetime = Field(default_factory=utcnow)
 

--- a/src/acemusic/api/routers/extraction.py
+++ b/src/acemusic/api/routers/extraction.py
@@ -20,6 +20,7 @@ from beanie.operators import In
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 
+from acemusic.stems_client import STEM_LABELS
 from acemusic.storage import get_storage_backend
 
 from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
@@ -27,6 +28,11 @@ from ..models import Clip
 from ..services import clips as clip_service, extraction as extraction_service
 
 logger = logging.getLogger(__name__)
+
+# A cached stem set counts as complete only when every label is present; if the
+# owner deleted one of the child clips, re-POSTing must re-run separation rather
+# than return a partial result.
+_EXPECTED_STEM_LABELS = frozenset(STEM_LABELS)
 
 # Router-level dependency gates every route behind a valid Bearer token (mirrors
 # the clips/editing routers), so unauthenticated requests get 401.
@@ -113,7 +119,7 @@ async def separate_stems(
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
 
     existing = await _existing_stems(clip)
-    if existing:
+    if _EXPECTED_STEM_LABELS.issubset({c.title for c in existing}):
         response.status_code = status.HTTP_200_OK
         return _stems_result(clip, existing)
 

--- a/src/acemusic/api/routers/extraction.py
+++ b/src/acemusic/api/routers/extraction.py
@@ -1,0 +1,175 @@
+"""Stem / MIDI extraction endpoints (US-10.2), mounted under ``/api/v1/clips``.
+
+* ``POST /clips/{id}/stems`` → separate into vocals/drums/bass/other (4 child clips)
+* ``GET  /clips/{id}/stems`` → the stem clip ids if separation has been done
+* ``POST /clips/{id}/midi``  → extract melody/chords/drums/bass MIDI files
+* ``GET  /clips/{id}/midi``  → download URLs for extracted MIDI files
+
+The POST endpoints are *cache-first*: if a clip already has stems (child clips)
+or MIDI (``Clip.midi_paths``), they return the existing results with 200 instead
+of enqueuing a duplicate job. Otherwise they persist a queued
+:class:`~acemusic.api.models.job.Job` and return 202 with a job id trackable via
+``GET /api/v1/jobs/{id}/status`` (mirrors the editing endpoints). Extraction is
+non-generative local CPU work, so no credits are deducted.
+"""
+
+import asyncio
+import logging
+
+from beanie.operators import In
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel
+
+from acemusic.storage import get_storage_backend
+
+from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..models import Clip
+from ..services import clips as clip_service, extraction as extraction_service
+
+logger = logging.getLogger(__name__)
+
+# Router-level dependency gates every route behind a valid Bearer token (mirrors
+# the clips/editing routers), so unauthenticated requests get 401.
+router = APIRouter(prefix="/clips", tags=["extraction"], dependencies=[Depends(get_current_user)])
+
+
+def _unprocessable(detail: str) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail)
+
+
+def _require_wav(clip: Clip) -> None:
+    """422 unless the clip's audio is wav.
+
+    Stem separation and MIDI extraction read the source through torchaudio /
+    basic-pitch, which need ffmpeg for compressed formats (absent on the
+    server). Gate at request time so a bad job fails fast with a clear message
+    instead of an opaque worker error (mirrors the editing endpoints).
+    """
+    fmt = clip_service.native_format(clip)
+    if fmt != "wav":
+        raise _unprocessable(f"unsupported format {fmt!r} for extraction; currently only wav is supported.")
+
+
+class ExtractionJobResponse(BaseModel):
+    """The accepted-job acknowledgement returned with HTTP 202."""
+
+    job_id: str
+    status: str = "queued"
+
+
+class StemsResult(BaseModel):
+    """Existing stems for a clip (returned by GET, and by POST on a cache hit)."""
+
+    stem_clip_ids: list[str]
+    labels: list[str]
+    parent_clip_id: str
+
+
+class MidiResult(BaseModel):
+    """Extracted MIDI for a clip (returned by GET, and by POST on a cache hit)."""
+
+    download_urls: dict[str, str]
+    parent_clip_id: str
+
+
+async def _existing_stems(clip: Clip) -> list[Clip]:
+    """Child clips produced by a prior stem-separation of ``clip`` (label-ordered)."""
+    stems = await Clip.find(
+        In(Clip.parent_clip_ids, [clip.id]),
+        Clip.generation_mode == extraction_service.STEMS_JOB_TYPE,
+    ).to_list()
+    # Stable, predictable order regardless of insertion/scan order.
+    return sorted(stems, key=lambda c: c.title or "")
+
+
+def _stems_result(parent: Clip, stems: list[Clip]) -> StemsResult:
+    return StemsResult(
+        stem_clip_ids=[str(c.id) for c in stems],
+        labels=[c.title or "" for c in stems],
+        parent_clip_id=str(parent.id),
+    )
+
+
+async def _midi_result(clip: Clip) -> MidiResult:
+    """Resolve the clip's stored MIDI keys to retrievable URLs at read time.
+
+    URLs are generated per request (S3 presigned URLs expire), so only the
+    storage keys are persisted on the clip.
+    """
+    storage = get_storage_backend()
+    urls: dict[str, str] = {}
+    for label, key in (clip.midi_paths or {}).items():
+        urls[label] = await asyncio.to_thread(storage.get_url, key)
+    return MidiResult(download_urls=urls, parent_clip_id=str(clip.id))
+
+
+@router.post("/{clip_id}/stems", status_code=status.HTTP_202_ACCEPTED, response_model=None)
+async def separate_stems(
+    clip_id: str,
+    response: Response,
+    current: CurrentUser = Depends(require_existing_user),
+) -> ExtractionJobResponse | StemsResult:
+    """Enqueue stem separation of ``clip_id`` (or return cached stems with 200)."""
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+
+    existing = await _existing_stems(clip)
+    if existing:
+        response.status_code = status.HTTP_200_OK
+        return _stems_result(clip, existing)
+
+    _require_wav(clip)
+    job = await extraction_service.create_extraction_job(
+        user_id=clip.user_id,
+        workspace_id=clip.workspace_id,
+        job_type=extraction_service.STEMS_JOB_TYPE,
+        clip_id=clip.id,
+    )
+    return ExtractionJobResponse(job_id=str(job.id))
+
+
+@router.get("/{clip_id}/stems", response_model=StemsResult)
+async def get_stems(
+    clip_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> StemsResult:
+    """Return the stem clip ids for ``clip_id`` (404 if not yet separated)."""
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    existing = await _existing_stems(clip)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No stems for this clip.")
+    return _stems_result(clip, existing)
+
+
+@router.post("/{clip_id}/midi", status_code=status.HTTP_202_ACCEPTED, response_model=None)
+async def extract_midi(
+    clip_id: str,
+    response: Response,
+    current: CurrentUser = Depends(require_existing_user),
+) -> ExtractionJobResponse | MidiResult:
+    """Enqueue MIDI extraction of ``clip_id`` (or return cached MIDI with 200)."""
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+
+    if clip.midi_paths:
+        response.status_code = status.HTTP_200_OK
+        return await _midi_result(clip)
+
+    _require_wav(clip)
+    job = await extraction_service.create_extraction_job(
+        user_id=clip.user_id,
+        workspace_id=clip.workspace_id,
+        job_type=extraction_service.MIDI_JOB_TYPE,
+        clip_id=clip.id,
+    )
+    return ExtractionJobResponse(job_id=str(job.id))
+
+
+@router.get("/{clip_id}/midi", response_model=MidiResult)
+async def get_midi(
+    clip_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> MidiResult:
+    """Return download URLs for ``clip_id``'s MIDI files (404 if not yet extracted)."""
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    if not clip.midi_paths:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No MIDI for this clip.")
+    return await _midi_result(clip)

--- a/src/acemusic/api/routers/extraction.py
+++ b/src/acemusic/api/routers/extraction.py
@@ -138,10 +138,15 @@ async def get_stems(
     clip_id: str,
     current: CurrentUser = Depends(require_existing_user),
 ) -> StemsResult:
-    """Return the stem clip ids for ``clip_id`` (404 if not yet separated)."""
+    """Return the stem clip ids for ``clip_id`` (404 until the full set exists).
+
+    A partial set (the owner deleted one of the child stem clips) is treated as
+    "not separated", matching the POST cache check — the endpoint never reports a
+    separation that is missing required labels.
+    """
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
     existing = await _existing_stems(clip)
-    if not existing:
+    if not _EXPECTED_STEM_LABELS.issubset({c.title for c in existing}):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No stems for this clip.")
     return _stems_result(clip, existing)
 

--- a/src/acemusic/api/routers/extraction.py
+++ b/src/acemusic/api/routers/extraction.py
@@ -13,7 +13,6 @@ of enqueuing a duplicate job. Otherwise they persist a queued
 non-generative local CPU work, so no credits are deducted.
 """
 
-import asyncio
 import logging
 
 from beanie.operators import In
@@ -21,7 +20,6 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 
 from acemusic.stems_client import STEM_LABELS
-from acemusic.storage import get_storage_backend
 
 from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
 from ..models import Clip
@@ -97,15 +95,8 @@ def _stems_result(parent: Clip, stems: list[Clip]) -> StemsResult:
 
 
 async def _midi_result(clip: Clip) -> MidiResult:
-    """Resolve the clip's stored MIDI keys to retrievable URLs at read time.
-
-    URLs are generated per request (S3 presigned URLs expire), so only the
-    storage keys are persisted on the clip.
-    """
-    storage = get_storage_backend()
-    urls: dict[str, str] = {}
-    for label, key in (clip.midi_paths or {}).items():
-        urls[label] = await asyncio.to_thread(storage.get_url, key)
+    """Resolve the clip's stored MIDI keys to retrievable URLs at read time."""
+    urls = await extraction_service.resolve_midi_urls(clip.midi_paths or {})
     return MidiResult(download_urls=urls, parent_clip_id=str(clip.id))
 
 
@@ -119,7 +110,7 @@ async def separate_stems(
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
 
     existing = await _existing_stems(clip)
-    if _EXPECTED_STEM_LABELS.issubset({c.title for c in existing}):
+    if _EXPECTED_STEM_LABELS.issubset({c.title or "" for c in existing}):
         response.status_code = status.HTTP_200_OK
         return _stems_result(clip, existing)
 
@@ -146,7 +137,7 @@ async def get_stems(
     """
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
     existing = await _existing_stems(clip)
-    if not _EXPECTED_STEM_LABELS.issubset({c.title for c in existing}):
+    if not _EXPECTED_STEM_LABELS.issubset({c.title or "" for c in existing}):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No stems for this clip.")
     return _stems_result(clip, existing)
 

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -19,7 +19,7 @@ from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import Clip, Job, JobStatus
 from ..services.common import coerce_object_id
 from ..services.editing import EDIT_JOB_TYPES
-from ..services.extraction import EXTRACTION_JOB_TYPES, MIDI_JOB_TYPE
+from ..services.extraction import EXTRACTION_JOB_TYPES, MIDI_JOB_TYPE, resolve_midi_urls
 from .generation import GenerationRequest, estimate_seconds
 
 logger = logging.getLogger(__name__)
@@ -78,21 +78,6 @@ def _estimate_for(job: Job) -> int:
         return 0
 
 
-async def _resolve_midi_urls(midi_paths: dict[str, str]) -> dict[str, str]:
-    """Map a completed MIDI job's stored keys to retrievable URLs via storage.
-
-    Keys are resolved fresh per request (S3 presigned URLs expire) and never
-    exposed raw, mirroring ``_resolve_audio_urls`` and the clip endpoints that
-    hide ``file_path``.
-    """
-    storage = get_storage_backend()
-    urls: dict[str, str] = {}
-    for label, key in midi_paths.items():
-        # get_url may hit the network (S3 presign), so keep it off the event loop.
-        urls[label] = await asyncio.to_thread(storage.get_url, key)
-    return urls
-
-
 async def _resolve_audio_urls(clip_ids: list[str]) -> list[str]:
     """Map a completed job's clip ids to retrievable audio URLs via storage."""
     if not clip_ids:
@@ -131,7 +116,7 @@ async def get_job_status(
     if job.status == JobStatus.COMPLETED:
         if job.job_type == MIDI_JOB_TYPE:
             # MIDI jobs record ``midi_paths`` (label -> storage key), not clips.
-            response.midi_download_urls = await _resolve_midi_urls((job.result or {}).get("midi_paths", {}))
+            response.midi_download_urls = await resolve_midi_urls((job.result or {}).get("midi_paths", {}))
         else:
             clip_ids = list((job.result or {}).get("clip_ids", []))
             response.clip_ids = clip_ids

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -19,6 +19,7 @@ from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import Clip, Job, JobStatus
 from ..services.common import coerce_object_id
 from ..services.editing import EDIT_JOB_TYPES
+from ..services.extraction import EXTRACTION_JOB_TYPES, MIDI_JOB_TYPE
 from .generation import GenerationRequest, estimate_seconds
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,11 @@ logger = logging.getLogger(__name__)
 # Editing jobs (crop/speed/remaster, US-10.1) are quick local CPU work, so a
 # small flat estimate replaces the duration-scaled generation heuristic.
 _EDIT_ESTIMATE_SECONDS = 5
+
+# Extraction jobs (stems/MIDI, US-10.2) run heavy ML models (demucs / basic-pitch)
+# on CPU, so they take far longer than an edit; a flat minute-ish estimate is a
+# reasonable advisory floor without modelling per-clip duration.
+_EXTRACTION_ESTIMATE_SECONDS = 60
 
 # Router-level dependency gates every route behind a valid Bearer token (mirrors
 # the generation router), so an unauthenticated request is rejected with 401.
@@ -46,6 +52,9 @@ class JobStatusResponse(BaseModel):
     estimated_time_seconds: int
     clip_ids: list[str] | None = None
     audio_urls: list[str] | None = None
+    # MIDI extraction jobs (US-10.2) produce files, not clips; their results
+    # surface here as label -> download URL (resolved fresh, like ``audio_urls``).
+    midi_download_urls: dict[str, str] | None = None
     error: str | None = None
 
 
@@ -61,10 +70,27 @@ def _estimate_for(job: Job) -> int:
     """
     if job.job_type in EDIT_JOB_TYPES:
         return _EDIT_ESTIMATE_SECONDS
+    if job.job_type in EXTRACTION_JOB_TYPES:
+        return _EXTRACTION_ESTIMATE_SECONDS
     try:
         return estimate_seconds(GenerationRequest(**job.input_params))
     except Exception:
         return 0
+
+
+async def _resolve_midi_urls(midi_paths: dict[str, str]) -> dict[str, str]:
+    """Map a completed MIDI job's stored keys to retrievable URLs via storage.
+
+    Keys are resolved fresh per request (S3 presigned URLs expire) and never
+    exposed raw, mirroring ``_resolve_audio_urls`` and the clip endpoints that
+    hide ``file_path``.
+    """
+    storage = get_storage_backend()
+    urls: dict[str, str] = {}
+    for label, key in midi_paths.items():
+        # get_url may hit the network (S3 presign), so keep it off the event loop.
+        urls[label] = await asyncio.to_thread(storage.get_url, key)
+    return urls
 
 
 async def _resolve_audio_urls(clip_ids: list[str]) -> list[str]:
@@ -103,9 +129,13 @@ async def get_job_status(
         estimated_time_seconds=_estimate_for(job),
     )
     if job.status == JobStatus.COMPLETED:
-        clip_ids = list((job.result or {}).get("clip_ids", []))
-        response.clip_ids = clip_ids
-        response.audio_urls = await _resolve_audio_urls(clip_ids)
+        if job.job_type == MIDI_JOB_TYPE:
+            # MIDI jobs record ``midi_paths`` (label -> storage key), not clips.
+            response.midi_download_urls = await _resolve_midi_urls((job.result or {}).get("midi_paths", {}))
+        else:
+            clip_ids = list((job.result or {}).get("clip_ids", []))
+            response.clip_ids = clip_ids
+            response.audio_urls = await _resolve_audio_urls(clip_ids)
     elif job.status == JobStatus.FAILED:
         response.error = job.error
     return response

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -131,10 +131,18 @@ async def update_clip_title(clip_id: str, user_id: str, title: str) -> Clip:
 
 
 async def delete_clip(clip_id: str, user_id: str) -> None:
-    """Delete the clip record and its stored audio (idempotent on the object)."""
+    """Delete the clip record and its stored audio (idempotent on the object).
+
+    Also removes any extracted MIDI objects (US-10.2 ``midi_paths``), which live
+    under their own storage keys rather than ``file_path`` and would otherwise
+    be orphaned when the parent clip is deleted.
+    """
     clip = await get_owned_clip(clip_id, user_id)
+    storage = get_storage_backend()
     # delete() does file/network I/O via the sync backend; keep it off the
     # event loop. Storage goes first so a crash between the two steps leaves a
     # re-deletable record rather than an orphaned file.
-    await asyncio.to_thread(get_storage_backend().delete, clip.file_path)
+    await asyncio.to_thread(storage.delete, clip.file_path)
+    for midi_key in (clip.midi_paths or {}).values():
+        await asyncio.to_thread(storage.delete, midi_key)
     await clip.delete()

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -11,6 +11,7 @@ ever applies to the audio endpoint.
 """
 
 import asyncio
+import logging
 import re
 from pathlib import Path
 from typing import Literal
@@ -23,6 +24,8 @@ from acemusic.storage import get_storage_backend
 from ..models import Clip
 from . import workspaces as workspace_service
 from .common import coerce_object_id
+
+logger = logging.getLogger(__name__)
 
 
 async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
@@ -143,6 +146,12 @@ async def delete_clip(clip_id: str, user_id: str) -> None:
     # event loop. Storage goes first so a crash between the two steps leaves a
     # re-deletable record rather than an orphaned file.
     await asyncio.to_thread(storage.delete, clip.file_path)
+    # MIDI cleanup is best-effort per key: one failing delete must not strand the
+    # remaining objects or block the clip-record deletion (matches the defensive
+    # cleanup in the extraction task handlers).
     for midi_key in (clip.midi_paths or {}).values():
-        await asyncio.to_thread(storage.delete, midi_key)
+        try:
+            await asyncio.to_thread(storage.delete, midi_key)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.warning("Failed to delete MIDI object %s while deleting clip %s", midi_key, clip.id)
     await clip.delete()

--- a/src/acemusic/api/services/extraction.py
+++ b/src/acemusic/api/services/extraction.py
@@ -16,6 +16,21 @@ MIDI_JOB_TYPE = "midi"
 
 EXTRACTION_JOB_TYPES = (STEMS_JOB_TYPE, MIDI_JOB_TYPE)
 
+# A job is still "in flight" (a worker may pick it up or already has) in these
+# states; a second request for the same clip rides it rather than competing.
+_ACTIVE_STATUSES = (JobStatus.QUEUED.value, JobStatus.PROCESSING.value)
+
+
+async def _find_active_job(job_type: str, clip_id: PydanticObjectId) -> Job | None:
+    """An already-queued/processing job of this type for this clip, if any."""
+    return await Job.find_one(
+        {
+            "job_type": job_type,
+            "status": {"$in": list(_ACTIVE_STATUSES)},
+            "input_params.clip_id": str(clip_id),
+        }
+    )
+
 
 async def create_extraction_job(
     *,
@@ -30,9 +45,17 @@ async def create_extraction_job(
     everything else (audio bytes, BPM) from the clip document at run time.
     ``workspace_id`` is the source clip's workspace so derived stems land next
     to their parent. Returns the saved :class:`Job` (with its id).
+
+    Extraction is idempotent per clip: if a job of the same type for this clip is
+    already queued or processing, that job is returned instead of enqueuing a
+    competitor — two concurrent workers would otherwise race (the second's
+    stale-stem cleanup could delete the first's just-stored results).
     """
     if job_type not in EXTRACTION_JOB_TYPES:
         raise ValueError(f"Unknown extraction job type: {job_type!r}")
+    active = await _find_active_job(job_type, clip_id)
+    if active is not None:
+        return active
     job = Job(
         user_id=user_id,
         workspace_id=workspace_id,

--- a/src/acemusic/api/services/extraction.py
+++ b/src/acemusic/api/services/extraction.py
@@ -6,7 +6,11 @@ Kept transport-agnostic (plain exceptions, never ``HTTPException``) like the
 other service modules.
 """
 
+import asyncio
+
 from beanie import PydanticObjectId
+
+from acemusic.storage import get_storage_backend
 
 from ..models import Job, JobStatus
 from ..tasks import dispatch_job
@@ -19,6 +23,21 @@ EXTRACTION_JOB_TYPES = (STEMS_JOB_TYPE, MIDI_JOB_TYPE)
 # A job is still "in flight" (a worker may pick it up or already has) in these
 # states; a second request for the same clip rides it rather than competing.
 _ACTIVE_STATUSES = (JobStatus.QUEUED.value, JobStatus.PROCESSING.value)
+
+
+async def resolve_midi_urls(midi_paths: dict[str, str]) -> dict[str, str]:
+    """Resolve stored MIDI keys (label -> storage key) to retrievable URLs.
+
+    URLs are generated fresh per call (S3 presigned URLs expire) and the raw
+    keys are never exposed, mirroring how clip audio URLs are served. Shared by
+    the MIDI retrieval endpoint and the job-status endpoint.
+    """
+    storage = get_storage_backend()
+    urls: dict[str, str] = {}
+    for label, key in midi_paths.items():
+        # get_url may hit the network (S3 presign), so keep it off the event loop.
+        urls[label] = await asyncio.to_thread(storage.get_url, key)
+    return urls
 
 
 async def _find_active_job(job_type: str, clip_id: PydanticObjectId) -> Job | None:

--- a/src/acemusic/api/services/extraction.py
+++ b/src/acemusic/api/services/extraction.py
@@ -1,0 +1,53 @@
+"""Extraction service layer (US-10.2).
+
+Persists queued stem-separation and MIDI-extraction jobs for the extraction
+endpoints, mirroring :func:`acemusic.api.services.editing.create_edit_job`.
+Kept transport-agnostic (plain exceptions, never ``HTTPException``) like the
+other service modules.
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import Job, JobStatus
+from ..tasks import dispatch_job
+
+STEMS_JOB_TYPE = "stems"
+MIDI_JOB_TYPE = "midi"
+
+EXTRACTION_JOB_TYPES = (STEMS_JOB_TYPE, MIDI_JOB_TYPE)
+
+
+async def create_extraction_job(
+    *,
+    user_id: PydanticObjectId,
+    workspace_id: PydanticObjectId,
+    job_type: str,
+    clip_id: PydanticObjectId,
+) -> Job:
+    """Persist a queued extraction job and dispatch it.
+
+    ``input_params`` carries only the source ``clip_id``; the worker re-reads
+    everything else (audio bytes, BPM) from the clip document at run time.
+    ``workspace_id`` is the source clip's workspace so derived stems land next
+    to their parent. Returns the saved :class:`Job` (with its id).
+    """
+    if job_type not in EXTRACTION_JOB_TYPES:
+        raise ValueError(f"Unknown extraction job type: {job_type!r}")
+    job = Job(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        job_type=job_type,
+        status=JobStatus.QUEUED,
+        input_params={"clip_id": str(clip_id)},
+    )
+    await job.insert()
+    try:
+        await dispatch_job(str(job.id))
+    except BaseException:
+        # Don't leave the job behind: the processor polls for QUEUED documents,
+        # so an orphan would still run even though the caller saw a failure.
+        # BaseException (not Exception) on purpose: asyncio.CancelledError must
+        # also clean up (mirrors create_edit_job).
+        await job.delete()
+        raise
+    return job

--- a/src/acemusic/api/tasks/extraction.py
+++ b/src/acemusic/api/tasks/extraction.py
@@ -1,0 +1,230 @@
+"""Extraction job handlers (US-10.2): stem-separation and MIDI workers.
+
+Each handler runs one claimed extraction :class:`~acemusic.api.models.job.Job`:
+download the source clip's audio from storage into a temp file, run the
+corresponding CPU-bound CLI client (:class:`~acemusic.stems_client.StemsClient`
+or :class:`~acemusic.midi_client.MidiClient`) in a worker thread, upload the
+results, and record them.
+
+* **Stems** become four child :class:`~acemusic.api.models.clip.Clip` records
+  (``generation_mode="stems"``) with lineage back to the source, mirroring how
+  the editing handlers store derived clips.
+* **MIDI** files are *not* clips — they are uploaded as ``.mid`` objects and
+  referenced from the source clip's ``midi_paths`` map, which is both the cache
+  and the retrieval source.
+
+Handlers receive the storage backend from the :class:`JobProcessor` (which owns
+the factory seam) and return the dict persisted as ``job.result``; exceptions
+propagate and the processor marks the job failed. The source clip — bytes and
+document — is never modified except to attach ``midi_paths``.
+
+``StemsClient`` and ``MidiClient`` are imported at module scope so tests can
+substitute lightweight doubles without running the real demucs / basic-pitch
+models (the extraction algorithms themselves are covered by US-5.3 / US-5.4).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from beanie import PydanticObjectId
+
+from acemusic.midi_client import MIDI_OUTPUT_LABELS, MidiClient
+from acemusic.stems_client import STEM_LABELS, StemsClient
+from acemusic.storage import StorageBackend
+
+from ..models import Clip, Job
+from ..services.clips import native_format
+from ..services.extraction import MIDI_JOB_TYPE, STEMS_JOB_TYPE
+
+logger = logging.getLogger(__name__)
+
+# Default sample rate if the stems client does not expose ``model_samplerate``
+# (mirrors acemusic.daw_export); test doubles need not load a real model.
+_DEFAULT_SAMPLE_RATE = 44100
+
+
+class ExtractionProcessingError(Exception):
+    """An extraction job could not be processed (missing source, ML failure)."""
+
+
+async def _load_source_clip(job: Job) -> Clip:
+    """Resolve the job's source clip, or fail the job with a clear error.
+
+    The clip may legitimately vanish between enqueue and processing (the owner
+    can DELETE it while the job is queued), so a miss is a job failure, not a
+    crash (mirrors the editing handlers).
+    """
+    clip_id = (job.input_params or {}).get("clip_id")
+    try:
+        oid = PydanticObjectId(clip_id)
+    except Exception as exc:
+        raise ExtractionProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
+    clip = await Clip.get(oid)
+    if clip is None:
+        raise ExtractionProcessingError(f"Source clip {clip_id} no longer exists")
+    return clip
+
+
+async def _download_source(storage: StorageBackend, source: Clip, dest: Path) -> None:
+    try:
+        data = await asyncio.to_thread(storage.download, source.file_path)
+    except FileNotFoundError as exc:
+        raise ExtractionProcessingError(
+            f"Source clip {source.id} audio object {source.file_path!r} is missing"
+        ) from exc
+    dest.write_bytes(data)
+
+
+def _separate_stems(source_path: Path, output_dir: Path, base_name: str) -> dict[str, Path]:
+    """Run demucs separation and write the stems (sync; called via ``to_thread``)."""
+    client = StemsClient()
+    stems = client.separate(source_path)
+    sample_rate = getattr(client, "model_samplerate", _DEFAULT_SAMPLE_RATE)
+    return client.save_stems(stems, output_dir, base_name, sample_rate=sample_rate, output_format="wav")
+
+
+def _extract_midi(source_path: Path, output_dir: Path, base_name: str, bpm: float) -> dict[str, Path]:
+    """Run basic-pitch extraction and write the MIDI files (sync; via ``to_thread``)."""
+    client = MidiClient()
+    extracted = client.extract(source_path)
+    return client.save_midi(extracted, output_dir, base_name, bpm=bpm)
+
+
+async def process_stems_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
+    """Separate the source into stems and store each as a linked child clip.
+
+    A failure partway through (upload/insert error on a later stem) rolls back
+    the clips and files already written, so a job that ends up ``failed`` never
+    leaves orphaned ``Clip`` rows or storage objects behind (mirrors the
+    generate path's rollback).
+    """
+    source = await _load_source_clip(job)
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-stems-") as tmp_dir:
+        input_path = Path(tmp_dir) / f"source.{native_format(source)}"
+        await _download_source(storage, source, input_path)
+        stem_paths = await asyncio.to_thread(_separate_stems, input_path, Path(tmp_dir), str(source.id))
+        # Read the produced stem bytes while the temp dir still exists, in the
+        # canonical label order so the result is deterministic.
+        produced = [(label, Path(stem_paths[label]).read_bytes()) for label in STEM_LABELS if label in stem_paths]
+
+    if not produced:
+        raise ExtractionProcessingError(f"Stem separation produced no output for clip {source.id}")
+
+    clip_ids = await _store_stem_clips(job, source, storage, produced)
+    return {"clip_ids": clip_ids}
+
+
+async def _store_stem_clips(
+    job: Job,
+    source: Clip,
+    storage: StorageBackend,
+    produced: list[tuple[str, bytes]],
+) -> list[str]:
+    """Upload each stem and insert its child Clip; roll back on any failure."""
+    clip_ids: list[str] = []
+    stored: list[tuple[Clip, str]] = []
+    try:
+        for label, data in produced:
+            clip_id = PydanticObjectId()
+            path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.wav"
+            await asyncio.to_thread(storage.upload, path, data)
+            clip = Clip(
+                id=clip_id,
+                user_id=job.user_id,
+                workspace_id=job.workspace_id,
+                file_path=path,
+                title=label,
+                format="wav",
+                # Stems are the same length as the source mix (time-aligned).
+                duration=source.duration,
+                bpm=source.bpm,
+                key=source.key,
+                parent_clip_ids=[source.id],
+                generation_mode=STEMS_JOB_TYPE,
+            )
+            await clip.insert()
+            stored.append((clip, path))
+            clip_ids.append(str(clip_id))
+    except Exception:
+        await _rollback_clips(storage, stored)
+        raise
+    return clip_ids
+
+
+async def _rollback_clips(storage: StorageBackend, stored: list[tuple[Clip, str]]) -> None:
+    """Best-effort cleanup of stem clips/files written before a mid-batch failure."""
+    for clip, path in stored:
+        try:
+            await clip.delete()
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned stem clip %s during rollback", clip.id)
+        try:
+            await asyncio.to_thread(storage.delete, path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned storage object %s during rollback", path)
+
+
+async def process_midi_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
+    """Extract MIDI from the source and store the files (not as clips).
+
+    The uploaded ``.mid`` objects are referenced from the source clip's
+    ``midi_paths`` map, which both caches the result and drives retrieval. A
+    failure after some uploads cleans them up so a failed job leaves no orphans
+    and never half-populates ``midi_paths``.
+    """
+    source = await _load_source_clip(job)
+    bpm = float(source.bpm) if source.bpm is not None else 120.0
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-midi-") as tmp_dir:
+        input_path = Path(tmp_dir) / f"source.{native_format(source)}"
+        await _download_source(storage, source, input_path)
+        midi_files = await asyncio.to_thread(_extract_midi, input_path, Path(tmp_dir), str(source.id), bpm)
+        produced = [
+            (label, Path(midi_files[label]).read_bytes()) for label in MIDI_OUTPUT_LABELS if label in midi_files
+        ]
+
+    if not produced:
+        raise ExtractionProcessingError(f"MIDI extraction produced no output for clip {source.id}")
+
+    midi_paths = await _store_midi_files(job, source, storage, produced)
+    # Record the artifacts on the parent clip: this is the cache + retrieval
+    # source. Use a targeted ``$set`` rather than a full ``save()``: the job can
+    # run for minutes, during which the owner may have edited the clip (e.g.
+    # renamed it); a full-document save of our stale copy would clobber that.
+    await source.set({Clip.midi_paths: midi_paths})
+    return {"midi_paths": midi_paths}
+
+
+async def _store_midi_files(
+    job: Job,
+    source: Clip,
+    storage: StorageBackend,
+    produced: list[tuple[str, bytes]],
+) -> dict[str, str]:
+    """Upload each MIDI file under the per-clip midi prefix; roll back on failure."""
+    midi_paths: dict[str, str] = {}
+    try:
+        for label, data in produced:
+            path = f"{job.user_id}/{job.workspace_id}/clips/{source.id}/midi/{label}.mid"
+            await asyncio.to_thread(storage.upload, path, data)
+            midi_paths[label] = path
+    except Exception:
+        for path in midi_paths.values():
+            try:
+                await asyncio.to_thread(storage.delete, path)
+            except Exception:  # pragma: no cover - cleanup is best-effort
+                logger.exception("Failed to delete orphaned MIDI object %s during rollback", path)
+        raise
+    return midi_paths
+
+
+EXTRACTION_JOB_HANDLERS = {
+    STEMS_JOB_TYPE: process_stems_job,
+    MIDI_JOB_TYPE: process_midi_job,
+}

--- a/src/acemusic/api/tasks/extraction.py
+++ b/src/acemusic/api/tasks/extraction.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any
 
 from beanie import PydanticObjectId
+from beanie.operators import In
 
 from acemusic.midi_client import MIDI_OUTPUT_LABELS, MidiClient
 from acemusic.stems_client import STEM_LABELS, StemsClient
@@ -116,8 +117,27 @@ async def process_stems_job(job: Job, storage: StorageBackend) -> dict[str, Any]
     if not produced:
         raise ExtractionProcessingError(f"Stem separation produced no output for clip {source.id}")
 
+    # Re-extraction (only reached when the cached set is incomplete — a complete
+    # set short-circuits in the router) replaces any leftover stem children so
+    # the result is a single, complete set rather than a duplicated mix.
+    await _delete_existing_stems(source, storage)
+
     clip_ids = await _store_stem_clips(job, source, storage, produced)
     return {"clip_ids": clip_ids}
+
+
+async def _delete_existing_stems(source: Clip, storage: StorageBackend) -> None:
+    """Remove any prior stem children of ``source`` (clip docs + audio objects)."""
+    existing = await Clip.find(
+        In(Clip.parent_clip_ids, [source.id]),
+        Clip.generation_mode == STEMS_JOB_TYPE,
+    ).to_list()
+    for clip in existing:
+        try:
+            await asyncio.to_thread(storage.delete, clip.file_path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete stale stem object %s", clip.file_path)
+        await clip.delete()
 
 
 async def _store_stem_clips(
@@ -126,14 +146,21 @@ async def _store_stem_clips(
     storage: StorageBackend,
     produced: list[tuple[str, bytes]],
 ) -> list[str]:
-    """Upload each stem and insert its child Clip; roll back on any failure."""
+    """Upload each stem and insert its child Clip; roll back on any failure.
+
+    Uploaded paths are tracked the moment the upload returns — *before* the
+    insert — so a clip insert that fails after its object is already stored
+    still has that object cleaned up (not just the earlier, fully-stored ones).
+    """
     clip_ids: list[str] = []
-    stored: list[tuple[Clip, str]] = []
+    inserted: list[Clip] = []
+    uploaded_paths: list[str] = []
     try:
         for label, data in produced:
             clip_id = PydanticObjectId()
             path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.wav"
             await asyncio.to_thread(storage.upload, path, data)
+            uploaded_paths.append(path)
             clip = Clip(
                 id=clip_id,
                 user_id=job.user_id,
@@ -149,21 +176,22 @@ async def _store_stem_clips(
                 generation_mode=STEMS_JOB_TYPE,
             )
             await clip.insert()
-            stored.append((clip, path))
+            inserted.append(clip)
             clip_ids.append(str(clip_id))
     except Exception:
-        await _rollback_clips(storage, stored)
+        await _rollback_clips(storage, inserted, uploaded_paths)
         raise
     return clip_ids
 
 
-async def _rollback_clips(storage: StorageBackend, stored: list[tuple[Clip, str]]) -> None:
+async def _rollback_clips(storage: StorageBackend, inserted: list[Clip], uploaded_paths: list[str]) -> None:
     """Best-effort cleanup of stem clips/files written before a mid-batch failure."""
-    for clip, path in stored:
+    for clip in inserted:
         try:
             await clip.delete()
         except Exception:  # pragma: no cover - cleanup is best-effort
             logger.exception("Failed to delete orphaned stem clip %s during rollback", clip.id)
+    for path in uploaded_paths:
         try:
             await asyncio.to_thread(storage.delete, path)
         except Exception:  # pragma: no cover - cleanup is best-effort
@@ -197,8 +225,23 @@ async def process_midi_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
     # source. Use a targeted ``$set`` rather than a full ``save()``: the job can
     # run for minutes, during which the owner may have edited the clip (e.g.
     # renamed it); a full-document save of our stale copy would clobber that.
-    await source.set({Clip.midi_paths: midi_paths})
+    # If the update fails, the uploaded files would be unreferenced — delete them
+    # so a failed job leaves no orphaned objects.
+    try:
+        await source.set({Clip.midi_paths: midi_paths})
+    except Exception:
+        await _delete_midi_objects(storage, midi_paths.values())
+        raise
     return {"midi_paths": midi_paths}
+
+
+async def _delete_midi_objects(storage: StorageBackend, paths) -> None:
+    """Best-effort removal of uploaded MIDI objects (rollback / clip deletion)."""
+    for path in paths:
+        try:
+            await asyncio.to_thread(storage.delete, path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned MIDI object %s", path)
 
 
 async def _store_midi_files(
@@ -215,11 +258,7 @@ async def _store_midi_files(
             await asyncio.to_thread(storage.upload, path, data)
             midi_paths[label] = path
     except Exception:
-        for path in midi_paths.values():
-            try:
-                await asyncio.to_thread(storage.delete, path)
-            except Exception:  # pragma: no cover - cleanup is best-effort
-                logger.exception("Failed to delete orphaned MIDI object %s during rollback", path)
+        await _delete_midi_objects(storage, list(midi_paths.values()))
         raise
     return midi_paths
 

--- a/src/acemusic/api/tasks/extraction.py
+++ b/src/acemusic/api/tasks/extraction.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -235,7 +236,7 @@ async def process_midi_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
     return {"midi_paths": midi_paths}
 
 
-async def _delete_midi_objects(storage: StorageBackend, paths) -> None:
+async def _delete_midi_objects(storage: StorageBackend, paths: Iterable[str]) -> None:
     """Best-effort removal of uploaded MIDI objects (rollback / clip deletion)."""
     for path in paths:
         try:

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -35,6 +35,7 @@ from .. import database
 from ..models import Clip, Job, JobStatus
 from ..models.common import utcnow
 from .editing import EDIT_JOB_HANDLERS
+from .extraction import EXTRACTION_JOB_HANDLERS
 
 logger = logging.getLogger(__name__)
 
@@ -116,8 +117,10 @@ class JobProcessor:
         # (and re-queued when stale), so jobs another deployment owns are left
         # alone. ``handlers`` lets callers add or override entries.
         self._handlers: dict[str, JobHandler] = {"generate": self._handle_generate}
-        for job_type, edit_handler in EDIT_JOB_HANDLERS.items():
-            self._handlers[job_type] = partial(self._run_edit_handler, edit_handler)
+        # Editing and extraction handlers share the same ``(job, storage)``
+        # contract, so both are adapted onto the registry the same way.
+        for job_type, storage_handler in {**EDIT_JOB_HANDLERS, **EXTRACTION_JOB_HANDLERS}.items():
+            self._handlers[job_type] = partial(self._run_edit_handler, storage_handler)
         if handlers:
             self._handlers.update(handlers)
         self._running = False
@@ -264,9 +267,9 @@ class JobProcessor:
             logger.exception("Job %s failed", job.id)
             await self._mark_failed(job, str(exc))
 
-    async def _run_edit_handler(self, edit_handler: Any, job: Job) -> dict[str, Any]:
-        """Adapt an editing handler ``(job, storage) -> result`` to the registry."""
-        return await edit_handler(job, self._storage_factory())
+    async def _run_edit_handler(self, storage_handler: Any, job: Job) -> dict[str, Any]:
+        """Adapt a ``(job, storage) -> result`` handler (editing/extraction) to the registry."""
+        return await storage_handler(job, self._storage_factory())
 
     async def _handle_generate(self, job: Job) -> dict[str, Any]:
         """Run an ACE-Step generation job: submit, poll, store clips."""

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -120,7 +120,7 @@ class JobProcessor:
         # Editing and extraction handlers share the same ``(job, storage)``
         # contract, so both are adapted onto the registry the same way.
         for job_type, storage_handler in {**EDIT_JOB_HANDLERS, **EXTRACTION_JOB_HANDLERS}.items():
-            self._handlers[job_type] = partial(self._run_edit_handler, storage_handler)
+            self._handlers[job_type] = partial(self._run_storage_handler, storage_handler)
         if handlers:
             self._handlers.update(handlers)
         self._running = False
@@ -267,7 +267,7 @@ class JobProcessor:
             logger.exception("Job %s failed", job.id)
             await self._mark_failed(job, str(exc))
 
-    async def _run_edit_handler(self, storage_handler: Any, job: Job) -> dict[str, Any]:
+    async def _run_storage_handler(self, storage_handler: Any, job: Job) -> dict[str, Any]:
         """Adapt a ``(job, storage) -> result`` handler (editing/extraction) to the registry."""
         return await storage_handler(job, self._storage_factory())
 

--- a/tests/test_clips_midi_api.py
+++ b/tests/test_clips_midi_api.py
@@ -1,0 +1,360 @@
+"""Tests for the MIDI-extraction endpoints (US-10.2, issue #82).
+
+Covers ``POST /clips/{id}/midi`` (enqueue or cache-hit) and
+``GET /clips/{id}/midi`` (download URLs). MIDI files are stored as objects, not
+clip records, and referenced from ``Clip.midi_paths``. The 401 auth-gate test
+runs in CI (no DB); the rest are ``integration``.
+
+The end-to-end lifecycle test substitutes a lightweight ``MidiClient`` double so
+the real basic-pitch model never runs — the extraction algorithm itself is
+covered by US-5.4 (``tests/test_midi.py``); here we verify the API/job wiring.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+
+import mido
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Job, JobStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+JOBS_URL = f"{API_V1_PREFIX}/jobs"
+
+MIDI_LABELS = ["melody", "chords", "drums", "bass"]
+
+
+def _midi_url(clip_id) -> str:
+    return f"{CLIPS_URL}/{clip_id}/midi"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize("method", ["post", "get"])
+    def test_missing_auth_header_returns_401(self, method: str) -> None:
+        client = TestClient(create_app())
+        resp = getattr(client, method)(_midi_url(PydanticObjectId()))
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app):
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(
+    user,
+    workspace: Workspace,
+    *,
+    duration: float | None = 10.0,
+    bpm: int | None = None,
+    fmt: str | None = "wav",
+    store_bytes: bytes | None = None,
+    midi_paths: dict | None = None,
+) -> Clip:
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt or 'wav'}"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=file_path,
+        format=fmt,
+        duration=duration,
+        bpm=bpm,
+        midi_paths=midi_paths,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _user_with_clip(email: str, **clip_kwargs):
+    user = await _make_user(email)
+    workspace = await _make_workspace(user)
+    clip = await _insert_clip(user, workspace, **clip_kwargs)
+    return user, workspace, clip
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown / malformed / other-user clip ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestClipNotFound:
+    @pytest.mark.parametrize("method", ["post", "get"])
+    async def test_unknown_clip_returns_404(self, client, settings, method: str) -> None:
+        user = await _make_user(f"midi-404-{method}@example.com")
+        resp = await getattr(client, method)(_midi_url(PydanticObjectId()), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("method", ["post", "get"])
+    async def test_malformed_id_returns_404(self, client, settings, method: str) -> None:
+        user = await _make_user(f"midi-malformed-{method}@example.com")
+        resp = await getattr(client, method)(_midi_url("not-an-object-id"), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("method", ["post", "get"])
+    async def test_other_users_clip_returns_404(self, client, settings, method: str) -> None:
+        _, _, clip = await _user_with_clip(f"midi-owner-{method}@example.com")
+        other = await _make_user(f"midi-other-{method}@example.com")
+        resp = await getattr(client, method)(_midi_url(clip.id), headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 422 — non-wav source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestFormatGate:
+    @pytest.mark.parametrize("fmt", ["mp3", "aac", "opus", "flac"])
+    async def test_non_wav_clip_returns_422(self, client, settings, fmt: str) -> None:
+        user, _, clip = await _user_with_clip(f"midi-fmt-{fmt}@example.com", fmt=fmt)
+        resp = await client.post(_midi_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert fmt in resp.json()["detail"]
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 202 — job enqueue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestMidiEnqueue:
+    async def test_returns_202_and_persists_job(self, client, settings) -> None:
+        user, workspace, clip = await _user_with_clip("midi-202@example.com")
+        resp = await client.post(_midi_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+
+        jobs = await Job.find_all().to_list()
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert str(job.id) == body["job_id"]
+        assert job.job_type == "midi"
+        assert job.status == JobStatus.QUEUED
+        assert job.workspace_id == workspace.id
+        assert job.input_params == {"clip_id": str(clip.id)}
+
+
+# ---------------------------------------------------------------------------
+# GET — 404 when absent, URLs when present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGetMidi:
+    async def test_get_returns_404_when_not_extracted(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("midi-get-404@example.com")
+        resp = await client.get(_midi_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_get_returns_download_urls_after_extraction(self, client, settings, local_storage) -> None:
+        user, workspace, clip = await _user_with_clip("midi-get-ok@example.com")
+        # Simulate a completed extraction: files in storage + midi_paths on the clip.
+        storage = get_storage_backend()
+        midi_paths = {}
+        for label in ("melody", "bass"):
+            key = f"{user.id}/{workspace.id}/clips/{clip.id}/midi/{label}.mid"
+            storage.upload(key, b"MThd")
+            midi_paths[label] = key
+        clip.midi_paths = midi_paths
+        await clip.save()
+
+        resp = await client.get(_midi_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["parent_clip_id"] == str(clip.id)
+        assert set(body["download_urls"]) == {"melody", "bass"}
+        assert all(body["download_urls"].values())
+
+
+# ---------------------------------------------------------------------------
+# Cache — POST returns existing MIDI with 200 instead of enqueuing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestMidiCache:
+    async def test_post_returns_200_with_cached_midi(self, client, settings, local_storage) -> None:
+        user, workspace, clip = await _user_with_clip("midi-cache@example.com")
+        storage = get_storage_backend()
+        key = f"{user.id}/{workspace.id}/clips/{clip.id}/midi/melody.mid"
+        storage.upload(key, b"MThd")
+        clip.midi_paths = {"melody": key}
+        await clip.save()
+
+        resp = await client.post(_midi_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert set(resp.json()["download_urls"]) == {"melody"}
+        assert await Job.count() == 0
+
+    async def test_cache_hit_works_even_for_non_wav_source(self, client, settings, local_storage) -> None:
+        # The cache check precedes the wav gate: an mp3 clip that already has
+        # MIDI still returns it rather than 422.
+        user, workspace, clip = await _user_with_clip("midi-cache-mp3@example.com", fmt="mp3")
+        storage = get_storage_backend()
+        key = f"{user.id}/{workspace.id}/clips/{clip.id}/midi/melody.mid"
+        storage.upload(key, b"MThd")
+        clip.midi_paths = {"melody": key}
+        await clip.save()
+
+        resp = await client.post(_midi_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end lifecycle with a stubbed MidiClient
+# ---------------------------------------------------------------------------
+
+
+class _FakeMidiClient:
+    """Writes minimal valid MIDI files without running basic-pitch."""
+
+    def extract(self, audio_path, from_stems=False, stem_paths=None, progress_callback=None):
+        return {label: [] for label in MIDI_LABELS}
+
+    def save_midi(self, midi_data, output_dir, base_name, bpm=120.0):
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        paths = {}
+        # Only melody and bass "have notes" — exercises the up-to-4 / subset case.
+        for label in ("melody", "bass"):
+            mid = mido.MidiFile(type=1)
+            track = mido.MidiTrack()
+            mid.tracks.append(track)
+            track.append(mido.MetaMessage("track_name", name=label, time=0))
+            track.append(mido.MetaMessage("end_of_track", time=0))
+            path = output_dir / f"{base_name}-{label}.mid"
+            mid.save(str(path))
+            paths[label] = path
+        return paths
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path / "storage"))
+    return tmp_path
+
+
+@pytest.mark.integration
+class TestMidiLifecycleEndToEnd:
+    async def test_midi_runs_to_completed_and_stores_files_not_clips(
+        self, client, settings, local_storage, write_tone, monkeypatch
+    ) -> None:
+        from acemusic.api.tasks import extraction as extraction_tasks
+        from acemusic.api.tasks.processor import JobProcessor
+
+        monkeypatch.setattr(extraction_tasks, "MidiClient", _FakeMidiClient)
+
+        user = await _make_user("midi-e2e@example.com")
+        workspace = await _make_workspace(user)
+        tone_path = local_storage / "tone.wav"
+        write_tone(tone_path, duration_s=2.0)
+        clip = await _insert_clip(user, workspace, duration=2.0, bpm=120, store_bytes=tone_path.read_bytes())
+        headers = _auth_headers(user, settings)
+        clips_before = await Clip.count()
+
+        accepted = await client.post(_midi_url(clip.id), headers=headers)
+        assert accepted.status_code == 202
+        job_id = accepted.json()["job_id"]
+
+        processor = JobProcessor(concurrency=1, poll_interval=0.05)
+        await processor.start()
+        try:
+            status_body = None
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                resp = await client.get(f"{JOBS_URL}/{job_id}/status", headers=headers)
+                assert resp.status_code == 200
+                status_body = resp.json()
+                assert status_body["status"] in {"queued", "processing", "completed"}, status_body.get("error")
+                if status_body["status"] == "completed":
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            await processor.stop()
+        assert status_body is not None and status_body["status"] == "completed", "midi job never completed"
+
+        # AC: job status is trackable through completion — the completed MIDI job
+        # surfaces resolved download URLs (not raw storage keys, and not clips).
+        assert set(status_body["midi_download_urls"]) == {"melody", "bass"}
+        assert "clip_ids" not in status_body  # excluded when None
+
+        # AC: downloadable .mid files, and NOT clip records (no new clips created).
+        assert await Clip.count() == clips_before
+        reloaded = await Clip.get(clip.id)
+        assert set(reloaded.midi_paths) == {"melody", "bass"}
+
+        get_resp = await client.get(_midi_url(clip.id), headers=headers)
+        assert get_resp.status_code == 200
+        urls = get_resp.json()["download_urls"]
+        assert set(urls) == {"melody", "bass"}
+        # The resolved local-storage URL points at a real .mid file on disk.
+        for url in urls.values():
+            assert Path(url).read_bytes().startswith(b"MThd")

--- a/tests/test_clips_midi_api.py
+++ b/tests/test_clips_midi_api.py
@@ -303,6 +303,26 @@ def local_storage(monkeypatch, tmp_path):
 
 
 @pytest.mark.integration
+class TestMidiCleanupOnClipDelete:
+    async def test_deleting_clip_removes_its_midi_objects(self, client, settings, local_storage) -> None:
+        # MIDI files live under their own keys (not file_path); deleting the
+        # parent clip must remove them too, not just the source audio.
+        user, workspace, clip = await _user_with_clip(
+            "midi-delete@example.com", store_bytes=b"RIFFsource"
+        )
+        storage = get_storage_backend()
+        key = f"{user.id}/{workspace.id}/clips/{clip.id}/midi/melody.mid"
+        storage.upload(key, b"MThd")
+        clip.midi_paths = {"melody": key}
+        await clip.save()
+
+        resp = await client.delete(f"{CLIPS_URL}/{clip.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 204
+        with pytest.raises(FileNotFoundError):
+            storage.download(key)
+
+
+@pytest.mark.integration
 class TestMidiLifecycleEndToEnd:
     async def test_midi_runs_to_completed_and_stores_files_not_clips(
         self, client, settings, local_storage, write_tone, monkeypatch

--- a/tests/test_clips_midi_api.py
+++ b/tests/test_clips_midi_api.py
@@ -307,9 +307,7 @@ class TestMidiCleanupOnClipDelete:
     async def test_deleting_clip_removes_its_midi_objects(self, client, settings, local_storage) -> None:
         # MIDI files live under their own keys (not file_path); deleting the
         # parent clip must remove them too, not just the source audio.
-        user, workspace, clip = await _user_with_clip(
-            "midi-delete@example.com", store_bytes=b"RIFFsource"
-        )
+        user, workspace, clip = await _user_with_clip("midi-delete@example.com", store_bytes=b"RIFFsource")
         storage = get_storage_backend()
         key = f"{user.id}/{workspace.id}/clips/{clip.id}/midi/melody.mid"
         storage.upload(key, b"MThd")

--- a/tests/test_clips_stems_api.py
+++ b/tests/test_clips_stems_api.py
@@ -164,17 +164,13 @@ class TestClipNotFound:
     @pytest.mark.parametrize("method", ["post", "get"])
     async def test_unknown_clip_returns_404(self, client, settings, method: str) -> None:
         user = await _make_user(f"stems-404-{method}@example.com")
-        resp = await getattr(client, method)(
-            _stems_url(PydanticObjectId()), headers=_auth_headers(user, settings)
-        )
+        resp = await getattr(client, method)(_stems_url(PydanticObjectId()), headers=_auth_headers(user, settings))
         assert resp.status_code == 404
 
     @pytest.mark.parametrize("method", ["post", "get"])
     async def test_malformed_id_returns_404(self, client, settings, method: str) -> None:
         user = await _make_user(f"stems-malformed-{method}@example.com")
-        resp = await getattr(client, method)(
-            _stems_url("not-an-object-id"), headers=_auth_headers(user, settings)
-        )
+        resp = await getattr(client, method)(_stems_url("not-an-object-id"), headers=_auth_headers(user, settings))
         assert resp.status_code == 404
 
     @pytest.mark.parametrize("method", ["post", "get"])

--- a/tests/test_clips_stems_api.py
+++ b/tests/test_clips_stems_api.py
@@ -245,6 +245,14 @@ class TestGetStems:
         resp = await client.get(_stems_url(clip.id), headers=_auth_headers(user, settings))
         assert resp.status_code == 404
 
+    async def test_get_returns_404_for_partial_set(self, client, settings) -> None:
+        # A partial set (one stem child deleted) is reported as "not separated",
+        # matching the POST cache check — never a result missing required labels.
+        user, _, clip = await _user_with_clip("stems-get-partial@example.com")
+        await _insert_stem_children(clip, labels=["drums", "bass", "other"])  # missing vocals
+        resp = await client.get(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
     async def test_get_returns_stem_ids_after_extraction(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("stems-get-ok@example.com")
         children = await _insert_stem_children(clip)

--- a/tests/test_clips_stems_api.py
+++ b/tests/test_clips_stems_api.py
@@ -291,13 +291,23 @@ class TestStemsCache:
         assert await Job.count() == 0
 
     async def test_cache_hit_works_even_for_non_wav_source(self, client, settings) -> None:
-        # The cache check precedes the wav gate: an mp3 clip that already has
-        # stems still returns them rather than 422.
+        # The cache check precedes the wav gate: an mp3 clip that already has a
+        # *complete* stem set still returns it rather than 422.
         user, _, clip = await _user_with_clip("stems-cache-mp3@example.com", fmt="mp3")
         await _insert_stem_children(clip)
         resp = await client.post(_stems_url(clip.id), headers=_auth_headers(user, settings))
         assert resp.status_code == 200
         assert await Job.count() == 0
+
+    async def test_incomplete_cache_re_enqueues(self, client, settings) -> None:
+        # If the owner deleted one stem child, an incomplete set must not be
+        # served as a cache hit — re-POST enqueues a fresh separation (202).
+        user, _, clip = await _user_with_clip("stems-cache-partial@example.com")
+        await _insert_stem_children(clip, labels=["drums", "bass", "other"])  # missing vocals
+
+        resp = await client.post(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        assert await Job.count() == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clips_stems_api.py
+++ b/tests/test_clips_stems_api.py
@@ -1,0 +1,392 @@
+"""Tests for the stem-separation endpoints (US-10.2, issue #82).
+
+Covers ``POST /clips/{id}/stems`` (enqueue or cache-hit) and
+``GET /clips/{id}/stems`` (retrieve stem clip ids). The 401 auth-gate test runs
+in CI (no DB); the rest are ``integration`` and drive the real app with
+``httpx.AsyncClient`` over a local MongoDB.
+
+The end-to-end lifecycle test substitutes a lightweight ``StemsClient`` double so
+the real demucs model never runs — the separation algorithm itself is covered by
+US-5.3 (``tests/test_stems.py``); here we verify the API/job wiring.
+"""
+
+import asyncio
+import time
+
+import numpy as np
+import pytest
+import soundfile as sf
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Job, JobStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+JOBS_URL = f"{API_V1_PREFIX}/jobs"
+
+STEM_LABELS = ["drums", "bass", "other", "vocals"]
+
+
+def _stems_url(clip_id) -> str:
+    return f"{CLIPS_URL}/{clip_id}/stems"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB; plain TestClient does not run the lifespan)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize("method", ["post", "get"])
+    def test_missing_auth_header_returns_401(self, method: str) -> None:
+        client = TestClient(create_app())
+        resp = getattr(client, method)(_stems_url(PydanticObjectId()))
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app):
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # Disable the background processor by default: most tests assert on the
+    # queued job record and do not want a worker claiming it. The lifecycle
+    # test starts its own processor explicitly.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(
+    user,
+    workspace: Workspace,
+    *,
+    duration: float | None = 10.0,
+    bpm: int | None = None,
+    key: str | None = None,
+    fmt: str | None = "wav",
+    store_bytes: bytes | None = None,
+) -> Clip:
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt or 'wav'}"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=file_path,
+        format=fmt,
+        duration=duration,
+        bpm=bpm,
+        key=key,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _user_with_clip(email: str, **clip_kwargs):
+    user = await _make_user(email)
+    workspace = await _make_workspace(user)
+    clip = await _insert_clip(user, workspace, **clip_kwargs)
+    return user, workspace, clip
+
+
+async def _insert_stem_children(parent: Clip, labels=STEM_LABELS) -> list[Clip]:
+    """Pre-create the 4 stem child clips, as a completed separation would."""
+    children = []
+    for label in labels:
+        child = Clip(
+            user_id=parent.user_id,
+            workspace_id=parent.workspace_id,
+            file_path=f"{parent.user_id}/{parent.workspace_id}/clips/{PydanticObjectId()}.wav",
+            title=label,
+            format="wav",
+            duration=parent.duration,
+            parent_clip_ids=[parent.id],
+            generation_mode="stems",
+        )
+        await child.insert()
+        children.append(child)
+    return children
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown / malformed / other-user clip ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestClipNotFound:
+    @pytest.mark.parametrize("method", ["post", "get"])
+    async def test_unknown_clip_returns_404(self, client, settings, method: str) -> None:
+        user = await _make_user(f"stems-404-{method}@example.com")
+        resp = await getattr(client, method)(
+            _stems_url(PydanticObjectId()), headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("method", ["post", "get"])
+    async def test_malformed_id_returns_404(self, client, settings, method: str) -> None:
+        user = await _make_user(f"stems-malformed-{method}@example.com")
+        resp = await getattr(client, method)(
+            _stems_url("not-an-object-id"), headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("method", ["post", "get"])
+    async def test_other_users_clip_returns_404(self, client, settings, method: str) -> None:
+        _, _, clip = await _user_with_clip(f"stems-owner-{method}@example.com")
+        other = await _make_user(f"stems-other-{method}@example.com")
+        resp = await getattr(client, method)(_stems_url(clip.id), headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 422 — non-wav source (no ffmpeg on the server)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestFormatGate:
+    @pytest.mark.parametrize("fmt", ["mp3", "aac", "opus", "flac"])
+    async def test_non_wav_clip_returns_422(self, client, settings, fmt: str) -> None:
+        user, _, clip = await _user_with_clip(f"stems-fmt-{fmt}@example.com", fmt=fmt)
+        resp = await client.post(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert fmt in resp.json()["detail"]
+        assert await Job.count() == 0
+
+    async def test_missing_format_falls_back_to_wav_suffix(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("stems-fmt-none@example.com", fmt=None)
+        resp = await client.post(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        assert await Job.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 202 — job enqueue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestStemsEnqueue:
+    async def test_returns_202_and_persists_job(self, client, settings) -> None:
+        user, workspace, clip = await _user_with_clip("stems-202@example.com")
+        resp = await client.post(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+
+        jobs = await Job.find_all().to_list()
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert str(job.id) == body["job_id"]
+        assert job.job_type == "stems"
+        assert job.status == JobStatus.QUEUED
+        assert job.user_id == user.id
+        assert job.workspace_id == workspace.id
+        assert job.input_params == {"clip_id": str(clip.id)}
+
+
+# ---------------------------------------------------------------------------
+# GET — 404 when absent, results when present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGetStems:
+    async def test_get_returns_404_when_not_extracted(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("stems-get-404@example.com")
+        resp = await client.get(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_get_returns_stem_ids_after_extraction(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("stems-get-ok@example.com")
+        children = await _insert_stem_children(clip)
+
+        resp = await client.get(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["parent_clip_id"] == str(clip.id)
+        assert set(body["labels"]) == set(STEM_LABELS)
+        assert set(body["stem_clip_ids"]) == {str(c.id) for c in children}
+
+    async def test_stems_are_scoped_to_their_own_parent(self, client, settings) -> None:
+        # A second clip with its own stems must not leak into the first clip's
+        # results — guards the parent_clip_ids cache query.
+        user = await _make_user("stems-parent-isolation@example.com")
+        workspace = await _make_workspace(user)
+        clip_a = await _insert_clip(user, workspace)
+        clip_b = await _insert_clip(user, workspace)
+        children_a = await _insert_stem_children(clip_a)
+        await _insert_stem_children(clip_b)
+
+        resp = await client.get(_stems_url(clip_a.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert set(resp.json()["stem_clip_ids"]) == {str(c.id) for c in children_a}
+
+
+# ---------------------------------------------------------------------------
+# Cache — POST returns existing stems with 200 instead of enqueuing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestStemsCache:
+    async def test_post_returns_200_with_cached_stems(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("stems-cache@example.com")
+        children = await _insert_stem_children(clip)
+
+        resp = await client.post(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body["stem_clip_ids"]) == {str(c.id) for c in children}
+        assert set(body["labels"]) == set(STEM_LABELS)
+        # No duplicate job is created on a cache hit.
+        assert await Job.count() == 0
+
+    async def test_cache_hit_works_even_for_non_wav_source(self, client, settings) -> None:
+        # The cache check precedes the wav gate: an mp3 clip that already has
+        # stems still returns them rather than 422.
+        user, _, clip = await _user_with_clip("stems-cache-mp3@example.com", fmt="mp3")
+        await _insert_stem_children(clip)
+        resp = await client.post(_stems_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end lifecycle with a stubbed StemsClient
+# ---------------------------------------------------------------------------
+
+
+class _FakeStemsClient:
+    """Writes four short WAV stems without running demucs."""
+
+    model_samplerate = 44100
+
+    def separate(self, audio_path, progress_callback=None):
+        # The real return is a tensor dict; the handler only forwards it to
+        # save_stems, which we also stub, so an opaque marker per label suffices.
+        return {label: label for label in STEM_LABELS}
+
+    def save_stems(self, stems, output_dir, base_name, sample_rate=44100, output_format="wav"):
+        from pathlib import Path
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        paths = {}
+        tone = (0.2 * np.sin(2 * np.pi * 220 * np.linspace(0, 0.5, int(sample_rate * 0.5), endpoint=False))).astype(
+            np.float32
+        )
+        for label in STEM_LABELS:
+            path = output_dir / f"{base_name}-{label}.{output_format}"
+            sf.write(str(path), np.column_stack([tone, tone]), sample_rate)
+            paths[label] = path
+        return paths
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path / "storage"))
+    return tmp_path
+
+
+@pytest.mark.integration
+class TestStemsLifecycleEndToEnd:
+    async def test_stems_run_to_completed_and_create_four_linked_clips(
+        self, client, settings, local_storage, write_tone, monkeypatch
+    ) -> None:
+        from acemusic.api.tasks import extraction as extraction_tasks
+        from acemusic.api.tasks.processor import JobProcessor
+
+        monkeypatch.setattr(extraction_tasks, "StemsClient", _FakeStemsClient)
+
+        user = await _make_user("stems-e2e@example.com")
+        workspace = await _make_workspace(user)
+        tone_path = local_storage / "tone.wav"
+        write_tone(tone_path, duration_s=2.0)
+        clip = await _insert_clip(user, workspace, duration=2.0, bpm=120, store_bytes=tone_path.read_bytes())
+        headers = _auth_headers(user, settings)
+
+        accepted = await client.post(_stems_url(clip.id), headers=headers)
+        assert accepted.status_code == 202
+        job_id = accepted.json()["job_id"]
+
+        processor = JobProcessor(concurrency=1, poll_interval=0.05)
+        await processor.start()
+        try:
+            status_body = None
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                resp = await client.get(f"{JOBS_URL}/{job_id}/status", headers=headers)
+                assert resp.status_code == 200
+                status_body = resp.json()
+                assert status_body["status"] in {"queued", "processing", "completed"}, status_body.get("error")
+                if status_body["status"] == "completed":
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            await processor.stop()
+        assert status_body is not None and status_body["status"] == "completed", "stems job never completed"
+
+        # AC: 4 playable clips linked to the parent, time-aligned/equal length.
+        assert len(status_body["clip_ids"]) == 4
+        assert len(status_body["audio_urls"]) == 4
+        children = [await Clip.get(PydanticObjectId(cid)) for cid in status_body["clip_ids"]]
+        assert {c.title for c in children} == set(STEM_LABELS)
+        for child in children:
+            assert child.parent_clip_ids == [clip.id]
+            assert child.generation_mode == "stems"
+            assert child.duration == clip.duration  # equal length
+
+        # The endpoint now reports the cached stems.
+        get_resp = await client.get(_stems_url(clip.id), headers=headers)
+        assert get_resp.status_code == 200
+        assert set(get_resp.json()["stem_clip_ids"]) == set(status_body["clip_ids"])

--- a/tests/test_clips_stems_api.py
+++ b/tests/test_clips_stems_api.py
@@ -232,6 +232,19 @@ class TestStemsEnqueue:
         assert job.workspace_id == workspace.id
         assert job.input_params == {"clip_id": str(clip.id)}
 
+    async def test_double_submit_reuses_in_flight_job(self, client, settings) -> None:
+        # Two POSTs before the first completes must not create competing jobs —
+        # the second rides the queued one (idempotent per clip).
+        user, _, clip = await _user_with_clip("stems-dedup@example.com")
+        headers = _auth_headers(user, settings)
+
+        first = await client.post(_stems_url(clip.id), headers=headers)
+        second = await client.post(_stems_url(clip.id), headers=headers)
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert first.json()["job_id"] == second.json()["job_id"]
+        assert await Job.count() == 1
+
 
 # ---------------------------------------------------------------------------
 # GET — 404 when absent, results when present


### PR DESCRIPTION
## Summary

Implements #82 (US-10.2): stem-separation and MIDI-extraction API endpoints, wrapping the existing `StemsClient`/`MidiClient` as async background jobs. Built to mirror the merged US-10.1 editing trio (router + service + tasks), so it slots into the same `JobProcessor` and `/jobs/{id}/status` flow.

- **`POST/GET /api/v1/clips/{id}/stems`** — separate into 4 child clips (`generation_mode="stems"`, lineage via `parent_clip_ids`).
- **`POST/GET /api/v1/clips/{id}/midi`** — extract `.mid` files, stored as objects and referenced from the new `Clip.midi_paths` (MIDI files are **not** clip records).
- **Cache-first POST**: a clip with a complete stem set (or existing `midi_paths`) returns `200` instead of enqueuing a duplicate job.
- **Idempotent enqueue**: a second POST for a clip with an in-flight job rides that job rather than creating a competitor.
- **Trackable**: stems jobs surface `clip_ids`/`audio_urls`; MIDI jobs surface resolved `midi_download_urls` via `GET /jobs/{id}/status`.
- wav-only source gate (no ffmpeg on the server); no credits deducted (matches editing).

## Acceptance Criteria

- [x] Stem separation produces 4 playable audio clips linked to the parent
- [x] MIDI extraction produces downloadable `.mid` files
- [x] Re-requesting stems/MIDI for a clip that already has them returns cached results
- [x] Job status is trackable through completion
- [x] Stems are time-aligned and equal length (inherit the source duration)

## Test Plan

- [x] TDD; 43 new tests in `tests/test_clips_stems_api.py` + `tests/test_clips_midi_api.py`
- [x] All tests passing (extraction, plus jobs/clips-CRUD/processor/editing regression suites green)
- [x] Linting clean (ruff + black)
- [x] Internal code review (advisory) completed — findings fixed (atomic `$set` for `midi_paths`; MIDI status exposure)
- [x] Cross-family review pass: **codex** (`codex review --base main`) — 5 successive P2 lifecycle findings fixed across review rounds; final residual finding rebutted below
- [x] Test mutation sanity check: breaking the complete-set cache check fails 9 tests

## Known Limitations / Intentionally Deferred

- **Simultaneous duplicate-POST race (rebuttal, not fixed):** the per-clip enqueue de-dup is a check-then-insert, so two *truly concurrent* POSTs for the same clip could still create two jobs. Fully closing this needs a unique partial index on the shared `Job` collection, but Mongo `partialFilterExpression` can't express `status ∈ {queued, processing}` — a schema redesign of shared US-9.2 infra, out of scope for this endpoint-level issue. The existing `create_generation_job`/`create_edit_job` do **no** de-dup at all, so this is already an improvement for the realistic sequential/retry case; the residual case degrades gracefully (`_resolve_audio_urls` skips missing clips, and `_delete_existing_stems` + complete-set caching converge to one valid stem set).
- **Source must be wav** — stem/MIDI inputs round-trip through libraries needing ffmpeg for compressed formats (absent on the server); enforced at request time with a 422, matching the editing endpoints.
- **Stem children are not cascade-deleted** when the parent clip is deleted — consistent with all other derived clips (editing outputs); only the parent's own audio and its `midi_paths` objects are removed.
- **Credits** for stems/MIDI are deferred to US-14.1 (DAW export), where the spec actually scopes them.

## Implementation Notes

The issue's CodeRabbit plan predated Stage 9 (it assumed a CLI-only repo with no HTTP server) and invented `api/schemas/` + `api/jobs/` packages. Adapted to the real codebase: grouped stems+midi as a single `extraction` module mirroring the `editing` trio, and added `Clip.midi_paths` for MIDI cache/retrieval since the storage backend has no `list()`/`exists()`.

Closes #82
