### PR TITLE
feat(api): full-song assembly endpoint (US-10.4)

### DIFF
--- a/src/acemusic/api/models/job.py
+++ b/src/acemusic/api/models/job.py
@@ -32,6 +32,9 @@ class Job(Document):
     input_params: dict = Field(default_factory=dict)
     result: dict | None = None
     error: str | None = None
+    # Human-readable progress for long, multi-step jobs (US-10.4 full-song writes
+    # "Processing section N of M" per section). None for single-step jobs.
+    progress: str | None = None
     created_at: datetime = Field(default_factory=utcnow)
     started_at: datetime | None = None
     completed_at: datetime | None = None

--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -32,6 +32,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from acemusic.constants import DURATION_MAX, LYRICS_MAX_LENGTH, PROMPT_MAX_LENGTH, STYLE_MAX_LENGTH
+from acemusic.song_structure import plan_sections
 from acemusic.utils import parse_time_string
 
 from ..auth.dependencies import CurrentUser, get_current_user
@@ -59,6 +60,13 @@ _MAX_MASHUP_CLIPS = 8
 # bloating a Mongo document or exhausting memory. voice_id is an identifier, so a
 # small bound suffices; style/prompt/lyrics reuse the shared generation caps.
 _VOICE_ID_MAX_LENGTH = 128
+
+# Full-song (US-10.4): the seed must be a short idea, not an already-long track —
+# the feature grows a clip *into* a song, so cap the seed and bound the section
+# count (each section is one paid ACE-Step extend, so an unbounded list would let
+# one request queue arbitrarily much GPU work).
+_FULL_SONG_MAX_SEED_SECONDS = 60.0
+_MAX_FULL_SONG_SECTIONS = 12
 
 # Router-level dependency gates every route behind a valid Bearer token (mirrors
 # the editing/generation routers), so unauthenticated requests get 401. No
@@ -206,6 +214,36 @@ class AddVocalRequest(BaseModel):
     lyrics: str = Field(min_length=1, max_length=LYRICS_MAX_LENGTH)
     voice_id: str | None = Field(default=None, max_length=_VOICE_ID_MAX_LENGTH)
     vocal_style: str | None = Field(default=None, max_length=STYLE_MAX_LENGTH)
