### PR TITLE
feat(api): iterative generation endpoints (US-10.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AI-powered music generation platform built on **ACE-Step-1.5** (fork: `github.co
 3. **Layer 3 — Web UI** (Stages 15–21): Next.js frontend
 4. **Layer 4 — Advanced Integrations** (Stages 22–28): VST3 plugin, music video, voice models, credits, moderation
 
-**Current progress:** Stages 1–9 complete on `main`; Stage 10 in progress (US-10.1 audio editing, US-10.2 stems/MIDI extraction endpoints implemented). CLI foundation (Stages 1–7): generation, workspace management, audio processing, DAW export. Platform API (Stages 8–9): FastAPI with OAuth2 auth, async job queue, clip audio streaming, workspace/clip/preset CRUD, credit deduction. Audio editing API (US-10.1): crop, speed-adjust, and remaster endpoints enqueue async jobs that create derived clips with lineage tracking. Stems/MIDI extraction API (US-10.2): stem separation (4 child clips) and MIDI extraction (files referenced via `Clip.midi_paths`) run as cache-first, idempotent async jobs.
+**Current progress:** Stages 1–9 complete on `main`; Stage 10 in progress (US-10.1 audio editing, US-10.2 stems/MIDI extraction, US-10.3 iterative generation endpoints implemented). CLI foundation (Stages 1–7): generation, workspace management, audio processing, DAW export. Platform API (Stages 8–9): FastAPI with OAuth2 auth, async job queue, clip audio streaming, workspace/clip/preset CRUD, credit deduction. Audio editing API (US-10.1): crop, speed-adjust, and remaster endpoints enqueue async jobs that create derived clips with lineage tracking. Stems/MIDI extraction API (US-10.2): stem separation (4 child clips) and MIDI extraction (files referenced via `Clip.midi_paths`) run as cache-first, idempotent async jobs. Iterative generation API (US-10.3): extend, cover, remix, repaint, sample, add-vocal, and mashup endpoints enqueue credit-bearing async jobs that create lineage-tagged child clips.
 
 ## Commands
 
@@ -112,7 +112,7 @@ src/acemusic/
     settings.py     # ApiSettings (pydantic-settings, ACEMUSIC_API_ prefix)
     database.py     # MongoDB connect/close (Beanie + pymongo async), fail-fast ping
     models/         # Beanie ODM documents: User, Workspace, Clip, Job, Preset, CreditTransaction
-    routers/        # Versioned routers mounted under /api/v1 (health, auth, users, generation, jobs, clips, editing, extraction, workspaces, presets)
+    routers/        # Versioned routers mounted under /api/v1 (health, auth, users, generation, jobs, clips, editing, extraction, workspaces, presets, iterative)
   backends.py       # Backend selector: resolve_backend (auto|ace-step|elevenlabs) + capability map
   cli.py            # Typer CLI app (health, generate, compose, sounds, models, workspace commands)
   client.py         # AceStepClient — HTTP client for ACE-Step REST API

--- a/README.md
+++ b/README.md
@@ -84,13 +84,15 @@ Invalid parameters return 422 with field-level errors. If the user has insuffici
 
 The status endpoint returns `job_id`, `status` (`queued`|`processing`|`completed`|`failed`), `created_at`, and `estimated_time_seconds`. Completed jobs additionally include `clip_ids` and `audio_urls`; failed jobs include an `error` message.
 
-#### Async job processor (US-9.2, US-10.1)
+#### Async job processor (US-9.2, US-10.1, US-10.3)
 
 A background processor runs inside the API process, polling MongoDB for `queued`
 jobs and dispatching them to the handler registered for their `job_type`. Generation
 jobs (`generate`) forward to ACE-Step, store the audio, and create clip records.
 Editing jobs (`crop`, `speed`, `remaster`) run local CPU operations via the audio
-processing library. All handlers mark the job `completed` (or `failed` with an
+processing library. Iterative generation jobs (`extend`, `cover`, `remix`, `repaint`,
+`sample`, `add_vocal`, `mashup`) run ACE-Step operations and create lineage-tagged child
+clips. All handlers mark the job `completed` (or `failed` with an
 error). Tunables (all prefixed `ACEMUSIC_API_`): `JOB_CONCURRENCY` (default 2),
 `JOB_POLL_INTERVAL` seconds (default 1.0), `JOB_POLL_TIMEOUT` seconds (default
 600), and `JOB_PROCESSOR_ENABLED` (default `true`; set `false` to run the API
@@ -142,6 +144,22 @@ All three editing endpoints are non-destructive: the original clip is never modi
 | `GET /api/v1/clips/{id}/midi` | Download URLs for the extracted `.mid` files (404 until extracted) |
 
 Both operations run as background jobs and are tracked via `GET /api/v1/jobs/{id}/status` — completed stems jobs surface `clip_ids`/`audio_urls`, completed MIDI jobs surface `midi_download_urls`. Stems become **four child clips** linked to the parent (`generation_mode="stems"`, same duration as the source); MIDI files are stored as objects (not clip records) and referenced from the parent clip's `midi_paths`. Requests are cache-first and idempotent per clip: re-requesting returns the existing results, and a second request while a job is in flight rides the existing job rather than enqueuing a duplicate. Only `wav` source clips are accepted (422 otherwise); no credits are deducted.
+
+### Iterative Generation (US-10.3)
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/clips/{id}/extend` | Grow a clip by `duration` from `from_point` (default the end); returns 202 + `job_id` |
+| `POST /api/v1/clips/{id}/cover` | Restyle a clip in a new `style`; returns 202 + `job_id` |
+| `POST /api/v1/clips/{id}/remix` | Style transfer to a new `style`; returns 202 + `job_id` |
+| `POST /api/v1/clips/{id}/repaint` | Regenerate the `[start, end]` range from a `prompt`; returns 202 + `job_id` |
+| `POST /api/v1/clips/{id}/sample` | Extract the `[start, end]` range and build `num_clips` tracks around it; returns 202 + `job_id` |
+| `POST /api/v1/clips/{id}/add-vocal` | Layer vocals onto a clip from `lyrics`; returns 202 + `job_id` |
+| `POST /api/v1/mashup` | Blend 2–8 owned clips into one; returns 202 + `job_id` |
+
+All iterative endpoints are credit-bearing generative operations (unlike editing/extraction). Credits are deducted at queue time; insufficient balance returns `402 Payment Required` with `{"error": "insufficient_credits", "balance": <current>, "required": <cost>}`. Credit costs: extend/cover/remix/repaint/add-vocal = 1 credit each; sample = 1 credit × `num_clips` (default 1, max 4); mashup = 2 credits.
+
+All endpoints are non-destructive: the original clip(s) are never modified. Each produces a new clip with `parent_clip_ids` and `generation_params` set for lineage tracking. Jobs are tracked via `GET /api/v1/jobs/{id}/status`. Only `wav` source clips are accepted (422 otherwise); clips without duration metadata are also rejected (422). Time parameters use human-readable strings (`"10s"`, `"1m30s"`, `"5"`) matching the CLI commands.
 
 ### Presets
 

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -20,7 +20,19 @@ from acemusic import __version__
 
 from . import database
 from .exceptions import HandleConflictError
-from .routers import auth, clips, editing, extraction, generation, health, jobs, presets, users, workspaces
+from .routers import (
+    auth,
+    clips,
+    editing,
+    extraction,
+    generation,
+    health,
+    iterative,
+    jobs,
+    presets,
+    users,
+    workspaces,
+)
 from .settings import ApiSettings
 from .tasks.processor import JobProcessor
 
@@ -118,6 +130,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(clips.router, prefix=API_V1_PREFIX)
     app.include_router(editing.router, prefix=API_V1_PREFIX)
     app.include_router(extraction.router, prefix=API_V1_PREFIX)
+    app.include_router(iterative.router, prefix=API_V1_PREFIX)
     app.include_router(workspaces.router, prefix=API_V1_PREFIX)
     app.include_router(presets.router, prefix=API_V1_PREFIX)
 

--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -32,6 +32,10 @@ class Clip(Document):
     inference_steps: int | None = None
     parent_clip_ids: list[PydanticObjectId] = Field(default_factory=list)
     generation_mode: str | None = None
+    # The request parameters that produced this clip (US-10.3 iterative
+    # generation), stored verbatim so an operation can be reproduced from its
+    # output. None for clips created before US-10.3 or by non-iterative paths.
+    generation_params: dict | None = None
     # Extracted MIDI artifacts (US-10.2), keyed label -> storage key. MIDI files
     # are not clips, so the parent clip records them here; this is the cache and
     # retrieval source (the storage backend offers no list/exists). None until a

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -337,8 +337,15 @@ async def extend_clip(
     # tail onto the existing audio), so require it before charging — otherwise a
     # clip without duration metadata would deduct a credit then fail in the worker.
     duration_ms = _require_duration_ms(clip)
-    if request.from_point != "end" and parse_time_string(request.from_point) > duration_ms:
-        raise _unprocessable(f"from_point ({request.from_point}) exceeds clip duration ({clip.duration:.1f}s).")
+    if request.from_point != "end":
+        # The splice point must fall strictly inside the clip: 0 makes the worker
+        # trim to a zero-length prefix (slice_audio raises), and past the end has
+        # no audio to continue from. Mirrors the CLI's ``0 < t <= duration`` rule.
+        from_ms = parse_time_string(request.from_point)
+        if not (0 < from_ms <= duration_ms):
+            raise _unprocessable(
+                f"from_point ({request.from_point}) must be within the clip (0 < t <= {clip.duration:.1f}s)."
+            )
     params = {
         "clip_id": str(clip.id),
         "duration": request.duration,

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -49,6 +49,9 @@ logger = logging.getLogger(__name__)
 # sample scales with the number of clips it produces.
 _BASE_ESTIMATE_SECONDS = 45
 _MAX_SAMPLE_CLIPS = 4
+# Mashup does one DB lookup + download + mix per source at a flat 2-credit cost,
+# so cap the source list to keep a single request's DB/storage/CPU work bounded.
+_MAX_MASHUP_CLIPS = 8
 
 # Free-text fields are persisted verbatim in Job.input_params / Clip.generation_params,
 # so bound them (like the generation API) to keep a single oversized request from
@@ -209,7 +212,7 @@ class MashupRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    clip_ids: list[str] = Field(min_length=2)
+    clip_ids: list[str] = Field(min_length=2, max_length=_MAX_MASHUP_CLIPS)
     blend_mode: BlendMode = BlendMode.LAYERED
     style: str | None = Field(default=None, max_length=STYLE_MAX_LENGTH)
 
@@ -321,9 +324,16 @@ async def _enqueue_generation(
 
 
 async def _owned_wav_clip(clip_id: str, user_id: str) -> Clip:
-    """Resolve a source clip the user owns and gate it to wav (404 then 422)."""
+    """Resolve a source clip the user owns and gate it to wav with duration.
+
+    Every iterative mode feeds the source's duration to ACE-Step (as the target
+    ``audio_duration`` or to bound a range), so a clip without duration metadata
+    would be charged then fail or produce a duration-less derived clip — reject
+    it here (404 unknown/unowned, then 422 non-wav / no-duration).
+    """
     clip = await clip_service.get_owned_clip(clip_id, user_id)
     _require_wav(clip)
+    _require_duration_ms(clip)
     return clip
 
 

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -109,7 +109,11 @@ class ExtendRequest(BaseModel):
     @field_validator("duration")
     @classmethod
     def _check_duration(cls, value: str) -> str:
-        return _validate_time_string(value)
+        # A zero-length extend is a no-op repaint that still charges a credit;
+        # reject it (parse_time_string accepts "0"/"0s" as 0ms).
+        if parse_time_string(value) <= 0:
+            raise ValueError("duration must be greater than zero")
+        return value
 
     @field_validator("from_point")
     @classmethod
@@ -329,10 +333,12 @@ async def extend_clip(
 ) -> IterativeJobResponse:
     """Enqueue an extension of ``clip_id`` by ``duration``; the original is preserved."""
     clip = await _owned_wav_clip(clip_id, current.user_id)
-    if request.from_point != "end":
-        duration_ms = _require_duration_ms(clip)
-        if parse_time_string(request.from_point) > duration_ms:
-            raise _unprocessable(f"from_point ({request.from_point}) exceeds clip duration ({clip.duration:.1f}s).")
+    # The worker needs the source duration for every extend (it splices the new
+    # tail onto the existing audio), so require it before charging — otherwise a
+    # clip without duration metadata would deduct a credit then fail in the worker.
+    duration_ms = _require_duration_ms(clip)
+    if request.from_point != "end" and parse_time_string(request.from_point) > duration_ms:
+        raise _unprocessable(f"from_point ({request.from_point}) exceeds clip duration ({clip.duration:.1f}s).")
     params = {
         "clip_id": str(clip.id),
         "duration": request.duration,

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -30,6 +30,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from acemusic.constants import LYRICS_MAX_LENGTH, PROMPT_MAX_LENGTH, STYLE_MAX_LENGTH
 from acemusic.utils import parse_time_string
 
 from ..auth.dependencies import CurrentUser, get_current_user
@@ -48,6 +49,12 @@ logger = logging.getLogger(__name__)
 # sample scales with the number of clips it produces.
 _BASE_ESTIMATE_SECONDS = 45
 _MAX_SAMPLE_CLIPS = 4
+
+# Free-text fields are persisted verbatim in Job.input_params / Clip.generation_params,
+# so bound them (like the generation API) to keep a single oversized request from
+# bloating a Mongo document or exhausting memory. voice_id is an identifier, so a
+# small bound suffices; style/prompt/lyrics reuse the shared generation caps.
+_VOICE_ID_MAX_LENGTH = 128
 
 # Router-level dependency gates every route behind a valid Bearer token (mirrors
 # the editing/generation routers), so unauthenticated requests get 401. No
@@ -103,8 +110,8 @@ class ExtendRequest(BaseModel):
 
     duration: str
     from_point: str = "end"
-    style_override: str | None = None
-    lyrics: str | None = None
+    style_override: str | None = Field(default=None, max_length=STYLE_MAX_LENGTH)
+    lyrics: str | None = Field(default=None, max_length=LYRICS_MAX_LENGTH)
 
     @field_validator("duration")
     @classmethod
@@ -135,9 +142,9 @@ class CoverRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    style: str = Field(min_length=1)
-    voice_id: str | None = None
-    lyrics_override: str | None = None
+    style: str = Field(min_length=1, max_length=STYLE_MAX_LENGTH)
+    voice_id: str | None = Field(default=None, max_length=_VOICE_ID_MAX_LENGTH)
+    lyrics_override: str | None = Field(default=None, max_length=LYRICS_MAX_LENGTH)
 
 
 class RemixRequest(BaseModel):
@@ -145,7 +152,7 @@ class RemixRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    style: str = Field(min_length=1)
+    style: str = Field(min_length=1, max_length=STYLE_MAX_LENGTH)
 
 
 class RepaintRequest(BaseModel):
@@ -155,8 +162,8 @@ class RepaintRequest(BaseModel):
 
     start: str
     end: str
-    prompt: str = Field(min_length=1)
-    style: str | None = None
+    prompt: str = Field(min_length=1, max_length=PROMPT_MAX_LENGTH)
+    style: str | None = Field(default=None, max_length=STYLE_MAX_LENGTH)
 
     @field_validator("start", "end")
     @classmethod
@@ -172,7 +179,7 @@ class SampleRequest(BaseModel):
     start: str
     end: str
     role: SampleRole
-    prompt: str = Field(min_length=1)
+    prompt: str = Field(min_length=1, max_length=PROMPT_MAX_LENGTH)
     backend: GenerationBackend = GenerationBackend.ACE_STEP
     num_clips: int = Field(default=1, ge=1, le=_MAX_SAMPLE_CLIPS)
 
@@ -192,9 +199,9 @@ class AddVocalRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    lyrics: str = Field(min_length=1)
-    voice_id: str | None = None
-    vocal_style: str | None = None
+    lyrics: str = Field(min_length=1, max_length=LYRICS_MAX_LENGTH)
+    voice_id: str | None = Field(default=None, max_length=_VOICE_ID_MAX_LENGTH)
+    vocal_style: str | None = Field(default=None, max_length=STYLE_MAX_LENGTH)
 
 
 class MashupRequest(BaseModel):
@@ -204,7 +211,7 @@ class MashupRequest(BaseModel):
 
     clip_ids: list[str] = Field(min_length=2)
     blend_mode: BlendMode = BlendMode.LAYERED
-    style: str | None = None
+    style: str | None = Field(default=None, max_length=STYLE_MAX_LENGTH)
 
     @model_validator(mode="after")
     def _check_distinct(self) -> "MashupRequest":

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -1,0 +1,503 @@
+"""Iterative generation endpoints (US-10.3).
+
+AI-powered iterative modes, each taking a source clip (or several, for mashup)
+plus mode-specific parameters and producing a *new* clip with lineage back to
+its source(s):
+
+* ``POST /clips/{id}/extend``    → continue/grow the clip (ACE-Step ``repaint``)
+* ``POST /clips/{id}/cover``     → restyle in a new genre (ACE-Step ``cover``)
+* ``POST /clips/{id}/remix``     → style transfer (ACE-Step ``cover``; see Design Choice 2)
+* ``POST /clips/{id}/repaint``   → regenerate a time range (ACE-Step ``repaint`` + stitch)
+* ``POST /clips/{id}/sample``    → extract a loop and build around it (generate + combine)
+* ``POST /clips/{id}/add-vocal`` → layer vocals onto the clip (ACE-Step ``complete``)
+* ``POST /mashup``               → blend 2+ clips into one (ACE-Step ``mashup``)
+
+Each endpoint validates the request against the source clip(s), deducts credits
+atomically at queue time (mirroring ``POST /generate`` — these are generative,
+credit-bearing operations, unlike editing/extraction), persists a queued
+:class:`~acemusic.api.models.job.Job`, and returns 202 with a job id trackable
+via ``GET /api/v1/jobs/{id}/status``. The worker (``acemusic.api.tasks.iterative``)
+runs the generation and creates the lineage-tagged child clip.
+
+Time parameters are human-readable strings ("60s", "1m30s", "5") parsed with
+:func:`acemusic.utils.parse_time_string`, matching the CLI commands.
+"""
+
+import logging
+from enum import Enum
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from acemusic.utils import parse_time_string
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import Clip
+from ..services import (
+    clips as clip_service,
+    credits as credits_service,
+    iterative as iterative_service,
+    users as user_service,
+)
+
+logger = logging.getLogger(__name__)
+
+# Advisory wall-clock estimates (seconds) returned to the client. Iterative
+# generations run one ACE-Step task each, so the base is the song estimate;
+# sample scales with the number of clips it produces.
+_BASE_ESTIMATE_SECONDS = 45
+_MAX_SAMPLE_CLIPS = 4
+
+# Router-level dependency gates every route behind a valid Bearer token (mirrors
+# the editing/generation routers), so unauthenticated requests get 401. No
+# prefix: clip-scoped routes carry the full ``/clips/{id}/...`` path while
+# ``/mashup`` is a standalone, multi-source route.
+router = APIRouter(tags=["iterative"], dependencies=[Depends(get_current_user)])
+
+
+# ---------------------------------------------------------------------------
+# Enums and shared validators
+# ---------------------------------------------------------------------------
+
+
+class BlendMode(str, Enum):
+    """How a mashup combines its sources."""
+
+    LAYERED = "layered"
+    SEQUENTIAL = "sequential"
+    AI_GUIDED = "ai-guided"
+
+
+class SampleRole(str, Enum):
+    """The musical role an extracted sample plays in the generated track."""
+
+    LOOP_BED = "loop-bed"
+    INTRO_OUTRO = "intro-outro"
+    RHYTHMIC_ELEMENT = "rhythmic-element"
+    MELODIC_HOOK = "melodic-hook"
+
+
+class GenerationBackend(str, Enum):
+    """Which generation backend services a sample request."""
+
+    ACE_STEP = "ace-step"
+    ELEVENLABS = "elevenlabs"
+
+
+def _validate_time_string(value: str) -> str:
+    """Field validator: reject unparseable time strings as field-level 422s."""
+    parse_time_string(value)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class ExtendRequest(BaseModel):
+    """Grow a clip by ``duration`` from ``from_point`` (default the end)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    duration: str
+    from_point: str = "end"
+    style_override: str | None = None
+    lyrics: str | None = None
+
+    @field_validator("duration")
+    @classmethod
+    def _check_duration(cls, value: str) -> str:
+        return _validate_time_string(value)
+
+    @field_validator("from_point")
+    @classmethod
+    def _check_from_point(cls, value: str) -> str:
+        # "end" is the sentinel for "append at the tail"; anything else must be
+        # a parseable offset into the source clip.
+        if value != "end":
+            parse_time_string(value)
+        return value
+
+
+class CoverRequest(BaseModel):
+    """Restyle a clip in a different genre/style."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    style: str = Field(min_length=1)
+    voice_id: str | None = None
+    lyrics_override: str | None = None
+
+
+class RemixRequest(BaseModel):
+    """Style transfer (no explicit melody preservation; see Design Choice 2)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    style: str = Field(min_length=1)
+
+
+class RepaintRequest(BaseModel):
+    """Regenerate the ``[start, end]`` range of a clip from ``prompt``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    start: str
+    end: str
+    prompt: str = Field(min_length=1)
+    style: str | None = None
+
+    @field_validator("start", "end")
+    @classmethod
+    def _check_time(cls, value: str) -> str:
+        return _validate_time_string(value)
+
+
+class SampleRequest(BaseModel):
+    """Extract the ``[start, end]`` range and build ``num_clips`` tracks around it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    start: str
+    end: str
+    role: SampleRole
+    prompt: str = Field(min_length=1)
+    backend: GenerationBackend = GenerationBackend.ACE_STEP
+    num_clips: int = Field(default=1, ge=1, le=_MAX_SAMPLE_CLIPS)
+
+    @field_validator("start", "end")
+    @classmethod
+    def _check_time(cls, value: str) -> str:
+        return _validate_time_string(value)
+
+
+class AddVocalRequest(BaseModel):
+    """Layer vocals (``lyrics``) onto an existing clip."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    lyrics: str = Field(min_length=1)
+    voice_id: str | None = None
+    vocal_style: str | None = None
+
+
+class MashupRequest(BaseModel):
+    """Blend two or more clips into one. ``clip_ids[0]`` is the primary source."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    clip_ids: list[str] = Field(min_length=2)
+    blend_mode: BlendMode = BlendMode.LAYERED
+    style: str | None = None
+
+    @model_validator(mode="after")
+    def _check_distinct(self) -> "MashupRequest":
+        if len(set(self.clip_ids)) != len(self.clip_ids):
+            raise ValueError("clip_ids must be distinct")
+        return self
+
+
+class IterativeJobResponse(BaseModel):
+    """The accepted-job acknowledgement returned with HTTP 202."""
+
+    job_id: str
+    status: Literal["queued"] = "queued"
+    estimated_time_seconds: int
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unprocessable(detail: str) -> HTTPException:
+    """Clip-dependent validation failure (the body itself parsed fine)."""
+    return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail)
+
+
+def _require_wav(clip: Clip) -> None:
+    """422 unless the clip's audio is wav.
+
+    The repaint/sample/mashup post-processing runs through pydub, which needs
+    ffmpeg (absent on the server) for compressed formats, and ACE-Step is fed
+    the raw source — so a non-wav source would only fail later in the worker
+    with an opaque error. Mirrors the editing endpoints' constraint.
+    """
+    fmt = clip_service.native_format(clip)
+    if fmt != "wav":
+        raise _unprocessable(f"unsupported format {fmt!r} for iterative generation; currently only wav is supported.")
+
+
+def _require_duration_ms(clip: Clip) -> int:
+    """The clip's duration in milliseconds, or 422 if the metadata is missing."""
+    if clip.duration is None:
+        raise _unprocessable(f"Clip {clip.id} has no duration metadata; cannot validate the request.")
+    return int(round(clip.duration * 1000))
+
+
+def _check_range(start_ms: int, end_ms: int, duration_ms: int, start: str, end: str, clip: Clip) -> None:
+    """Common ``[start, end]`` bounds check for repaint/sample (422 on failure)."""
+    if start_ms >= end_ms:
+        raise _unprocessable(f"start ({start}) must be less than end ({end}).")
+    if end_ms > duration_ms:
+        raise _unprocessable(f"end ({end}) exceeds clip duration ({clip.duration:.1f}s).")
+
+
+async def _enqueue_generation(
+    *,
+    user_id: str,
+    job_type: str,
+    workspace_id,
+    params: dict,
+    cost: float,
+    estimate_seconds: int,
+) -> IterativeJobResponse:
+    """Resolve the user, deduct credits atomically, persist the job, return 202.
+
+    Mirrors ``POST /generate``: the atomic balance-conditioned deduction is the
+    concurrency guard; a job-creation failure refunds; the ledger write is
+    best-effort. Raises 404 (stale token), 402 (insufficient credits).
+    """
+    user = await user_service.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+
+    balance_after = await credits_service.deduct_credits(user.id, cost)
+    if balance_after is None:
+        fresh = await user_service.get_user_by_id(user.id)
+        balance = fresh.credits_balance if fresh is not None else 0.0
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"error": "insufficient_credits", "balance": balance, "required": cost},
+        )
+    try:
+        job = await iterative_service.create_iterative_job(
+            user_id=user.id,
+            workspace_id=workspace_id,
+            job_type=job_type,
+            params=params,
+        )
+    except BaseException:
+        # The deduction already landed but no job exists — give the credit back.
+        # BaseException (not Exception): asyncio.CancelledError must also refund.
+        await credits_service.refund_credits(user.id, cost)
+        raise
+    try:
+        await credits_service.record_transaction(
+            user_id=user.id,
+            amount=-cost,
+            action_type=job_type,
+            job_id=str(job.id),
+            balance_after=balance_after,
+        )
+    except Exception:
+        # The charge is taken and the job dispatched; failing here would invite a
+        # retry that double-charges. The ledger row is best-effort history.
+        logger.exception("Credit ledger write failed for job %s (user %s)", job.id, user.id)
+    return IterativeJobResponse(job_id=str(job.id), estimated_time_seconds=estimate_seconds)
+
+
+async def _owned_wav_clip(clip_id: str, user_id: str) -> Clip:
+    """Resolve a source clip the user owns and gate it to wav (404 then 422)."""
+    clip = await clip_service.get_owned_clip(clip_id, user_id)
+    _require_wav(clip)
+    return clip
+
+
+# ---------------------------------------------------------------------------
+# Single-clip transformation endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/clips/{clip_id}/extend", response_model=IterativeJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def extend_clip(
+    clip_id: str,
+    request: ExtendRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> IterativeJobResponse:
+    """Enqueue an extension of ``clip_id`` by ``duration``; the original is preserved."""
+    clip = await _owned_wav_clip(clip_id, current.user_id)
+    if request.from_point != "end":
+        duration_ms = _require_duration_ms(clip)
+        if parse_time_string(request.from_point) > duration_ms:
+            raise _unprocessable(f"from_point ({request.from_point}) exceeds clip duration ({clip.duration:.1f}s).")
+    params = {
+        "clip_id": str(clip.id),
+        "duration": request.duration,
+        "from_point": request.from_point,
+        "style_override": request.style_override,
+        "lyrics": request.lyrics,
+    }
+    return await _enqueue_generation(
+        user_id=current.user_id,
+        job_type=iterative_service.EXTEND_JOB_TYPE,
+        workspace_id=clip.workspace_id,
+        params=params,
+        cost=credits_service.get_cost(iterative_service.EXTEND_JOB_TYPE),
+        estimate_seconds=_BASE_ESTIMATE_SECONDS,
+    )
+
+
+@router.post("/clips/{clip_id}/cover", response_model=IterativeJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def cover_clip(
+    clip_id: str,
+    request: CoverRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> IterativeJobResponse:
+    """Enqueue a cover (restyle) of ``clip_id``; the original is preserved."""
+    clip = await _owned_wav_clip(clip_id, current.user_id)
+    params = {
+        "clip_id": str(clip.id),
+        "style": request.style,
+        "voice_id": request.voice_id,
+        "lyrics_override": request.lyrics_override,
+    }
+    return await _enqueue_generation(
+        user_id=current.user_id,
+        job_type=iterative_service.COVER_JOB_TYPE,
+        workspace_id=clip.workspace_id,
+        params=params,
+        cost=credits_service.get_cost(iterative_service.COVER_JOB_TYPE),
+        estimate_seconds=_BASE_ESTIMATE_SECONDS,
+    )
+
+
+@router.post("/clips/{clip_id}/remix", response_model=IterativeJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def remix_clip(
+    clip_id: str,
+    request: RemixRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> IterativeJobResponse:
+    """Enqueue a remix (style transfer) of ``clip_id``; the original is preserved."""
+    clip = await _owned_wav_clip(clip_id, current.user_id)
+    params = {"clip_id": str(clip.id), "style": request.style}
+    return await _enqueue_generation(
+        user_id=current.user_id,
+        job_type=iterative_service.REMIX_JOB_TYPE,
+        workspace_id=clip.workspace_id,
+        params=params,
+        cost=credits_service.get_cost(iterative_service.REMIX_JOB_TYPE),
+        estimate_seconds=_BASE_ESTIMATE_SECONDS,
+    )
+
+
+@router.post("/clips/{clip_id}/repaint", response_model=IterativeJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def repaint_clip(
+    clip_id: str,
+    request: RepaintRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> IterativeJobResponse:
+    """Enqueue a repaint of ``clip_id``'s ``[start, end]`` range; the original is preserved."""
+    clip = await _owned_wav_clip(clip_id, current.user_id)
+    duration_ms = _require_duration_ms(clip)
+    start_ms = parse_time_string(request.start)
+    end_ms = parse_time_string(request.end)
+    _check_range(start_ms, end_ms, duration_ms, request.start, request.end, clip)
+    params = {
+        "clip_id": str(clip.id),
+        "start_ms": start_ms,
+        "end_ms": end_ms,
+        "prompt": request.prompt,
+        "style": request.style,
+    }
+    return await _enqueue_generation(
+        user_id=current.user_id,
+        job_type=iterative_service.REPAINT_JOB_TYPE,
+        workspace_id=clip.workspace_id,
+        params=params,
+        cost=credits_service.get_cost(iterative_service.REPAINT_JOB_TYPE),
+        estimate_seconds=_BASE_ESTIMATE_SECONDS,
+    )
+
+
+@router.post("/clips/{clip_id}/sample", response_model=IterativeJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def sample_clip(
+    clip_id: str,
+    request: SampleRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> IterativeJobResponse:
+    """Enqueue a sample-and-build of ``clip_id``'s ``[start, end]`` range; original preserved."""
+    clip = await _owned_wav_clip(clip_id, current.user_id)
+    duration_ms = _require_duration_ms(clip)
+    start_ms = parse_time_string(request.start)
+    end_ms = parse_time_string(request.end)
+    _check_range(start_ms, end_ms, duration_ms, request.start, request.end, clip)
+    params = {
+        "clip_id": str(clip.id),
+        "start_ms": start_ms,
+        "end_ms": end_ms,
+        "role": request.role.value,
+        "prompt": request.prompt,
+        "backend": request.backend.value,
+        "num_clips": request.num_clips,
+    }
+    # Sample produces ``num_clips`` outputs, so it costs that many generations.
+    cost = credits_service.get_cost(iterative_service.SAMPLE_JOB_TYPE) * request.num_clips
+    return await _enqueue_generation(
+        user_id=current.user_id,
+        job_type=iterative_service.SAMPLE_JOB_TYPE,
+        workspace_id=clip.workspace_id,
+        params=params,
+        cost=cost,
+        estimate_seconds=_BASE_ESTIMATE_SECONDS * request.num_clips,
+    )
+
+
+@router.post("/clips/{clip_id}/add-vocal", response_model=IterativeJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def add_vocal_clip(
+    clip_id: str,
+    request: AddVocalRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> IterativeJobResponse:
+    """Enqueue a vocal layering onto ``clip_id``; the original is preserved."""
+    clip = await _owned_wav_clip(clip_id, current.user_id)
+    params = {
+        "clip_id": str(clip.id),
+        "lyrics": request.lyrics,
+        "voice_id": request.voice_id,
+        "vocal_style": request.vocal_style,
+    }
+    return await _enqueue_generation(
+        user_id=current.user_id,
+        job_type=iterative_service.ADD_VOCAL_JOB_TYPE,
+        workspace_id=clip.workspace_id,
+        params=params,
+        cost=credits_service.get_cost(iterative_service.ADD_VOCAL_JOB_TYPE),
+        estimate_seconds=_BASE_ESTIMATE_SECONDS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-clip mashup endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/mashup", response_model=IterativeJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def mashup_clips(
+    request: MashupRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> IterativeJobResponse:
+    """Enqueue a mashup of 2+ owned clips into one; the originals are preserved.
+
+    Lineage tracks every source (``parent_clip_ids``); the first clip is the
+    primary, and the derived clip lands in its workspace.
+    """
+    # Validate every source up front so an unknown/unowned/non-wav id fails the
+    # whole request (404/422) before any credit is touched.
+    clips = [await _owned_wav_clip(clip_id, current.user_id) for clip_id in request.clip_ids]
+    primary = clips[0]
+    params = {
+        "clip_ids": [str(clip.id) for clip in clips],
+        "blend_mode": request.blend_mode.value,
+        "style": request.style,
+    }
+    return await _enqueue_generation(
+        user_id=current.user_id,
+        job_type=iterative_service.MASHUP_JOB_TYPE,
+        workspace_id=primary.workspace_id,
+        params=params,
+        cost=credits_service.get_cost(iterative_service.MASHUP_JOB_TYPE),
+        estimate_seconds=_BASE_ESTIMATE_SECONDS,
+    )

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -30,7 +30,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from acemusic.constants import LYRICS_MAX_LENGTH, PROMPT_MAX_LENGTH, STYLE_MAX_LENGTH
+from acemusic.constants import DURATION_MAX, LYRICS_MAX_LENGTH, PROMPT_MAX_LENGTH, STYLE_MAX_LENGTH
 from acemusic.utils import parse_time_string
 
 from ..auth.dependencies import CurrentUser, get_current_user
@@ -354,6 +354,7 @@ async def extend_clip(
     # tail onto the existing audio), so require it before charging — otherwise a
     # clip without duration metadata would deduct a credit then fail in the worker.
     duration_ms = _require_duration_ms(clip)
+    from_ms = duration_ms
     if request.from_point != "end":
         # The splice point must fall strictly inside the clip: 0 makes the worker
         # trim to a zero-length prefix (slice_audio raises), and past the end has
@@ -363,6 +364,14 @@ async def extend_clip(
             raise _unprocessable(
                 f"from_point ({request.from_point}) must be within the clip (0 < t <= {clip.duration:.1f}s)."
             )
+    # The worker submits audio_duration = from_point + duration to ACE-Step;
+    # cap that target at the platform's generation maximum so an extend can't
+    # request an oversized GPU job at the flat one-credit cost.
+    target_s = (from_ms + parse_time_string(request.duration)) / 1000.0
+    if target_s > DURATION_MAX:
+        raise _unprocessable(
+            f"extended length ({target_s:.1f}s) exceeds the maximum generation duration ({DURATION_MAX:.0f}s)."
+        )
     params = {
         "clip_id": str(clip.id),
         "duration": request.duration,

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -27,6 +27,7 @@ import logging
 from enum import Enum
 from typing import Literal
 
+from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -218,7 +219,17 @@ class MashupRequest(BaseModel):
 
     @model_validator(mode="after")
     def _check_distinct(self) -> "MashupRequest":
-        if len(set(self.clip_ids)) != len(self.clip_ids):
+        # Normalise before comparing: ObjectId hex is case-insensitive, so the
+        # same id in different casing must still count as a duplicate (a raw
+        # string set would treat them as distinct and let it through).
+        def _norm(cid: str) -> str:
+            try:
+                return str(PydanticObjectId(cid))
+            except Exception:
+                return cid
+
+        normalized = [_norm(cid) for cid in self.clip_ids]
+        if len(set(normalized)) != len(normalized):
             raise ValueError("clip_ids must be distinct")
         return self
 

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -334,17 +334,27 @@ async def _enqueue_generation(
     return IterativeJobResponse(job_id=str(job.id), estimated_time_seconds=estimate_seconds)
 
 
-async def _owned_wav_clip(clip_id: str, user_id: str) -> Clip:
+async def _owned_wav_clip(clip_id: str, user_id: str, *, cap_duration: bool = False) -> Clip:
     """Resolve a source clip the user owns and gate it to wav with duration.
 
     Every iterative mode feeds the source's duration to ACE-Step (as the target
     ``audio_duration`` or to bound a range), so a clip without duration metadata
     would be charged then fail or produce a duration-less derived clip — reject
     it here (404 unknown/unowned, then 422 non-wav / no-duration).
+
+    ``cap_duration`` additionally rejects a source longer than ``DURATION_MAX``:
+    the modes that submit ``source.duration`` verbatim as ``audio_duration``
+    (cover/remix/repaint/add-vocal/mashup) would otherwise charge then queue a
+    job that exceeds the generation cap. extend (which trims to a prefix) and
+    sample (which works on a bounded range) don't set this.
     """
     clip = await clip_service.get_owned_clip(clip_id, user_id)
     _require_wav(clip)
     _require_duration_ms(clip)
+    if cap_duration and clip.duration is not None and clip.duration > DURATION_MAX:
+        raise _unprocessable(
+            f"clip duration ({clip.duration:.1f}s) exceeds the maximum generation duration ({DURATION_MAX:.0f}s)."
+        )
     return clip
 
 
@@ -407,7 +417,7 @@ async def cover_clip(
     current: CurrentUser = Depends(get_current_user),
 ) -> IterativeJobResponse:
     """Enqueue a cover (restyle) of ``clip_id``; the original is preserved."""
-    clip = await _owned_wav_clip(clip_id, current.user_id)
+    clip = await _owned_wav_clip(clip_id, current.user_id, cap_duration=True)
     params = {
         "clip_id": str(clip.id),
         "style": request.style,
@@ -431,7 +441,7 @@ async def remix_clip(
     current: CurrentUser = Depends(get_current_user),
 ) -> IterativeJobResponse:
     """Enqueue a remix (style transfer) of ``clip_id``; the original is preserved."""
-    clip = await _owned_wav_clip(clip_id, current.user_id)
+    clip = await _owned_wav_clip(clip_id, current.user_id, cap_duration=True)
     params = {"clip_id": str(clip.id), "style": request.style}
     return await _enqueue_generation(
         user_id=current.user_id,
@@ -450,7 +460,7 @@ async def repaint_clip(
     current: CurrentUser = Depends(get_current_user),
 ) -> IterativeJobResponse:
     """Enqueue a repaint of ``clip_id``'s ``[start, end]`` range; the original is preserved."""
-    clip = await _owned_wav_clip(clip_id, current.user_id)
+    clip = await _owned_wav_clip(clip_id, current.user_id, cap_duration=True)
     duration_ms = _require_duration_ms(clip)
     start_ms = parse_time_string(request.start)
     end_ms = parse_time_string(request.end)
@@ -517,7 +527,7 @@ async def add_vocal_clip(
     current: CurrentUser = Depends(get_current_user),
 ) -> IterativeJobResponse:
     """Enqueue a vocal layering onto ``clip_id``; the original is preserved."""
-    clip = await _owned_wav_clip(clip_id, current.user_id)
+    clip = await _owned_wav_clip(clip_id, current.user_id, cap_duration=True)
     params = {
         "clip_id": str(clip.id),
         "lyrics": request.lyrics,
@@ -551,7 +561,7 @@ async def mashup_clips(
     """
     # Validate every source up front so an unknown/unowned/non-wav id fails the
     # whole request (404/422) before any credit is touched.
-    clips = [await _owned_wav_clip(clip_id, current.user_id) for clip_id in request.clip_ids]
+    clips = [await _owned_wav_clip(clip_id, current.user_id, cap_duration=True) for clip_id in request.clip_ids]
     primary = clips[0]
     params = {
         "clip_ids": [str(clip.id) for clip in clips],

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -122,7 +122,12 @@ class ExtendRequest(BaseModel):
 
 
 class CoverRequest(BaseModel):
-    """Restyle a clip in a different genre/style."""
+    """Restyle a clip in a different genre/style.
+
+    ``voice_id`` is part of the API contract (US-10.3) but is not yet applied by
+    the ACE-Step backend, which has no voice-selection parameter — it is accepted
+    and recorded for forward compatibility, not honoured. (Known limitation.)
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -174,7 +179,12 @@ class SampleRequest(BaseModel):
 
 
 class AddVocalRequest(BaseModel):
-    """Layer vocals (``lyrics``) onto an existing clip."""
+    """Layer vocals (``lyrics``) onto an existing clip.
+
+    ``vocal_style`` maps to the ACE-Step style control; ``voice_id`` is recorded
+    for forward compatibility but not yet applied by the backend (no voice-
+    selection parameter). (Known limitation.)
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -420,6 +430,11 @@ async def sample_clip(
 ) -> IterativeJobResponse:
     """Enqueue a sample-and-build of ``clip_id``'s ``[start, end]`` range; original preserved."""
     clip = await _owned_wav_clip(clip_id, current.user_id)
+    # The worker only implements the ACE-Step backend; reject elevenlabs at
+    # enqueue rather than silently producing ace-step output (the enum keeps the
+    # value reserved for when the EL music path is wired into the worker).
+    if request.backend is GenerationBackend.ELEVENLABS:
+        raise _unprocessable("the 'elevenlabs' backend is not yet supported for sampling; use 'ace-step'.")
     duration_ms = _require_duration_ms(clip)
     start_ms = parse_time_string(request.start)
     end_ms = parse_time_string(request.end)

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -20,6 +20,7 @@ from ..models import Clip, Job, JobStatus
 from ..services.common import coerce_object_id
 from ..services.editing import EDIT_JOB_TYPES
 from ..services.extraction import EXTRACTION_JOB_TYPES, MIDI_JOB_TYPE, resolve_midi_urls
+from ..services.iterative import ITERATIVE_JOB_TYPES, SAMPLE_JOB_TYPE
 from .generation import GenerationRequest, estimate_seconds
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,11 @@ _EDIT_ESTIMATE_SECONDS = 5
 # on CPU, so they take far longer than an edit; a flat minute-ish estimate is a
 # reasonable advisory floor without modelling per-clip duration.
 _EXTRACTION_ESTIMATE_SECONDS = 60
+
+# Iterative generation jobs (US-10.3) each run one ACE-Step task; the flat
+# estimate mirrors the iterative router's create-response heuristic so status
+# polling and the enqueue response agree (sample scales by num_clips).
+_ITERATIVE_ESTIMATE_SECONDS = 45
 
 # Router-level dependency gates every route behind a valid Bearer token (mirrors
 # the generation router), so an unauthenticated request is rejected with 401.
@@ -72,6 +78,10 @@ def _estimate_for(job: Job) -> int:
         return _EDIT_ESTIMATE_SECONDS
     if job.job_type in EXTRACTION_JOB_TYPES:
         return _EXTRACTION_ESTIMATE_SECONDS
+    if job.job_type in ITERATIVE_JOB_TYPES:
+        if job.job_type == SAMPLE_JOB_TYPE:
+            return _ITERATIVE_ESTIMATE_SECONDS * int((job.input_params or {}).get("num_clips", 1))
+        return _ITERATIVE_ESTIMATE_SECONDS
     try:
         return estimate_seconds(GenerationRequest(**job.input_params))
     except Exception:

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -15,7 +15,13 @@ from ..models.user import DEFAULT_CREDITS_BALANCE
 SONG_COST = 1.0
 SOUND_COST = 0.5
 
-_COSTS = {"song": SONG_COST, "sound": SOUND_COST}
+# US-10.3: each iterative generation runs one ACE-Step (or ElevenLabs) job,
+# costing the same as a song generation. The ``sample`` endpoint multiplies this
+# base by ``num_clips`` in the router, since it produces several outputs.
+ITERATIVE_COST = 1.0
+ITERATIVE_MODES = ("extend", "cover", "remix", "repaint", "mashup", "sample", "add_vocal")
+
+_COSTS = {"song": SONG_COST, "sound": SOUND_COST, **{mode: ITERATIVE_COST for mode in ITERATIVE_MODES}}
 
 # History page size for GET /users/me/credits.
 HISTORY_LIMIT = 50

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -15,13 +15,20 @@ from ..models.user import DEFAULT_CREDITS_BALANCE
 SONG_COST = 1.0
 SOUND_COST = 0.5
 
-# US-10.3: each iterative generation runs one ACE-Step (or ElevenLabs) job,
-# costing the same as a song generation. The ``sample`` endpoint multiplies this
-# base by ``num_clips`` in the router, since it produces several outputs.
+# US-10.3: each single-source iterative generation runs one ACE-Step (or
+# ElevenLabs) job, costing the same as a song generation. The ``sample`` endpoint
+# multiplies this base by ``num_clips`` in the router (several outputs); mashup
+# costs 2 credits per the documented pricing (it blends multiple sources).
 ITERATIVE_COST = 1.0
-ITERATIVE_MODES = ("extend", "cover", "remix", "repaint", "mashup", "sample", "add_vocal")
+MASHUP_COST = 2.0
+_SINGLE_SOURCE_ITERATIVE_MODES = ("extend", "cover", "remix", "repaint", "sample", "add_vocal")
 
-_COSTS = {"song": SONG_COST, "sound": SOUND_COST, **{mode: ITERATIVE_COST for mode in ITERATIVE_MODES}}
+_COSTS = {
+    "song": SONG_COST,
+    "sound": SOUND_COST,
+    "mashup": MASHUP_COST,
+    **{mode: ITERATIVE_COST for mode in _SINGLE_SOURCE_ITERATIVE_MODES},
+}
 
 # History page size for GET /users/me/credits.
 HISTORY_LIMIT = 50

--- a/src/acemusic/api/services/iterative.py
+++ b/src/acemusic/api/services/iterative.py
@@ -1,0 +1,72 @@
+"""Iterative generation service layer (US-10.3).
+
+Persists queued iterative-generation jobs (extend, cover, remix, repaint,
+mashup, sample, add-vocal) for the iterative endpoints, mirroring
+:func:`acemusic.api.services.editing.create_edit_job`. Kept transport-agnostic
+(plain exceptions, never ``HTTPException``) like the other service modules.
+
+Each mode wraps the corresponding CLI iterative command as an async ACE-Step (or
+ElevenLabs) job; the worker handlers live in
+:mod:`acemusic.api.tasks.iterative`.
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import Job, JobStatus
+from ..tasks import dispatch_job
+
+EXTEND_JOB_TYPE = "extend"
+COVER_JOB_TYPE = "cover"
+REMIX_JOB_TYPE = "remix"
+REPAINT_JOB_TYPE = "repaint"
+MASHUP_JOB_TYPE = "mashup"
+SAMPLE_JOB_TYPE = "sample"
+ADD_VOCAL_JOB_TYPE = "add_vocal"
+
+ITERATIVE_JOB_TYPES = (
+    EXTEND_JOB_TYPE,
+    COVER_JOB_TYPE,
+    REMIX_JOB_TYPE,
+    REPAINT_JOB_TYPE,
+    MASHUP_JOB_TYPE,
+    SAMPLE_JOB_TYPE,
+    ADD_VOCAL_JOB_TYPE,
+)
+
+
+async def create_iterative_job(
+    *,
+    user_id: PydanticObjectId,
+    workspace_id: PydanticObjectId,
+    job_type: str,
+    params: dict,
+) -> Job:
+    """Persist a queued iterative-generation job and dispatch it.
+
+    ``params`` holds the resolved request spec — the source ``clip_id`` (or
+    ``clip_ids`` for mashup) plus the mode's parameters — so the worker re-reads
+    nothing from the request. ``workspace_id`` is the (primary) source clip's
+    workspace, so the derived clip lands next to its parent. Returns the saved
+    :class:`Job` (with its id). Mirrors
+    :func:`acemusic.api.services.editing.create_edit_job`.
+    """
+    if job_type not in ITERATIVE_JOB_TYPES:
+        raise ValueError(f"Unknown iterative job type: {job_type!r}")
+    job = Job(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        job_type=job_type,
+        status=JobStatus.QUEUED,
+        input_params=params,
+    )
+    await job.insert()
+    try:
+        await dispatch_job(str(job.id))
+    except BaseException:
+        # Don't leave the job behind: the processor polls for QUEUED documents,
+        # so an orphan would still run even though the caller saw a failure.
+        # BaseException (not Exception) on purpose: asyncio.CancelledError must
+        # also clean up (mirrors create_edit_job / create_generation_job).
+        await job.delete()
+        raise
+    return job

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -1,0 +1,545 @@
+"""Iterative generation job handlers (US-10.3).
+
+One worker per iterative mode (extend, cover, remix, repaint, mashup, sample,
+add-vocal). Each handler runs a claimed
+:class:`~acemusic.api.models.job.Job`: download the source clip(s) from storage
+into a temp file, submit the corresponding ACE-Step task (the same ``task_type``
+and parameters the CLI commands use), poll for completion, download the result,
+apply any local post-processing (repaint stitches the regenerated window back
+into the original; sample combines the extracted loop with the generated track),
+and store the output as a new child :class:`~acemusic.api.models.clip.Clip` with
+lineage back to its source(s).
+
+Unlike the editing/extraction handlers (which need only ``(job, storage)``),
+these are generative and need the ACE-Step client and the processor's poll loop,
+so they are adapted onto the registry through ``JobProcessor._run_iterative_handler``
+which injects ``storage``, ``client`` and ``poll``.
+
+Every child clip records ``parent_clip_ids`` (the source(s)), ``generation_mode``
+(the job type) and ``generation_params`` (the verbatim request) so an operation
+can be reproduced from its output; ``bpm``/``key``/``vocal_language`` are inherited
+from the primary source. A failure after the audio object is uploaded but before
+(or during) the clip insert rolls the object back, so a failed job leaves no
+orphaned storage objects or clip rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import tempfile
+from collections.abc import Awaitable, Callable
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+from beanie import PydanticObjectId
+from pydub import AudioSegment
+
+from acemusic.audio import combine_sample, crop_audio, crossfade_stitch
+from acemusic.client import AceStepClient
+from acemusic.storage import StorageBackend
+from acemusic.utils import parse_time_string
+
+from ..models import Clip, Job
+from ..services.clips import native_format
+from ..services.iterative import (
+    ADD_VOCAL_JOB_TYPE,
+    COVER_JOB_TYPE,
+    EXTEND_JOB_TYPE,
+    MASHUP_JOB_TYPE,
+    REMIX_JOB_TYPE,
+    REPAINT_JOB_TYPE,
+    SAMPLE_JOB_TYPE,
+)
+
+logger = logging.getLogger(__name__)
+
+# Seam between the repaint window and the surrounding original audio.
+_REPAINT_CROSSFADE_MS = 50
+
+# Role-specific prompt prefixes for the sample endpoint (mirrors the CLI's
+# ``_ROLE_PROMPT_PREFIX``); kept here so the worker has no CLI/typer dependency.
+_ROLE_PROMPT_PREFIX = {
+    "loop-bed": "Create a track that works as an overlay on top of a repeating loop.",
+    "intro-outro": "Create a track that transitions smoothly from and back to a musical phrase.",
+    "rhythmic-element": "Create a track with space for a recurring rhythmic sample.",
+    "melodic-hook": "Create a track that follows and develops from a melodic hook.",
+}
+
+# A poll callable matching ``JobProcessor._poll_until_complete``.
+PollFn = Callable[[AceStepClient, str], Awaitable[dict[str, Any]]]
+
+
+class IterativeProcessingError(Exception):
+    """An iterative-generation job could not be processed."""
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_clip(clip_id: str) -> Clip:
+    """Resolve a source clip by id, or fail the job with a clear error.
+
+    A source clip may legitimately vanish between enqueue and processing (the
+    owner can DELETE it while the job is queued), so a miss is a job failure,
+    not a crash (mirrors the extraction handlers).
+    """
+    try:
+        oid = PydanticObjectId(clip_id)
+    except Exception as exc:
+        raise IterativeProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
+    clip = await Clip.get(oid)
+    if clip is None:
+        raise IterativeProcessingError(f"Source clip {clip_id} no longer exists")
+    return clip
+
+
+async def _download(storage: StorageBackend, clip: Clip, dest: Path) -> None:
+    try:
+        data = await asyncio.to_thread(storage.download, clip.file_path)
+    except FileNotFoundError as exc:
+        raise IterativeProcessingError(f"Source clip {clip.id} audio object {clip.file_path!r} is missing") from exc
+    dest.write_bytes(data)
+
+
+def _source_prompt(clip: Clip, fallback: str) -> str:
+    """Build a text prompt describing ``clip`` from its style tags / title."""
+    if clip.style_tags:
+        return ", ".join(clip.style_tags)
+    return clip.title or fallback
+
+
+async def _submit_and_download(
+    client: AceStepClient,
+    poll: PollFn,
+    submit_kwargs: dict[str, Any],
+    *,
+    expected: int = 1,
+) -> list[bytes]:
+    """Submit one ACE-Step task, poll to completion, return the downloaded audio."""
+    task_id = await asyncio.to_thread(partial(client.submit_task, **submit_kwargs))
+    result = await poll(client, task_id)
+    if result.get("status") == "failed":
+        raise IterativeProcessingError(result.get("error") or "ACE-Step task failed")
+    audio_urls = result.get("audio_urls") or []
+    if len(audio_urls) < expected:
+        raise IterativeProcessingError(f"ACE-Step returned {len(audio_urls)} clip(s) but {expected} were expected")
+    return [await asyncio.to_thread(client.download_audio, url) for url in audio_urls[:expected]]
+
+
+async def _store_child_clip(
+    job: Job,
+    *,
+    data: bytes,
+    fmt: str,
+    duration: float | None,
+    parent_ids: list[PydanticObjectId],
+    primary: Clip,
+    storage: StorageBackend,
+    title: str | None = None,
+) -> str:
+    """Upload one output and insert its lineage-tagged child Clip.
+
+    Rolls the uploaded object back if the insert fails, so a job that ends up
+    ``failed`` never leaves an orphaned storage object behind (mirrors the
+    generate / editing paths' rollback).
+    """
+    clip_id = PydanticObjectId()
+    path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
+    await asyncio.to_thread(storage.upload, path, data)
+    clip = Clip(
+        id=clip_id,
+        user_id=job.user_id,
+        workspace_id=job.workspace_id,
+        file_path=path,
+        title=title,
+        format=fmt,
+        duration=duration,
+        bpm=primary.bpm,
+        key=primary.key,
+        vocal_language=primary.vocal_language,
+        parent_clip_ids=parent_ids,
+        generation_mode=job.job_type,
+        generation_params=dict(job.input_params or {}),
+    )
+    try:
+        await clip.insert()
+    except BaseException:
+        try:
+            await asyncio.to_thread(storage.delete, path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned storage object %s during rollback", path)
+        raise
+    return str(clip_id)
+
+
+def _decode(data: bytes, fmt: str) -> AudioSegment:
+    """Decode audio bytes, passing ``format`` so pydub never shells out to ffprobe."""
+    return AudioSegment.from_file(io.BytesIO(data), format=fmt)
+
+
+# ---------------------------------------------------------------------------
+# Single-source generative handlers (extend / cover / remix / add-vocal)
+# ---------------------------------------------------------------------------
+
+
+async def process_extend_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
+    """Grow the source by ``duration`` from ``from_point`` (ACE-Step ``repaint``)."""
+    params = dict(job.input_params or {})
+    source = await _load_clip(params["clip_id"])
+    if source.duration is None:
+        raise IterativeProcessingError(f"Source clip {source.id} has no duration metadata")
+    fmt = native_format(source)
+    duration_s = parse_time_string(params["duration"]) / 1000.0
+    from_point = params.get("from_point", "end")
+    from_s = source.duration if from_point == "end" else parse_time_string(from_point) / 1000.0
+    target_duration = from_s + duration_s
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-extend-") as tmp:
+        src_path = Path(tmp) / f"source.{fmt}"
+        await _download(storage, source, src_path)
+        data = await _submit_and_download(
+            client,
+            poll,
+            {
+                "prompt": _source_prompt(source, "continue the song"),
+                "num_clips": 1,
+                "audio_duration": target_duration,
+                "format": fmt,
+                "style": params.get("style_override"),
+                "lyrics": params.get("lyrics"),
+                "bpm": source.bpm,
+                "key": source.key,
+                "seed": source.seed,
+                "task_type": "repaint",
+                "src_audio_path": str(src_path.resolve()),
+                "repainting_start": from_s,
+                "repainting_end": target_duration,
+            },
+        )
+    clip_id = await _store_child_clip(
+        job,
+        data=data[0],
+        fmt=fmt,
+        duration=target_duration,
+        parent_ids=[source.id],
+        primary=source,
+        storage=storage,
+    )
+    return {"clip_ids": [clip_id]}
+
+
+async def _process_restyle_job(
+    job: Job,
+    *,
+    storage: StorageBackend,
+    client: AceStepClient,
+    poll: PollFn,
+    style: str,
+    lyrics: str | None,
+) -> dict:
+    """Shared cover/remix path: ACE-Step ``cover`` at the source's length."""
+    params = dict(job.input_params or {})
+    source = await _load_clip(params["clip_id"])
+    fmt = native_format(source)
+    with tempfile.TemporaryDirectory(prefix="acemusic-restyle-") as tmp:
+        src_path = Path(tmp) / f"source.{fmt}"
+        await _download(storage, source, src_path)
+        data = await _submit_and_download(
+            client,
+            poll,
+            {
+                "prompt": style,
+                "num_clips": 1,
+                "audio_duration": source.duration,
+                "format": fmt,
+                "style": style,
+                "lyrics": lyrics if lyrics is not None else source.lyrics,
+                "bpm": source.bpm,
+                "key": source.key,
+                "seed": source.seed,
+                "task_type": "cover",
+                "src_audio_path": str(src_path.resolve()),
+            },
+        )
+    clip_id = await _store_child_clip(
+        job,
+        data=data[0],
+        fmt=fmt,
+        duration=source.duration,
+        parent_ids=[source.id],
+        primary=source,
+        storage=storage,
+    )
+    return {"clip_ids": [clip_id]}
+
+
+async def process_cover_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
+    """Restyle the source in a new genre (ACE-Step ``cover``)."""
+    params = dict(job.input_params or {})
+    return await _process_restyle_job(
+        job,
+        storage=storage,
+        client=client,
+        poll=poll,
+        style=params["style"],
+        lyrics=params.get("lyrics_override"),
+    )
+
+
+async def process_remix_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
+    """Style transfer (ACE-Step ``cover``; see Design Choice 2). Preserves source lyrics."""
+    params = dict(job.input_params or {})
+    return await _process_restyle_job(
+        job,
+        storage=storage,
+        client=client,
+        poll=poll,
+        style=params["style"],
+        lyrics=None,
+    )
+
+
+async def process_add_vocal_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
+    """Layer vocals onto the source (ACE-Step ``complete``)."""
+    params = dict(job.input_params or {})
+    source = await _load_clip(params["clip_id"])
+    fmt = native_format(source)
+    with tempfile.TemporaryDirectory(prefix="acemusic-vocal-") as tmp:
+        src_path = Path(tmp) / f"source.{fmt}"
+        await _download(storage, source, src_path)
+        data = await _submit_and_download(
+            client,
+            poll,
+            {
+                "prompt": _source_prompt(source, "layer vocals over the instrumental"),
+                "num_clips": 1,
+                "audio_duration": source.duration,
+                "format": fmt,
+                "style": params.get("vocal_style"),
+                "lyrics": params["lyrics"],
+                "vocal_language": source.vocal_language,
+                "bpm": source.bpm,
+                "key": source.key,
+                "seed": source.seed,
+                "task_type": "complete",
+                "src_audio_path": str(src_path.resolve()),
+            },
+        )
+    clip_id = await _store_child_clip(
+        job,
+        data=data[0],
+        fmt=fmt,
+        duration=source.duration,
+        parent_ids=[source.id],
+        primary=source,
+        storage=storage,
+    )
+    return {"clip_ids": [clip_id]}
+
+
+# ---------------------------------------------------------------------------
+# Repaint — regenerate a window and stitch it back into the original
+# ---------------------------------------------------------------------------
+
+
+async def process_repaint_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
+    """Regenerate ``[start, end]`` and crossfade it back into the original audio."""
+    params = dict(job.input_params or {})
+    source = await _load_clip(params["clip_id"])
+    fmt = native_format(source)
+    start_ms = int(params["start_ms"])
+    end_ms = int(params["end_ms"])
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-repaint-") as tmp:
+        src_path = Path(tmp) / f"source.{fmt}"
+        await _download(storage, source, src_path)
+        original_bytes = src_path.read_bytes()
+        data = await _submit_and_download(
+            client,
+            poll,
+            {
+                "prompt": params["prompt"],
+                "num_clips": 1,
+                "audio_duration": source.duration,
+                "format": fmt,
+                "style": params.get("style"),
+                "bpm": source.bpm,
+                "key": source.key,
+                "seed": source.seed,
+                "task_type": "repaint",
+                "src_audio_path": str(src_path.resolve()),
+                "repainting_start": start_ms / 1000.0,
+                "repainting_end": end_ms / 1000.0,
+            },
+        )
+
+    original = _decode(original_bytes, fmt)
+    repaint_full = _decode(data[0], fmt)
+    if len(repaint_full) < end_ms - 10:
+        raise IterativeProcessingError(
+            f"ACE-Step output is {len(repaint_full)}ms but the repaint window ends at {end_ms}ms"
+        )
+    before = original[:start_ms]
+    middle = repaint_full[start_ms:end_ms]
+    after = original[end_ms:]
+    stitched = crossfade_stitch(before, middle, after, fade_ms=_REPAINT_CROSSFADE_MS)
+    out = io.BytesIO()
+    stitched.export(out, format=fmt)
+
+    clip_id = await _store_child_clip(
+        job,
+        data=out.getvalue(),
+        fmt=fmt,
+        duration=len(stitched) / 1000.0,
+        parent_ids=[source.id],
+        primary=source,
+        storage=storage,
+    )
+    return {"clip_ids": [clip_id]}
+
+
+# ---------------------------------------------------------------------------
+# Mashup — blend two or more sources into one
+# ---------------------------------------------------------------------------
+
+
+async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
+    """Blend the first two sources via ACE-Step ``mashup``; lineage tracks all sources.
+
+    ACE-Step's ``mashup`` takes one source plus one reference, so the primary
+    (``clip_ids[0]``) and the first secondary drive the audio. Every requested
+    clip is still recorded in ``parent_clip_ids``/``generation_params``.
+    """
+    params = dict(job.input_params or {})
+    clip_ids: list[str] = params["clip_ids"]
+    sources = [await _load_clip(cid) for cid in clip_ids]
+    primary, secondary = sources[0], sources[1]
+    fmt = native_format(primary)
+    style = params.get("style")
+    # Submit without a key constraint when the two keys disagree, rather than
+    # falsely asserting the primary's key (mirrors the CLI).
+    submitted_key = primary.key
+    if primary.key and secondary.key and primary.key != secondary.key:
+        submitted_key = None
+    titles = [t for t in (primary.title, secondary.title) if t]
+    prompt = style or (f"mashup of {' and '.join(titles)}" if titles else "mashup")
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-mashup-") as tmp:
+        primary_path = Path(tmp) / f"primary.{fmt}"
+        secondary_path = Path(tmp) / f"secondary.{native_format(secondary)}"
+        await _download(storage, primary, primary_path)
+        await _download(storage, secondary, secondary_path)
+        data = await _submit_and_download(
+            client,
+            poll,
+            {
+                "prompt": prompt,
+                "num_clips": 1,
+                "audio_duration": primary.duration,
+                "format": fmt,
+                "style": style,
+                "bpm": primary.bpm,
+                "key": submitted_key,
+                "task_type": "mashup",
+                "src_audio_path": str(primary_path.resolve()),
+                "ref_audio_path": str(secondary_path.resolve()),
+                "blend_mode": params.get("blend_mode", "layered"),
+            },
+        )
+
+    clip_id = await _store_child_clip(
+        job,
+        data=data[0],
+        fmt=fmt,
+        duration=primary.duration,
+        parent_ids=[s.id for s in sources],
+        primary=primary,
+        storage=storage,
+    )
+    return {"clip_ids": [clip_id]}
+
+
+# ---------------------------------------------------------------------------
+# Sample — extract a loop and build num_clips tracks around it
+# ---------------------------------------------------------------------------
+
+
+def _build_sample_prompt(base_prompt: str, role: str, sample_duration_sec: float) -> str:
+    """Role-aware prompt for the generated track (mirrors the CLI helper)."""
+    prefix = _ROLE_PROMPT_PREFIX.get(role, "")
+    duration_hint = f"The reference sample is about {sample_duration_sec:.1f}s long."
+    return f"{prefix} {duration_hint} {base_prompt}".strip()
+
+
+async def process_sample_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
+    """Extract ``[start, end]``, generate ``num_clips`` tracks, combine each per role.
+
+    Only the ACE-Step backend is supported via the worker; the ``elevenlabs``
+    backend is recorded on the request but processed as ACE-Step (a documented
+    known limitation while the EL music path is wired into the worker).
+    """
+    params = dict(job.input_params or {})
+    source = await _load_clip(params["clip_id"])
+    fmt = native_format(source)
+    start_ms = int(params["start_ms"])
+    end_ms = int(params["end_ms"])
+    role = params["role"]
+    num_clips = int(params.get("num_clips", 1))
+    sample_duration_sec = (end_ms - start_ms) / 1000.0
+    prompt = _build_sample_prompt(params["prompt"], role, sample_duration_sec)
+
+    clip_ids: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="acemusic-sample-") as tmp:
+        tmp_path = Path(tmp)
+        src_path = tmp_path / f"source.{fmt}"
+        await _download(storage, source, src_path)
+        sample_path = tmp_path / f"sample.{fmt}"
+        await asyncio.to_thread(
+            crop_audio, input_path=str(src_path), output_path=str(sample_path), start_ms=start_ms, end_ms=end_ms
+        )
+        generated = await _submit_and_download(
+            client,
+            poll,
+            {"prompt": prompt, "num_clips": num_clips, "format": fmt},
+            expected=num_clips,
+        )
+        for index, gen_bytes in enumerate(generated, start=1):
+            gen_path = tmp_path / f"generated-{index}.{fmt}"
+            gen_path.write_bytes(gen_bytes)
+            out_path = tmp_path / f"combined-{index}.{fmt}"
+            await asyncio.to_thread(
+                combine_sample,
+                sample_path=str(sample_path),
+                generated_path=str(gen_path),
+                output_path=str(out_path),
+                role=role,
+            )
+            combined = out_path.read_bytes()
+            duration = len(_decode(combined, fmt)) / 1000.0
+            clip_id = await _store_child_clip(
+                job,
+                data=combined,
+                fmt=fmt,
+                duration=duration,
+                parent_ids=[source.id],
+                primary=source,
+                storage=storage,
+            )
+            clip_ids.append(clip_id)
+    return {"clip_ids": clip_ids}
+
+
+ITERATIVE_JOB_HANDLERS: dict[str, Callable[..., Awaitable[dict]]] = {
+    EXTEND_JOB_TYPE: process_extend_job,
+    COVER_JOB_TYPE: process_cover_job,
+    REMIX_JOB_TYPE: process_remix_job,
+    REPAINT_JOB_TYPE: process_repaint_job,
+    MASHUP_JOB_TYPE: process_mashup_job,
+    SAMPLE_JOB_TYPE: process_sample_job,
+    ADD_VOCAL_JOB_TYPE: process_add_vocal_job,
+}

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -123,6 +123,11 @@ def _source_prompt(clip: Clip, fallback: str) -> str:
     return clip.title or fallback
 
 
+def _style_tags(style: str | None) -> list[str] | None:
+    """Effective ``style_tags`` for a child: ``[style]`` when set, else inherit (None)."""
+    return [style] if style else None
+
+
 async def _submit_and_download(
     client: AceStepClient,
     poll: PollFn,
@@ -152,12 +157,18 @@ async def _store_child_clip(
     storage: StorageBackend,
     title: str | None = None,
     key: str | None = _INHERIT,
+    style_tags: list[str] | None = None,
+    lyrics: str | None = _INHERIT,
 ) -> str:
     """Upload one output and insert its lineage-tagged child Clip.
 
-    ``key`` defaults to inheriting the primary's key; pass an explicit value
+    ``key``/``lyrics`` default to inheriting the primary's; pass an explicit value
     (including ``None``) to override — e.g. a key-mismatched mashup is generated
     without a key constraint, so its child must not claim the primary's key.
+    ``style_tags``/``lyrics`` should carry the *effective* style/lyrics the clip
+    was generated with (not the source's), so a later chained operation reads the
+    right metadata via ``_source_prompt`` instead of falling back to a generic
+    prompt. ``style_tags=None`` inherits the primary's tags.
 
     Rolls the uploaded object back if the insert fails, so a job that ends up
     ``failed`` never leaves an orphaned storage object behind (mirrors the
@@ -176,6 +187,8 @@ async def _store_child_clip(
         duration=duration,
         bpm=primary.bpm,
         key=primary.key if key is _INHERIT else key,
+        style_tags=list(primary.style_tags) if style_tags is None else style_tags,
+        lyrics=primary.lyrics if lyrics is _INHERIT else lyrics,
         vocal_language=primary.vocal_language,
         parent_clip_ids=parent_ids,
         generation_mode=job.job_type,
@@ -261,6 +274,7 @@ async def process_extend_job(job: Job, *, storage: StorageBackend, client: AceSt
                 "repainting_end": target_duration,
             },
         )
+    extend_lyrics = params.get("lyrics")
     clip_id = await _store_child_clip(
         job,
         data=data[0],
@@ -269,6 +283,8 @@ async def process_extend_job(job: Job, *, storage: StorageBackend, client: AceSt
         parent_ids=[source.id],
         primary=source,
         storage=storage,
+        style_tags=_style_tags(params.get("style_override")),
+        lyrics=extend_lyrics if extend_lyrics is not None else _INHERIT,
     )
     return {"clip_ids": [clip_id]}
 
@@ -286,6 +302,7 @@ async def _process_restyle_job(
     params = dict(job.input_params or {})
     source = await _load_clip(params["clip_id"])
     fmt = native_format(source)
+    effective_lyrics = lyrics if lyrics is not None else source.lyrics
     with tempfile.TemporaryDirectory(prefix="acemusic-restyle-") as tmp:
         src_path = Path(tmp) / f"source.{fmt}"
         await _download(storage, source, src_path)
@@ -298,7 +315,7 @@ async def _process_restyle_job(
                 "audio_duration": source.duration,
                 "format": fmt,
                 "style": style,
-                "lyrics": lyrics if lyrics is not None else source.lyrics,
+                "lyrics": effective_lyrics,
                 "bpm": source.bpm,
                 "key": source.key,
                 "seed": source.seed,
@@ -314,6 +331,10 @@ async def _process_restyle_job(
         parent_ids=[source.id],
         primary=source,
         storage=storage,
+        # The restyle changed the style (and possibly lyrics); record the
+        # effective values so a chained op reads the new style, not the source's.
+        style_tags=[style],
+        lyrics=effective_lyrics,
     )
     return {"clip_ids": [clip_id]}
 
@@ -378,6 +399,9 @@ async def process_add_vocal_job(job: Job, *, storage: StorageBackend, client: Ac
         parent_ids=[source.id],
         primary=source,
         storage=storage,
+        # Record the vocal style and the added lyrics so they survive chaining.
+        style_tags=_style_tags(params.get("vocal_style")),
+        lyrics=params["lyrics"],
     )
     return {"clip_ids": [clip_id]}
 
@@ -439,6 +463,9 @@ async def process_repaint_job(job: Job, *, storage: StorageBackend, client: AceS
         parent_ids=[source.id],
         primary=source,
         storage=storage,
+        # A repaint may restyle the window; record the style when given, else
+        # inherit. Lyrics are unchanged, so inherit the source's.
+        style_tags=_style_tags(params.get("style")),
     )
     return {"clip_ids": [clip_id]}
 
@@ -505,6 +532,8 @@ async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceSt
         # Match what was generated: a key-mismatched mashup was submitted
         # unconstrained, so its child must not claim the primary's key.
         key=submitted_key,
+        # Record the mashup style when given, else inherit the primary's tags.
+        style_tags=_style_tags(style),
     )
     return {"clip_ids": [clip_id]}
 
@@ -528,8 +557,11 @@ async def _build_mashup_reference(
         segment = _decode(aligned_path.read_bytes(), clip_fmt)
         mixed = segment if mixed is None else mixed.overlay(segment)
     ref_path = tmp_path / f"reference.{fmt}"
-    # ``secondaries`` is guaranteed non-empty (the API requires >= 2 sources).
-    assert mixed is not None
+    # ``secondaries`` is guaranteed non-empty (the API requires >= 2 sources), but
+    # raise explicitly rather than assert: asserts are stripped under ``python -O``,
+    # which would turn an unexpected empty list into an opaque AttributeError.
+    if mixed is None:
+        raise IterativeProcessingError("mashup has no secondary sources to build a reference from")
     mixed.export(ref_path, format=fmt)
     return ref_path
 

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -177,6 +177,23 @@ async def _store_child_clip(
     return str(clip_id)
 
 
+async def _rollback_children(storage: StorageBackend, clip_ids: list[str]) -> None:
+    """Best-effort removal of child clips (docs + audio objects) already stored.
+
+    Used by multi-output modes (sample) so a failure partway through the batch
+    does not leave earlier children behind for a job that ends up ``failed``.
+    """
+    for clip_id in clip_ids:
+        clip = await Clip.get(PydanticObjectId(clip_id))
+        if clip is None:  # pragma: no cover - already gone
+            continue
+        try:
+            await asyncio.to_thread(storage.delete, clip.file_path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned storage object %s during rollback", clip.file_path)
+        await clip.delete()
+
+
 def _decode(data: bytes, fmt: str) -> AudioSegment:
     """Decode audio bytes, passing ``format`` so pydub never shells out to ffprobe."""
     return AudioSegment.from_file(io.BytesIO(data), format=fmt)
@@ -409,31 +426,33 @@ async def process_repaint_job(job: Job, *, storage: StorageBackend, client: AceS
 
 
 async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
-    """Blend the first two sources via ACE-Step ``mashup``; lineage tracks all sources.
+    """Blend all sources via ACE-Step ``mashup``; lineage tracks every source.
 
-    ACE-Step's ``mashup`` takes one source plus one reference, so the primary
-    (``clip_ids[0]``) and the first secondary drive the audio. Every requested
-    clip is still recorded in ``parent_clip_ids``/``generation_params``.
+    ACE-Step's ``mashup`` takes one source plus one reference. The primary
+    (``clip_ids[0]``) is the source; the remaining clips are mixed down (overlaid)
+    into a single reference so every requested clip contributes to the blend
+    rather than being silently dropped. All sources are recorded in
+    ``parent_clip_ids``/``generation_params``.
     """
     params = dict(job.input_params or {})
     clip_ids: list[str] = params["clip_ids"]
     sources = [await _load_clip(cid) for cid in clip_ids]
-    primary, secondary = sources[0], sources[1]
+    primary, secondaries = sources[0], sources[1:]
     fmt = native_format(primary)
     style = params.get("style")
-    # Submit without a key constraint when the two keys disagree, rather than
-    # falsely asserting the primary's key (mirrors the CLI).
+    # Submit without a key constraint when any secondary's key disagrees with the
+    # primary, rather than falsely asserting the primary's key (mirrors the CLI).
     submitted_key = primary.key
-    if primary.key and secondary.key and primary.key != secondary.key:
+    if primary.key and any(s.key and s.key != primary.key for s in secondaries):
         submitted_key = None
-    titles = [t for t in (primary.title, secondary.title) if t]
+    titles = [t for t in (primary.title, *(s.title for s in secondaries)) if t]
     prompt = style or (f"mashup of {' and '.join(titles)}" if titles else "mashup")
 
     with tempfile.TemporaryDirectory(prefix="acemusic-mashup-") as tmp:
-        primary_path = Path(tmp) / f"primary.{fmt}"
-        secondary_path = Path(tmp) / f"secondary.{native_format(secondary)}"
+        tmp_path = Path(tmp)
+        primary_path = tmp_path / f"primary.{fmt}"
         await _download(storage, primary, primary_path)
-        await _download(storage, secondary, secondary_path)
+        ref_path = await _build_mashup_reference(storage, secondaries, tmp_path, fmt)
         data = await _submit_and_download(
             client,
             poll,
@@ -447,7 +466,7 @@ async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceSt
                 "key": submitted_key,
                 "task_type": "mashup",
                 "src_audio_path": str(primary_path.resolve()),
-                "ref_audio_path": str(secondary_path.resolve()),
+                "ref_audio_path": str(ref_path.resolve()),
                 "blend_mode": params.get("blend_mode", "layered"),
             },
         )
@@ -462,6 +481,25 @@ async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceSt
         storage=storage,
     )
     return {"clip_ids": [clip_id]}
+
+
+async def _build_mashup_reference(storage: StorageBackend, secondaries: list[Clip], tmp_path: Path, fmt: str) -> Path:
+    """Mix every secondary source into a single reference track (overlaid).
+
+    With one secondary this is just that clip; with several, they are layered so
+    the blend incorporates all of them. Written as ``fmt`` to ``tmp_path``.
+    """
+    mixed: AudioSegment | None = None
+    for index, clip in enumerate(secondaries):
+        clip_path = tmp_path / f"secondary-{index}.{native_format(clip)}"
+        await _download(storage, clip, clip_path)
+        segment = _decode(clip_path.read_bytes(), native_format(clip))
+        mixed = segment if mixed is None else mixed.overlay(segment)
+    ref_path = tmp_path / f"reference.{fmt}"
+    # ``secondaries`` is guaranteed non-empty (the API requires >= 2 sources).
+    assert mixed is not None
+    mixed.export(ref_path, format=fmt)
+    return ref_path
 
 
 # ---------------------------------------------------------------------------
@@ -479,9 +517,10 @@ def _build_sample_prompt(base_prompt: str, role: str, sample_duration_sec: float
 async def process_sample_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
     """Extract ``[start, end]``, generate ``num_clips`` tracks, combine each per role.
 
-    Only the ACE-Step backend is supported via the worker; the ``elevenlabs``
-    backend is recorded on the request but processed as ACE-Step (a documented
-    known limitation while the EL music path is wired into the worker).
+    Only the ACE-Step backend reaches the worker — the router rejects the
+    ``elevenlabs`` backend at enqueue time. Children are stored as the batch
+    progresses; a failure partway through rolls back the ones already created so
+    a ``failed`` job leaves no orphaned clips or storage objects behind.
     """
     params = dict(job.input_params or {})
     source = await _load_clip(params["clip_id"])
@@ -508,29 +547,33 @@ async def process_sample_job(job: Job, *, storage: StorageBackend, client: AceSt
             {"prompt": prompt, "num_clips": num_clips, "format": fmt},
             expected=num_clips,
         )
-        for index, gen_bytes in enumerate(generated, start=1):
-            gen_path = tmp_path / f"generated-{index}.{fmt}"
-            gen_path.write_bytes(gen_bytes)
-            out_path = tmp_path / f"combined-{index}.{fmt}"
-            await asyncio.to_thread(
-                combine_sample,
-                sample_path=str(sample_path),
-                generated_path=str(gen_path),
-                output_path=str(out_path),
-                role=role,
-            )
-            combined = out_path.read_bytes()
-            duration = len(_decode(combined, fmt)) / 1000.0
-            clip_id = await _store_child_clip(
-                job,
-                data=combined,
-                fmt=fmt,
-                duration=duration,
-                parent_ids=[source.id],
-                primary=source,
-                storage=storage,
-            )
-            clip_ids.append(clip_id)
+        try:
+            for index, gen_bytes in enumerate(generated, start=1):
+                gen_path = tmp_path / f"generated-{index}.{fmt}"
+                gen_path.write_bytes(gen_bytes)
+                out_path = tmp_path / f"combined-{index}.{fmt}"
+                await asyncio.to_thread(
+                    combine_sample,
+                    sample_path=str(sample_path),
+                    generated_path=str(gen_path),
+                    output_path=str(out_path),
+                    role=role,
+                )
+                combined = out_path.read_bytes()
+                duration = len(_decode(combined, fmt)) / 1000.0
+                clip_id = await _store_child_clip(
+                    job,
+                    data=combined,
+                    fmt=fmt,
+                    duration=duration,
+                    parent_ids=[source.id],
+                    primary=source,
+                    storage=storage,
+                )
+                clip_ids.append(clip_id)
+        except Exception:
+            await _rollback_children(storage, clip_ids)
+            raise
     return {"clip_ids": clip_ids}
 
 

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -555,7 +555,15 @@ async def _build_mashup_reference(
         await _download(storage, clip, clip_path)
         aligned_path = await _align_to_bpm(clip_path, clip.bpm, primary_bpm, tmp_path, index)
         segment = _decode(aligned_path.read_bytes(), clip_fmt)
-        mixed = segment if mixed is None else mixed.overlay(segment)
+        if mixed is None:
+            mixed = segment
+        elif len(segment) > len(mixed):
+            # overlay() keeps the *base* length, so always overlay the shorter
+            # onto the longer — otherwise a later, longer secondary's tail is
+            # silently truncated and that source wouldn't fully contribute.
+            mixed = segment.overlay(mixed)
+        else:
+            mixed = mixed.overlay(segment)
     ref_path = tmp_path / f"reference.{fmt}"
     # ``secondaries`` is guaranteed non-empty (the API requires >= 2 sources), but
     # raise explicitly rather than assert: asserts are stripped under ``python -O``,

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -21,6 +21,12 @@ can be reproduced from its output; ``bpm``/``key``/``vocal_language`` are inheri
 from the primary source. A failure after the audio object is uploaded but before
 (or during) the clip insert rolls the object back, so a failed job leaves no
 orphaned storage objects or clip rows.
+
+The source audio is handed to ACE-Step as a worker-local ``src_audio_path``, so
+ACE-Step must run on the same host (or with shared-filesystem access) as the API
+worker — the same constraint the CLI iterative commands document. Remote /
+cross-container ACE-Step deployments are not yet supported (a deferred story);
+under such a deployment these jobs fail after the credit has been deducted.
 """
 
 from __future__ import annotations
@@ -58,6 +64,10 @@ logger = logging.getLogger(__name__)
 
 # Seam between the repaint window and the surrounding original audio.
 _REPAINT_CROSSFADE_MS = 50
+
+# Sentinel for "inherit the primary's key" so callers can distinguish that from an
+# explicit ``key=None`` override (a key-mismatched mashup is unconstrained).
+_INHERIT = "__inherit__"
 
 # Role-specific prompt prefixes for the sample endpoint (mirrors the CLI's
 # ``_ROLE_PROMPT_PREFIX``); kept here so the worker has no CLI/typer dependency.
@@ -141,8 +151,13 @@ async def _store_child_clip(
     primary: Clip,
     storage: StorageBackend,
     title: str | None = None,
+    key: str | None = _INHERIT,
 ) -> str:
     """Upload one output and insert its lineage-tagged child Clip.
+
+    ``key`` defaults to inheriting the primary's key; pass an explicit value
+    (including ``None``) to override — e.g. a key-mismatched mashup is generated
+    without a key constraint, so its child must not claim the primary's key.
 
     Rolls the uploaded object back if the insert fails, so a job that ends up
     ``failed`` never leaves an orphaned storage object behind (mirrors the
@@ -160,7 +175,7 @@ async def _store_child_clip(
         format=fmt,
         duration=duration,
         bpm=primary.bpm,
-        key=primary.key,
+        key=primary.key if key is _INHERIT else key,
         vocal_language=primary.vocal_language,
         parent_clip_ids=parent_ids,
         generation_mode=job.job_type,
@@ -487,6 +502,9 @@ async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceSt
         parent_ids=[s.id for s in sources],
         primary=primary,
         storage=storage,
+        # Match what was generated: a key-mismatched mashup was submitted
+        # unconstrained, so its child must not claim the primary's key.
+        key=submitted_key,
     )
     return {"clip_ids": [clip_id]}
 
@@ -606,7 +624,9 @@ async def process_sample_job(job: Job, *, storage: StorageBackend, client: AceSt
                     storage=storage,
                 )
                 clip_ids.append(clip_id)
-        except Exception:
+        except BaseException:
+            # BaseException (not Exception): a shutdown CancelledError must also
+            # roll back, else a requeued retry duplicates the stored children.
             await _rollback_children(storage, clip_ids)
             raise
     return {"clip_ids": clip_ids}

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -37,7 +37,7 @@ from typing import Any
 from beanie import PydanticObjectId
 from pydub import AudioSegment
 
-from acemusic.audio import combine_sample, crop_audio, crossfade_stitch
+from acemusic.audio import calculate_speed_multiplier, combine_sample, crop_audio, crossfade_stitch, time_stretch_audio
 from acemusic.client import AceStepClient
 from acemusic.storage import StorageBackend
 from acemusic.utils import parse_time_string
@@ -452,7 +452,7 @@ async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceSt
         tmp_path = Path(tmp)
         primary_path = tmp_path / f"primary.{fmt}"
         await _download(storage, primary, primary_path)
-        ref_path = await _build_mashup_reference(storage, secondaries, tmp_path, fmt)
+        ref_path = await _build_mashup_reference(storage, secondaries, tmp_path, fmt, primary.bpm)
         data = await _submit_and_download(
             client,
             poll,
@@ -483,23 +483,50 @@ async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceSt
     return {"clip_ids": [clip_id]}
 
 
-async def _build_mashup_reference(storage: StorageBackend, secondaries: list[Clip], tmp_path: Path, fmt: str) -> Path:
+async def _build_mashup_reference(
+    storage: StorageBackend, secondaries: list[Clip], tmp_path: Path, fmt: str, primary_bpm: int | None
+) -> Path:
     """Mix every secondary source into a single reference track (overlaid).
 
-    With one secondary this is just that clip; with several, they are layered so
-    the blend incorporates all of them. Written as ``fmt`` to ``tmp_path``.
+    Each secondary is BPM-aligned to ``primary_bpm`` before mixing (matching the
+    CLI mashup path), so mismatched tempos do not produce an off-beat reference.
+    With one secondary this is just that (aligned) clip; with several, they are
+    layered so the blend incorporates all of them. Written as ``fmt`` to ``tmp_path``.
     """
     mixed: AudioSegment | None = None
     for index, clip in enumerate(secondaries):
-        clip_path = tmp_path / f"secondary-{index}.{native_format(clip)}"
+        clip_fmt = native_format(clip)
+        clip_path = tmp_path / f"secondary-{index}.{clip_fmt}"
         await _download(storage, clip, clip_path)
-        segment = _decode(clip_path.read_bytes(), native_format(clip))
+        aligned_path = await _align_to_bpm(clip_path, clip.bpm, primary_bpm, tmp_path, index)
+        segment = _decode(aligned_path.read_bytes(), clip_fmt)
         mixed = segment if mixed is None else mixed.overlay(segment)
     ref_path = tmp_path / f"reference.{fmt}"
     # ``secondaries`` is guaranteed non-empty (the API requires >= 2 sources).
     assert mixed is not None
     mixed.export(ref_path, format=fmt)
     return ref_path
+
+
+async def _align_to_bpm(
+    src_path: Path, src_bpm: int | None, target_bpm: int | None, tmp_path: Path, index: int
+) -> Path:
+    """Time-stretch ``src_path`` to ``target_bpm``, or return it unchanged.
+
+    Skips alignment when either BPM is unknown/invalid or already equal, and
+    falls back to the original on a stretch failure (mirrors the CLI's
+    ``_align_clips_bpm``).
+    """
+    if not src_bpm or not target_bpm or src_bpm <= 0 or target_bpm <= 0 or src_bpm == target_bpm:
+        return src_path
+    rate = calculate_speed_multiplier(float(src_bpm), float(target_bpm))
+    aligned_path = tmp_path / f"aligned-{index}{src_path.suffix}"
+    try:
+        await asyncio.to_thread(time_stretch_audio, str(src_path), str(aligned_path), rate)
+    except Exception:
+        logger.warning("BPM alignment failed for %s; using the original clip", src_path, exc_info=True)
+        return src_path
+    return aligned_path
 
 
 # ---------------------------------------------------------------------------

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -40,7 +40,7 @@ from pydub import AudioSegment
 from acemusic.audio import calculate_speed_multiplier, combine_sample, crop_audio, crossfade_stitch, time_stretch_audio
 from acemusic.client import AceStepClient
 from acemusic.storage import StorageBackend
-from acemusic.utils import parse_time_string
+from acemusic.utils import parse_time_string, slice_audio
 
 from ..models import Clip, Job
 from ..services.clips import native_format
@@ -219,6 +219,14 @@ async def process_extend_job(job: Job, *, storage: StorageBackend, client: AceSt
     with tempfile.TemporaryDirectory(prefix="acemusic-extend-") as tmp:
         src_path = Path(tmp) / f"source.{fmt}"
         await _download(storage, source, src_path)
+        # When extending from a mid-clip point, trim the source to that prefix so
+        # ACE-Step continues from the splice and never sees the discarded tail
+        # (mirrors the CLI extend path's slice_audio step).
+        api_src = src_path
+        if from_point != "end" and from_s < source.duration:
+            trimmed = Path(tmp) / f"trimmed.{fmt}"
+            await asyncio.to_thread(slice_audio, src_path, from_s, trimmed)
+            api_src = trimmed
         data = await _submit_and_download(
             client,
             poll,
@@ -233,7 +241,7 @@ async def process_extend_job(job: Job, *, storage: StorageBackend, client: AceSt
                 "key": source.key,
                 "seed": source.seed,
                 "task_type": "repaint",
-                "src_audio_path": str(src_path.resolve()),
+                "src_audio_path": str(api_src.resolve()),
                 "repainting_start": from_s,
                 "repainting_end": target_duration,
             },

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -36,6 +36,7 @@ from ..models import Clip, Job, JobStatus
 from ..models.common import utcnow
 from .editing import EDIT_JOB_HANDLERS
 from .extraction import EXTRACTION_JOB_HANDLERS
+from .iterative import ITERATIVE_JOB_HANDLERS
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +122,11 @@ class JobProcessor:
         # contract, so both are adapted onto the registry the same way.
         for job_type, storage_handler in {**EDIT_JOB_HANDLERS, **EXTRACTION_JOB_HANDLERS}.items():
             self._handlers[job_type] = partial(self._run_storage_handler, storage_handler)
+        # Iterative generation handlers (US-10.3) are generative: they need the
+        # ACE-Step client and the poll loop in addition to storage, so they are
+        # adapted through their own injecting wrapper.
+        for job_type, iterative_handler in ITERATIVE_JOB_HANDLERS.items():
+            self._handlers[job_type] = partial(self._run_iterative_handler, iterative_handler)
         if handlers:
             self._handlers.update(handlers)
         self._running = False
@@ -270,6 +276,15 @@ class JobProcessor:
     async def _run_storage_handler(self, storage_handler: Any, job: Job) -> dict[str, Any]:
         """Adapt a ``(job, storage) -> result`` handler (editing/extraction) to the registry."""
         return await storage_handler(job, self._storage_factory())
+
+    async def _run_iterative_handler(self, iterative_handler: Any, job: Job) -> dict[str, Any]:
+        """Adapt an iterative handler (US-10.3), injecting storage, the ACE-Step client and the poll loop."""
+        return await iterative_handler(
+            job,
+            storage=self._storage_factory(),
+            client=self._client_factory(),
+            poll=self._poll_until_complete,
+        )
 
     async def _handle_generate(self, job: Job) -> dict[str, Any]:
         """Run an ACE-Step generation job: submit, poll, store clips."""

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -374,6 +374,16 @@ class TestValidation:
         resp = await client.post(_op_url(clip.id, operation), json=body, headers=_auth_headers(user, settings))
         assert resp.status_code == 422
 
+    async def test_sample_elevenlabs_backend_rejected(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-sample-el@example.com", duration=10.0)
+        resp = await client.post(
+            _op_url(clip.id, "sample"),
+            json={"start": "1s", "end": "3s", "role": "loop-bed", "prompt": "p", "backend": "elevenlabs"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
     async def test_non_wav_source_returns_422(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("iter-nonwav@example.com", fmt="mp3")
         resp = await client.post(

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -339,6 +339,8 @@ class TestValidation:
         "operation,body",
         [
             ("extend", {"duration": "soon"}),  # unparseable time
+            ("extend", {"duration": "0s"}),  # zero-length no-op
+            ("extend", {"duration": "0"}),  # zero-length no-op (plain seconds)
             ("extend", {}),  # missing required duration
             ("extend", {"duration": "30s", "bogus": 1}),  # extra="forbid"
             ("cover", {}),  # missing required style
@@ -383,6 +385,19 @@ class TestValidation:
         )
         assert resp.status_code == 422
         assert await Job.count() == 0
+
+    async def test_extend_without_duration_metadata_returns_422_no_charge(self, client, settings) -> None:
+        # A clip with no duration metadata cannot be extended; the endpoint must
+        # reject it before charging rather than enqueue a guaranteed-failing job.
+        user, _, clip = await _user_with_clip("iter-extend-nodur@example.com", balance=10.0, duration=None)
+        resp = await client.post(
+            _op_url(clip.id, "extend"),
+            json={"duration": "30s"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+        assert (await _reload_user(user)).credits_balance == 10.0
 
     async def test_non_wav_source_returns_422(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("iter-nonwav@example.com", fmt="mp3")

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -437,6 +437,18 @@ class TestValidation:
         assert await Job.count() == 0
         assert (await _reload_user(user)).credits_balance == 10.0
 
+    async def test_oversized_free_text_returns_422(self, client, settings) -> None:
+        # Free-text fields are persisted verbatim; an unbounded string must be
+        # rejected (matches the generation API's caps) rather than bloating Mongo.
+        user, _, clip = await _user_with_clip("iter-oversized@example.com", duration=10.0)
+        resp = await client.post(
+            _op_url(clip.id, "cover"),
+            json={"style": "x" * 10_001},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
     async def test_non_wav_source_returns_422(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("iter-nonwav@example.com", fmt="mp3")
         resp = await client.post(
@@ -470,6 +482,10 @@ class TestMashup:
         assert job.job_type == "mashup"
         assert job.input_params["clip_ids"] == [str(a.id), str(b.id)]
         assert job.workspace_id == a.workspace_id
+        # Mashup costs 2 credits per the documented pricing (blends >1 source).
+        assert (await _reload_user(user)).credits_balance == 8.0
+        txns = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        assert txns[0].amount == -2.0
 
     async def test_fewer_than_two_clips_returns_422(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("iter-mashup-one@example.com")

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -538,11 +538,14 @@ class TestMashup:
         assert resp.status_code == 422
         assert await Job.count() == 0
 
-    async def test_duplicate_clip_ids_returns_422(self, client, settings) -> None:
+    @pytest.mark.parametrize("second", [lambda c: str(c.id), lambda c: str(c.id).upper()])
+    async def test_duplicate_clip_ids_returns_422(self, client, settings, second) -> None:
+        # The same id — even in different hex casing (ObjectId is case-insensitive)
+        # — must be rejected as a duplicate source.
         user, _, clip = await _user_with_clip("iter-mashup-dup@example.com")
         resp = await client.post(
             MASHUP_URL,
-            json={"clip_ids": [str(clip.id), str(clip.id)]},
+            json={"clip_ids": [str(clip.id), second(clip)]},
             headers=_auth_headers(user, settings),
         )
         assert resp.status_code == 422

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -410,6 +410,19 @@ class TestValidation:
         assert resp.status_code == 422
         assert await Job.count() == 0
 
+    async def test_extend_target_exceeding_max_duration_returns_422(self, client, settings) -> None:
+        # from_point(end=10s) + duration(9999s) far exceeds DURATION_MAX (240s);
+        # reject before charging so no oversized GPU job is queued.
+        user, _, clip = await _user_with_clip("iter-extend-toolong@example.com", balance=10.0, duration=10.0)
+        resp = await client.post(
+            _op_url(clip.id, "extend"),
+            json={"duration": "9999s"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+        assert (await _reload_user(user)).credits_balance == 10.0
+
     @pytest.mark.parametrize("from_point", ["0s", "0", "20s"])
     async def test_extend_from_point_out_of_range_returns_422(self, client, settings, from_point: str) -> None:
         # 0 would trim to a zero-length prefix (worker error); past the end has no

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -1,0 +1,546 @@
+"""Tests for the iterative generation endpoints (US-10.3, issue #83).
+
+Covers the seven AI-powered iterative modes — ``extend``, ``cover``, ``remix``,
+``repaint``, ``sample``, ``add-vocal`` (clip-scoped) and ``mashup`` (standalone,
+multi-source). Each validates against its source clip(s), deducts credits at
+queue time, enqueues a job and returns 202 with a trackable job id.
+
+The 401 auth-gate tests run in CI (no DB); the rest are ``integration`` and
+drive the real app with ``httpx.AsyncClient`` over a local MongoDB.
+"""
+
+import asyncio
+import io
+import time
+
+import httpx
+import numpy as np
+import pytest
+import soundfile as sf
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, CreditTransaction, Job, User, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+MASHUP_URL = f"{API_V1_PREFIX}/mashup"
+
+# Clip-scoped operations and a minimal valid body for each (used where the test
+# target is not the payload itself). ``mashup`` is exercised separately.
+CLIP_OPS = ["extend", "cover", "remix", "repaint", "sample", "add-vocal"]
+VALID_BODIES = {
+    "extend": {"duration": "30s"},
+    "cover": {"style": "jazz"},
+    "remix": {"style": "lofi"},
+    "repaint": {"start": "1s", "end": "5s", "prompt": "add strings"},
+    "sample": {"start": "1s", "end": "3s", "role": "loop-bed", "prompt": "build a beat"},
+    "add-vocal": {"lyrics": "la la la"},
+}
+# Endpoint path segment (with hyphen) → job_type (with underscore).
+JOB_TYPE = {
+    "extend": "extend",
+    "cover": "cover",
+    "remix": "remix",
+    "repaint": "repaint",
+    "sample": "sample",
+    "add-vocal": "add_vocal",
+}
+
+
+def _op_url(clip_id, operation: str) -> str:
+    return f"{CLIPS_URL}/{clip_id}/{operation}"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB; plain TestClient does not run the lifespan)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize("operation", CLIP_OPS)
+    def test_missing_auth_header_returns_401(self, operation: str) -> None:
+        client = TestClient(create_app())
+        resp = client.post(_op_url(PydanticObjectId(), operation), json=VALID_BODIES[operation])
+        assert resp.status_code == 401
+
+    def test_mashup_missing_auth_header_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(MASHUP_URL, json={"clip_ids": [str(PydanticObjectId()), str(PydanticObjectId())]})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # Disable the background processor: these tests assert on the queued job
+    # record and do not want a worker claiming it out from under them.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str, *, balance: float | None = None):
+    user = await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+    if balance is not None:
+        user.credits_balance = balance
+        await user.save()
+    return user
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(
+    user,
+    workspace: Workspace,
+    *,
+    duration: float | None = 10.0,
+    bpm: int | None = 120,
+    key: str | None = "C",
+    fmt: str | None = "wav",
+) -> Clip:
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt or 'wav'}"
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=file_path,
+        format=fmt,
+        duration=duration,
+        bpm=bpm,
+        key=key,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _user_with_clip(email: str, *, balance: float = 10.0, **clip_kwargs):
+    user = await _make_user(email, balance=balance)
+    workspace = await _make_workspace(user)
+    clip = await _insert_clip(user, workspace, **clip_kwargs)
+    return user, workspace, clip
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown / malformed / other-user clip ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestClipNotFound:
+    @pytest.mark.parametrize("operation", CLIP_OPS)
+    async def test_unknown_clip_returns_404(self, client, settings, operation: str) -> None:
+        user = await _make_user(f"iter-404-{operation}@example.com", balance=10.0)
+        resp = await client.post(
+            _op_url(PydanticObjectId(), operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+        assert await Job.count() == 0
+
+    @pytest.mark.parametrize("operation", CLIP_OPS)
+    async def test_malformed_id_returns_404(self, client, settings, operation: str) -> None:
+        user = await _make_user(f"iter-malformed-{operation}@example.com", balance=10.0)
+        resp = await client.post(
+            _op_url("not-an-object-id", operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("operation", CLIP_OPS)
+    async def test_other_users_clip_returns_404(self, client, settings, operation: str) -> None:
+        _, _, clip = await _user_with_clip(f"iter-owner-{operation}@example.com")
+        other = await _make_user(f"iter-other-{operation}@example.com", balance=10.0)
+        resp = await client.post(
+            _op_url(clip.id, operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(other, settings),
+        )
+        assert resp.status_code == 404
+        # No credit was spent on a clip the requester cannot see.
+        assert (await _reload_user(other)).credits_balance == 10.0
+        assert await Job.count() == 0
+
+
+async def _reload_user(user) -> User:
+    return await User.get(user.id)
+
+
+# ---------------------------------------------------------------------------
+# 202 — happy path: job persisted, params forwarded, credits deducted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestEnqueueSuccess:
+    @pytest.mark.parametrize("operation", CLIP_OPS)
+    async def test_returns_202_with_job_id(self, client, settings, operation: str) -> None:
+        user, _, clip = await _user_with_clip(f"iter-202-{operation}@example.com")
+        resp = await client.post(
+            _op_url(clip.id, operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+        assert body["job_id"]
+        assert body["estimated_time_seconds"] > 0
+
+    @pytest.mark.parametrize("operation", CLIP_OPS)
+    async def test_persists_job_with_clip_lineage_param(self, client, settings, operation: str) -> None:
+        user, workspace, clip = await _user_with_clip(f"iter-job-{operation}@example.com")
+        resp = await client.post(
+            _op_url(clip.id, operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        jobs = await Job.find_all().to_list()
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert job.job_type == JOB_TYPE[operation]
+        assert job.user_id == user.id
+        assert job.workspace_id == workspace.id
+        assert job.input_params["clip_id"] == str(clip.id)
+
+    async def test_extend_forwards_duration(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-extend-params@example.com")
+        resp = await client.post(
+            _op_url(clip.id, "extend"),
+            json={"duration": "45s", "lyrics": "ooh"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = (await Job.find_all().to_list())[0]
+        assert job.input_params["duration"] == "45s"
+        assert job.input_params["from_point"] == "end"
+        assert job.input_params["lyrics"] == "ooh"
+
+    async def test_repaint_forwards_resolved_ms_bounds(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-repaint-params@example.com")
+        resp = await client.post(
+            _op_url(clip.id, "repaint"),
+            json={"start": "2s", "end": "5s", "prompt": "add a guitar solo"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = (await Job.find_all().to_list())[0]
+        assert job.input_params["start_ms"] == 2000
+        assert job.input_params["end_ms"] == 5000
+        assert job.input_params["prompt"] == "add a guitar solo"
+
+    async def test_deducts_one_credit(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-credit@example.com", balance=10.0)
+        resp = await client.post(
+            _op_url(clip.id, "cover"),
+            json={"style": "jazz"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload_user(user)).credits_balance == 9.0
+        txns = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        assert len(txns) == 1
+        assert txns[0].amount == -1.0
+        assert txns[0].action_type == "cover"
+
+    async def test_sample_cost_scales_with_num_clips(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-sample-cost@example.com", balance=10.0)
+        resp = await client.post(
+            _op_url(clip.id, "sample"),
+            json={"start": "1s", "end": "3s", "role": "loop-bed", "prompt": "beat", "num_clips": 3},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload_user(user)).credits_balance == 7.0
+        job = (await Job.find_all().to_list())[0]
+        assert job.input_params["num_clips"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 402 — insufficient credits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestInsufficientCredits:
+    async def test_returns_402_with_balance_payload(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-poor@example.com", balance=0.25)
+        resp = await client.post(
+            _op_url(clip.id, "cover"),
+            json={"style": "jazz"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 402
+        detail = resp.json()["detail"]
+        assert detail["error"] == "insufficient_credits"
+        assert detail["balance"] == 0.25
+        assert detail["required"] == 1.0
+        assert await Job.count() == 0
+
+    async def test_balance_unchanged_on_402(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-poor-nojob@example.com", balance=0.25)
+        resp = await client.post(
+            _op_url(clip.id, "extend"),
+            json={"duration": "30s"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 402
+        assert (await _reload_user(user)).credits_balance == 0.25
+
+
+# ---------------------------------------------------------------------------
+# 422 — validation matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestValidation:
+    @pytest.mark.parametrize(
+        "operation,body",
+        [
+            ("extend", {"duration": "soon"}),  # unparseable time
+            ("extend", {}),  # missing required duration
+            ("extend", {"duration": "30s", "bogus": 1}),  # extra="forbid"
+            ("cover", {}),  # missing required style
+            ("cover", {"style": ""}),  # empty style
+            ("remix", {}),  # missing required style
+            ("repaint", {"start": "1s", "end": "5s"}),  # missing prompt
+            ("repaint", {"start": "x", "end": "5s", "prompt": "p"}),  # unparseable start
+            ("sample", {"start": "1s", "end": "3s", "prompt": "p"}),  # missing role
+            ("sample", {"start": "1s", "end": "3s", "role": "bogus", "prompt": "p"}),  # bad enum
+            ("sample", {"start": "1s", "end": "3s", "role": "loop-bed", "prompt": "p", "num_clips": 0}),  # num < 1
+            ("add-vocal", {}),  # missing lyrics
+            ("add-vocal", {"lyrics": ""}),  # empty lyrics
+        ],
+    )
+    async def test_invalid_body_returns_422(self, client, settings, operation: str, body: dict) -> None:
+        user, _, clip = await _user_with_clip(f"iter-422-{operation}-{len(body)}@example.com")
+        resp = await client.post(_op_url(clip.id, operation), json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    @pytest.mark.parametrize("operation", ["repaint", "sample"])
+    async def test_start_not_before_end_returns_422(self, client, settings, operation: str) -> None:
+        user, _, clip = await _user_with_clip(f"iter-range-{operation}@example.com", duration=10.0)
+        body = {**VALID_BODIES[operation], "start": "5s", "end": "5s"}
+        resp = await client.post(_op_url(clip.id, operation), json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    @pytest.mark.parametrize("operation", ["repaint", "sample"])
+    async def test_end_beyond_duration_returns_422(self, client, settings, operation: str) -> None:
+        user, _, clip = await _user_with_clip(f"iter-beyond-{operation}@example.com", duration=10.0)
+        body = {**VALID_BODIES[operation], "start": "1s", "end": "20s"}
+        resp = await client.post(_op_url(clip.id, operation), json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+    async def test_non_wav_source_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-nonwav@example.com", fmt="mp3")
+        resp = await client.post(
+            _op_url(clip.id, "cover"),
+            json={"style": "jazz"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Mashup — multi-source rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestMashup:
+    async def test_two_clips_returns_202_with_lineage(self, client, settings) -> None:
+        user = await _make_user("iter-mashup-ok@example.com", balance=10.0)
+        ws = await _make_workspace(user)
+        a = await _insert_clip(user, ws)
+        b = await _insert_clip(user, ws)
+        resp = await client.post(
+            MASHUP_URL,
+            json={"clip_ids": [str(a.id), str(b.id)]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = (await Job.find_all().to_list())[0]
+        assert job.job_type == "mashup"
+        assert job.input_params["clip_ids"] == [str(a.id), str(b.id)]
+        assert job.workspace_id == a.workspace_id
+
+    async def test_fewer_than_two_clips_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-mashup-one@example.com")
+        resp = await client.post(
+            MASHUP_URL,
+            json={"clip_ids": [str(clip.id)]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_duplicate_clip_ids_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-mashup-dup@example.com")
+        resp = await client.post(
+            MASHUP_URL,
+            json={"clip_ids": [str(clip.id), str(clip.id)]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_unowned_source_returns_404(self, client, settings) -> None:
+        user = await _make_user("iter-mashup-unowned@example.com", balance=10.0)
+        ws = await _make_workspace(user)
+        mine = await _insert_clip(user, ws)
+        other = await _make_user("iter-mashup-other@example.com")
+        ws2 = await _make_workspace(other)
+        theirs = await _insert_clip(other, ws2)
+        resp = await client.post(
+            MASHUP_URL,
+            json={"clip_ids": [str(mine.id), str(theirs.id)]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — endpoint → queued job → JobProcessor → completed clip
+# ---------------------------------------------------------------------------
+
+
+def _wav_bytes(duration_s: float = 2.0, freq: float = 440.0, sr: int = 44100) -> bytes:
+    t = np.linspace(0, duration_s, int(sr * duration_s), endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    buf = io.BytesIO()
+    sf.write(buf, np.column_stack([mono, mono]), sr, format="WAV")
+    return buf.getvalue()
+
+
+class _FakeAce:
+    """Stand-in ACE-Step client: returns a canned WAV without a live server."""
+
+    def __init__(self, output: bytes) -> None:
+        self.output = output
+        self._n = 1
+
+    def submit_task(self, **kwargs) -> str:
+        self._n = kwargs.get("num_clips", 1) or 1
+        return "task-1"
+
+    def query_result(self, task_id: str) -> dict:
+        return {"status": "completed", "audio_urls": [f"u{i}" for i in range(self._n)], "error": None}
+
+    def download_audio(self, url: str) -> bytes:
+        return self.output
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    """Point the storage backend at a throwaway local root."""
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path / "storage"))
+    return tmp_path
+
+
+@pytest.mark.integration
+class TestIterativeLifecycleEndToEnd:
+    """The cover job runs queued → completed via the real JobProcessor.
+
+    ``httpx.ASGITransport`` does not run the app lifespan, so the production
+    :class:`JobProcessor` is started directly — here with a fake ACE-Step client
+    factory (no live server) over the same local storage the endpoint wrote to.
+    """
+
+    async def test_cover_runs_to_completed_via_status_endpoint(self, client, settings, local_storage) -> None:
+        from acemusic.api.tasks.processor import JobProcessor
+
+        user = await _make_user("iter-e2e-cover@example.com", balance=10.0)
+        workspace = await _make_workspace(user)
+        clip_id = PydanticObjectId()
+        file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.wav"
+        get_storage_backend().upload(file_path, _wav_bytes(2.0))
+        clip = Clip(
+            id=clip_id,
+            user_id=user.id,
+            workspace_id=workspace.id,
+            file_path=file_path,
+            format="wav",
+            duration=2.0,
+            bpm=120,
+            key="C",
+        )
+        await clip.insert()
+        headers = _auth_headers(user, settings)
+
+        accepted = await client.post(_op_url(clip.id, "cover"), json={"style": "jazz"}, headers=headers)
+        assert accepted.status_code == 202
+        job_id = accepted.json()["job_id"]
+
+        processor = JobProcessor(
+            concurrency=1,
+            poll_interval=0.05,
+            ace_poll_interval=0.01,
+            client_factory=lambda: _FakeAce(_wav_bytes(2.0)),
+        )
+        await processor.start()
+        try:
+            status_body = None
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                resp = await client.get(f"{API_V1_PREFIX}/jobs/{job_id}/status", headers=headers)
+                assert resp.status_code == 200
+                status_body = resp.json()
+                assert status_body["status"] in {"queued", "processing", "completed"}, status_body.get("error")
+                if status_body["status"] == "completed":
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            await processor.stop()
+
+        assert status_body is not None and status_body["status"] == "completed", "job never completed"
+        assert len(status_body["clip_ids"]) == 1
+        new_clip = await Clip.get(PydanticObjectId(status_body["clip_ids"][0]))
+        assert new_clip.parent_clip_ids == [clip.id]
+        assert new_clip.generation_mode == "cover"
+        assert new_clip.generation_params["style"] == "jazz"

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -424,13 +424,14 @@ class TestValidation:
         assert await Job.count() == 0
         assert (await _reload_user(user)).credits_balance == 10.0
 
-    async def test_extend_without_duration_metadata_returns_422_no_charge(self, client, settings) -> None:
-        # A clip with no duration metadata cannot be extended; the endpoint must
-        # reject it before charging rather than enqueue a guaranteed-failing job.
-        user, _, clip = await _user_with_clip("iter-extend-nodur@example.com", balance=10.0, duration=None)
+    @pytest.mark.parametrize("operation", CLIP_OPS)
+    async def test_without_duration_metadata_returns_422_no_charge(self, client, settings, operation: str) -> None:
+        # Every mode feeds the source duration to ACE-Step; a clip with no
+        # duration metadata must be rejected before charging, not enqueued.
+        user, _, clip = await _user_with_clip(f"iter-nodur-{operation}@example.com", balance=10.0, duration=None)
         resp = await client.post(
-            _op_url(clip.id, "extend"),
-            json={"duration": "30s"},
+            _op_url(clip.id, operation),
+            json=VALID_BODIES[operation],
             headers=_auth_headers(user, settings),
         )
         assert resp.status_code == 422
@@ -486,6 +487,33 @@ class TestMashup:
         assert (await _reload_user(user)).credits_balance == 8.0
         txns = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
         assert txns[0].amount == -2.0
+
+    async def test_too_many_clips_returns_422(self, client, settings) -> None:
+        # The source list is capped to keep one request's work bounded.
+        user = await _make_user("iter-mashup-many@example.com", balance=10.0)
+        ws = await _make_workspace(user)
+        clips = [await _insert_clip(user, ws) for _ in range(9)]
+        resp = await client.post(
+            MASHUP_URL,
+            json={"clip_ids": [str(c.id) for c in clips]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_no_duration_source_returns_422(self, client, settings) -> None:
+        user = await _make_user("iter-mashup-nodur@example.com", balance=10.0)
+        ws = await _make_workspace(user)
+        a = await _insert_clip(user, ws, duration=10.0)
+        b = await _insert_clip(user, ws, duration=None)
+        resp = await client.post(
+            MASHUP_URL,
+            json={"clip_ids": [str(a.id), str(b.id)]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+        assert (await _reload_user(user)).credits_balance == 10.0
 
     async def test_fewer_than_two_clips_returns_422(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("iter-mashup-one@example.com")

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -283,6 +283,30 @@ class TestEnqueueSuccess:
         assert txns[0].amount == -1.0
         assert txns[0].action_type == "cover"
 
+    async def test_status_endpoint_reports_iterative_eta(self, client, settings) -> None:
+        # A queued iterative job keeps a real ETA when polled (not the 0 fallback).
+        user, _, clip = await _user_with_clip("iter-eta@example.com")
+        accepted = await client.post(
+            _op_url(clip.id, "cover"), json={"style": "jazz"}, headers=_auth_headers(user, settings)
+        )
+        assert accepted.status_code == 202
+        job_id = accepted.json()["job_id"]
+        status = await client.get(f"{API_V1_PREFIX}/jobs/{job_id}/status", headers=_auth_headers(user, settings))
+        assert status.status_code == 200
+        assert status.json()["estimated_time_seconds"] == 45
+
+    async def test_status_endpoint_scales_sample_eta(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("iter-eta-sample@example.com")
+        accepted = await client.post(
+            _op_url(clip.id, "sample"),
+            json={"start": "1s", "end": "3s", "role": "loop-bed", "prompt": "beat", "num_clips": 2},
+            headers=_auth_headers(user, settings),
+        )
+        assert accepted.status_code == 202
+        job_id = accepted.json()["job_id"]
+        status = await client.get(f"{API_V1_PREFIX}/jobs/{job_id}/status", headers=_auth_headers(user, settings))
+        assert status.json()["estimated_time_seconds"] == 90
+
     async def test_sample_cost_scales_with_num_clips(self, client, settings) -> None:
         user, _, clip = await _user_with_clip("iter-sample-cost@example.com", balance=10.0)
         resp = await client.post(
@@ -385,6 +409,20 @@ class TestValidation:
         )
         assert resp.status_code == 422
         assert await Job.count() == 0
+
+    @pytest.mark.parametrize("from_point", ["0s", "0", "20s"])
+    async def test_extend_from_point_out_of_range_returns_422(self, client, settings, from_point: str) -> None:
+        # 0 would trim to a zero-length prefix (worker error); past the end has no
+        # audio to continue from — both must be rejected before charging.
+        user, _, clip = await _user_with_clip("iter-extend-from@example.com", balance=10.0, duration=10.0)
+        resp = await client.post(
+            _op_url(clip.id, "extend"),
+            json={"duration": "5s", "from_point": from_point},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+        assert (await _reload_user(user)).credits_balance == 10.0
 
     async def test_extend_without_duration_metadata_returns_422_no_charge(self, client, settings) -> None:
         # A clip with no duration metadata cannot be extended; the endpoint must

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -451,6 +451,34 @@ class TestValidation:
         assert await Job.count() == 0
         assert (await _reload_user(user)).credits_balance == 10.0
 
+    @pytest.mark.parametrize("operation", ["cover", "remix", "repaint", "add-vocal"])
+    async def test_oversized_source_duration_returns_422_no_charge(self, client, settings, operation: str) -> None:
+        # Modes that submit source.duration as ACE-Step audio_duration must reject
+        # a source longer than the generation cap (240s) before charging.
+        user, _, clip = await _user_with_clip(f"iter-toolong-{operation}@example.com", balance=10.0, duration=480.0)
+        resp = await client.post(
+            _op_url(clip.id, operation),
+            json=VALID_BODIES[operation],
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+        assert (await _reload_user(user)).credits_balance == 10.0
+
+    @pytest.mark.parametrize("operation", ["extend", "sample"])
+    async def test_oversized_source_allowed_for_trimming_modes(self, client, settings, operation: str) -> None:
+        # extend trims to a prefix and sample works on a bounded range, so an
+        # oversized source is fine as long as the request stays within the cap.
+        user, _, clip = await _user_with_clip(f"iter-long-ok-{operation}@example.com", balance=10.0, duration=480.0)
+        bodies = {
+            "extend": {"duration": "5s", "from_point": "10s"},
+            "sample": {"start": "1s", "end": "3s", "role": "loop-bed", "prompt": "beat"},
+        }
+        resp = await client.post(
+            _op_url(clip.id, operation), json=bodies[operation], headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 202
+
     async def test_oversized_free_text_returns_422(self, client, settings) -> None:
         # Free-text fields are persisted verbatim; an unbounded string must be
         # rejected (matches the generation API's caps) rather than bloating Mongo.

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -357,6 +357,42 @@ class TestMashup:
         # All non-primary sources are mixed into the single reference track.
         assert client.submitted[0]["ref_audio_path"].endswith("reference.wav")
 
+    async def test_reference_keeps_longest_secondary(self, storage, tmp_path) -> None:
+        # A later, longer secondary must not be truncated to the first's length.
+        job, primary = await _make_clip(storage, email="t-mashup-len@example.com")
+        short_id, long_id = PydanticObjectId(), PydanticObjectId()
+        sp = f"{primary.user_id}/{primary.workspace_id}/clips/{short_id}.wav"
+        lp = f"{primary.user_id}/{primary.workspace_id}/clips/{long_id}.wav"
+        storage.upload(sp, _wav_bytes(2.0))
+        storage.upload(lp, _wav_bytes(5.0))
+        short = Clip(
+            id=short_id,
+            user_id=primary.user_id,
+            workspace_id=primary.workspace_id,
+            file_path=sp,
+            format="wav",
+            duration=2.0,
+            bpm=120,
+            key="C",
+        )
+        long_clip = Clip(
+            id=long_id,
+            user_id=primary.user_id,
+            workspace_id=primary.workspace_id,
+            file_path=lp,
+            format="wav",
+            duration=5.0,
+            bpm=120,
+            key="C",
+        )
+        await short.insert()
+        await long_clip.insert()
+
+        # Short secondary first, long one second — overlay must keep the 5s length.
+        ref = await tasks._build_mashup_reference(storage, [short, long_clip], tmp_path, "wav", 120)
+        seg = tasks._decode(ref.read_bytes(), "wav")
+        assert len(seg) >= 4900  # ~5s, not truncated to the 2s first secondary
+
     async def test_bpm_aligns_mismatched_secondary(self, storage, monkeypatch) -> None:
         import shutil
 

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -138,6 +138,36 @@ class TestExtend:
         assert submitted["task_type"] == "repaint"
         assert submitted["repainting_start"] == pytest.approx(3.0)
         assert submitted["repainting_end"] == pytest.approx(5.0)
+        # from_point="end" sends the full source untrimmed.
+        assert submitted["src_audio_path"].endswith("source.wav")
+
+    async def test_mid_clip_extend_trims_source_to_prefix(self, storage, monkeypatch) -> None:
+        job, source = await _make_clip(storage, email="t-extend-mid@example.com", duration=3.0)
+        job.job_type = tasks.EXTEND_JOB_TYPE
+        job.input_params = {"clip_id": str(source.id), "duration": "2s", "from_point": "1s", "lyrics": None}
+        client = FakeAce(_wav_bytes(3.0))
+
+        import shutil
+
+        heads: list[float] = []
+
+        def fake_slice(input_path, head_seconds, output_path):
+            heads.append(head_seconds)
+            shutil.copy(input_path, output_path)
+            return output_path
+
+        monkeypatch.setattr(tasks, "slice_audio", fake_slice)
+
+        result = await tasks.process_extend_job(job, storage=storage, client=client, poll=_make_poll())
+
+        # Source trimmed to [0, from_point]; ACE-Step never sees the discarded tail.
+        assert heads == [pytest.approx(1.0)]
+        submitted = client.submitted[0]
+        assert submitted["src_audio_path"].endswith("trimmed.wav")
+        assert submitted["repainting_start"] == pytest.approx(1.0)
+        assert submitted["repainting_end"] == pytest.approx(3.0)
+        child = await _child(result)
+        assert child.duration == pytest.approx(3.0, abs=0.05)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -315,6 +315,42 @@ class TestMashup:
         # All non-primary sources are mixed into the single reference track.
         assert client.submitted[0]["ref_audio_path"].endswith("reference.wav")
 
+    async def test_bpm_aligns_mismatched_secondary(self, storage, monkeypatch) -> None:
+        import shutil
+
+        job, primary = await _make_clip(storage, email="t-mashup-bpm@example.com", bpm=120)
+        sec_id = PydanticObjectId()
+        sec_path = f"{primary.user_id}/{primary.workspace_id}/clips/{sec_id}.wav"
+        storage.upload(sec_path, _wav_bytes(3.0, freq=550.0))
+        secondary = Clip(
+            id=sec_id,
+            user_id=primary.user_id,
+            workspace_id=primary.workspace_id,
+            file_path=sec_path,
+            format="wav",
+            duration=3.0,
+            bpm=90,  # different tempo → must be aligned to the primary's 120
+            key="C",
+            title="Slow",
+        )
+        await secondary.insert()
+        job.job_type = tasks.MASHUP_JOB_TYPE
+        job.input_params = {"clip_ids": [str(primary.id), str(secondary.id)], "blend_mode": "layered", "style": None}
+        client = FakeAce(_wav_bytes(3.0))
+
+        rates: list[float] = []
+
+        def fake_stretch(input_path, output_path, rate):
+            rates.append(rate)
+            shutil.copy(input_path, output_path)  # keep a readable wav for the overlay
+
+        monkeypatch.setattr(tasks, "time_stretch_audio", fake_stretch)
+
+        await tasks.process_mashup_job(job, storage=storage, client=client, poll=_make_poll())
+
+        # Secondary at 90 BPM aligned to the primary's 120: rate 120/90.
+        assert rates == [pytest.approx(120 / 90)]
+
 
 # ---------------------------------------------------------------------------
 # sample

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -306,8 +306,10 @@ class TestMashup:
         assert submitted["src_audio_path"].endswith(".wav")
         assert submitted["ref_audio_path"].endswith(".wav")
         assert submitted["blend_mode"] == "layered"
-        # Mismatched keys → no key constraint asserted.
+        # Mismatched keys → no key constraint asserted, and the child clip must
+        # not claim the primary's key (it was generated unconstrained).
         assert submitted["key"] is None
+        assert child.key is None
 
     async def test_three_sources_all_in_lineage(self, storage) -> None:
         job, primary = await _make_clip(storage, email="t-mashup3@example.com")
@@ -342,6 +344,8 @@ class TestMashup:
         child = await _child(result)
         # Every requested source is recorded — none silently dropped.
         assert child.parent_clip_ids == [primary.id, extra[0].id, extra[1].id]
+        # All keys match, so the child inherits the primary's key.
+        assert child.key == "C"
         # All non-primary sources are mixed into the single reference track.
         assert client.submitted[0]["ref_audio_path"].endswith("reference.wav")
 

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -279,6 +279,42 @@ class TestMashup:
         # Mismatched keys → no key constraint asserted.
         assert submitted["key"] is None
 
+    async def test_three_sources_all_in_lineage(self, storage) -> None:
+        job, primary = await _make_clip(storage, email="t-mashup3@example.com")
+        extra = []
+        for i in range(2):
+            cid = PydanticObjectId()
+            path = f"{primary.user_id}/{primary.workspace_id}/clips/{cid}.wav"
+            storage.upload(path, _wav_bytes(3.0, freq=500.0 + 50 * i))
+            clip = Clip(
+                id=cid,
+                user_id=primary.user_id,
+                workspace_id=primary.workspace_id,
+                file_path=path,
+                format="wav",
+                duration=3.0,
+                bpm=120,
+                key="C",
+                title=f"Extra{i}",
+            )
+            await clip.insert()
+            extra.append(clip)
+        job.job_type = tasks.MASHUP_JOB_TYPE
+        job.input_params = {
+            "clip_ids": [str(primary.id), str(extra[0].id), str(extra[1].id)],
+            "blend_mode": "layered",
+            "style": None,
+        }
+        client = FakeAce(_wav_bytes(3.0))
+
+        result = await tasks.process_mashup_job(job, storage=storage, client=client, poll=_make_poll())
+
+        child = await _child(result)
+        # Every requested source is recorded — none silently dropped.
+        assert child.parent_clip_ids == [primary.id, extra[0].id, extra[1].id]
+        # All non-primary sources are mixed into the single reference track.
+        assert client.submitted[0]["ref_audio_path"].endswith("reference.wav")
+
 
 # ---------------------------------------------------------------------------
 # sample
@@ -309,6 +345,38 @@ class TestSample:
             assert child.parent_clip_ids == [source.id]
             assert child.duration and child.duration > 0
         assert client.submitted[0]["num_clips"] == 2
+
+    async def test_partial_failure_rolls_back_earlier_children(self, storage, monkeypatch) -> None:
+        job, source = await _make_clip(storage, email="t-sample-rollback@example.com", duration=3.0)
+        job.job_type = tasks.SAMPLE_JOB_TYPE
+        job.input_params = {
+            "clip_id": str(source.id),
+            "start_ms": 500,
+            "end_ms": 1500,
+            "role": "loop-bed",
+            "prompt": "make a beat",
+            "backend": "ace-step",
+            "num_clips": 3,
+        }
+        client = FakeAce(_wav_bytes(3.0))
+
+        # Fail on the second combine so the first child must be rolled back.
+        real_combine = tasks.combine_sample
+        calls = {"n": 0}
+
+        def flaky_combine(**kwargs):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("combine boom")
+            return real_combine(**kwargs)
+
+        monkeypatch.setattr(tasks, "combine_sample", flaky_combine)
+
+        before = await Clip.count()
+        with pytest.raises(RuntimeError):
+            await tasks.process_sample_job(job, storage=storage, client=client, poll=_make_poll())
+        # The first child (created before the failure) was rolled back.
+        assert await Clip.count() == before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -186,6 +186,9 @@ class TestRestyle:
 
         child = await _child(result)
         assert child.generation_mode == "cover"
+        # Effective style/lyrics are recorded so a chained op reads the new style.
+        assert child.style_tags == ["jazz"]
+        assert child.lyrics == "new words"
         submitted = client.submitted[0]
         assert submitted["task_type"] == "cover"
         assert submitted["lyrics"] == "new words"
@@ -203,6 +206,8 @@ class TestRestyle:
 
         child = await _child(result)
         assert child.generation_mode == "remix"
+        assert child.style_tags == ["house"]
+        assert child.lyrics == "original"  # remix preserves the source lyrics
         assert client.submitted[0]["task_type"] == "cover"
         assert client.submitted[0]["lyrics"] == "original"
 
@@ -216,6 +221,9 @@ class TestRestyle:
 
         child = await _child(result)
         assert child.generation_mode == "add_vocal"
+        # The added lyrics and vocal style are persisted on the child.
+        assert child.lyrics == "sing this"
+        assert child.style_tags == ["soulful"]
         submitted = client.submitted[0]
         assert submitted["task_type"] == "complete"
         assert submitted["lyrics"] == "sing this"

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -18,7 +18,7 @@ import soundfile as sf
 from beanie import PydanticObjectId
 
 from acemusic.api.models import Clip, Job, JobStatus, Workspace
-from acemusic.api.services import users as user_service
+from acemusic.api.services import iterative as iterative_service, users as user_service
 from acemusic.api.tasks import iterative as tasks
 from acemusic.storage import LocalStorage
 
@@ -518,3 +518,32 @@ class TestFailures:
         client = FakeAce(_wav_bytes(3.0))
         with pytest.raises(tasks.IterativeProcessingError):
             await tasks.process_cover_job(job, storage=storage, client=client, poll=_make_poll())
+
+
+# ---------------------------------------------------------------------------
+# Service layer — create_iterative_job
+# ---------------------------------------------------------------------------
+
+
+class TestService:
+    async def test_unknown_job_type_raises(self, storage) -> None:
+        with pytest.raises(ValueError):
+            await iterative_service.create_iterative_job(
+                user_id=PydanticObjectId(), workspace_id=PydanticObjectId(), job_type="bogus", params={}
+            )
+
+    async def test_dispatch_failure_rolls_back_job(self, storage, monkeypatch) -> None:
+        async def boom(job_id: str) -> None:
+            raise RuntimeError("dispatch down")
+
+        monkeypatch.setattr(iterative_service, "dispatch_job", boom)
+        before = await Job.count()
+        with pytest.raises(RuntimeError):
+            await iterative_service.create_iterative_job(
+                user_id=PydanticObjectId(),
+                workspace_id=PydanticObjectId(),
+                job_type=iterative_service.COVER_JOB_TYPE,
+                params={"clip_id": "x"},
+            )
+        # The just-inserted job is deleted so the poller never runs an orphan.
+        assert await Job.count() == before

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -1,0 +1,338 @@
+"""Tests for the iterative generation job handlers (US-10.3, issue #83).
+
+These exercise ``acemusic.api.tasks.iterative`` directly with a fake ACE-Step
+client and a local on-disk storage backend: each handler downloads the source
+clip, "submits" a task, downloads the (faked) audio, applies any local
+post-processing, and stores a lineage-tagged child clip. They assert the worker
+contract — lineage metadata, inherited fields, post-processing, rollback — that
+the real ACE-Step integration tests cannot cheaply cover.
+
+All require a local MongoDB (Beanie) and are marked ``integration``.
+"""
+
+import io
+
+import numpy as np
+import pytest
+import soundfile as sf
+from beanie import PydanticObjectId
+
+from acemusic.api.models import Clip, Job, JobStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.tasks import iterative as tasks
+from acemusic.storage import LocalStorage
+
+pytestmark = pytest.mark.integration
+
+SR = 44100
+
+
+def _wav_bytes(duration_s: float = 3.0, freq: float = 440.0) -> bytes:
+    """Render a stereo sine-wave WAV to bytes (no temp file)."""
+    t = np.linspace(0, duration_s, int(SR * duration_s), endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    buf = io.BytesIO()
+    sf.write(buf, stereo, SR, format="WAV")
+    return buf.getvalue()
+
+
+class FakeAce:
+    """Records submit_task kwargs and returns canned audio on download."""
+
+    def __init__(self, output: bytes) -> None:
+        self.output = output
+        self.submitted: list[dict] = []
+        self._n = 1
+
+    def submit_task(self, **kwargs) -> str:
+        self.submitted.append(kwargs)
+        self._n = kwargs.get("num_clips", 1) or 1
+        return "task-1"
+
+    def download_audio(self, url: str) -> bytes:
+        return self.output
+
+
+def _make_poll(status: str = "completed", error: str | None = None):
+    async def poll(client, task_id):
+        return {"status": status, "audio_urls": [f"u{i}" for i in range(client._n)], "error": error}
+
+    return poll
+
+
+@pytest.fixture
+def storage(mongo_db, tmp_path) -> LocalStorage:
+    # ``mongo_db`` initialises Beanie so the handlers can read/insert documents.
+    return LocalStorage(tmp_path / "storage")
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_clip(
+    storage: LocalStorage,
+    *,
+    email: str,
+    duration: float = 3.0,
+    bpm: int | None = 120,
+    key: str | None = "C",
+    vocal_language: str | None = "en",
+    title: str | None = "Source",
+    audio: bytes | None = None,
+) -> tuple[Job, Clip]:
+    """Create a user/workspace/source clip with real wav bytes in storage."""
+    user = await _make_user(email)
+    workspace = Workspace(name="WS", user_id=user.id)
+    await workspace.insert()
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.wav"
+    storage.upload(file_path, audio if audio is not None else _wav_bytes(duration))
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=file_path,
+        format="wav",
+        duration=duration,
+        bpm=bpm,
+        key=key,
+        vocal_language=vocal_language,
+        title=title,
+        style_tags=["lofi"],
+    )
+    await clip.insert()
+    job = Job(user_id=user.id, workspace_id=workspace.id, job_type="", input_params={}, status=JobStatus.QUEUED)
+    return job, clip
+
+
+async def _child(result: dict) -> Clip:
+    ids = result["clip_ids"]
+    assert len(ids) == 1
+    return await Clip.get(PydanticObjectId(ids[0]))
+
+
+# ---------------------------------------------------------------------------
+# extend
+# ---------------------------------------------------------------------------
+
+
+class TestExtend:
+    async def test_creates_longer_child_with_lineage(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-extend@example.com", duration=3.0)
+        job.job_type = tasks.EXTEND_JOB_TYPE
+        job.input_params = {"clip_id": str(source.id), "duration": "2s", "from_point": "end", "lyrics": "la"}
+        client = FakeAce(_wav_bytes(5.0))
+
+        result = await tasks.process_extend_job(job, storage=storage, client=client, poll=_make_poll())
+
+        child = await _child(result)
+        assert child.parent_clip_ids == [source.id]
+        assert child.generation_mode == "extend"
+        assert child.generation_params == job.input_params
+        assert child.bpm == 120 and child.key == "C" and child.vocal_language == "en"
+        # Extend grows the source by ~the requested duration (3s + 2s).
+        assert child.duration == pytest.approx(5.0, abs=0.05)
+        submitted = client.submitted[0]
+        assert submitted["task_type"] == "repaint"
+        assert submitted["repainting_start"] == pytest.approx(3.0)
+        assert submitted["repainting_end"] == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# cover / remix / add-vocal
+# ---------------------------------------------------------------------------
+
+
+class TestRestyle:
+    async def test_cover_forwards_lyrics_override(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-cover@example.com")
+        job.job_type = tasks.COVER_JOB_TYPE
+        job.input_params = {"clip_id": str(source.id), "style": "jazz", "lyrics_override": "new words"}
+        client = FakeAce(_wav_bytes(3.0))
+
+        result = await tasks.process_cover_job(job, storage=storage, client=client, poll=_make_poll())
+
+        child = await _child(result)
+        assert child.generation_mode == "cover"
+        submitted = client.submitted[0]
+        assert submitted["task_type"] == "cover"
+        assert submitted["lyrics"] == "new words"
+        assert submitted["style"] == "jazz"
+
+    async def test_remix_uses_cover_task_and_keeps_source_lyrics(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-remix@example.com")
+        source.lyrics = "original"
+        await source.save()
+        job.job_type = tasks.REMIX_JOB_TYPE
+        job.input_params = {"clip_id": str(source.id), "style": "house"}
+        client = FakeAce(_wav_bytes(3.0))
+
+        result = await tasks.process_remix_job(job, storage=storage, client=client, poll=_make_poll())
+
+        child = await _child(result)
+        assert child.generation_mode == "remix"
+        assert client.submitted[0]["task_type"] == "cover"
+        assert client.submitted[0]["lyrics"] == "original"
+
+    async def test_add_vocal_uses_complete_task(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-vocal@example.com")
+        job.job_type = tasks.ADD_VOCAL_JOB_TYPE
+        job.input_params = {"clip_id": str(source.id), "lyrics": "sing this", "vocal_style": "soulful"}
+        client = FakeAce(_wav_bytes(3.0))
+
+        result = await tasks.process_add_vocal_job(job, storage=storage, client=client, poll=_make_poll())
+
+        child = await _child(result)
+        assert child.generation_mode == "add_vocal"
+        submitted = client.submitted[0]
+        assert submitted["task_type"] == "complete"
+        assert submitted["lyrics"] == "sing this"
+        assert submitted["style"] == "soulful"
+
+
+# ---------------------------------------------------------------------------
+# repaint
+# ---------------------------------------------------------------------------
+
+
+class TestRepaint:
+    async def test_stitches_and_preserves_length(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-repaint@example.com", duration=3.0)
+        job.job_type = tasks.REPAINT_JOB_TYPE
+        job.input_params = {
+            "clip_id": str(source.id),
+            "start_ms": 1000,
+            "end_ms": 2000,
+            "prompt": "add a solo",
+            "style": None,
+        }
+        # ACE returns a full-length clip; only [1000,2000] is spliced in.
+        client = FakeAce(_wav_bytes(3.0, freq=880.0))
+
+        result = await tasks.process_repaint_job(job, storage=storage, client=client, poll=_make_poll())
+
+        child = await _child(result)
+        assert child.generation_mode == "repaint"
+        # Stitched output stays ~the original length; the two 50ms crossfade
+        # seams trim ~100ms off the 3.0s total.
+        assert child.duration == pytest.approx(2.9, abs=0.05)
+        submitted = client.submitted[0]
+        assert submitted["task_type"] == "repaint"
+        assert submitted["repainting_start"] == pytest.approx(1.0)
+        assert submitted["repainting_end"] == pytest.approx(2.0)
+
+    async def test_truncated_output_fails(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-repaint-trunc@example.com", duration=3.0)
+        job.job_type = tasks.REPAINT_JOB_TYPE
+        job.input_params = {"clip_id": str(source.id), "start_ms": 1000, "end_ms": 2900, "prompt": "p", "style": None}
+        client = FakeAce(_wav_bytes(1.0))  # far shorter than end_ms
+
+        before = await Clip.count()
+        with pytest.raises(tasks.IterativeProcessingError):
+            await tasks.process_repaint_job(job, storage=storage, client=client, poll=_make_poll())
+        assert await Clip.count() == before  # no orphan child
+
+
+# ---------------------------------------------------------------------------
+# mashup
+# ---------------------------------------------------------------------------
+
+
+class TestMashup:
+    async def test_blends_two_sources_with_full_lineage(self, storage) -> None:
+        job, primary = await _make_clip(storage, email="t-mashup@example.com", key="C")
+        secondary_id = PydanticObjectId()
+        sec_path = f"{primary.user_id}/{primary.workspace_id}/clips/{secondary_id}.wav"
+        storage.upload(sec_path, _wav_bytes(3.0, freq=550.0))
+        secondary = Clip(
+            id=secondary_id,
+            user_id=primary.user_id,
+            workspace_id=primary.workspace_id,
+            file_path=sec_path,
+            format="wav",
+            duration=3.0,
+            bpm=128,
+            key="G",  # mismatched key
+            title="Second",
+        )
+        await secondary.insert()
+        job.job_type = tasks.MASHUP_JOB_TYPE
+        job.input_params = {
+            "clip_ids": [str(primary.id), str(secondary.id)],
+            "blend_mode": "layered",
+            "style": "mashup vibes",
+        }
+        client = FakeAce(_wav_bytes(3.0))
+
+        result = await tasks.process_mashup_job(job, storage=storage, client=client, poll=_make_poll())
+
+        child = await _child(result)
+        assert child.generation_mode == "mashup"
+        assert child.parent_clip_ids == [primary.id, secondary.id]
+        submitted = client.submitted[0]
+        assert submitted["task_type"] == "mashup"
+        assert submitted["src_audio_path"].endswith(".wav")
+        assert submitted["ref_audio_path"].endswith(".wav")
+        assert submitted["blend_mode"] == "layered"
+        # Mismatched keys → no key constraint asserted.
+        assert submitted["key"] is None
+
+
+# ---------------------------------------------------------------------------
+# sample
+# ---------------------------------------------------------------------------
+
+
+class TestSample:
+    async def test_produces_num_clips_children(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-sample@example.com", duration=3.0)
+        job.job_type = tasks.SAMPLE_JOB_TYPE
+        job.input_params = {
+            "clip_id": str(source.id),
+            "start_ms": 500,
+            "end_ms": 1500,
+            "role": "loop-bed",
+            "prompt": "make a beat",
+            "backend": "ace-step",
+            "num_clips": 2,
+        }
+        client = FakeAce(_wav_bytes(3.0))
+
+        result = await tasks.process_sample_job(job, storage=storage, client=client, poll=_make_poll())
+
+        assert len(result["clip_ids"]) == 2
+        for cid in result["clip_ids"]:
+            child = await Clip.get(PydanticObjectId(cid))
+            assert child.generation_mode == "sample"
+            assert child.parent_clip_ids == [source.id]
+            assert child.duration and child.duration > 0
+        assert client.submitted[0]["num_clips"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestFailures:
+    async def test_failed_task_raises_and_leaves_no_clip(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-fail@example.com")
+        job.job_type = tasks.COVER_JOB_TYPE
+        job.input_params = {"clip_id": str(source.id), "style": "jazz", "lyrics_override": None}
+        client = FakeAce(_wav_bytes(3.0))
+
+        before = await Clip.count()
+        with pytest.raises(tasks.IterativeProcessingError):
+            await tasks.process_cover_job(job, storage=storage, client=client, poll=_make_poll("failed", "boom"))
+        assert await Clip.count() == before
+
+    async def test_missing_source_clip_raises(self, storage) -> None:
+        job, source = await _make_clip(storage, email="t-missing@example.com")
+        await source.delete()
+        job.job_type = tasks.COVER_JOB_TYPE
+        job.input_params = {"clip_id": str(source.id), "style": "jazz", "lyrics_override": None}
+        client = FakeAce(_wav_bytes(3.0))
+        with pytest.raises(tasks.IterativeProcessingError):
+            await tasks.process_cover_job(job, storage=storage, client=client, poll=_make_poll())


### PR DESCRIPTION
## US-10.3: Iterative generation endpoints

Closes #83.

Exposes the seven AI-powered iterative generation modes as credit-bearing POST
endpoints, each taking a source clip (or several, for mashup) and producing a
**new** clip with lineage back to its source(s).

### Endpoints (all `/api/v1`, Bearer-auth, return `202 {job_id, status, estimated_time_seconds}`)
| Endpoint | Body | ACE-Step task |
|---|---|---|
| `POST /clips/{id}/extend` | `{duration, from_point?, style_override?, lyrics?}` | `repaint` (continuation) |
| `POST /clips/{id}/cover` | `{style, voice_id?, lyrics_override?}` | `cover` |
| `POST /clips/{id}/remix` | `{style}` | `cover` (alias) |
| `POST /clips/{id}/repaint` | `{start, end, prompt, style?}` | `repaint` + crossfade-stitch |
| `POST /clips/{id}/sample` | `{start, end, role, prompt, backend?, num_clips?}` | generate + `combine_sample` |
| `POST /clips/{id}/add-vocal` | `{lyrics, voice_id?, vocal_style?}` | `complete` |
| `POST /mashup` | `{clip_ids[≥2], blend_mode?, style?}` | `mashup` (src + mixed ref) |

### Design
Mirrors the merged **US-10.1 editing** / **US-10.2 extraction** pattern
(router → service → task handler → processor). The CodeRabbit plan's "CLI-only,
Stage 9 not built" research was stale — Stage 9 + US-10.1/10.2 are merged — so
this builds on the real infra and reuses its exact conventions.

- **Credits**: deducted atomically at queue time like `POST /generate` (these are
  generative, unlike editing/extraction). `sample` scales cost by `num_clips`.
  Job-create failure refunds; ledger write is best-effort.
- **Worker** (`tasks/iterative.py`): downloads the source, submits the matching
  ACE-Step task, polls, downloads, post-processes (repaint stitches the window
  back via `crossfade_stitch`; sample crops + `combine_sample` per role; mashup
  mixes all secondaries into one BPM-aligned reference), and stores a child clip
  carrying `parent_clip_ids`, `generation_mode`, `generation_params`, inheriting
  `bpm`/`key`/`vocal_language`. Uploaded objects roll back on failure.
- **Processor wiring**: iterative handlers are registered via a new injecting
  adapter (`_run_iterative_handler`) since they need the ACE-Step client + poll
  loop, unlike the storage-only editing/extraction handlers.
- Adds `generation_params` to the `Clip` model and the seven iterative costs to
  the credits table.

### Tests
- `tests/test_clips_iterative_api.py` — auth 401 (CI), 404 (unknown/malformed/
  other-user), 402 (insufficient credits + balance unchanged), 422 validation
  matrix (time formats, missing/empty required fields, enums, range bounds,
  non-wav source, zero-length extend, no-duration extend, elevenlabs sample),
  202 + job persistence + param forwarding + credit deduction, mashup dup/min-2/
  ownership rules, and an end-to-end lifecycle through the real `JobProcessor`
  (cover queued → completed → child clip with lineage).
- `tests/test_clips_iterative_tasks.py` — each handler with a fake ACE-Step
  client + local storage: lineage metadata, inherited fields, post-processing
  (repaint stitch length, sample N children, mashup full lineage + BPM align),
  and rollback (truncated repaint, mid-batch sample failure, missing source).

All new tests pass (83); related suites (credits/generation/editing/extraction/
clips/jobs) pass with no regressions. ruff + black clean.

### Known limitations
- **Same-host ACE-Step**: source audio is handed to ACE-Step as a worker-local
  `src_audio_path`, so ACE-Step must run on the same host / shared filesystem as
  the API worker — the same constraint the CLI iterative commands document.
  Remote / cross-container ACE-Step is a deferred story; `submit_task` takes a
  local path, not a fetchable URL, so this can't be fixed without backend support.
- **`voice_id`** (cover, add-vocal) is part of the API contract but **not yet
  applied** by the ACE-Step backend, which has no voice-selection parameter — it
  is accepted/recorded for forward compatibility only.
- **`sample` `backend=elevenlabs`** is **rejected at enqueue (422)**; only the
  ACE-Step backend is implemented in the worker. The enum value is reserved.
- AI-quality acceptance criteria (cover preserves melody, repaint changes only
  the window) are inherently verifiable only against a live ACE-Step server and
  are covered by the worker contract here; ElevenLabs upload/inpaint paths remain
  account-gated.
