### PR TITLE
feat(api): batch processing endpoints (US-10.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ All iterative endpoints are credit-bearing generative operations (unlike editing
 
 All endpoints are non-destructive: the original clip(s) are never modified. Each produces a new clip with `parent_clip_ids` and `generation_params` set for lineage tracking. Jobs are tracked via `GET /api/v1/jobs/{id}/status`. Only `wav` source clips are accepted (422 otherwise); clips without duration metadata are also rejected (422). Time parameters use human-readable strings (`"10s"`, `"1m30s"`, `"5"`) matching the CLI commands.
 
+### Batch Processing (US-10.5)
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/batch/stems` | Queue stem separation for many clips at once (`{clip_ids[]}`); returns 202 + `batch_job_id` and one `sub_job_id` per queued clip |
+| `POST /api/v1/batch/export` | Queue audio export of many clips to `format` (`{clip_ids[], format}`); returns 202 + `batch_job_id` and `sub_job_ids` |
+| `GET /api/v1/batch/{batch_id}/status` | Overall progress (`completed`/`processing`/`failed`/`partial_success`) with a per-clip breakdown (404 if missing or not owned) |
+
+Each request fans out into one sub-job per clip, tracked under a `BatchJob`. The 50-clip cap, an empty list, and duplicate ids each return 422. A clip that is unknown, not owned, or (for stems) non-`wav` is recorded as a **failed sub-job** rather than rejecting the whole request, so individual failures never halt the batch — the status reports `partial_success`. Stems sub-jobs reuse the single-clip stems job (wav only); export sub-jobs transcode any generated source (`wav`/`flac`/`mp3`/`aac`/`opus`) to a `wav`/`wav32`/`flac`/`mp3` target via ffmpeg and surface a `download_url` when complete. Like the single-clip extraction endpoints, these are non-generative local work, so **no credits are deducted**.
+
 ### Presets
 
 | Endpoint | Purpose |

--- a/docs/demos/demo_batch_us105.py
+++ b/docs/demos/demo_batch_us105.py
@@ -1,0 +1,198 @@
+"""Live demo driver for US-10.5 batch processing endpoints (issue #85).
+
+Drives the real FastAPI app over httpx ASGI against a throwaway MongoDB,
+exercising every acceptance criterion and printing outcome evidence. Stems use a
+lightweight StemsClient double (no demucs); export uses the real ffmpeg-backed
+export_audio so the produced file is genuine.
+
+Usage: ACEMUSIC_TEST_MONGODB_URL=mongodb://localhost:27017 uv run python docs/demos/demo_batch_us105.py
+"""
+
+import asyncio
+import os
+import tempfile
+import uuid
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+_TMP = tempfile.mkdtemp(prefix="demo-us105-")
+os.environ["ACEMUSIC_STORAGE_BACKEND"] = "local"
+os.environ["ACEMUSIC_STORAGE_LOCAL_ROOT"] = str(Path(_TMP) / "storage")
+
+import httpx  # noqa: E402
+from beanie import PydanticObjectId  # noqa: E402
+
+from acemusic.api import database  # noqa: E402
+from acemusic.api.auth.tokens import create_access_token  # noqa: E402
+from acemusic.api.main import API_V1_PREFIX, create_app  # noqa: E402
+from acemusic.api.models import BatchJob, Clip, Workspace  # noqa: E402
+from acemusic.api.services import users as user_service  # noqa: E402
+from acemusic.api.settings import ApiSettings  # noqa: E402
+from acemusic.api.tasks import extraction as extraction_tasks  # noqa: E402
+from acemusic.api.tasks.processor import JobProcessor  # noqa: E402
+from acemusic.storage import get_storage_backend  # noqa: E402
+
+BATCH = f"{API_V1_PREFIX}/batch"
+STEM_LABELS = ["drums", "bass", "other", "vocals"]
+
+
+class _FakeStemsClient:
+    model_samplerate = 44100
+
+    def separate(self, audio_path, progress_callback=None):
+        return {label: label for label in STEM_LABELS}
+
+    def save_stems(self, stems, output_dir, base_name, sample_rate=44100, output_format="wav"):
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        tone = (0.2 * np.sin(2 * np.pi * 220 * np.linspace(0, 0.5, int(sample_rate * 0.5), endpoint=False))).astype(
+            np.float32
+        )
+        paths = {}
+        for label in STEM_LABELS:
+            path = output_dir / f"{base_name}-{label}.{output_format}"
+            sf.write(str(path), np.column_stack([tone, tone]), sample_rate)
+            paths[label] = path
+        return paths
+
+
+def _headers(user, settings):
+    token = create_access_token(
+        user_id=str(user.id), email=user.email, subscription_tier=user.subscription_tier, settings=settings
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _tone_bytes(path: Path, *, fmt="wav", seconds=1.0) -> bytes:
+    sr = 44100
+    tone = (0.2 * np.sin(2 * np.pi * 220 * np.linspace(0, seconds, int(sr * seconds), endpoint=False))).astype(
+        np.float32
+    )
+    wav = path.with_suffix(".wav")
+    sf.write(str(wav), np.column_stack([tone, tone]), sr)
+    if fmt == "wav":
+        return wav.read_bytes()
+    from pydub import AudioSegment  # only when transcoding the source
+
+    out = path.with_suffix(f".{fmt}")
+    AudioSegment.from_file(str(wav), format="wav").export(str(out), format=fmt)
+    return out.read_bytes()
+
+
+async def _insert_clip(user, ws, *, fmt="wav", with_bytes=False) -> Clip:
+    cid = PydanticObjectId()
+    file_path = f"{user.id}/{ws.id}/clips/{cid}.{fmt}"
+    if with_bytes:
+        get_storage_backend().upload(file_path, _tone_bytes(Path(_TMP) / str(cid), fmt=fmt))
+    clip = Clip(id=cid, user_id=user.id, workspace_id=ws.id, file_path=file_path, format=fmt, duration=1.0, bpm=120)
+    await clip.insert()
+    return clip
+
+
+async def _poll(client, batch_id, headers, *, timeout=30.0):
+    proc = JobProcessor(concurrency=2, poll_interval=0.05)
+    await proc.start()
+    try:
+        deadline = asyncio.get_event_loop().time() + timeout
+        body = None
+        while asyncio.get_event_loop().time() < deadline:
+            r = await client.get(f"{BATCH}/{batch_id}/status", headers=headers)
+            body = r.json()
+            if body["overall_status"] in ("completed", "failed", "partial_success"):
+                break
+            await asyncio.sleep(0.05)
+        return body
+    finally:
+        await proc.stop()
+
+
+def _line(title):
+    print(f"\n{'=' * 4} {title} {'=' * 4}")
+
+
+async def main() -> None:
+    extraction_tasks.StemsClient = _FakeStemsClient  # avoid demucs
+
+    settings = ApiSettings(
+        _env_file=None,
+        mongodb_url=os.environ.get("ACEMUSIC_TEST_MONGODB_URL", "mongodb://localhost:27017"),
+        mongodb_db_name=f"acemusic_demo_{uuid.uuid4().hex[:8]}",
+        jwt_secret_key="demo-secret-key-at-least-32-bytes-long-xx",
+        job_processor_enabled=False,
+    )
+    mongo_client = await database.init_db(settings)
+    app = create_app(settings)
+    transport = httpx.ASGITransport(app=app)
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://demo") as client:
+            user = await user_service.get_or_create_user(
+                email="demo@example.com", provider="google", oauth_id="g-demo", name="Demo"
+            )
+            ws = Workspace(name="Demo WS", user_id=user.id)
+            await ws.insert()
+            headers = _headers(user, settings)
+
+            # --- AC3: >50 clips -> 422 -----------------------------------
+            _line("AC3  POST /batch/stems with 51 clips -> 422")
+            ids51 = [str(PydanticObjectId()) for _ in range(51)]
+            r = await client.post(f"{BATCH}/stems", json={"clip_ids": ids51}, headers=headers)
+            print(f"51 clips  -> HTTP {r.status_code}  (detail: {r.json()['detail'][0]['type']})")
+            ids50 = [str(PydanticObjectId()) for _ in range(50)]
+            r50 = await client.post(f"{BATCH}/stems", json={"clip_ids": ids50}, headers=headers)
+            print(f"50 clips  -> HTTP {r50.status_code}  (boundary accepted)")
+
+            # --- AC1 + AC4: batch stems, individual status, partial success
+            _line("AC1+AC4  POST /batch/stems: 2 good clips + 1 unknown id")
+            good = [await _insert_clip(user, ws, with_bytes=True) for _ in range(2)]
+            bogus = str(PydanticObjectId())
+            clip_ids = [str(c.id) for c in good] + [bogus]
+            created = await client.post(f"{BATCH}/stems", json={"clip_ids": clip_ids}, headers=headers)
+            body = created.json()
+            print(f"enqueue   -> HTTP {created.status_code}  batch_job_id={body['batch_job_id']}")
+            print(f"sub_job_ids: {len(body['sub_job_ids'])} real jobs (the unknown clip has no job)")
+            final = await _poll(client, body["batch_job_id"], headers)
+            print(f"\noverall_status   : {final['overall_status']}")
+            print(f"overall_progress : {final['overall_progress']}")
+            print(f"completed/failed : {final['completed_count']}/{final['failed_count']} of {final['total']}")
+            print("per-clip status:")
+            for s in final["sub_jobs"]:
+                extra = f"  -> {len(s['clip_ids'])} stem clips" if s.get("clip_ids") else f"  ({s.get('error')})"
+                print(f"  - {s['clip_id']}  {s['status']}{extra}")
+
+            # --- AC2: batch export produces files (real ffmpeg) ----------
+            _line("AC2  POST /batch/export: wav + mp3 sources -> flac files")
+            wav_clip = await _insert_clip(user, ws, fmt="wav", with_bytes=True)
+            mp3_clip = await _insert_clip(user, ws, fmt="mp3", with_bytes=True)
+            exp = await client.post(
+                f"{BATCH}/export",
+                json={"clip_ids": [str(wav_clip.id), str(mp3_clip.id)], "format": "flac"},
+                headers=headers,
+            )
+            ebody = exp.json()
+            print(f"enqueue   -> HTTP {exp.status_code}  batch_job_id={ebody['batch_job_id']}")
+            efinal = await _poll(client, ebody["batch_job_id"], headers)
+            print(f"overall_status   : {efinal['overall_status']}  ({efinal['completed_count']}/{efinal['total']})")
+            storage = get_storage_backend()
+            batch_doc = await BatchJob.get(PydanticObjectId(ebody["batch_job_id"]))
+            from acemusic.api.models import Job
+
+            for s in efinal["sub_jobs"]:
+                job = await Job.get(PydanticObjectId(s["job_id"]))
+                key = (job.result or {}).get("export_path")
+                data = storage.download(key)
+                marker = data[:4]
+                src_fmt = next(c.format for c in [wav_clip, mp3_clip] if str(c.id) == s["clip_id"])
+                print(f"  - {src_fmt:>3} source -> {s['status']}  {len(data)} bytes  marker={marker!r}  (fLaC = valid FLAC)")
+            print(f"\nbatch operation field: {batch_doc.operation!r}, target format: {batch_doc.format!r}")
+
+            print("\nAll acceptance criteria demonstrated against the live API.")
+    finally:
+        await mongo_client.drop_database(settings.mongodb_db_name)
+        await database.close_db(mongo_client)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/demos/demo_batch_us105.py
+++ b/docs/demos/demo_batch_us105.py
@@ -185,7 +185,9 @@ async def main() -> None:
                 data = storage.download(key)
                 marker = data[:4]
                 src_fmt = next(c.format for c in [wav_clip, mp3_clip] if str(c.id) == s["clip_id"])
-                print(f"  - {src_fmt:>3} source -> {s['status']}  {len(data)} bytes  marker={marker!r}  (fLaC = valid FLAC)")
+                print(
+                    f"  - {src_fmt:>3} source -> {s['status']}  {len(data)} bytes  marker={marker!r}  (fLaC = valid FLAC)"
+                )
             print(f"\nbatch operation field: {batch_doc.operation!r}, target format: {batch_doc.format!r}")
 
             print("\nAll acceptance criteria demonstrated against the live API.")

--- a/docs/demos/us-10.5-batch.md
+++ b/docs/demos/us-10.5-batch.md
@@ -1,0 +1,86 @@
+# US-10.5 — Batch processing endpoints (stems & export)
+
+*2026-06-15T20:23:12Z*
+
+US-10.5 adds three endpoints that run stems extraction or audio export across many clips in one request, tracked as a single batch:
+
+- `POST /api/v1/batch/stems` — `{clip_ids[]}` → 202 `{batch_job_id, sub_job_ids[]}`
+- `POST /api/v1/batch/export` — `{clip_ids[], format}` → 202 `{batch_job_id, sub_job_ids[]}`
+- `GET  /api/v1/batch/{batch_id}/status` → overall progress + per-clip status
+
+This demo drives the **real FastAPI app** (httpx ASGI) against a throwaway MongoDB. Stems use a lightweight `StemsClient` double (no demucs), but **export uses the real ffmpeg-backed `export_audio`** so the produced files are genuine. Each acceptance criterion is exercised against live endpoints.
+
+First, confirm the three batch routes are mounted on the live app.
+
+```bash
+uv run python -c "
+from acemusic.api.main import create_app
+app = create_app()
+for r in sorted(app.routes, key=lambda r: getattr(r, \"path\", \"\")):
+    p = getattr(r, \"path\", \"\")
+    if \"/batch\" in p:
+        print(sorted(r.methods - {\"HEAD\",\"OPTIONS\"}), p)
+"
+```
+
+```output
+['POST'] /api/v1/batch/export
+['POST'] /api/v1/batch/stems
+['GET'] /api/v1/batch/{batch_id}/status
+```
+
+Now run the full live scenario. The driver seeds a user, workspace, and clips, then exercises every acceptance criterion end-to-end against the running app + MongoDB. The four sections below map directly to the four acceptance criteria:
+
+- **AC3** — a 51-clip request is rejected 422; the 50-clip boundary is accepted.
+- **AC1 + AC4** — batch stems over 2 valid clips + 1 unknown id: each clip is tracked individually, and one bad clip does not halt the others — the batch reports `partial_success`.
+- **AC2** — batch export of a wav source AND an mp3 source to FLAC, proving real files are produced (the `fLaC` stream marker confirms a valid FLAC), including the non-wav source path.
+
+Now run the full live scenario. The driver seeds a user, workspace, and clips, then exercises every acceptance criterion end-to-end against the running app + MongoDB. The four sections below map directly to the four acceptance criteria:
+
+- **AC3** — a 51-clip request is rejected 422; the 50-clip boundary is accepted.
+- **AC1 + AC4** — batch stems over 2 valid clips + 1 unknown id: each clip is tracked individually, and one bad clip does not halt the others — the batch reports `partial_success`.
+- **AC2** — batch export of a wav source AND an mp3 source to FLAC, proving real files are produced (the `fLaC` stream marker confirms a valid FLAC), including the non-wav source path.
+
+```bash
+uv run python docs/demos/demo_batch_us105.py 2>/dev/null
+```
+
+```output
+
+==== AC3  POST /batch/stems with 51 clips -> 422 ====
+51 clips  -> HTTP 422  (detail: too_long)
+50 clips  -> HTTP 202  (boundary accepted)
+
+==== AC1+AC4  POST /batch/stems: 2 good clips + 1 unknown id ====
+enqueue   -> HTTP 202  batch_job_id=6a305f8552a8011cb6c53f98
+sub_job_ids: 2 real jobs (the unknown clip has no job)
+
+overall_status   : partial_success
+overall_progress : 1.0
+completed/failed : 2/1 of 3
+per-clip status:
+  - 6a305f8552a8011cb6c53f93  completed  -> 4 stem clips
+  - 6a305f8552a8011cb6c53f94  completed  -> 4 stem clips
+  - 6a305f8552a8011cb6c53f95  failed  (Clip not found.)
+
+==== AC2  POST /batch/export: wav + mp3 sources -> flac files ====
+enqueue   -> HTTP 202  batch_job_id=6a305f8652a8011cb6c53fa5
+overall_status   : completed  (2/2)
+  - wav source -> completed  20097 bytes  marker=b'fLaC'  (fLaC = valid FLAC)
+  - mp3 source -> completed  20825 bytes  marker=b'fLaC'  (fLaC = valid FLAC)
+
+batch operation field: 'export', target format: 'flac'
+
+All acceptance criteria demonstrated against the live API.
+```
+
+**Every acceptance criterion is demonstrated against the live API:**
+
+| Criterion | Evidence |
+|---|---|
+| Batch stems processes all clips & tracks individual status | 2 clips each produced 4 stem clips; per-clip status surfaced in `GET /status` |
+| Batch export produces files in the requested format | wav **and** mp3 sources → valid FLAC files (`fLaC` marker), real ffmpeg transcode |
+| >50 clips → 422 | 51 clips rejected (`too_long`); 50 accepted at the boundary |
+| Individual failures don’t halt the batch (partial success) | unknown clip failed in isolation; the 2 valid clips completed → `partial_success` |
+
+Stems and export are non-generative local work, so — like the single-clip extraction endpoints — **no credits are deducted**.

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -22,6 +22,7 @@ from . import database
 from .exceptions import HandleConflictError
 from .routers import (
     auth,
+    batch,
     clips,
     editing,
     extraction,
@@ -131,6 +132,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(editing.router, prefix=API_V1_PREFIX)
     app.include_router(extraction.router, prefix=API_V1_PREFIX)
     app.include_router(iterative.router, prefix=API_V1_PREFIX)
+    app.include_router(batch.router, prefix=API_V1_PREFIX)
     app.include_router(workspaces.router, prefix=API_V1_PREFIX)
     app.include_router(presets.router, prefix=API_V1_PREFIX)
 

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -3,6 +3,7 @@
 ``ALL_MODELS`` is the registration list passed to ``init_beanie``.
 """
 
+from .batch_job import BatchClipEntry, BatchJob
 from .clip import Clip
 from .credit_transaction import CreditTransaction
 from .job import Job, JobStatus
@@ -11,7 +12,7 @@ from .refresh_token import RefreshToken
 from .user import User
 from .workspace import Workspace
 
-ALL_MODELS = [User, Workspace, Clip, Job, RefreshToken, Preset, CreditTransaction]
+ALL_MODELS = [User, Workspace, Clip, Job, RefreshToken, Preset, CreditTransaction, BatchJob]
 
 __all__ = [
     "User",
@@ -20,6 +21,8 @@ __all__ = [
     "CreditTransaction",
     "Job",
     "JobStatus",
+    "BatchJob",
+    "BatchClipEntry",
     "RefreshToken",
     "Preset",
     "PRESET_PARAM_FIELDS",

--- a/src/acemusic/api/models/batch_job.py
+++ b/src/acemusic/api/models/batch_job.py
@@ -1,0 +1,49 @@
+"""Batch-job document model (US-10.5).
+
+A :class:`BatchJob` groups the per-clip sub-jobs spawned by a single batch
+request (``POST /batch/stems`` or ``POST /batch/export``) so their overall
+progress can be tracked. It lives in its own ``batch_jobs`` collection — never
+the ``jobs`` collection — because the :class:`~acemusic.api.tasks.processor.JobProcessor`
+claims any queued document in ``jobs`` whose ``job_type`` is registered, and a
+batch parent has no handler and must not be claimed.
+
+Each :class:`BatchClipEntry` records one requested clip. ``job_id`` points at the
+real sub-:class:`~acemusic.api.models.job.Job` created for that clip; it is
+``None`` when the clip failed request-time validation (unknown/not-owned, or a
+non-wav source), in which case ``error`` explains why. Live sub-job status is
+read from the referenced ``Job`` at status-check time, so only the immutable
+mapping is stored here.
+"""
+
+from datetime import datetime
+
+from beanie import Document, PydanticObjectId
+from pydantic import BaseModel, Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+
+class BatchClipEntry(BaseModel):
+    """One clip in a batch: its sub-job id, or a request-time failure reason."""
+
+    clip_id: str
+    job_id: str | None = None
+    error: str | None = None
+
+
+class BatchJob(Document):
+    """A batch of per-clip sub-jobs (stems extraction or audio export)."""
+
+    user_id: PydanticObjectId
+    operation: str  # "stems" | "export"
+    # Target format for export batches; None for stems.
+    format: str | None = None
+    entries: list[BatchClipEntry] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=utcnow)
+
+    class Settings:
+        name = "batch_jobs"
+        indexes = [
+            IndexModel([("user_id", ASCENDING)]),
+        ]

--- a/src/acemusic/api/routers/batch.py
+++ b/src/acemusic/api/routers/batch.py
@@ -1,0 +1,226 @@
+"""Batch processing endpoints (US-10.5), mounted under ``/api/v1/batch``.
+
+* ``POST /batch/stems``  → queue stem separation for many clips at once
+* ``POST /batch/export`` → queue audio export (wav/wav32/flac/mp3) for many clips
+* ``GET  /batch/{id}/status`` → overall progress + per-clip status
+
+Each request fans out into one sub-job per clip (an ordinary ``stems`` or
+``export`` job) tracked under a :class:`~acemusic.api.models.batch_job.BatchJob`.
+A clip that fails validation (unknown/not-owned, or non-wav) is recorded as a
+failed sub-job rather than rejecting the whole request, so individual failures
+never halt the batch (partial success). The 50-clip cap is enforced by Pydantic,
+so an over-large request is a 422 before any work is queued.
+
+These operations are non-generative local CPU work, so — like the single-clip
+extraction endpoints — no credits are deducted.
+"""
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from acemusic.audio import EXPORT_FORMATS
+from acemusic.storage import get_storage_backend
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import BatchJob, Job, JobStatus
+from ..services import batch as batch_service
+from ..services.common import coerce_object_id
+
+logger = logging.getLogger(__name__)
+
+# Per-request cap (issue #85): more than this many clips is a 422.
+MAX_BATCH_CLIPS = 50
+
+# Router-level dependency gates every route behind a valid Bearer token (mirrors
+# the extraction/jobs routers), so unauthenticated requests get 401.
+router = APIRouter(prefix="/batch", tags=["batch"], dependencies=[Depends(get_current_user)])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class _BatchRequest(BaseModel):
+    """Shared clip-list validation for batch requests."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    clip_ids: list[str] = Field(min_length=1, max_length=MAX_BATCH_CLIPS)
+
+    @model_validator(mode="after")
+    def _distinct_clip_ids(self) -> "_BatchRequest":
+        if len(set(self.clip_ids)) != len(self.clip_ids):
+            raise ValueError("clip_ids must be distinct")
+        return self
+
+
+class BatchStemsRequest(_BatchRequest):
+    """Body for ``POST /batch/stems``."""
+
+
+class BatchExportRequest(_BatchRequest):
+    """Body for ``POST /batch/export``."""
+
+    format: str
+
+    @field_validator("format")
+    @classmethod
+    def _supported_format(cls, value: str) -> str:
+        if value not in EXPORT_FORMATS:
+            raise ValueError(f"unsupported format {value!r}; expected one of {sorted(EXPORT_FORMATS)}")
+        return value
+
+
+class BatchJobCreated(BaseModel):
+    """The accepted-batch acknowledgement returned with HTTP 202."""
+
+    batch_job_id: str
+    sub_job_ids: list[str]
+
+
+class SubJobStatus(BaseModel):
+    """One clip's status within a batch (result fields populated when relevant)."""
+
+    clip_id: str
+    job_id: str | None = None
+    status: str
+    error: str | None = None
+    # Stems sub-jobs produce stem clip ids; export sub-jobs produce a file URL.
+    clip_ids: list[str] | None = None
+    download_url: str | None = None
+
+
+class BatchStatus(BaseModel):
+    """Overall batch progress with a per-clip breakdown."""
+
+    batch_job_id: str
+    operation: str
+    overall_status: str
+    overall_progress: float
+    total: int
+    completed_count: int
+    failed_count: int
+    sub_jobs: list[SubJobStatus]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+def _created(batch: BatchJob) -> BatchJobCreated:
+    return BatchJobCreated(
+        batch_job_id=str(batch.id),
+        sub_job_ids=[e.job_id for e in batch.entries if e.job_id is not None],
+    )
+
+
+@router.post("/stems", response_model=BatchJobCreated, status_code=status.HTTP_202_ACCEPTED)
+async def batch_stems(
+    request: BatchStemsRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> BatchJobCreated:
+    """Queue stem separation for every clip in ``clip_ids``."""
+    batch = await batch_service.create_batch(
+        user_id=current.user_id,
+        operation=batch_service.BATCH_STEMS_OPERATION,
+        clip_ids=request.clip_ids,
+    )
+    return _created(batch)
+
+
+@router.post("/export", response_model=BatchJobCreated, status_code=status.HTTP_202_ACCEPTED)
+async def batch_export(
+    request: BatchExportRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> BatchJobCreated:
+    """Queue audio export of every clip in ``clip_ids`` to ``format``."""
+    batch = await batch_service.create_batch(
+        user_id=current.user_id,
+        operation=batch_service.BATCH_EXPORT_OPERATION,
+        clip_ids=request.clip_ids,
+        format=request.format,
+    )
+    return _created(batch)
+
+
+async def _sub_job_status(entry, operation: str) -> SubJobStatus:
+    """Resolve one entry to its current status (live for real sub-jobs)."""
+    if entry.job_id is None:
+        # Request-time validation failure: terminal failure, no live job.
+        return SubJobStatus(clip_id=entry.clip_id, status=JobStatus.FAILED.value, error=entry.error)
+
+    job = await Job.get(coerce_object_id(entry.job_id))
+    if job is None:
+        # The sub-job vanished (e.g. owner-deleted); report it as failed rather
+        # than crashing the whole status read.
+        return SubJobStatus(
+            clip_id=entry.clip_id,
+            job_id=entry.job_id,
+            status=JobStatus.FAILED.value,
+            error="Sub-job no longer exists.",
+        )
+
+    sub = SubJobStatus(clip_id=entry.clip_id, job_id=entry.job_id, status=job.status.value)
+    if job.status == JobStatus.FAILED:
+        sub.error = job.error
+    elif job.status == JobStatus.COMPLETED:
+        result = job.result or {}
+        if operation == batch_service.BATCH_EXPORT_OPERATION:
+            export_path = result.get("export_path")
+            if export_path:
+                storage = get_storage_backend()
+                sub.download_url = await asyncio.to_thread(storage.get_url, export_path)
+        else:
+            sub.clip_ids = list(result.get("clip_ids", []))
+    return sub
+
+
+def _overall_status(*, total: int, completed: int, failed: int) -> str:
+    """Aggregate verdict: running wins, then all-completed / all-failed / mixed."""
+    if completed + failed < total:
+        return JobStatus.PROCESSING.value
+    if failed == total:
+        return JobStatus.FAILED.value
+    if completed == total:
+        return JobStatus.COMPLETED.value
+    return "partial_success"
+
+
+@router.get("/{batch_id}/status", response_model=BatchStatus, response_model_exclude_none=True)
+async def get_batch_status(
+    batch_id: str,
+    current: CurrentUser = Depends(get_current_user),
+) -> BatchStatus:
+    """Return overall progress and per-clip status for ``batch_id`` (404 otherwise).
+
+    Owner-scoped: a batch that does not exist *or* belongs to another user yields
+    404, so the endpoint never reveals another user's batches.
+    """
+    oid = coerce_object_id(batch_id)
+    batch = await BatchJob.get(oid) if oid is not None else None
+    if batch is None or str(batch.user_id) != current.user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Batch not found.")
+
+    sub_jobs = [await _sub_job_status(entry, batch.operation) for entry in batch.entries]
+    total = len(sub_jobs)
+    completed = sum(1 for s in sub_jobs if s.status == JobStatus.COMPLETED.value)
+    failed = sum(1 for s in sub_jobs if s.status == JobStatus.FAILED.value)
+    # Guard against an empty batch (not reachable via the API — min_length=1 —
+    # but keeps the math total-safe).
+    progress = (completed + failed) / total if total else 1.0
+
+    return BatchStatus(
+        batch_job_id=str(batch.id),
+        operation=batch.operation,
+        overall_status=_overall_status(total=total, completed=completed, failed=failed),
+        overall_progress=progress,
+        total=total,
+        completed_count=completed,
+        failed_count=failed,
+        sub_jobs=sub_jobs,
+    )

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -20,6 +20,7 @@ from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import Clip, Job, JobStatus
 from ..services.common import coerce_object_id
 from ..services.editing import EDIT_JOB_TYPES
+from ..services.export import EXPORT_JOB_TYPES
 from ..services.extraction import EXTRACTION_JOB_TYPES, MIDI_JOB_TYPE, resolve_midi_urls
 from ..services.iterative import FULL_SONG_JOB_TYPE, ITERATIVE_JOB_TYPES, SAMPLE_JOB_TYPE
 from .generation import GenerationRequest, estimate_seconds
@@ -78,7 +79,8 @@ def _estimate_for(job: Job) -> int:
     longer validates (e.g. a schema change) falls back to 0 rather than failing
     the status read.
     """
-    if job.job_type in EDIT_JOB_TYPES:
+    if job.job_type in EDIT_JOB_TYPES or job.job_type in EXPORT_JOB_TYPES:
+        # Export (US-10.5) is quick local transcode work, like an edit.
         return _EDIT_ESTIMATE_SECONDS
     if job.job_type in EXTRACTION_JOB_TYPES:
         return _EXTRACTION_ESTIMATE_SECONDS

--- a/src/acemusic/api/services/batch.py
+++ b/src/acemusic/api/services/batch.py
@@ -50,8 +50,11 @@ async def create_batch(
         if clip is None:
             entries.append(BatchClipEntry(clip_id=clip_id, error="Clip not found."))
             continue
+        # Stems extraction (torchaudio / basic-pitch) needs a wav source; export
+        # transcodes through ffmpeg, which reads any supported format, so the
+        # wav-only gate applies to stems only (matches the single-clip endpoints).
         src_fmt = native_format(clip)
-        if src_fmt != "wav":
+        if operation == BATCH_STEMS_OPERATION and src_fmt != "wav":
             entries.append(
                 BatchClipEntry(
                     clip_id=clip_id,

--- a/src/acemusic/api/services/batch.py
+++ b/src/acemusic/api/services/batch.py
@@ -1,0 +1,85 @@
+"""Batch coordination service (US-10.5).
+
+Fans a batch request out into one sub-job per clip and records the mapping in a
+:class:`~acemusic.api.models.batch_job.BatchJob`. Each clip is resolved and
+validated independently: an unknown/not-owned clip, or a non-wav source, becomes
+a *failed entry* (``job_id=None`` with a reason) rather than aborting the whole
+request — so one bad clip never halts the batch (partial success). Valid clips
+get a real sub-:class:`~acemusic.api.models.job.Job` (an ordinary ``stems`` or
+``export`` job that the existing :class:`JobProcessor` handles unchanged).
+
+Kept transport-agnostic (plain exceptions, never ``HTTPException``) like the
+other service modules: ownership is checked via the non-raising
+:func:`acemusic.api.services.clips.find_owned_clip`.
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import BatchClipEntry, BatchJob
+from . import clips as clip_service
+from .clips import native_format
+from .export import create_export_job
+from .extraction import STEMS_JOB_TYPE, create_extraction_job
+
+BATCH_STEMS_OPERATION = "stems"
+BATCH_EXPORT_OPERATION = "export"
+
+BATCH_OPERATIONS = (BATCH_STEMS_OPERATION, BATCH_EXPORT_OPERATION)
+
+
+async def create_batch(
+    *,
+    user_id: str,
+    operation: str,
+    clip_ids: list[str],
+    format: str | None = None,
+) -> BatchJob:
+    """Create one sub-job per clip and persist the batch mapping.
+
+    ``operation`` is ``"stems"`` or ``"export"``; ``format`` is required for
+    export and ignored for stems. Returns the saved :class:`BatchJob`.
+    """
+    if operation not in BATCH_OPERATIONS:
+        raise ValueError(f"Unknown batch operation: {operation!r}")
+    if operation == BATCH_EXPORT_OPERATION and format is None:
+        raise ValueError("Export batches require a format.")
+
+    entries: list[BatchClipEntry] = []
+    for clip_id in clip_ids:
+        clip = await clip_service.find_owned_clip(clip_id, user_id)
+        if clip is None:
+            entries.append(BatchClipEntry(clip_id=clip_id, error="Clip not found."))
+            continue
+        src_fmt = native_format(clip)
+        if src_fmt != "wav":
+            entries.append(
+                BatchClipEntry(
+                    clip_id=clip_id,
+                    error=f"unsupported format {src_fmt!r}; only wav is supported.",
+                )
+            )
+            continue
+        if operation == BATCH_STEMS_OPERATION:
+            job = await create_extraction_job(
+                user_id=clip.user_id,
+                workspace_id=clip.workspace_id,
+                job_type=STEMS_JOB_TYPE,
+                clip_id=clip.id,
+            )
+        else:
+            job = await create_export_job(
+                user_id=clip.user_id,
+                workspace_id=clip.workspace_id,
+                clip_id=clip.id,
+                format=format,
+            )
+        entries.append(BatchClipEntry(clip_id=clip_id, job_id=str(job.id)))
+
+    batch = BatchJob(
+        user_id=PydanticObjectId(user_id),
+        operation=operation,
+        format=format,
+        entries=entries,
+    )
+    await batch.insert()
+    return batch

--- a/src/acemusic/api/services/batch.py
+++ b/src/acemusic/api/services/batch.py
@@ -13,6 +13,8 @@ other service modules: ownership is checked via the non-raising
 :func:`acemusic.api.services.clips.find_owned_clip`.
 """
 
+import logging
+
 from beanie import PydanticObjectId
 
 from ..models import BatchClipEntry, BatchJob
@@ -20,6 +22,8 @@ from . import clips as clip_service
 from .clips import native_format
 from .export import create_export_job
 from .extraction import STEMS_JOB_TYPE, create_extraction_job
+
+logger = logging.getLogger(__name__)
 
 BATCH_STEMS_OPERATION = "stems"
 BATCH_EXPORT_OPERATION = "export"
@@ -62,20 +66,28 @@ async def create_batch(
                 )
             )
             continue
-        if operation == BATCH_STEMS_OPERATION:
-            job = await create_extraction_job(
-                user_id=clip.user_id,
-                workspace_id=clip.workspace_id,
-                job_type=STEMS_JOB_TYPE,
-                clip_id=clip.id,
-            )
-        else:
-            job = await create_export_job(
-                user_id=clip.user_id,
-                workspace_id=clip.workspace_id,
-                clip_id=clip.id,
-                format=format,
-            )
+        # Isolate sub-job creation per clip: a failure here (e.g. a DB write
+        # error) must not abort the whole batch and orphan the sub-jobs already
+        # queued — record it as a failed entry and carry on (partial success).
+        try:
+            if operation == BATCH_STEMS_OPERATION:
+                job = await create_extraction_job(
+                    user_id=clip.user_id,
+                    workspace_id=clip.workspace_id,
+                    job_type=STEMS_JOB_TYPE,
+                    clip_id=clip.id,
+                )
+            else:
+                job = await create_export_job(
+                    user_id=clip.user_id,
+                    workspace_id=clip.workspace_id,
+                    clip_id=clip.id,
+                    format=format,
+                )
+        except Exception:
+            logger.exception("Failed to queue %s sub-job for clip %s", operation, clip_id)
+            entries.append(BatchClipEntry(clip_id=clip_id, error=f"Failed to queue {operation} job."))
+            continue
         entries.append(BatchClipEntry(clip_id=clip_id, job_id=str(job.id)))
 
     batch = BatchJob(

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -60,11 +60,25 @@ def _contains_regex(text: str) -> dict:
     return {"$regex": re.escape(text), "$options": "i"}
 
 
-async def get_owned_clip(clip_id: str, user_id: str) -> Clip:
-    """Return the clip if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
+async def find_owned_clip(clip_id: str, user_id: str) -> Clip | None:
+    """Return the clip if ``user_id`` owns it, else None (no raise).
+
+    The non-raising sibling of :func:`get_owned_clip`, for callers that must
+    handle an unknown/not-owned clip without aborting — e.g. batch processing
+    (US-10.5), which records a per-clip failure and continues rather than failing
+    the whole request.
+    """
     oid = coerce_object_id(clip_id)
     clip = await Clip.get(oid) if oid is not None else None
     if clip is None or str(clip.user_id) != user_id:
+        return None
+    return clip
+
+
+async def get_owned_clip(clip_id: str, user_id: str) -> Clip:
+    """Return the clip if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
+    clip = await find_owned_clip(clip_id, user_id)
+    if clip is None:
         raise _clip_not_found()
     return clip
 

--- a/src/acemusic/api/services/export.py
+++ b/src/acemusic/api/services/export.py
@@ -1,0 +1,49 @@
+"""Export service layer (US-10.5).
+
+Persists queued audio-export jobs for batch export, mirroring
+:func:`acemusic.api.services.extraction.create_extraction_job`. Kept
+transport-agnostic (plain exceptions, never ``HTTPException``) like the other
+service modules. ``input_params`` carries the source ``clip_id`` and the target
+``format``; the worker re-reads the audio bytes from the clip at run time.
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import Job, JobStatus
+from ..tasks import dispatch_job
+
+EXPORT_JOB_TYPE = "export"
+
+EXPORT_JOB_TYPES = (EXPORT_JOB_TYPE,)
+
+
+async def create_export_job(
+    *,
+    user_id: PydanticObjectId,
+    workspace_id: PydanticObjectId,
+    clip_id: PydanticObjectId,
+    format: str,
+) -> Job:
+    """Persist a queued export job and dispatch it.
+
+    ``workspace_id`` is the source clip's workspace so the exported file lands
+    next to its source. Returns the saved :class:`Job` (with its id).
+    """
+    job = Job(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        job_type=EXPORT_JOB_TYPE,
+        status=JobStatus.QUEUED,
+        input_params={"clip_id": str(clip_id), "format": format},
+    )
+    await job.insert()
+    try:
+        await dispatch_job(str(job.id))
+    except BaseException:
+        # Don't leave the job behind: the processor polls for QUEUED documents,
+        # so an orphan would still run even though the caller saw a failure.
+        # BaseException (not Exception) on purpose: asyncio.CancelledError must
+        # also clean up (mirrors create_extraction_job).
+        await job.delete()
+        raise
+    return job

--- a/src/acemusic/api/tasks/export.py
+++ b/src/acemusic/api/tasks/export.py
@@ -1,0 +1,98 @@
+"""Export job handler (US-10.5): the batch-export worker.
+
+Runs one claimed ``export`` :class:`~acemusic.api.models.job.Job`: download the
+source clip's audio from storage into a temp file, transcode it to the requested
+format with :func:`acemusic.audio.export_audio` (ffmpeg, via a worker thread),
+upload the result under the per-user ``exports/`` prefix, and record its storage
+key. The exported file is an *object*, not a clip — it is referenced from the
+job result (``export_path``) and surfaced as a download URL by the batch-status
+endpoint, mirroring how MIDI extraction records ``midi_paths``.
+
+The handler shares the editing/extraction ``(job, storage)`` contract, so the
+:class:`~acemusic.api.tasks.processor.JobProcessor` adapts it the same way. The
+source clip — bytes and document — is never modified.
+
+``export_audio`` requires ffmpeg to encode flac/mp3/24-bit wav; on a server
+without ffmpeg the job fails with a clear error (the source clips themselves are
+wav, matching the extraction endpoints' wav-only constraint).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from beanie import PydanticObjectId
+
+from acemusic.audio import EXPORT_FORMATS, export_audio
+from acemusic.storage import StorageBackend
+
+from ..models import Clip, Job
+from ..services.clips import native_format
+
+# Container/extension each export format is written to (wav32 is a wav variant).
+_FORMAT_EXTENSIONS = {"wav": "wav", "wav32": "wav", "flac": "flac", "mp3": "mp3"}
+
+
+class ExportProcessingError(Exception):
+    """An export job could not be processed (missing source, bad format)."""
+
+
+async def _load_source_clip(job: Job) -> Clip:
+    """Resolve the job's source clip, or fail the job with a clear error.
+
+    The clip may legitimately vanish between enqueue and processing (the owner
+    can DELETE it while the job is queued), so a miss is a job failure, not a
+    crash (mirrors the extraction handlers).
+    """
+    clip_id = (job.input_params or {}).get("clip_id")
+    try:
+        oid = PydanticObjectId(clip_id)
+    except Exception as exc:
+        raise ExportProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
+    clip = await Clip.get(oid)
+    if clip is None:
+        raise ExportProcessingError(f"Source clip {clip_id} no longer exists")
+    return clip
+
+
+async def _download_source(storage: StorageBackend, source: Clip, dest: Path) -> None:
+    try:
+        data = await asyncio.to_thread(storage.download, source.file_path)
+    except FileNotFoundError as exc:
+        raise ExportProcessingError(f"Source clip {source.id} audio object {source.file_path!r} is missing") from exc
+    dest.write_bytes(data)
+
+
+async def process_export_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
+    """Transcode the source clip to the requested format and store the file."""
+    fmt = (job.input_params or {}).get("format")
+    if fmt not in EXPORT_FORMATS:
+        raise ExportProcessingError(f"Unsupported export format: {fmt!r}. Expected one of {EXPORT_FORMATS}.")
+
+    source = await _load_source_clip(job)
+    src_fmt = native_format(source)
+    if src_fmt != "wav":
+        # The transcode reads the source through pydub/ffmpeg, which needs ffmpeg
+        # for compressed inputs (absent on the server). Generated clips are wav;
+        # gate here so a bad job fails fast (mirrors the extraction endpoints).
+        raise ExportProcessingError(f"unsupported source format {src_fmt!r} for export; only wav is supported.")
+
+    ext = _FORMAT_EXTENSIONS[fmt]
+    with tempfile.TemporaryDirectory(prefix="acemusic-export-") as tmp_dir:
+        input_path = Path(tmp_dir) / "source.wav"
+        await _download_source(storage, source, input_path)
+        dest_path = Path(tmp_dir) / f"export.{ext}"
+        await asyncio.to_thread(export_audio, input_path, dest_path, fmt)
+        data = dest_path.read_bytes()
+
+    export_path = f"{job.user_id}/{job.workspace_id}/exports/{job.id}.{ext}"
+    await asyncio.to_thread(storage.upload, export_path, data)
+    return {"export_path": export_path, "format": fmt}
+
+
+EXPORT_JOB_HANDLERS = {
+    "export": process_export_job,
+}

--- a/src/acemusic/api/tasks/export.py
+++ b/src/acemusic/api/tasks/export.py
@@ -65,7 +65,7 @@ async def _download_source(storage: StorageBackend, source: Clip, dest: Path) ->
         data = await asyncio.to_thread(storage.download, source.file_path)
     except FileNotFoundError as exc:
         raise ExportProcessingError(f"Source clip {source.id} audio object {source.file_path!r} is missing") from exc
-    dest.write_bytes(data)
+    await asyncio.to_thread(dest.write_bytes, data)
 
 
 async def process_export_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
@@ -85,7 +85,7 @@ async def process_export_job(job: Job, storage: StorageBackend) -> dict[str, Any
         await _download_source(storage, source, input_path)
         dest_path = Path(tmp_dir) / f"export.{ext}"
         await asyncio.to_thread(export_audio, input_path, dest_path, fmt)
-        data = dest_path.read_bytes()
+        data = await asyncio.to_thread(dest_path.read_bytes)
 
     export_path = f"{job.user_id}/{job.workspace_id}/exports/{job.id}.{ext}"
     await asyncio.to_thread(storage.upload, export_path, data)

--- a/src/acemusic/api/tasks/export.py
+++ b/src/acemusic/api/tasks/export.py
@@ -12,9 +12,11 @@ The handler shares the editing/extraction ``(job, storage)`` contract, so the
 :class:`~acemusic.api.tasks.processor.JobProcessor` adapts it the same way. The
 source clip — bytes and document — is never modified.
 
-``export_audio`` requires ffmpeg to encode flac/mp3/24-bit wav; on a server
-without ffmpeg the job fails with a clear error (the source clips themselves are
-wav, matching the extraction endpoints' wav-only constraint).
+``export_audio`` requires ffmpeg to decode the source and encode the target
+(flac/mp3/24-bit wav); on a server without ffmpeg the job fails with a clear
+error. The source may be any format the API can generate (wav/flac/mp3/aac/opus)
+— ffmpeg reads them all — so the temp input keeps the source's real extension to
+give pydub the right decode hint.
 """
 
 from __future__ import annotations
@@ -73,16 +75,13 @@ async def process_export_job(job: Job, storage: StorageBackend) -> dict[str, Any
         raise ExportProcessingError(f"Unsupported export format: {fmt!r}. Expected one of {EXPORT_FORMATS}.")
 
     source = await _load_source_clip(job)
-    src_fmt = native_format(source)
-    if src_fmt != "wav":
-        # The transcode reads the source through pydub/ffmpeg, which needs ffmpeg
-        # for compressed inputs (absent on the server). Generated clips are wav;
-        # gate here so a bad job fails fast (mirrors the extraction endpoints).
-        raise ExportProcessingError(f"unsupported source format {src_fmt!r} for export; only wav is supported.")
+    src_ext = native_format(source)
 
     ext = _FORMAT_EXTENSIONS[fmt]
     with tempfile.TemporaryDirectory(prefix="acemusic-export-") as tmp_dir:
-        input_path = Path(tmp_dir) / "source.wav"
+        # Keep the source's real extension so export_audio's pydub decode hint
+        # (derived from the suffix) matches the actual format.
+        input_path = Path(tmp_dir) / f"source.{src_ext}"
         await _download_source(storage, source, input_path)
         dest_path = Path(tmp_dir) / f"export.{ext}"
         await asyncio.to_thread(export_audio, input_path, dest_path, fmt)

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -35,6 +35,7 @@ from .. import database
 from ..models import Clip, Job, JobStatus
 from ..models.common import utcnow
 from .editing import EDIT_JOB_HANDLERS
+from .export import EXPORT_JOB_HANDLERS
 from .extraction import EXTRACTION_JOB_HANDLERS
 from .iterative import ITERATIVE_JOB_HANDLERS
 
@@ -118,9 +119,13 @@ class JobProcessor:
         # (and re-queued when stale), so jobs another deployment owns are left
         # alone. ``handlers`` lets callers add or override entries.
         self._handlers: dict[str, JobHandler] = {"generate": self._handle_generate}
-        # Editing and extraction handlers share the same ``(job, storage)``
-        # contract, so both are adapted onto the registry the same way.
-        for job_type, storage_handler in {**EDIT_JOB_HANDLERS, **EXTRACTION_JOB_HANDLERS}.items():
+        # Editing, extraction, and export handlers share the same ``(job, storage)``
+        # contract, so all are adapted onto the registry the same way.
+        for job_type, storage_handler in {
+            **EDIT_JOB_HANDLERS,
+            **EXTRACTION_JOB_HANDLERS,
+            **EXPORT_JOB_HANDLERS,
+        }.items():
             self._handlers[job_type] = partial(self._run_storage_handler, storage_handler)
         # Iterative generation handlers (US-10.3) are generative: they need the
         # ACE-Step client and the poll loop in addition to storage, so they are

--- a/tests/test_batch_api.py
+++ b/tests/test_batch_api.py
@@ -416,6 +416,12 @@ class TestBatchExportLifecycle:
     async def test_real_transcode_decodes_non_wav_source(self, client, settings, local_storage, write_tone) -> None:
         # Proves the source-extension fix: a real mp3 source decodes through
         # ffmpeg and exports to flac (uses the real export_audio, no stub).
+        # Shells out to ffmpeg, which CI lacks — skip there (matches test_audio.py).
+        import shutil
+
+        if shutil.which("ffmpeg") is None:
+            pytest.skip("ffmpeg not installed; required for real transcode")
+
         from pydub import AudioSegment
 
         user = await _make_user("batch-export-real-mp3@example.com")

--- a/tests/test_batch_api.py
+++ b/tests/test_batch_api.py
@@ -1,0 +1,399 @@
+"""Tests for the batch processing endpoints (US-10.5, issue #85).
+
+Covers ``POST /batch/stems``, ``POST /batch/export`` (enqueue one sub-job per
+clip) and ``GET /batch/{id}/status`` (aggregate progress + per-clip breakdown).
+
+The auth-gate and request-validation tests run in CI (no DB; plain ``TestClient``
+does not run the lifespan, and ``get_current_user`` only decodes the token). The
+rest are ``integration`` and drive the real app with ``httpx.AsyncClient`` over a
+local MongoDB. The lifecycle tests substitute lightweight doubles for the
+demucs ``StemsClient`` and the ffmpeg-backed ``export_audio`` so neither real
+dependency runs — the algorithms are covered elsewhere; here we verify the
+batch/job wiring.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import BatchJob, Clip, Job, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+BATCH_URL = f"{API_V1_PREFIX}/batch"
+STEM_LABELS = ["drums", "bass", "other", "vocals"]
+
+_CI_SECRET = "test-secret-key-at-least-32-bytes-long-xx"
+
+
+def _stems_url() -> str:
+    return f"{BATCH_URL}/stems"
+
+
+def _export_url() -> str:
+    return f"{BATCH_URL}/export"
+
+
+def _status_url(batch_id) -> str:
+    return f"{BATCH_URL}/{batch_id}/status"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate + request validation — run in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_stems_missing_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(_stems_url(), json={"clip_ids": [str(PydanticObjectId())]})
+        assert resp.status_code == 401
+
+    def test_export_missing_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(_export_url(), json={"clip_ids": [str(PydanticObjectId())], "format": "mp3"})
+        assert resp.status_code == 401
+
+    def test_status_missing_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.get(_status_url(PydanticObjectId()))
+        assert resp.status_code == 401
+
+
+class TestRequestValidation:
+    """Pydantic rejects bad envelopes before any DB/service work (CI-safe)."""
+
+    def _client(self):
+        settings = ApiSettings().model_copy(update={"jwt_secret_key": _CI_SECRET})
+        token = create_access_token(
+            user_id=str(PydanticObjectId()), email="ci@example.com", subscription_tier="free", settings=settings
+        )
+        return TestClient(create_app(settings)), {"Authorization": f"Bearer {token}"}
+
+    def test_more_than_50_clips_returns_422(self) -> None:
+        # AC: requesting more than 50 clips returns 422.
+        client, headers = self._client()
+        clip_ids = [str(PydanticObjectId()) for _ in range(51)]
+        resp = client.post(_stems_url(), json={"clip_ids": clip_ids}, headers=headers)
+        assert resp.status_code == 422
+
+    def test_export_more_than_50_clips_returns_422(self) -> None:
+        client, headers = self._client()
+        clip_ids = [str(PydanticObjectId()) for _ in range(51)]
+        resp = client.post(_export_url(), json={"clip_ids": clip_ids, "format": "mp3"}, headers=headers)
+        assert resp.status_code == 422
+
+    def test_empty_clip_list_returns_422(self) -> None:
+        client, headers = self._client()
+        resp = client.post(_stems_url(), json={"clip_ids": []}, headers=headers)
+        assert resp.status_code == 422
+
+    def test_duplicate_clip_ids_returns_422(self) -> None:
+        client, headers = self._client()
+        dup = str(PydanticObjectId())
+        resp = client.post(_stems_url(), json={"clip_ids": [dup, dup]}, headers=headers)
+        assert resp.status_code == 422
+
+    def test_export_unsupported_format_returns_422(self) -> None:
+        client, headers = self._client()
+        resp = client.post(
+            _export_url(), json={"clip_ids": [str(PydanticObjectId())], "format": "ogg"}, headers=headers
+        )
+        assert resp.status_code == 422
+
+    def test_export_missing_format_returns_422(self) -> None:
+        client, headers = self._client()
+        resp = client.post(_export_url(), json={"clip_ids": [str(PydanticObjectId())]}, headers=headers)
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app):
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # Disable the background processor by default: enqueue tests assert on the
+    # queued sub-jobs and do not want a worker claiming them. The lifecycle
+    # tests start their own processor explicitly.
+    return mongo_settings.model_copy(update={"jwt_secret_key": _CI_SECRET, "job_processor_enabled": False})
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path / "storage"))
+    return tmp_path
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), email=user.email, subscription_tier=user.subscription_tier, settings=settings
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(user, workspace, *, fmt: str | None = "wav", store_bytes: bytes | None = None) -> Clip:
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt or 'wav'}"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
+    clip = Clip(
+        id=clip_id, user_id=user.id, workspace_id=workspace.id, file_path=file_path, format=fmt, duration=2.0, bpm=120
+    )
+    await clip.insert()
+    return clip
+
+
+async def _poll_batch(client, batch_id, headers, *, until=("completed", "failed", "partial_success"), timeout=30.0):
+    from acemusic.api.tasks.processor import JobProcessor
+
+    processor = JobProcessor(concurrency=2, poll_interval=0.05)
+    await processor.start()
+    try:
+        body = None
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            resp = await client.get(_status_url(batch_id), headers=headers)
+            assert resp.status_code == 200
+            body = resp.json()
+            if body["overall_status"] in until:
+                break
+            await asyncio.sleep(0.05)
+    finally:
+        await processor.stop()
+    return body
+
+
+# --- stems: enqueue --------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestBatchStemsEnqueue:
+    async def test_returns_202_with_a_subjob_per_clip(self, client, settings) -> None:
+        user = await _make_user("batch-stems-202@example.com")
+        ws = await _make_workspace(user)
+        clips = [await _insert_clip(user, ws) for _ in range(3)]
+        ids = [str(c.id) for c in clips]
+
+        resp = await client.post(_stems_url(), json={"clip_ids": ids}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        body = resp.json()
+        assert len(body["sub_job_ids"]) == 3
+
+        batch = await BatchJob.get(PydanticObjectId(body["batch_job_id"]))
+        assert batch is not None and batch.operation == "stems"
+        assert [e.clip_id for e in batch.entries] == ids
+        # Each valid clip got a real queued stems sub-job.
+        jobs = await Job.find_all().to_list()
+        assert {j.job_type for j in jobs} == {"stems"}
+        assert len(jobs) == 3
+
+    async def test_unknown_clip_becomes_failed_entry_without_aborting(self, client, settings) -> None:
+        # AC: individual failures do not halt the batch.
+        user = await _make_user("batch-stems-mixed@example.com")
+        ws = await _make_workspace(user)
+        good = await _insert_clip(user, ws)
+        bogus = str(PydanticObjectId())
+
+        resp = await client.post(
+            _stems_url(), json={"clip_ids": [str(good.id), bogus]}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 202
+        assert len(resp.json()["sub_job_ids"]) == 1  # only the good clip queued
+
+        body = await client.get(_status_url(resp.json()["batch_job_id"]), headers=_auth_headers(user, settings))
+        data = body.json()
+        assert data["total"] == 2
+        by_clip = {s["clip_id"]: s for s in data["sub_jobs"]}
+        assert by_clip[bogus]["status"] == "failed"
+        assert by_clip[str(good.id)]["status"] in {"queued", "processing"}
+
+    async def test_non_wav_clip_becomes_failed_entry(self, client, settings) -> None:
+        user = await _make_user("batch-stems-nonwav@example.com")
+        ws = await _make_workspace(user)
+        mp3 = await _insert_clip(user, ws, fmt="mp3")
+
+        resp = await client.post(_stems_url(), json={"clip_ids": [str(mp3.id)]}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        assert resp.json()["sub_job_ids"] == []
+        assert await Job.count() == 0  # no sub-job queued for the bad clip
+        batch = await BatchJob.get(PydanticObjectId(resp.json()["batch_job_id"]))
+        assert "mp3" in (batch.entries[0].error or "")
+
+    async def test_50_clips_is_accepted(self, client, settings) -> None:
+        # The 50-clip boundary is allowed (51 is rejected by validation, tested
+        # in CI). Unknown ids become failed entries, so this also exercises the
+        # all-unknown path returning 202 rather than erroring.
+        user = await _make_user("batch-stems-50@example.com")
+        ids = [str(PydanticObjectId()) for _ in range(50)]
+        resp = await client.post(_stems_url(), json={"clip_ids": ids}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        batch = await BatchJob.get(PydanticObjectId(resp.json()["batch_job_id"]))
+        assert len(batch.entries) == 50
+
+
+# --- status: ownership -----------------------------------------------------
+
+
+@pytest.mark.integration
+class TestBatchStatusOwnership:
+    async def test_unknown_batch_returns_404(self, client, settings) -> None:
+        user = await _make_user("batch-status-404@example.com")
+        resp = await client.get(_status_url(PydanticObjectId()), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_malformed_batch_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("batch-status-malformed@example.com")
+        resp = await client.get(_status_url("not-an-id"), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_batch_returns_404(self, client, settings) -> None:
+        owner = await _make_user("batch-owner@example.com")
+        ws = await _make_workspace(owner)
+        clip = await _insert_clip(owner, ws)
+        created = await client.post(
+            _stems_url(), json={"clip_ids": [str(clip.id)]}, headers=_auth_headers(owner, settings)
+        )
+        batch_id = created.json()["batch_job_id"]
+
+        other = await _make_user("batch-intruder@example.com")
+        resp = await client.get(_status_url(batch_id), headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+
+
+# --- lifecycle: stems with a stubbed StemsClient ---------------------------
+
+
+class _FakeStemsClient:
+    """Writes four short WAV stems without running demucs."""
+
+    model_samplerate = 44100
+
+    def separate(self, audio_path, progress_callback=None):
+        return {label: label for label in STEM_LABELS}
+
+    def save_stems(self, stems, output_dir, base_name, sample_rate=44100, output_format="wav"):
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        tone = (0.2 * np.sin(2 * np.pi * 220 * np.linspace(0, 0.5, int(sample_rate * 0.5), endpoint=False))).astype(
+            np.float32
+        )
+        paths = {}
+        for label in STEM_LABELS:
+            path = output_dir / f"{base_name}-{label}.{output_format}"
+            sf.write(str(path), np.column_stack([tone, tone]), sample_rate)
+            paths[label] = path
+        return paths
+
+
+@pytest.mark.integration
+class TestBatchStemsLifecycle:
+    async def test_partial_success_one_completes_one_fails(
+        self, client, settings, local_storage, write_tone, monkeypatch
+    ) -> None:
+        # AC: batch stems tracks individual status and reports partial success.
+        from acemusic.api.tasks import extraction as extraction_tasks
+
+        monkeypatch.setattr(extraction_tasks, "StemsClient", _FakeStemsClient)
+
+        user = await _make_user("batch-stems-partial@example.com")
+        ws = await _make_workspace(user)
+        tone_path = local_storage / "tone.wav"
+        write_tone(tone_path, duration_s=2.0)
+        good = await _insert_clip(user, ws, store_bytes=tone_path.read_bytes())
+        bogus = str(PydanticObjectId())
+        headers = _auth_headers(user, settings)
+
+        created = await client.post(_stems_url(), json={"clip_ids": [str(good.id), bogus]}, headers=headers)
+        batch_id = created.json()["batch_job_id"]
+
+        body = await _poll_batch(client, batch_id, headers)
+        assert body["overall_status"] == "partial_success", body
+        assert body["completed_count"] == 1
+        assert body["failed_count"] == 1
+        assert body["overall_progress"] == 1.0
+
+        by_clip = {s["clip_id"]: s for s in body["sub_jobs"]}
+        assert by_clip[bogus]["status"] == "failed"
+        completed = by_clip[str(good.id)]
+        assert completed["status"] == "completed"
+        assert len(completed["clip_ids"]) == 4  # four stem clips
+
+
+# --- lifecycle: export with a stubbed export_audio -------------------------
+
+
+def _fake_export_audio(src, dest, fmt):
+    Path(dest).write_bytes(b"FAKE-EXPORT-" + fmt.encode())
+    return Path(dest)
+
+
+@pytest.mark.integration
+class TestBatchExportLifecycle:
+    async def test_export_runs_to_completed_with_download_urls(
+        self, client, settings, local_storage, write_tone, monkeypatch
+    ) -> None:
+        # AC: batch export produces files for all clips in the requested format.
+        from acemusic.api.tasks import export as export_tasks
+
+        monkeypatch.setattr(export_tasks, "export_audio", _fake_export_audio)
+
+        user = await _make_user("batch-export-e2e@example.com")
+        ws = await _make_workspace(user)
+        tone_path = local_storage / "tone.wav"
+        write_tone(tone_path, duration_s=2.0)
+        clips = [await _insert_clip(user, ws, store_bytes=tone_path.read_bytes()) for _ in range(2)]
+        headers = _auth_headers(user, settings)
+
+        created = await client.post(
+            _export_url(), json={"clip_ids": [str(c.id) for c in clips], "format": "mp3"}, headers=headers
+        )
+        assert created.status_code == 202
+        batch_id = created.json()["batch_job_id"]
+
+        body = await _poll_batch(client, batch_id, headers)
+        assert body["overall_status"] == "completed", body
+        assert body["completed_count"] == 2
+        for sub in body["sub_jobs"]:
+            assert sub["status"] == "completed"
+            assert sub["download_url"]  # exported file is retrievable
+
+        # The export objects were actually written to storage.
+        jobs = await Job.find(Job.job_type == "export").to_list()
+        storage = get_storage_backend()
+        for job in jobs:
+            assert storage.download((job.result or {})["export_path"]).startswith(b"FAKE-EXPORT-")

--- a/tests/test_batch_api.py
+++ b/tests/test_batch_api.py
@@ -265,6 +265,30 @@ class TestBatchStemsEnqueue:
         batch = await BatchJob.get(PydanticObjectId(resp.json()["batch_job_id"]))
         assert len(batch.entries) == 50
 
+    async def test_subjob_enqueue_failure_is_isolated(self, client, settings, monkeypatch) -> None:
+        # A failure creating a sub-job (e.g. a DB write error) must not abort the
+        # batch — it is recorded as a failed entry and the BatchJob still persists.
+        from acemusic.api.services import batch as batch_service
+
+        async def _boom(**kwargs):
+            raise RuntimeError("db unavailable")
+
+        monkeypatch.setattr(batch_service, "create_extraction_job", _boom)
+
+        user = await _make_user("batch-stems-enqueue-fail@example.com")
+        ws = await _make_workspace(user)
+        clip = await _insert_clip(user, ws)
+        headers = _auth_headers(user, settings)
+
+        resp = await client.post(_stems_url(), json={"clip_ids": [str(clip.id)]}, headers=headers)
+        assert resp.status_code == 202
+        assert resp.json()["sub_job_ids"] == []
+
+        body = (await client.get(_status_url(resp.json()["batch_job_id"]), headers=headers)).json()
+        assert body["overall_status"] == "failed"
+        assert body["sub_jobs"][0]["status"] == "failed"
+        assert "Failed to queue" in body["sub_jobs"][0]["error"]
+
 
 # --- status: ownership -----------------------------------------------------
 

--- a/tests/test_batch_api.py
+++ b/tests/test_batch_api.py
@@ -397,3 +397,43 @@ class TestBatchExportLifecycle:
         storage = get_storage_backend()
         for job in jobs:
             assert storage.download((job.result or {})["export_path"]).startswith(b"FAKE-EXPORT-")
+
+    async def test_non_wav_clip_is_queued_for_export(self, client, settings) -> None:
+        # Unlike stems (wav-only), export transcodes any generated format, so an
+        # mp3 clip is queued — not recorded as a failed entry.
+        user = await _make_user("batch-export-nonwav@example.com")
+        ws = await _make_workspace(user)
+        mp3 = await _insert_clip(user, ws, fmt="mp3")
+
+        resp = await client.post(
+            _export_url(), json={"clip_ids": [str(mp3.id)], "format": "flac"}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 202
+        assert len(resp.json()["sub_job_ids"]) == 1
+        jobs = await Job.find(Job.job_type == "export").to_list()
+        assert len(jobs) == 1 and jobs[0].input_params["clip_id"] == str(mp3.id)
+
+    async def test_real_transcode_decodes_non_wav_source(self, client, settings, local_storage, write_tone) -> None:
+        # Proves the source-extension fix: a real mp3 source decodes through
+        # ffmpeg and exports to flac (uses the real export_audio, no stub).
+        from pydub import AudioSegment
+
+        user = await _make_user("batch-export-real-mp3@example.com")
+        ws = await _make_workspace(user)
+        tone_path = local_storage / "tone.wav"
+        write_tone(tone_path, duration_s=1.0)
+        mp3_path = local_storage / "tone.mp3"
+        AudioSegment.from_file(str(tone_path), format="wav").export(str(mp3_path), format="mp3")
+        clip = await _insert_clip(user, ws, fmt="mp3", store_bytes=mp3_path.read_bytes())
+        headers = _auth_headers(user, settings)
+
+        created = await client.post(_export_url(), json={"clip_ids": [str(clip.id)], "format": "flac"}, headers=headers)
+        batch_id = created.json()["batch_job_id"]
+
+        body = await _poll_batch(client, batch_id, headers)
+        assert body["overall_status"] == "completed", body
+        sub = body["sub_jobs"][0]
+        assert sub["status"] == "completed" and sub["download_url"]
+        job = (await Job.find(Job.job_type == "export").to_list())[0]
+        data = get_storage_backend().download((job.result or {})["export_path"])
+        assert data[:4] == b"fLaC"  # valid FLAC stream marker


### PR DESCRIPTION
## US-10.5 — Batch processing endpoints (closes #85)

Run stems extraction or audio export across many clips in one request, tracked as a single batch.

### Endpoints
- `POST /api/v1/batch/stems` — `{clip_ids[]}` → 202 `{batch_job_id, sub_job_ids[]}`
- `POST /api/v1/batch/export` — `{clip_ids[], format}` → 202 `{batch_job_id, sub_job_ids[]}`
- `GET /api/v1/batch/{batch_id}/status` → overall progress + per-clip status

### Design
The CodeRabbit plan on the issue predated the API layer, so this mirrors the **live** stems-extraction
pattern instead (router → service → `(job, storage)` worker handler → status):

- A **`BatchJob`** document (its own `batch_jobs` collection) groups per-clip sub-jobs. It lives outside
  the `jobs` collection because the `JobProcessor` claims any queued `jobs` document whose `job_type` is
  registered — a batch parent has no handler and must not be claimed.
- **Batch stems** reuses the existing `"stems"` job per clip (zero new worker logic; rides an in-flight
  job per clip via the existing idempotency).
- **Batch export** adds an `"export"` job type wrapping `export_audio` (wav/wav32/flac/mp3), storing the
  result under `{user}/{ws}/exports/{job_id}.{ext}` and surfacing a download URL in the status.
- **No credits** are deducted — these are non-generative local CPU work, matching the single-clip
  extraction endpoints.

### Acceptance criteria
- [x] Batch stems processes all provided clips and tracks individual status
- [x] Batch export produces files for all clips in the requested format
- [x] Requesting more than 50 clips returns 422 (also: empty list and duplicate ids → 422)
- [x] Individual failures do not halt the batch — unknown/not-owned/non-wav clips become failed
      sub-jobs and processing failures are isolated per job; the batch reports `partial_success`

### Tests
`tests/test_batch_api.py` — 9 CI-safe (auth gate + request validation, no DB) and 9 integration
(real MongoDB; demucs `StemsClient` and ffmpeg `export_audio` stubbed). Full unit suite (1171) and
touched-module integration suites green.

### Known limitations
- Export requires **ffmpeg** on the server to decode the source and encode the target; where it is absent
  the export sub-job fails with a clear error. (Stems remains wav-only — torchaudio/basic-pitch can't
  decode compressed audio without ffmpeg; export transcodes any generated source: wav/flac/mp3/aac/opus.)
- Batch export **target** formats are limited to `wav`/`wav32`/`flac`/`mp3` (what `export_audio` writes).
  DAW/stems/MIDI bundle export is deferred to the full export API (Stage 14), per the issue's dependency note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch processing endpoints for stem separation and audio export (up to 50 clips per request).
  * Added a batch status endpoint to track overall progress and per-clip outcomes.
  * Partial success is supported: validation or per-clip failures don’t block valid clips.
* **Bug Fixes**
  * Improved clip lookup behavior to consistently handle malformed/unknown clip IDs.
  * Included export jobs in background job processing/estimation.
* **Documentation**
  * Documented the new batch processing capabilities and behavior.
* **Tests**
  * Added comprehensive batch API tests and lifecycle coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->