+
+
+class FullSongRequest(BaseModel):
+    """Assemble a full song from a short seed by chaining one extend per section.
+
+    ``structure_plan`` overrides the canonical intro→outro section list; each name
+    must be a known section (validated against the seed at enqueue time). ``style``
+    anchors every section's conditioning, and ``lyrics`` (if given) is applied to
+    every section.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_duration: int = Field(default=210, gt=0)
+    structure_plan: list[str] | None = None
+    style: str | None = Field(default=None, max_length=STYLE_MAX_LENGTH)
+    lyrics: str | None = Field(default=None, max_length=LYRICS_MAX_LENGTH)
+
+    @field_validator("structure_plan")
+    @classmethod
+    def _check_structure_plan(cls, value: list[str] | None) -> list[str] | None:
+        # Section *names* are validated against the seed by plan_sections at
+        # enqueue time (router), where a clear 422 can be raised; here we only
+        # bound the shape (non-empty, within the section cap).
+        if value is not None:
+            if not value:
+                raise ValueError("structure_plan must not be empty")
+            if len(value) > _MAX_FULL_SONG_SECTIONS:
+                raise ValueError(f"structure_plan may have at most {_MAX_FULL_SONG_SECTIONS} sections")
+        return value
 
 
 class MashupRequest(BaseModel):
@@ -541,6 +579,62 @@ async def add_vocal_clip(
         params=params,
         cost=credits_service.get_cost(iterative_service.ADD_VOCAL_JOB_TYPE),
         estimate_seconds=_BASE_ESTIMATE_SECONDS,
+    )
+
+
+@router.post("/clips/{clip_id}/full-song", response_model=IterativeJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def full_song(
+    clip_id: str,
+    request: FullSongRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> IterativeJobResponse:
+    """Enqueue a full-song assembly of ``clip_id``; the seed is preserved.
+
+    Grows a short seed into a ~target-duration song by chaining one paid extend
+    per planned section, so credits scale with the section count.
+    """
+    clip = await _owned_wav_clip(clip_id, current.user_id)
+    # _owned_wav_clip already 422s a clip without duration metadata; bind the
+    # value so the planner is well-typed (and stay defensive if that changes).
+    seed_duration = clip.duration
+    if seed_duration is None:
+        raise _unprocessable(f"Clip {clip.id} has no duration metadata; cannot plan a full song.")
+    # The seed is a short idea to grow *into* a song; an already-long clip is a
+    # misuse (and would blow past the per-section duration budget immediately).
+    if seed_duration >= _FULL_SONG_MAX_SEED_SECONDS:
+        raise _unprocessable(
+            f"full-song requires a seed shorter than {_FULL_SONG_MAX_SEED_SECONDS:.0f}s "
+            f"(clip is {seed_duration:.1f}s)."
+        )
+    # Each section's repaint submits audio_duration up to target_duration, so the
+    # whole song must fit the backend's generation cap.
+    if request.target_duration > DURATION_MAX:
+        raise _unprocessable(
+            f"target_duration ({request.target_duration}s) exceeds the maximum song length ({DURATION_MAX:.0f}s)."
+        )
+    # plan_sections enforces the remaining invariants against the actual seed:
+    # target must exceed the seed, and every structure_plan name must be known.
+    try:
+        sections = plan_sections(seed_duration, request.target_duration, structure=request.structure_plan)
+    except ValueError as exc:
+        raise _unprocessable(str(exc)) from exc
+    num_sections = len(sections)
+    params = {
+        "clip_id": str(clip.id),
+        "target_duration": request.target_duration,
+        "structure_plan": request.structure_plan,
+        "style": request.style,
+        "lyrics": request.lyrics,
+    }
+    # One paid extend per section (mirrors sample's per-output pricing).
+    cost = credits_service.get_cost(iterative_service.FULL_SONG_JOB_TYPE) * num_sections
+    return await _enqueue_generation(
+        user_id=current.user_id,
+        job_type=iterative_service.FULL_SONG_JOB_TYPE,
+        workspace_id=clip.workspace_id,
+        params=params,
+        cost=cost,
+        estimate_seconds=_BASE_ESTIMATE_SECONDS * num_sections,
     )
 
 

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
+from acemusic.song_structure import SONG_STRUCTURE
 from acemusic.storage import get_storage_backend
 
 from ..auth.dependencies import CurrentUser, get_current_user
@@ -20,7 +21,7 @@ from ..models import Clip, Job, JobStatus
 from ..services.common import coerce_object_id
 from ..services.editing import EDIT_JOB_TYPES
 from ..services.extraction import EXTRACTION_JOB_TYPES, MIDI_JOB_TYPE, resolve_midi_urls
-from ..services.iterative import ITERATIVE_JOB_TYPES, SAMPLE_JOB_TYPE
+from ..services.iterative import FULL_SONG_JOB_TYPE, ITERATIVE_JOB_TYPES, SAMPLE_JOB_TYPE
 from .generation import GenerationRequest, estimate_seconds
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,9 @@ class JobStatusResponse(BaseModel):
     status: JobStatus
     created_at: datetime
     estimated_time_seconds: int
+    # Per-step progress for long multi-step jobs (US-10.4 full-song); only set
+    # while the job is queued/processing, dropped once it completes or fails.
+    progress: str | None = None
     clip_ids: list[str] | None = None
     audio_urls: list[str] | None = None
     # MIDI extraction jobs (US-10.2) produce files, not clips; their results
@@ -81,6 +85,11 @@ def _estimate_for(job: Job) -> int:
     if job.job_type in ITERATIVE_JOB_TYPES:
         if job.job_type == SAMPLE_JOB_TYPE:
             return _ITERATIVE_ESTIMATE_SECONDS * int((job.input_params or {}).get("num_clips", 1))
+        if job.job_type == FULL_SONG_JOB_TYPE:
+            # One extend per section; scale by the planned section count so the
+            # status estimate matches the enqueue response.
+            structure = (job.input_params or {}).get("structure_plan") or SONG_STRUCTURE
+            return _ITERATIVE_ESTIMATE_SECONDS * len(structure)
         return _ITERATIVE_ESTIMATE_SECONDS
     try:
         return estimate_seconds(GenerationRequest(**job.input_params))
@@ -123,6 +132,9 @@ async def get_job_status(
         created_at=job.created_at,
         estimated_time_seconds=_estimate_for(job),
     )
+    if job.status in (JobStatus.QUEUED, JobStatus.PROCESSING):
+        # Progress is in-flight state; a terminal job exposes its result/error instead.
+        response.progress = job.progress
     if job.status == JobStatus.COMPLETED:
         if job.job_type == MIDI_JOB_TYPE:
             # MIDI jobs record ``midi_paths`` (label -> storage key), not clips.

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -23,10 +23,16 @@ ITERATIVE_COST = 1.0
 MASHUP_COST = 2.0
 _SINGLE_SOURCE_ITERATIVE_MODES = ("extend", "cover", "remix", "repaint", "sample", "add_vocal")
 
+# US-10.4: full-song chains one extend per planned section, so ``full_song`` costs
+# ITERATIVE_COST *per section*; the router multiplies this base by the section
+# count (mirroring how ``sample`` multiplies by ``num_clips``).
+FULL_SONG_COST = ITERATIVE_COST
+
 _COSTS = {
     "song": SONG_COST,
     "sound": SOUND_COST,
     "mashup": MASHUP_COST,
+    "full_song": FULL_SONG_COST,
     **{mode: ITERATIVE_COST for mode in _SINGLE_SOURCE_ITERATIVE_MODES},
 }
 

--- a/src/acemusic/api/services/iterative.py
+++ b/src/acemusic/api/services/iterative.py
@@ -22,6 +22,8 @@ REPAINT_JOB_TYPE = "repaint"
 MASHUP_JOB_TYPE = "mashup"
 SAMPLE_JOB_TYPE = "sample"
 ADD_VOCAL_JOB_TYPE = "add_vocal"
+# US-10.4: full-song assembly chains several extends into one long job.
+FULL_SONG_JOB_TYPE = "full_song"
 
 ITERATIVE_JOB_TYPES = (
     EXTEND_JOB_TYPE,
@@ -31,6 +33,7 @@ ITERATIVE_JOB_TYPES = (
     MASHUP_JOB_TYPE,
     SAMPLE_JOB_TYPE,
     ADD_VOCAL_JOB_TYPE,
+    FULL_SONG_JOB_TYPE,
 )
 
 

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -50,6 +50,7 @@ from acemusic.storage import StorageBackend
 from acemusic.utils import parse_time_string, slice_audio
 
 from ..models import Clip, Job
+from ..services import credits as credits_service
 from ..services.clips import native_format
 from ..services.iterative import (
     ADD_VOCAL_JOB_TYPE,
@@ -729,53 +730,71 @@ async def process_full_song_job(job: Job, *, storage: StorageBackend, client: Ac
     parent_id = seed.id
     running_duration = seed.duration
     final_clip_id: str | None = None
+    completed = 0
 
-    with tempfile.TemporaryDirectory(prefix="acemusic-fullsong-") as tmp:
-        tmp_path = Path(tmp)
-        src_path = tmp_path / f"section-0.{fmt}"
-        await _download(storage, seed, src_path)
+    try:
+        with tempfile.TemporaryDirectory(prefix="acemusic-fullsong-") as tmp:
+            tmp_path = Path(tmp)
+            src_path = tmp_path / f"section-0.{fmt}"
+            await _download(storage, seed, src_path)
 
-        for index, section in enumerate(sections, start=1):
-            await job.set({Job.progress: f"Processing section {index} of {total}"})
-            repaint_end = running_duration + section.duration_s
-            section_style = ", ".join(part for part in (base_style_resolved, section.style_hint) if part)
-            data = await _submit_and_download(
-                client,
-                poll,
-                {
-                    "prompt": prompt,
-                    "num_clips": 1,
-                    "audio_duration": repaint_end,
-                    "format": fmt,
-                    "style": section_style,
-                    "lyrics": effective_lyrics,
-                    "bpm": seed.bpm,
-                    "key": seed.key,
-                    "seed": seed.seed,
-                    "task_type": "repaint",
-                    "src_audio_path": str(src_path.resolve()),
-                    "repainting_start": running_duration,
-                    "repainting_end": repaint_end,
-                },
-            )
-            clip_id = await _store_child_clip(
-                job,
-                data=data[0],
-                fmt=fmt,
-                duration=repaint_end,
-                parent_ids=[parent_id],
-                primary=seed,
-                storage=storage,
-                title=_full_song_title(seed.title, section.name, is_final=index == total),
-                style_tags=[section_style],
-                lyrics=effective_lyrics if effective_lyrics is not None else _INHERIT,
-            )
-            # Feed this section's audio into the next repaint and chain lineage.
-            src_path = tmp_path / f"section-{index}.{fmt}"
-            src_path.write_bytes(data[0])
-            parent_id = PydanticObjectId(clip_id)
-            running_duration = repaint_end
-            final_clip_id = clip_id
+            for index, section in enumerate(sections, start=1):
+                await job.set({Job.progress: f"Processing section {index} of {total}"})
+                repaint_end = running_duration + section.duration_s
+                section_style = ", ".join(part for part in (base_style_resolved, section.style_hint) if part)
+                data = await _submit_and_download(
+                    client,
+                    poll,
+                    {
+                        "prompt": prompt,
+                        "num_clips": 1,
+                        "audio_duration": repaint_end,
+                        "format": fmt,
+                        "style": section_style,
+                        "lyrics": effective_lyrics,
+                        "bpm": seed.bpm,
+                        "key": seed.key,
+                        "seed": seed.seed,
+                        "task_type": "repaint",
+                        "src_audio_path": str(src_path.resolve()),
+                        "repainting_start": running_duration,
+                        "repainting_end": repaint_end,
+                    },
+                )
+                clip_id = await _store_child_clip(
+                    job,
+                    data=data[0],
+                    fmt=fmt,
+                    duration=repaint_end,
+                    parent_ids=[parent_id],
+                    primary=seed,
+                    storage=storage,
+                    title=_full_song_title(seed.title, section.name, is_final=index == total),
+                    style_tags=[section_style],
+                    lyrics=effective_lyrics if effective_lyrics is not None else _INHERIT,
+                )
+                # Feed this section's audio into the next repaint and chain lineage.
+                src_path = tmp_path / f"section-{index}.{fmt}"
+                src_path.write_bytes(data[0])
+                parent_id = PydanticObjectId(clip_id)
+                running_duration = repaint_end
+                final_clip_id = clip_id
+                completed += 1
+    except BaseException:
+        # Credits were charged upfront at enqueue for every *planned* section, but
+        # the AC bills by extends *performed*: refund the sections we never reached
+        # so a mid-chain failure only charges for completed extends. The committed
+        # section clips are intentionally kept as partial progress (mirrors the CLI).
+        # BaseException (not Exception): a shutdown CancelledError must refund too.
+        unperformed = total - completed
+        if unperformed > 0:
+            try:
+                await credits_service.refund_credits(
+                    job.user_id, unperformed * credits_service.get_cost(FULL_SONG_JOB_TYPE)
+                )
+            except Exception:  # pragma: no cover - refund is best-effort; never mask the cause
+                logger.exception("Failed to refund %d unperformed full-song section(s) for job %s", unperformed, job.id)
+        raise
 
     if final_clip_id is None:
         # plan_sections guarantees a non-empty list (it raises on empty), so this

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -45,6 +45,7 @@ from pydub import AudioSegment
 
 from acemusic.audio import calculate_speed_multiplier, combine_sample, crop_audio, crossfade_stitch, time_stretch_audio
 from acemusic.client import AceStepClient
+from acemusic.song_structure import plan_sections
 from acemusic.storage import StorageBackend
 from acemusic.utils import parse_time_string, slice_audio
 
@@ -54,6 +55,7 @@ from ..services.iterative import (
     ADD_VOCAL_JOB_TYPE,
     COVER_JOB_TYPE,
     EXTEND_JOB_TYPE,
+    FULL_SONG_JOB_TYPE,
     MASHUP_JOB_TYPE,
     REMIX_JOB_TYPE,
     REPAINT_JOB_TYPE,
@@ -672,6 +674,117 @@ async def process_sample_job(job: Job, *, storage: StorageBackend, client: AceSt
     return {"clip_ids": clip_ids}
 
 
+# ---------------------------------------------------------------------------
+# Full-song — chain one extend per planned section into a complete song
+# ---------------------------------------------------------------------------
+
+
+def _full_song_title(seed_title: str | None, section_name: str, *, is_final: bool) -> str | None:
+    """Title for a section clip: the final clip is the song, others are labelled.
+
+    Mirrors the CLI full-song titles ("<seed> (full song)" for the assembled
+    result, "<seed> - <section>" for the intermediate sections).
+    """
+    if not seed_title:
+        return None
+    return f"{seed_title} (full song)" if is_final else f"{seed_title} - {section_name}"
+
+
+async def process_full_song_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
+    """Grow the seed into a full song by chaining one ACE-Step ``repaint`` per section.
+
+    Plans a section list with :func:`plan_sections` (honouring an optional
+    ``structure_plan`` override), then extends the running track section by
+    section — each ``repaint`` continues from the previous result's tail and is
+    stored as a lineage-chained child clip (``generation_mode='full_song'``). The
+    style of every section anchors to the *seed*'s style (never the previous
+    section's) so hints don't compound, with the section's own ``style_hint``
+    appended for structural variety. ``job.progress`` is updated to
+    "Processing section N of M" before each section so a poller can track it.
+
+    Returns ``{"clip_ids": [<final assembled clip id>]}``. Sections committed
+    before a mid-chain failure are left in place as partial progress (mirroring
+    the CLI), so a ``failed`` job still exposes the work done so far.
+    """
+    params = dict(job.input_params or {})
+    seed = await _load_clip(params["clip_id"])
+    if seed.duration is None:
+        raise IterativeProcessingError(f"Seed clip {seed.id} has no duration metadata")
+    fmt = native_format(seed)
+    target_duration = float(params["target_duration"])
+    structure_plan = params.get("structure_plan")
+    sections = plan_sections(seed.duration, target_duration, structure=structure_plan)
+    total = len(sections)
+
+    base_style = params.get("style")
+    # Anchor every section to the seed's own style (joined tags), so a long chain
+    # doesn't drift as each section's hint would otherwise compound into the next.
+    # Resolved once: the anchor is loop-invariant; only the per-section hint varies.
+    base_style_tags = ", ".join(seed.style_tags) if seed.style_tags else None
+    base_style_resolved = base_style or base_style_tags
+    base_lyrics = params.get("lyrics")
+    effective_lyrics = base_lyrics if base_lyrics is not None else seed.lyrics
+    prompt = _source_prompt(seed, "continue the song")
+
+    parent_id = seed.id
+    running_duration = seed.duration
+    final_clip_id: str | None = None
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-fullsong-") as tmp:
+        tmp_path = Path(tmp)
+        src_path = tmp_path / f"section-0.{fmt}"
+        await _download(storage, seed, src_path)
+
+        for index, section in enumerate(sections, start=1):
+            await job.set({Job.progress: f"Processing section {index} of {total}"})
+            repaint_end = running_duration + section.duration_s
+            section_style = ", ".join(part for part in (base_style_resolved, section.style_hint) if part)
+            data = await _submit_and_download(
+                client,
+                poll,
+                {
+                    "prompt": prompt,
+                    "num_clips": 1,
+                    "audio_duration": repaint_end,
+                    "format": fmt,
+                    "style": section_style,
+                    "lyrics": effective_lyrics,
+                    "bpm": seed.bpm,
+                    "key": seed.key,
+                    "seed": seed.seed,
+                    "task_type": "repaint",
+                    "src_audio_path": str(src_path.resolve()),
+                    "repainting_start": running_duration,
+                    "repainting_end": repaint_end,
+                },
+            )
+            clip_id = await _store_child_clip(
+                job,
+                data=data[0],
+                fmt=fmt,
+                duration=repaint_end,
+                parent_ids=[parent_id],
+                primary=seed,
+                storage=storage,
+                title=_full_song_title(seed.title, section.name, is_final=index == total),
+                style_tags=[section_style],
+                lyrics=effective_lyrics if effective_lyrics is not None else _INHERIT,
+            )
+            # Feed this section's audio into the next repaint and chain lineage.
+            src_path = tmp_path / f"section-{index}.{fmt}"
+            src_path.write_bytes(data[0])
+            parent_id = PydanticObjectId(clip_id)
+            running_duration = repaint_end
+            final_clip_id = clip_id
+
+    if final_clip_id is None:
+        # plan_sections guarantees a non-empty list (it raises on empty), so this
+        # is only reachable if that invariant is ever broken — fail loudly rather
+        # than return an invalid {"clip_ids": [None]} result.
+        raise IterativeProcessingError("Full-song planning produced no sections")
+    return {"clip_ids": [final_clip_id]}
+
+
 ITERATIVE_JOB_HANDLERS: dict[str, Callable[..., Awaitable[dict]]] = {
     EXTEND_JOB_TYPE: process_extend_job,
     COVER_JOB_TYPE: process_cover_job,
@@ -680,4 +793,5 @@ ITERATIVE_JOB_HANDLERS: dict[str, Callable[..., Awaitable[dict]]] = {
     MASHUP_JOB_TYPE: process_mashup_job,
     SAMPLE_JOB_TYPE: process_sample_job,
     ADD_VOCAL_JOB_TYPE: process_add_vocal_job,
+    FULL_SONG_JOB_TYPE: process_full_song_job,
 }

--- a/src/acemusic/song_structure.py
+++ b/src/acemusic/song_structure.py
@@ -42,11 +42,18 @@ class Section:
     style_hint: str
 
 
-def plan_sections(seed_duration: float, target_duration: int | float) -> list[Section]:
-    """Distribute (target_duration - seed_duration) across the seven canonical sections.
+def plan_sections(
+    seed_duration: float,
+    target_duration: int | float,
+    structure: list[str] | None = None,
+) -> list[Section]:
+    """Distribute (target_duration - seed_duration) across an ordered section list.
 
-    Returns sections in canonical order (intro → outro). Each section receives
-    a slice of the remaining time proportional to its configured weight.
+    ``structure`` defaults to the seven canonical sections (:data:`SONG_STRUCTURE`)
+    but may be overridden — e.g. the full-song API's ``structure_plan`` (US-10.4).
+    Every name must have a :data:`SECTION_CONFIG` entry. Returns sections in the
+    given order; each receives a slice of the remaining time proportional to its
+    configured weight.
 
     When there is enough headroom, each section is rounded up to
     MIN_SECTION_SECONDS so it produces an audible chunk. When the remainder is
@@ -55,16 +62,22 @@ def plan_sections(seed_duration: float, target_duration: int | float) -> list[Se
     overshoots ``target_duration``. Every section still gets a positive
     duration.
 
-    Raises ValueError if target_duration is non-positive or shorter than the
-    seed.
+    Raises ValueError if ``structure`` is empty or names an unknown section, or
+    if target_duration is non-positive or shorter than the seed.
     """
+    sections = SONG_STRUCTURE if structure is None else list(structure)
+    if not sections:
+        raise ValueError("structure must contain at least one section")
+    unknown = [name for name in sections if name not in SECTION_CONFIG]
+    if unknown:
+        raise ValueError(f"unknown section(s) {unknown}; valid sections are {sorted(SECTION_CONFIG)}")
     if target_duration <= 0:
         raise ValueError(f"target_duration must be positive, got {target_duration}")
     if target_duration <= seed_duration:
         raise ValueError(f"target_duration ({target_duration}s) must exceed seed_duration ({seed_duration}s)")
 
     remaining = float(target_duration) - float(seed_duration)
-    weights = [SECTION_CONFIG[name][0] for name in SONG_STRUCTURE]
+    weights = [SECTION_CONFIG[name][0] for name in sections]
     total_weight = sum(weights)
     raw_durations = [remaining * (w / total_weight) for w in weights]
 
@@ -77,5 +90,5 @@ def plan_sections(seed_duration: float, target_duration: int | float) -> list[Se
 
     return [
         Section(name=name, duration_s=duration, style_hint=SECTION_CONFIG[name][1])
-        for name, duration in zip(SONG_STRUCTURE, durations)
+        for name, duration in zip(sections, durations)
     ]

--- a/tests/test_clips_full_song_api.py
+++ b/tests/test_clips_full_song_api.py
@@ -560,6 +560,24 @@ class TestFullSongHandler:
         children = await Clip.find(Clip.generation_mode == "full_song").to_list()
         assert len(children) == 2
 
+    async def test_mid_chain_failure_refunds_unperformed_sections(self, storage) -> None:
+        # Credits are charged upfront for the full planned count; a mid-chain
+        # failure refunds the sections never performed (4 planned − 2 done = 2).
+        user, workspace, clip = await self._seed(storage)
+        start = (await User.get(user.id)).credits_balance
+        job = await self._job(user, workspace, clip, structure_plan=["intro", "verse", "chorus", "outro"])
+        with pytest.raises(IterativeProcessingError, match="ace boom"):
+            await self._run(job, _FailingAce(_wav_bytes(2.0), fail_on=3), storage)
+        assert (await User.get(user.id)).credits_balance == start + 2.0
+
+    async def test_full_success_does_not_refund(self, storage) -> None:
+        # All sections completed → nothing to refund (the upfront charge stands).
+        user, workspace, clip = await self._seed(storage)
+        start = (await User.get(user.id)).credits_balance
+        job = await self._job(user, workspace, clip, structure_plan=["intro", "outro"])
+        await self._run(job, _RecordingAce(_wav_bytes(2.0)), storage)
+        assert (await User.get(user.id)).credits_balance == start
+
 
 # ---------------------------------------------------------------------------
 # End-to-end — endpoint → queued job → JobProcessor → completed clip

--- a/tests/test_clips_full_song_api.py
+++ b/tests/test_clips_full_song_api.py
@@ -1,0 +1,636 @@
+"""Tests for the full-song assembly endpoint (US-10.4, issue #84).
+
+``POST /api/v1/clips/{id}/full-song`` grows a short seed clip into a complete
+song by chaining one paid ACE-Step extend per planned section, tracked as a
+single background job that reports per-section progress via the job-status
+endpoint. Credits scale with the number of extends (sections).
+
+The 401 auth-gate test runs in CI (no DB; the plain ``TestClient`` does not run
+the lifespan); the rest are ``integration`` and drive the real app with
+``httpx.AsyncClient`` over a local MongoDB.
+"""
+
+import asyncio
+import io
+import time
+
+import httpx
+import numpy as np
+import pytest
+import soundfile as sf
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, CreditTransaction, Job, JobStatus, User, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.api.tasks.iterative import IterativeProcessingError
+from acemusic.song_structure import SONG_STRUCTURE
+from acemusic.storage import LocalStorage, get_storage_backend
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+
+
+def _url(clip_id) -> str:
+    return f"{CLIPS_URL}/{clip_id}/full-song"
+
+
+def _status_url(job_id) -> str:
+    return f"{API_V1_PREFIX}/jobs/{job_id}/status"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_missing_auth_header_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(_url(PydanticObjectId()), json={})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration scaffolding — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # Disable the background processor: most tests assert on the queued job and
+    # do not want a worker claiming it. The lifecycle test starts its own.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str, *, balance: float | None = None):
+    user = await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+    if balance is not None:
+        user.credits_balance = balance
+        await user.save()
+    return user
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(user, workspace, *, duration=10.0, bpm=120, key="C", fmt="wav", style_tags=None) -> Clip:
+    clip_id = PydanticObjectId()
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt or 'wav'}",
+        format=fmt,
+        duration=duration,
+        bpm=bpm,
+        key=key,
+        style_tags=style_tags or ["dream pop"],
+    )
+    await clip.insert()
+    return clip
+
+
+async def _user_with_clip(email: str, *, balance: float = 10.0, **clip_kwargs):
+    user = await _make_user(email, balance=balance)
+    workspace = await _make_workspace(user)
+    clip = await _insert_clip(user, workspace, **clip_kwargs)
+    return user, workspace, clip
+
+
+async def _reload_user(user) -> User:
+    return await User.get(user.id)
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown / malformed / other-user clip ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestClipNotFound:
+    async def test_unknown_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("fs-404@example.com", balance=10.0)
+        resp = await client.post(_url(PydanticObjectId()), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+        assert await Job.count() == 0
+
+    async def test_malformed_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("fs-malformed@example.com", balance=10.0)
+        resp = await client.post(_url("not-an-object-id"), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_clip_returns_404(self, client, settings) -> None:
+        _, _, clip = await _user_with_clip("fs-owner@example.com")
+        other = await _make_user("fs-other@example.com", balance=10.0)
+        resp = await client.post(_url(clip.id), json={}, headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+        assert (await _reload_user(other)).credits_balance == 10.0
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 422 — validation (the body parsed; the request is logically invalid)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestValidation:
+    async def test_seed_at_or_over_60s_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-longseed@example.com", duration=60.0)
+        resp = await client.post(_url(clip.id), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert "60s" in resp.json()["detail"]
+        assert await Job.count() == 0
+
+    async def test_seed_just_under_60s_is_accepted(self, client, settings) -> None:
+        # Boundary happy-path: 59.9s is "shorter than 60s", so it must enqueue.
+        user, _, clip = await _user_with_clip("fs-seed-599@example.com", duration=59.9)
+        resp = await client.post(_url(clip.id), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        assert await Job.count() == 1
+
+    async def test_target_not_exceeding_seed_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-target-low@example.com", duration=30.0)
+        resp = await client.post(_url(clip.id), json={"target_duration": 20}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_target_over_backend_max_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-target-high@example.com", duration=10.0)
+        resp = await client.post(_url(clip.id), json={"target_duration": 999}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_unknown_structure_section_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-badsection@example.com", duration=10.0)
+        resp = await client.post(
+            _url(clip.id),
+            json={"structure_plan": ["intro", "drop", "outro"]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_empty_structure_plan_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-emptystructure@example.com", duration=10.0)
+        resp = await client.post(_url(clip.id), json={"structure_plan": []}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_extra_field_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-extra@example.com", duration=10.0)
+        resp = await client.post(_url(clip.id), json={"bogus": 1}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+    async def test_missing_duration_metadata_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-nodur@example.com", duration=None)
+        resp = await client.post(_url(clip.id), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+    async def test_non_wav_source_returns_422(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-mp3@example.com", duration=10.0, fmt="mp3")
+        resp = await client.post(_url(clip.id), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 202 — happy path: job persisted, params forwarded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestEnqueueSuccess:
+    async def test_returns_202_with_job_id(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-202@example.com")
+        resp = await client.post(_url(clip.id), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+        assert body["job_id"]
+        assert body["estimated_time_seconds"] > 0
+
+    async def test_persists_job_with_resolved_params(self, client, settings) -> None:
+        user, workspace, clip = await _user_with_clip("fs-job@example.com")
+        resp = await client.post(
+            _url(clip.id),
+            json={"target_duration": 180, "style": "orchestral", "lyrics": "ooh"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        jobs = await Job.find_all().to_list()
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert job.job_type == "full_song"
+        assert job.workspace_id == workspace.id
+        assert job.input_params["clip_id"] == str(clip.id)
+        assert job.input_params["target_duration"] == 180
+        assert job.input_params["style"] == "orchestral"
+        assert job.input_params["lyrics"] == "ooh"
+
+    async def test_custom_structure_plan_is_persisted(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-structure@example.com")
+        structure = ["intro", "verse", "chorus", "outro"]
+        resp = await client.post(
+            _url(clip.id), json={"structure_plan": structure}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 202
+        job = (await Job.find_all().to_list())[0]
+        assert job.input_params["structure_plan"] == structure
+
+
+# ---------------------------------------------------------------------------
+# Credits — deducted per extend (one per section)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestCredits:
+    async def test_deducts_one_credit_per_section(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-credit@example.com", balance=10.0)
+        resp = await client.post(_url(clip.id), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        # Default structure is the seven canonical sections → seven extends.
+        expected = float(len(SONG_STRUCTURE))
+        assert (await _reload_user(user)).credits_balance == 10.0 - expected
+        txns = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        assert len(txns) == 1
+        assert txns[0].amount == -expected
+        assert txns[0].action_type == "full_song"
+
+    async def test_cost_scales_with_structure_length(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-credit-custom@example.com", balance=10.0)
+        resp = await client.post(
+            _url(clip.id),
+            json={"structure_plan": ["intro", "verse", "chorus", "outro"]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload_user(user)).credits_balance == 6.0  # 10 - 4
+
+    async def test_insufficient_credits_returns_402(self, client, settings) -> None:
+        user, _, clip = await _user_with_clip("fs-poor@example.com", balance=3.0)
+        resp = await client.post(_url(clip.id), json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 402
+        detail = resp.json()["detail"]
+        assert detail["error"] == "insufficient_credits"
+        assert detail["balance"] == 3.0
+        assert detail["required"] == float(len(SONG_STRUCTURE))
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Progress — surfaced by the job-status endpoint while in flight
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestProgressSurfaced:
+    async def test_status_endpoint_returns_progress_while_processing(self, client, settings) -> None:
+        user = await _make_user("fs-progress@example.com", balance=10.0)
+        workspace = await _make_workspace(user)
+        job = Job(
+            user_id=user.id,
+            workspace_id=workspace.id,
+            job_type="full_song",
+            status=JobStatus.PROCESSING,
+            input_params={"target_duration": 210},
+            progress="Processing section 3 of 7",
+        )
+        await job.insert()
+        resp = await client.get(_status_url(job.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["progress"] == "Processing section 3 of 7"
+
+    async def test_progress_dropped_once_completed(self, client, settings) -> None:
+        user = await _make_user("fs-progress-done@example.com", balance=10.0)
+        workspace = await _make_workspace(user)
+        job = Job(
+            user_id=user.id,
+            workspace_id=workspace.id,
+            job_type="full_song",
+            status=JobStatus.COMPLETED,
+            input_params={"target_duration": 210},
+            progress="Processing section 7 of 7",
+            result={"clip_ids": []},
+        )
+        await job.insert()
+        resp = await client.get(_status_url(job.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert "progress" not in resp.json()
+
+    async def test_progress_dropped_once_failed(self, client, settings) -> None:
+        # A mid-chain failure may leave a stale progress string in the document;
+        # the status endpoint must not surface it once the job is terminal.
+        user = await _make_user("fs-progress-failed@example.com", balance=10.0)
+        workspace = await _make_workspace(user)
+        job = Job(
+            user_id=user.id,
+            workspace_id=workspace.id,
+            job_type="full_song",
+            status=JobStatus.FAILED,
+            input_params={"target_duration": 210},
+            progress="Processing section 3 of 7",
+            error="boom",
+        )
+        await job.insert()
+        resp = await client.get(_status_url(job.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "progress" not in body
+        assert body["error"] == "boom"
+
+
+# ---------------------------------------------------------------------------
+# Worker handler — deterministic, section-by-section assertions
+# ---------------------------------------------------------------------------
+
+
+def _wav_bytes(duration_s: float = 2.0, freq: float = 440.0, sr: int = 44100) -> bytes:
+    t = np.linspace(0, duration_s, int(sr * duration_s), endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    buf = io.BytesIO()
+    sf.write(buf, np.column_stack([mono, mono]), sr, format="WAV")
+    return buf.getvalue()
+
+
+class _RecordingAce:
+    """ACE-Step double that records every submit so per-section behaviour is testable."""
+
+    def __init__(self, output: bytes) -> None:
+        self.output = output
+        self.submits: list[dict] = []
+
+    def submit_task(self, **kwargs) -> str:
+        self.submits.append(kwargs)
+        return f"task-{len(self.submits)}"
+
+    def query_result(self, task_id: str) -> dict:
+        return {"status": "completed", "audio_urls": ["u0"], "error": None}
+
+    def download_audio(self, url: str) -> bytes:
+        return self.output
+
+
+class _FailingAce:
+    """ACE-Step double whose Nth task (1-based ``fail_on``) reports a failure."""
+
+    def __init__(self, output: bytes, *, fail_on: int) -> None:
+        self.output = output
+        self.fail_on = fail_on
+
+    def submit_task(self, **kwargs) -> str:
+        # Encode the call ordinal in the task id so query_result can fail the Nth.
+        self._n = getattr(self, "_n", 0) + 1
+        return f"task-{self._n}"
+
+    def query_result(self, task_id: str) -> dict:
+        n = int(task_id.split("-")[1])
+        if n >= self.fail_on:
+            return {"status": "failed", "audio_urls": [], "error": "ace boom"}
+        return {"status": "completed", "audio_urls": ["u0"], "error": None}
+
+    def download_audio(self, url: str) -> bytes:
+        return self.output
+
+
+async def _poll(client, task_id):
+    return await asyncio.to_thread(client.query_result, task_id)
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path / "storage"))
+    return tmp_path
+
+
+@pytest.fixture
+def storage(mongo_db, tmp_path) -> LocalStorage:
+    # ``mongo_db`` initialises Beanie so the handler can read/insert documents
+    # on this test's event loop; the LocalStorage instance is passed directly.
+    return LocalStorage(tmp_path / "storage")
+
+
+@pytest.mark.integration
+class TestFullSongHandler:
+    async def _seed(self, storage: LocalStorage, *, duration=10.0, style_tags=None):
+        user = await _make_user(f"fs-handler-{PydanticObjectId()}@example.com", balance=50.0)
+        workspace = await _make_workspace(user)
+        clip_id = PydanticObjectId()
+        file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.wav"
+        storage.upload(file_path, _wav_bytes(2.0))
+        clip = Clip(
+            id=clip_id,
+            user_id=user.id,
+            workspace_id=workspace.id,
+            file_path=file_path,
+            format="wav",
+            duration=duration,
+            bpm=120,
+            key="C",
+            style_tags=style_tags or ["dream pop"],
+        )
+        await clip.insert()
+        return user, workspace, clip
+
+    async def _run(self, job, ace, storage: LocalStorage):
+        from acemusic.api.tasks.iterative import process_full_song_job
+
+        return await process_full_song_job(job, storage=storage, client=ace, poll=_poll)
+
+    async def _job(self, user, workspace, clip, **params):
+        job = Job(
+            user_id=user.id,
+            workspace_id=workspace.id,
+            job_type="full_song",
+            status=JobStatus.PROCESSING,
+            input_params={"clip_id": str(clip.id), "target_duration": 210, "structure_plan": None, **params},
+        )
+        await job.insert()
+        return job
+
+    async def test_runs_one_extend_per_section(self, storage) -> None:
+        user, workspace, clip = await self._seed(storage)
+        ace = _RecordingAce(_wav_bytes(2.0))
+        job = await self._job(user, workspace, clip)
+        result = await self._run(job, ace, storage)
+        assert len(ace.submits) == len(SONG_STRUCTURE)
+        assert all(s["task_type"] == "repaint" for s in ace.submits)
+        assert len(result["clip_ids"]) == 1
+
+    async def test_final_clip_duration_approximates_target(self, storage) -> None:
+        user, workspace, clip = await self._seed(storage, duration=10.0)
+        job = await self._job(user, workspace, clip, target_duration=210)
+        result = await self._run(job, _RecordingAce(_wav_bytes(2.0)), storage)
+        final = await Clip.get(PydanticObjectId(result["clip_ids"][0]))
+        assert final.duration == pytest.approx(210, abs=1.0)
+        assert final.generation_mode == "full_song"
+
+    async def test_lineage_chains_seed_through_sections(self, storage) -> None:
+        user, workspace, clip = await self._seed(storage)
+        result = await self._run(await self._job(user, workspace, clip), _RecordingAce(_wav_bytes(2.0)), storage)
+        # Every full_song child plus the seed; walk the single-parent chain back.
+        children = await Clip.find(Clip.generation_mode == "full_song").to_list()
+        assert len(children) == len(SONG_STRUCTURE)
+        final = await Clip.get(PydanticObjectId(result["clip_ids"][0]))
+        seen = 0
+        node = final
+        while node.parent_clip_ids:
+            assert len(node.parent_clip_ids) == 1
+            node = await Clip.get(node.parent_clip_ids[0])
+            seen += 1
+        assert node.id == clip.id  # chain terminates at the seed
+        assert seen == len(SONG_STRUCTURE)
+
+    async def test_sections_carry_distinct_styles_for_variety(self, storage) -> None:
+        user, workspace, clip = await self._seed(storage, style_tags=["dream pop"])
+        ace = _RecordingAce(_wav_bytes(2.0))
+        await self._run(await self._job(user, workspace, clip), ace, storage)
+        styles = [s["style"] for s in ace.submits]
+        # Distinct section hints → audible structural variety (not pure repetition).
+        assert len(set(styles)) >= 3
+        # Every section anchors to the seed's own style so the chain doesn't drift.
+        assert all("dream pop" in s for s in styles)
+
+    async def test_style_override_anchors_every_section(self, storage) -> None:
+        user, workspace, clip = await self._seed(storage, style_tags=["dream pop"])
+        ace = _RecordingAce(_wav_bytes(2.0))
+        await self._run(await self._job(user, workspace, clip, style="orchestral"), ace, storage)
+        assert all("orchestral" in s["style"] for s in ace.submits)
+        assert all("dream pop" not in s["style"] for s in ace.submits)
+
+    async def test_progress_updated_per_section(self, storage) -> None:
+        user, workspace, clip = await self._seed(storage)
+        job = await self._job(user, workspace, clip)
+        await self._run(job, _RecordingAce(_wav_bytes(2.0)), storage)
+        refreshed = await Job.get(job.id)
+        assert refreshed.progress == f"Processing section {len(SONG_STRUCTURE)} of {len(SONG_STRUCTURE)}"
+
+    async def test_custom_structure_controls_section_count(self, storage) -> None:
+        user, workspace, clip = await self._seed(storage)
+        ace = _RecordingAce(_wav_bytes(2.0))
+        job = await self._job(user, workspace, clip, structure_plan=["intro", "chorus", "outro"])
+        result = await self._run(job, ace, storage)
+        assert len(ace.submits) == 3
+        assert len(result["clip_ids"]) == 1
+
+    async def test_mid_chain_failure_preserves_earlier_sections(self, storage) -> None:
+        # Intentional policy (mirrors the CLI): sections committed before a
+        # mid-chain failure are kept as partial progress — full_song does not
+        # roll children back, unlike the multi-output sample handler.
+        user, workspace, clip = await self._seed(storage)
+        job = await self._job(user, workspace, clip, structure_plan=["intro", "verse", "chorus", "outro"])
+        with pytest.raises(IterativeProcessingError, match="ace boom"):
+            await self._run(job, _FailingAce(_wav_bytes(2.0), fail_on=3), storage)
+        # Sections 1 and 2 committed before the third failed.
+        children = await Clip.find(Clip.generation_mode == "full_song").to_list()
+        assert len(children) == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — endpoint → queued job → JobProcessor → completed clip
+# ---------------------------------------------------------------------------
+
+
+class _FakeAce:
+    def __init__(self, output: bytes) -> None:
+        self.output = output
+
+    def submit_task(self, **kwargs) -> str:
+        return "task-1"
+
+    def query_result(self, task_id: str) -> dict:
+        return {"status": "completed", "audio_urls": ["u0"], "error": None}
+
+    def download_audio(self, url: str) -> bytes:
+        return self.output
+
+
+@pytest.mark.integration
+class TestLifecycleEndToEnd:
+    async def test_full_song_runs_to_completed_via_status_endpoint(self, client, settings, local_storage) -> None:
+        from acemusic.api.tasks.processor import JobProcessor
+
+        user = await _make_user("fs-e2e@example.com", balance=20.0)
+        workspace = await _make_workspace(user)
+        clip_id = PydanticObjectId()
+        file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.wav"
+        get_storage_backend().upload(file_path, _wav_bytes(2.0))
+        clip = Clip(
+            id=clip_id,
+            user_id=user.id,
+            workspace_id=workspace.id,
+            file_path=file_path,
+            format="wav",
+            duration=10.0,
+            bpm=120,
+            key="C",
+            style_tags=["dream pop"],
+        )
+        await clip.insert()
+        headers = _auth_headers(user, settings)
+
+        accepted = await client.post(_url(clip.id), json={"target_duration": 210}, headers=headers)
+        assert accepted.status_code == 202
+        job_id = accepted.json()["job_id"]
+
+        processor = JobProcessor(
+            concurrency=1,
+            poll_interval=0.05,
+            ace_poll_interval=0.01,
+            client_factory=lambda: _FakeAce(_wav_bytes(2.0)),
+        )
+        await processor.start()
+        try:
+            status_body = None
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                resp = await client.get(_status_url(job_id), headers=headers)
+                assert resp.status_code == 200
+                status_body = resp.json()
+                assert status_body["status"] in {"queued", "processing", "completed"}, status_body.get("error")
+                if status_body["status"] == "completed":
+                    break
+                await asyncio.sleep(0.05)
+        finally:
+            await processor.stop()
+
+        assert status_body is not None and status_body["status"] == "completed", "job never completed"
+        assert len(status_body["clip_ids"]) == 1
+        final = await Clip.get(PydanticObjectId(status_body["clip_ids"][0]))
+        assert final.generation_mode == "full_song"
+        assert final.duration == pytest.approx(210, abs=1.0)

--- a/tests/test_song_structure.py
+++ b/tests/test_song_structure.py
@@ -88,3 +88,40 @@ class TestPlanSections:
     def test_negative_target_raises(self):
         with pytest.raises(ValueError):
             plan_sections(seed_duration=30.0, target_duration=-10)
+
+
+class TestPlanSectionsCustomStructure:
+    """A caller may override the canonical structure (US-10.4 ``structure_plan``)."""
+
+    def test_custom_structure_is_honoured_in_order(self):
+        structure = ["intro", "verse", "chorus", "outro"]
+        sections = plan_sections(seed_duration=30.0, target_duration=210, structure=structure)
+        assert [s.name for s in sections] == structure
+
+    def test_custom_structure_durations_sum_to_remaining(self):
+        structure = ["verse", "chorus", "verse", "chorus"]
+        sections = plan_sections(seed_duration=30.0, target_duration=180, structure=structure)
+        total = sum(s.duration_s for s in sections)
+        assert total == pytest.approx(180 - 30, abs=0.5)
+
+    def test_custom_structure_uses_section_style_hints(self):
+        sections = plan_sections(seed_duration=20.0, target_duration=120, structure=["intro", "outro"])
+        assert sections[0].style_hint == SECTION_CONFIG["intro"][1]
+        assert sections[1].style_hint == SECTION_CONFIG["outro"][1]
+
+    def test_none_structure_falls_back_to_canonical(self):
+        sections = plan_sections(seed_duration=30.0, target_duration=210, structure=None)
+        assert [s.name for s in sections] == SONG_STRUCTURE
+
+    def test_unknown_section_name_raises(self):
+        with pytest.raises(ValueError, match="unknown section"):
+            plan_sections(seed_duration=30.0, target_duration=210, structure=["intro", "drop", "outro"])
+
+    def test_empty_structure_raises(self):
+        with pytest.raises(ValueError, match="at least one section"):
+            plan_sections(seed_duration=30.0, target_duration=210, structure=[])
+
+    def test_repeated_sections_each_get_a_slice(self):
+        sections = plan_sections(seed_duration=30.0, target_duration=210, structure=["chorus", "chorus"])
+        assert len(sections) == 2
+        assert all(s.duration_s > 0 for s in sections)


### PR DESCRIPTION
## Summary

Implements **US-10.4 — Full-song assembly endpoint** (closes #84).

Adds `POST /api/v1/clips/{id}/full-song`: it grows a short seed clip into a
~target-duration song by chaining one ACE-Step `repaint` extend per planned song
section, runs as a single background job, reports per-section progress via the
job-status endpoint, and deducts one credit per section.

### Plan note — the issue's CodeRabbit plan was obsolete

The plan comment on #84 was written (2026-05-31) when "No FastAPI backend, job
queue, or credits system exists." Since then the API layer shipped (#119, #120,
#121, #142, #83): MongoDB+Beanie, a real `JobProcessor` + handler registry, a
credits service, and the iterative endpoints. This PR therefore **mirrors the
existing iterative pattern** (`extend`/`cover`/`remix`) instead of building the
FastAPI/in-memory-job/stub-credits scaffolding the original plan described.

## Changes

| Area | Change |
|------|--------|
| `song_structure.plan_sections` | optional `structure` override (backs `structure_plan`); validates section names |
| `models/job.Job` | new `progress` field |
| `routers/jobs` | surfaces `progress` ("Processing section N of M") while queued/processing; full_song estimate scales by section count |
| `services/credits` | `full_song` cost = `ITERATIVE_COST` per section |
| `services/iterative` | `FULL_SONG_JOB_TYPE` |
| `tasks/iterative.process_full_song_job` | chains repaint extends, lineage-chained child clips, seed-anchored per-section styles, partial progress kept on mid-chain failure |
| `routers/iterative` | `FullSongRequest` + endpoint with validation + per-section credit cost |

## Acceptance criteria

- [x] Full-song produces a clip of approximately the target duration — handler records `duration=target`; asserted in handler + e2e tests.
- [x] Job status shows progress per section — `Job.progress` set to `"Processing section N of M"`, surfaced by `GET /jobs/{id}/status`.
- [x] Output has audible structural variety — distinct per-section `style_hint` appended to the seed anchor; asserted (`>=3` distinct styles).
- [x] Source clip shorter than 60s required; longer → 422 — validated (`>= 60s` rejected); boundary tests at 59.9s/60.0s.
- [x] Credits deducted by number of extends — `cost = FULL_SONG_COST × num_sections`, deducted atomically upfront; asserted for the 7-section default and a 4-section custom structure.

## Testing

- `tests/test_clips_full_song_api.py` (new): auth gate (CI), 404/422 validation, 202 + job persistence, credits (per-section + 402), progress surfacing (processing/completed/failed), a deterministic handler suite (per-section submit, lineage chain, distinct styles, duration≈target, custom structure, mid-chain partial-persist), and an end-to-end queued→completed run via the real `JobProcessor`.
- `tests/test_song_structure.py`: custom-structure override cases.
- Full suite green locally: **1162** unit + **168** integration (affected suites) + **31** full-song. ruff + black clean.

## Known limitations

- **Credits are charged upfront for the full planned section count** (atomic, consistent with the existing iterative endpoints). On a mid-chain failure the worker **refunds the sections never performed**, so the user is only billed for completed extends (AC #5). Partial section clips committed before a failure are intentionally **kept** (mirrors the CLI full-song behaviour), so the work done so far is not lost.
- The worker hands ACE-Step a worker-local `src_audio_path`, so ACE-Step must run on the same host / shared filesystem as the API worker — the same constraint the other iterative handlers document. Remote/cross-container ACE-Step is a deferred story.
- `progress` is a human-readable string surfaced only while the job is in flight; it is intentionally dropped from terminal (completed/failed) status responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a full-song endpoint to assemble multi-section songs from a seed clip, with optional custom structure planning and per-section style/lyrics conditioning.
* **Job Updates**
  * Job status now includes human-readable progress while jobs are queued or processing (shown only for active jobs).
* **Pricing**
  * Full-song credit deduction is based on the number of planned sections; insufficient credits return an error.
* **Chores**
  * Added configurable song structure planning with stronger input validation (including duration and structure rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->