### PR TITLE
feat(api): clip lineage & children endpoints (US-10.6)

### DIFF
--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -53,4 +53,7 @@ class Clip(Document):
             IndexModel([("workspace_id", ASCENDING), ("created_at", DESCENDING)]),
             IndexModel([("user_id", ASCENDING)]),
             IndexModel([("created_at", DESCENDING)]),
+            # Multikey index over the parent list powers the children lookup
+            # ("clips derived from this clip", US-10.6) without a collection scan.
+            IndexModel([("parent_clip_ids", ASCENDING)]),
         ]

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -174,6 +174,8 @@ class ClipSummary(BaseModel):
 
 
 class LineageNode(ClipSummary):
+    """A lineage node: a clip summary plus its distance from the queried clip."""
+
     # 0 is the queried clip; 1 its parents; 2 their parents; … (US-10.6).
     depth: int
 
@@ -183,6 +185,8 @@ class LineageNode(ClipSummary):
 
 
 class ClipLineageResponse(BaseModel):
+    """A clip's ancestry tree (US-10.6): the clip at depth 0 and its ancestors."""
+
     clip_id: str
     # The depth cap that was applied (always ``MAX_LINEAGE_DEPTH``), not the
     # deepest node returned — read ``nodes[*].depth`` for that.
@@ -194,6 +198,8 @@ class ClipLineageResponse(BaseModel):
 
 
 class ClipChildrenResponse(BaseModel):
+    """The clips directly derived from a clip (US-10.6)."""
+
     clip_id: str
     total: int
     children: list[ClipSummary]

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -152,6 +152,46 @@ class ClipListResponse(BaseModel):
     total_pages: int
 
 
+class ClipSummary(BaseModel):
+    """A node in a lineage/children response: enough to identify a clip and how
+    it was made, without the full metadata payload of ``ClipResponse``."""
+
+    id: str
+    title: str | None
+    generation_mode: str | None
+    parent_clip_ids: list[str]
+    created_at: datetime
+
+    @classmethod
+    def from_clip(cls, clip: Clip) -> "ClipSummary":
+        return cls(
+            id=str(clip.id),
+            title=clip.title,
+            generation_mode=clip.generation_mode,
+            parent_clip_ids=[str(pid) for pid in clip.parent_clip_ids],
+            created_at=clip.created_at,
+        )
+
+
+class LineageNode(ClipSummary):
+    # 0 is the queried clip; 1 its parents; 2 their parents; … (US-10.6).
+    depth: int
+
+
+class ClipLineageResponse(BaseModel):
+    clip_id: str
+    max_depth: int
+    # True when ancestors remain beyond ``max_depth`` (the tree was capped).
+    truncated: bool
+    nodes: list[LineageNode]
+
+
+class ClipChildrenResponse(BaseModel):
+    clip_id: str
+    total: int
+    children: list[ClipSummary]
+
+
 @router.get("", response_model=ClipListResponse)
 async def list_clips(
     # Annotated[..., Query()] (not plain Depends) makes FastAPI validate the
@@ -185,6 +225,35 @@ async def list_clips(
 async def get_clip(clip_id: str, current: CurrentUser = Depends(require_existing_user)) -> ClipResponse:
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
     return ClipResponse.from_clip(clip)
+
+
+@router.get("/{clip_id}/lineage", response_model=ClipLineageResponse)
+async def get_clip_lineage(clip_id: str, current: CurrentUser = Depends(require_existing_user)) -> ClipLineageResponse:
+    """Return the clip's full ancestry tree — parents, grandparents, … up to the
+    original generation (US-10.6), capped at ``MAX_LINEAGE_DEPTH`` levels."""
+    nodes, truncated = await clip_service.get_lineage(clip_id, current.user_id)
+    # nodes[0] is always the subject clip (depth 0); echo its normalized id so the
+    # response matches the children endpoint regardless of the path's id casing.
+    subject, _ = nodes[0]
+    return ClipLineageResponse(
+        clip_id=str(subject.id),
+        max_depth=clip_service.MAX_LINEAGE_DEPTH,
+        truncated=truncated,
+        nodes=[LineageNode(**ClipSummary.from_clip(clip).model_dump(), depth=depth) for clip, depth in nodes],
+    )
+
+
+@router.get("/{clip_id}/children", response_model=ClipChildrenResponse)
+async def get_clip_children(
+    clip_id: str, current: CurrentUser = Depends(require_existing_user)
+) -> ClipChildrenResponse:
+    """Return the clips directly derived from this clip (US-10.6)."""
+    clip, children = await clip_service.get_children(clip_id, current.user_id)
+    return ClipChildrenResponse(
+        clip_id=str(clip.id),
+        total=len(children),
+        children=[ClipSummary.from_clip(child) for child in children],
+    )
 
 
 @router.patch("/{clip_id}", response_model=ClipResponse)

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -177,12 +177,19 @@ class LineageNode(ClipSummary):
     # 0 is the queried clip; 1 its parents; 2 their parents; … (US-10.6).
     depth: int
 
+    @classmethod
+    def from_clip(cls, clip: Clip, depth: int) -> "LineageNode":
+        return cls(**ClipSummary.from_clip(clip).model_dump(), depth=depth)
+
 
 class ClipLineageResponse(BaseModel):
     clip_id: str
-    max_depth: int
-    # True when ancestors remain beyond ``max_depth`` (the tree was capped).
-    truncated: bool
+    # The depth cap that was applied (always ``MAX_LINEAGE_DEPTH``), not the
+    # deepest node returned — read ``nodes[*].depth`` for that.
+    depth_limit: int
+    # True when ancestors remain beyond ``depth_limit`` (the tree was capped).
+    # Ownership-filtered ancestors are excluded silently, not reflected here.
+    depth_truncated: bool
     nodes: list[LineageNode]
 
 
@@ -237,9 +244,9 @@ async def get_clip_lineage(clip_id: str, current: CurrentUser = Depends(require_
     subject, _ = nodes[0]
     return ClipLineageResponse(
         clip_id=str(subject.id),
-        max_depth=clip_service.MAX_LINEAGE_DEPTH,
-        truncated=truncated,
-        nodes=[LineageNode(**ClipSummary.from_clip(clip).model_dump(), depth=depth) for clip, depth in nodes],
+        depth_limit=clip_service.MAX_LINEAGE_DEPTH,
+        depth_truncated=truncated,
+        nodes=[LineageNode.from_clip(clip, depth) for clip, depth in nodes],
     )
 
 

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Literal
 
 from beanie import PydanticObjectId
+from beanie.operators import In
 from fastapi import HTTPException, status
 
 from acemusic.storage import get_storage_backend
@@ -26,6 +27,10 @@ from . import workspaces as workspace_service
 from .common import coerce_object_id
 
 logger = logging.getLogger(__name__)
+
+# US-10.6: cap ancestry traversal so a corrupt/cyclic graph can never walk
+# unboundedly. 50 levels is the documented maximum lineage depth.
+MAX_LINEAGE_DEPTH = 50
 
 
 async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
@@ -169,3 +174,77 @@ async def delete_clip(clip_id: str, user_id: str) -> None:
         except Exception:  # pragma: no cover - cleanup is best-effort
             logger.warning("Failed to delete MIDI object %s while deleting clip %s", midi_key, clip.id)
     await clip.delete()
+
+
+async def get_lineage(
+    clip_id: str,
+    user_id: str,
+    *,
+    max_depth: int = MAX_LINEAGE_DEPTH,
+) -> tuple[list[tuple[Clip, int]], bool]:
+    """Return the clip's ancestry tree as ``(clip, depth)`` pairs, plus a
+    ``truncated`` flag (US-10.6).
+
+    The subject clip is depth 0; its ``parent_clip_ids`` are depth 1, their
+    parents depth 2, and so on up to the original generation. Traversal walks the
+    graph breadth-first, resolving one whole depth level per query
+    (``In(Clip.id, …)``), so a 20-level chain costs ~20 indexed ``_id`` lookups
+    rather than one round-trip per node.
+
+    Ownership-scoped to ``user_id`` (matching CRUD): the subject 404s if not
+    owned, and an ancestor owned by someone else (e.g. a public clip derived
+    from) is simply absent from the tree rather than leaked. A ``visited`` set
+    collapses diamond lineage (shared ancestors via multi-parent mashups) to a
+    single node and guards against cycles. ``truncated`` is True when ancestors
+    remain beyond ``max_depth``.
+    """
+    subject = await get_owned_clip(clip_id, user_id)
+    owner = PydanticObjectId(user_id)
+
+    nodes: list[tuple[Clip, int]] = [(subject, 0)]
+    visited: set[PydanticObjectId] = {subject.id}
+    frontier: set[PydanticObjectId] = {pid for pid in subject.parent_clip_ids if pid not in visited}
+
+    truncated = False
+    depth = 1
+    while frontier:
+        if depth > max_depth:
+            # Ancestors still reachable past the cap — report it rather than
+            # silently dropping them.
+            truncated = True
+            break
+        level = await Clip.find(In(Clip.id, list(frontier)), Clip.user_id == owner).to_list()
+        # Stable ordering keeps the response deterministic regardless of how the
+        # database returns the batch (oldest first, then id as a tiebreak).
+        level.sort(key=lambda c: (c.created_at, c.id))
+        next_frontier: set[PydanticObjectId] = set()
+        for clip in level:
+            if clip.id in visited:
+                continue
+            visited.add(clip.id)
+            nodes.append((clip, depth))
+            next_frontier.update(pid for pid in clip.parent_clip_ids if pid not in visited)
+        frontier = next_frontier
+        depth += 1
+
+    return nodes, truncated
+
+
+async def get_children(clip_id: str, user_id: str) -> tuple[Clip, list[Clip]]:
+    """Return the clip plus the clips directly derived from it (US-10.6).
+
+    A child is any owned clip that lists ``clip_id`` among its
+    ``parent_clip_ids`` — covers single-source ops (extend/cover/remix/stems/…)
+    and multi-source mashups alike. Owner-scoped like the rest of clip CRUD;
+    newest-first for a stable, useful order.
+    """
+    clip = await get_owned_clip(clip_id, user_id)
+    children = (
+        await Clip.find(
+            In(Clip.parent_clip_ids, [clip.id]),
+            Clip.user_id == PydanticObjectId(user_id),
+        )
+        .sort(("created_at", -1), ("_id", -1))
+        .to_list()
+    )
+    return clip, children

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -237,6 +237,10 @@ async def get_children(clip_id: str, user_id: str) -> tuple[Clip, list[Clip]]:
     ``parent_clip_ids`` — covers single-source ops (extend/cover/remix/stems/…)
     and multi-source mashups alike. Owner-scoped like the rest of clip CRUD;
     newest-first for a stable, useful order.
+
+    Returns the full child set unpaginated: a clip's direct children are bounded
+    by how many times the user has derived from it. If a frequently-sampled clip
+    ever makes this unbounded, add pagination here (mirroring ``list_clips``).
     """
     clip = await get_owned_clip(clip_id, user_id)
     children = (

--- a/tests/test_clips_lineage_api.py
+++ b/tests/test_clips_lineage_api.py
@@ -1,0 +1,357 @@
+"""Tests for the clip lineage endpoints (US-10.6, issue #86).
+
+Covers ``GET /clips/{id}/lineage`` (full ancestry tree, parents → grandparents →
+… up to the original generation) and ``GET /clips/{id}/children`` (clips derived
+from a clip). The lineage graph is already written by every derive operation
+(extend/cover/remix/mashup/stems set ``parent_clip_ids``); these endpoints only
+read it back.
+
+The 401 auth-gate tests run in CI (no DB); the rest are ``integration`` and drive
+the real app with ``httpx.AsyncClient`` over a local MongoDB.
+"""
+
+import itertools
+import time
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.services.clips import MAX_LINEAGE_DEPTH
+from acemusic.api.settings import ApiSettings
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            f"{CLIPS_URL}/{PydanticObjectId()}/lineage",
+            f"{CLIPS_URL}/{PydanticObjectId()}/children",
+        ],
+    )
+    def test_missing_auth_header_returns_401(self, url: str) -> None:
+        client = TestClient(create_app())
+        resp = client.get(url)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+_SEQ = itertools.count(1)
+
+
+async def _insert_clip(
+    user,
+    workspace: Workspace,
+    *,
+    title: str | None = None,
+    parents: list[Clip] | None = None,
+    generation_mode: str | None = None,
+    created_at: datetime | None = None,
+) -> Clip:
+    # Monotonic created_at keeps ordering deterministic across clips inserted
+    # within the same millisecond.
+    if created_at is None:
+        created_at = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=next(_SEQ))
+    clip_id = PydanticObjectId()
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.wav",
+        format="wav",
+        title=title,
+        parent_clip_ids=[p.id for p in (parents or [])],
+        generation_mode=generation_mode,
+        created_at=created_at,
+    )
+    await clip.insert()
+    return clip
+
+
+# ---------------------------------------------------------------------------
+# Lineage (ancestry)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLineage:
+    async def test_extend_child_shows_its_parent(self, client, settings) -> None:
+        """AC: a clip created via extend shows its parent in the lineage response."""
+        user = await _make_user("lineage-extend@example.com")
+        ws = await _make_workspace(user)
+        original = await _insert_clip(user, ws, title="original")
+        extended = await _insert_clip(user, ws, title="extended", parents=[original], generation_mode="extend")
+
+        resp = await client.get(f"{CLIPS_URL}/{extended.id}/lineage", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["clip_id"] == str(extended.id)
+        assert body["max_depth"] == MAX_LINEAGE_DEPTH
+        assert body["truncated"] is False
+
+        by_depth = {n["depth"]: n for n in body["nodes"]}
+        # depth 0 is the queried clip itself; depth 1 is its parent.
+        assert by_depth[0]["id"] == str(extended.id)
+        assert by_depth[0]["generation_mode"] == "extend"
+        assert by_depth[1]["id"] == str(original.id)
+        assert by_depth[1]["title"] == "original"
+        assert by_depth[1]["created_at"]
+
+    async def test_mashup_child_shows_all_sources(self, client, settings) -> None:
+        """AC: a clip with multiple parents (mashup) shows all sources."""
+        user = await _make_user("lineage-mashup@example.com")
+        ws = await _make_workspace(user)
+        a = await _insert_clip(user, ws, title="A")
+        b = await _insert_clip(user, ws, title="B")
+        c = await _insert_clip(user, ws, title="C")
+        mashup = await _insert_clip(user, ws, title="mashup", parents=[a, b, c], generation_mode="mashup")
+
+        resp = await client.get(f"{CLIPS_URL}/{mashup.id}/lineage", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        nodes = resp.json()["nodes"]
+        depth1_ids = {n["id"] for n in nodes if n["depth"] == 1}
+        assert depth1_ids == {str(a.id), str(b.id), str(c.id)}
+
+    async def test_full_chain_returned_to_original(self, client, settings) -> None:
+        """AC: lineage traversal returns the full tree up to the original generation."""
+        user = await _make_user("lineage-chain@example.com")
+        ws = await _make_workspace(user)
+        clips = [await _insert_clip(user, ws, title="gen-0")]
+        for i in range(1, 6):
+            clips.append(await _insert_clip(user, ws, title=f"gen-{i}", parents=[clips[-1]], generation_mode="extend"))
+
+        resp = await client.get(f"{CLIPS_URL}/{clips[-1].id}/lineage", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["truncated"] is False
+        # All six generations are present, each at its own depth.
+        depth_by_id = {n["id"]: n["depth"] for n in body["nodes"]}
+        assert depth_by_id[str(clips[-1].id)] == 0
+        assert depth_by_id[str(clips[0].id)] == 5
+        assert len(body["nodes"]) == 6
+
+    async def test_diamond_lineage_lists_shared_ancestor_once(self, client, settings) -> None:
+        """A clip whose two parents share a grandparent lists the grandparent once."""
+        user = await _make_user("lineage-diamond@example.com")
+        ws = await _make_workspace(user)
+        root = await _insert_clip(user, ws, title="root")
+        left = await _insert_clip(user, ws, title="left", parents=[root], generation_mode="cover")
+        right = await _insert_clip(user, ws, title="right", parents=[root], generation_mode="remix")
+        merged = await _insert_clip(user, ws, title="merged", parents=[left, right], generation_mode="mashup")
+
+        resp = await client.get(f"{CLIPS_URL}/{merged.id}/lineage", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        ids = [n["id"] for n in resp.json()["nodes"]]
+        assert ids.count(str(root.id)) == 1
+
+    async def test_depth_cap_truncates(self, client, settings) -> None:
+        """AC: maximum lineage depth is 50; deeper chains report truncated=True."""
+        user = await _make_user("lineage-cap@example.com")
+        ws = await _make_workspace(user)
+        clip = await _insert_clip(user, ws, title="origin")
+        # One more generation than the cap so an ancestor sits beyond depth 50.
+        for i in range(MAX_LINEAGE_DEPTH + 1):
+            clip = await _insert_clip(user, ws, title=f"g{i}", parents=[clip], generation_mode="extend")
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/lineage", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["truncated"] is True
+        assert max(n["depth"] for n in body["nodes"]) == MAX_LINEAGE_DEPTH
+
+    async def test_original_clip_has_empty_lineage(self, client, settings) -> None:
+        user = await _make_user("lineage-root@example.com")
+        ws = await _make_workspace(user)
+        clip = await _insert_clip(user, ws, title="solo")
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/lineage", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert [n["id"] for n in body["nodes"]] == [str(clip.id)]
+        assert body["nodes"][0]["depth"] == 0
+        assert body["truncated"] is False
+
+    async def test_twenty_level_chain_resolves_quickly(self, client, settings) -> None:
+        """AC: lineage queries complete within 500ms for chains up to 20 levels deep."""
+        user = await _make_user("lineage-perf@example.com")
+        ws = await _make_workspace(user)
+        clip = await _insert_clip(user, ws, title="g0")
+        for i in range(1, 21):
+            clip = await _insert_clip(user, ws, title=f"g{i}", parents=[clip], generation_mode="extend")
+
+        headers = _auth_headers(user, settings)
+        start = time.perf_counter()
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/lineage", headers=headers)
+        elapsed = time.perf_counter() - start
+        assert resp.status_code == 200
+        assert len(resp.json()["nodes"]) == 21
+        assert elapsed < 0.5
+
+    async def test_unknown_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("lineage-unknown@example.com")
+        resp = await client.get(f"{CLIPS_URL}/{PydanticObjectId()}/lineage", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_malformed_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("lineage-malformed@example.com")
+        resp = await client.get(f"{CLIPS_URL}/not-an-object-id/lineage", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_clip_returns_404(self, client, settings) -> None:
+        owner = await _make_user("lineage-owner@example.com")
+        other = await _make_user("lineage-other@example.com")
+        ws = await _make_workspace(owner)
+        clip = await _insert_clip(owner, ws, title="theirs")
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/lineage", headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_ancestors_are_excluded(self, client, settings) -> None:
+        """Lineage is owner-scoped: an ancestor owned by another user is not leaked."""
+        owner = await _make_user("lineage-scope-owner@example.com")
+        other = await _make_user("lineage-scope-other@example.com")
+        owner_ws = await _make_workspace(owner)
+        other_ws = await _make_workspace(other)
+        foreign_root = await _insert_clip(other, other_ws, title="foreign")
+        child = await _insert_clip(owner, owner_ws, title="mine", parents=[foreign_root], generation_mode="cover")
+
+        resp = await client.get(f"{CLIPS_URL}/{child.id}/lineage", headers=_auth_headers(owner, settings))
+        assert resp.status_code == 200
+        ids = {n["id"] for n in resp.json()["nodes"]}
+        assert str(foreign_root.id) not in ids
+        assert ids == {str(child.id)}
+
+
+# ---------------------------------------------------------------------------
+# Children (descendants — direct)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestChildren:
+    async def test_returns_all_derived_clips(self, client, settings) -> None:
+        """AC: children endpoint returns all clips derived from a given clip."""
+        user = await _make_user("children-all@example.com")
+        ws = await _make_workspace(user)
+        source = await _insert_clip(user, ws, title="source")
+        extended = await _insert_clip(user, ws, title="extended", parents=[source], generation_mode="extend")
+        covered = await _insert_clip(user, ws, title="covered", parents=[source], generation_mode="cover")
+        # A grandchild (child of `extended`) is NOT a direct child of `source`.
+        await _insert_clip(user, ws, title="grandchild", parents=[extended], generation_mode="extend")
+
+        resp = await client.get(f"{CLIPS_URL}/{source.id}/children", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["clip_id"] == str(source.id)
+        assert body["total"] == 2
+        assert {c["id"] for c in body["children"]} == {str(extended.id), str(covered.id)}
+
+    async def test_includes_mashup_children(self, client, settings) -> None:
+        """A clip used as one of several mashup sources counts the mashup as its child."""
+        user = await _make_user("children-mashup@example.com")
+        ws = await _make_workspace(user)
+        a = await _insert_clip(user, ws, title="A")
+        b = await _insert_clip(user, ws, title="B")
+        mashup = await _insert_clip(user, ws, title="mashup", parents=[a, b], generation_mode="mashup")
+
+        resp = await client.get(f"{CLIPS_URL}/{a.id}/children", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert [c["id"] for c in resp.json()["children"]] == [str(mashup.id)]
+
+    async def test_leaf_clip_has_no_children(self, client, settings) -> None:
+        user = await _make_user("children-leaf@example.com")
+        ws = await _make_workspace(user)
+        clip = await _insert_clip(user, ws, title="leaf")
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/children", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 0
+        assert body["children"] == []
+
+    async def test_children_are_owner_scoped(self, client, settings) -> None:
+        """Another user's derived clip never appears in the owner's children view."""
+        owner = await _make_user("children-owner@example.com")
+        other = await _make_user("children-other@example.com")
+        owner_ws = await _make_workspace(owner)
+        other_ws = await _make_workspace(other)
+        source = await _insert_clip(owner, owner_ws, title="shared-source")
+        mine = await _insert_clip(owner, owner_ws, title="mine", parents=[source], generation_mode="extend")
+        # Another user derived from the same source id (e.g. a public clip).
+        await _insert_clip(other, other_ws, title="theirs", parents=[source], generation_mode="extend")
+
+        resp = await client.get(f"{CLIPS_URL}/{source.id}/children", headers=_auth_headers(owner, settings))
+        assert resp.status_code == 200
+        assert [c["id"] for c in resp.json()["children"]] == [str(mine.id)]
+
+    async def test_unknown_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("children-unknown@example.com")
+        resp = await client.get(f"{CLIPS_URL}/{PydanticObjectId()}/children", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_clip_returns_404(self, client, settings) -> None:
+        owner = await _make_user("children-404-owner@example.com")
+        other = await _make_user("children-404-other@example.com")
+        ws = await _make_workspace(owner)
+        clip = await _insert_clip(owner, ws, title="theirs")
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/children", headers=_auth_headers(other, settings))
+        assert resp.status_code == 404

--- a/tests/test_clips_lineage_api.py
+++ b/tests/test_clips_lineage_api.py
@@ -144,8 +144,8 @@ class TestLineage:
         assert resp.status_code == 200
         body = resp.json()
         assert body["clip_id"] == str(extended.id)
-        assert body["max_depth"] == MAX_LINEAGE_DEPTH
-        assert body["truncated"] is False
+        assert body["depth_limit"] == MAX_LINEAGE_DEPTH
+        assert body["depth_truncated"] is False
 
         by_depth = {n["depth"]: n for n in body["nodes"]}
         # depth 0 is the queried clip itself; depth 1 is its parent.
@@ -181,7 +181,7 @@ class TestLineage:
         resp = await client.get(f"{CLIPS_URL}/{clips[-1].id}/lineage", headers=_auth_headers(user, settings))
         assert resp.status_code == 200
         body = resp.json()
-        assert body["truncated"] is False
+        assert body["depth_truncated"] is False
         # All six generations are present, each at its own depth.
         depth_by_id = {n["id"]: n["depth"] for n in body["nodes"]}
         assert depth_by_id[str(clips[-1].id)] == 0
@@ -214,7 +214,7 @@ class TestLineage:
         resp = await client.get(f"{CLIPS_URL}/{clip.id}/lineage", headers=_auth_headers(user, settings))
         assert resp.status_code == 200
         body = resp.json()
-        assert body["truncated"] is True
+        assert body["depth_truncated"] is True
         assert max(n["depth"] for n in body["nodes"]) == MAX_LINEAGE_DEPTH
 
     async def test_original_clip_has_empty_lineage(self, client, settings) -> None:
@@ -227,7 +227,7 @@ class TestLineage:
         body = resp.json()
         assert [n["id"] for n in body["nodes"]] == [str(clip.id)]
         assert body["nodes"][0]["depth"] == 0
-        assert body["truncated"] is False
+        assert body["depth_truncated"] is False
 
     async def test_twenty_level_chain_resolves_quickly(self, client, settings) -> None:
         """AC: lineage queries complete within 500ms for chains up to 20 levels deep."""

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -48,7 +48,8 @@ class TestIndexes:
 
         clip_idx = await db["clips"].index_information()
         indexed_fields = {meta["key"][0][0] for meta in clip_idx.values()}
-        assert {"workspace_id", "user_id", "created_at"} <= indexed_fields
+        # parent_clip_ids backs the US-10.6 children lookup.
+        assert {"workspace_id", "user_id", "created_at", "parent_clip_ids"} <= indexed_fields
 
 
 class TestUserCrud:


### PR DESCRIPTION
## US-10.6 — Clip Lineage Tracking

Closes #86.

Exposes the clip lineage graph that derive operations **already write**. The
MongoDB `Clip` model has stored `parent_clip_ids`, `generation_mode`, and
`generation_params` since US-8.2/US-10.3, and every operation
(extend/cover/remix/repaint/add_vocal/stems → `[source]`, mashup → all sources)
populates them. This PR adds the two read endpoints that traverse that graph.

> **Note on the issue's CodeRabbit plan:** it was auto-generated against the
> pre-API (SQLite/CLI) era and is stale — it proposed a `clip_parents` junction
> table, recursive SQL CTEs, and bootstrapping a new FastAPI `api.py`. None of
> that applies to the live MongoDB + Beanie API. This PR mirrors the live
> clips router/service pattern instead.

### Endpoints
- **`GET /api/v1/clips/{id}/lineage`** — full ancestry tree (parents →
  grandparents → … up to the original generation). Returns nodes with
  `id`, `title`, `generation_mode`, `parent_clip_ids`, `created_at`, and `depth`
  (0 = the queried clip), plus `max_depth` and a `truncated` flag.
- **`GET /api/v1/clips/{id}/children`** — clips directly derived from a clip
  (single-source ops and multi-source mashups alike), newest-first.

### Design
- **Traversal** (`services/clips.get_lineage`): breadth-first *up* the
  `parent_clip_ids` graph, resolving one whole depth level per query
  (`In(Clip.id, …)`) — a 20-level chain is ~20 indexed `_id` lookups, not one
  round-trip per node. A `visited` set collapses diamond lineage (shared
  ancestors via mashups) to a single node and guards against cycles. Capped at
  `MAX_LINEAGE_DEPTH = 50`; `truncated=True` when ancestors remain beyond the cap.
- **Owner-scoped** like the rest of clip CRUD: the subject 404s if not owned, and
  ancestors/children are filtered to the requester (a foreign ancestor — e.g. a
  public clip derived from — is absent rather than leaked).
- **Index**: a multikey index on `parent_clip_ids` backs the children lookup.

### Tests (`tests/test_clips_lineage_api.py`)
- Auth gate (runs in CI, no DB) + integration (real MongoDB).
- Every acceptance criterion: extend parent, mashup multi-parent, full chain to
  origin, children of a clip, depth-50 cap/`truncated`, diamond de-duplication,
  owner-scoping (404s + ancestor/child exclusion), and a 20-level <500 ms perf check.
- `179 passed` across the clips/mongodb integration suites (no regressions).

### Acceptance Criteria
- [x] A clip created via extend shows its parent in the lineage response
- [x] A clip with multiple parents (mashup) shows all sources
- [x] Lineage traversal returns the full tree up to the original generation
- [x] Children endpoint returns all clips derived from a given clip
- [x] Lineage queries complete within 500 ms for chains up to 20 levels deep

### Out of scope (YAGNI)
- No SQLite/CLI, junction-table, or data-migration work — the data model is done.
- No write-path changes — operations already populate lineage.

### Known limitations
- Lineage/children are owner-scoped; cross-user ancestry (only reachable via a
  public clip someone else derived from) is intentionally excluded from the tree.
  `truncated` reflects the depth cap only, not ownership-boundary omissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated clip relationship APIs: **lineage** (depth-capped ancestry with a truncation indicator) and **children** (directly derived child clips, newest-first).
  * Responses include structured node/summary data and enforce owner-scoped visibility.
* **Performance**
  * Added a database index to speed up lookups by `parent_clip_ids`.
* **Tests**
  * Added integration tests for auth enforcement, privacy, truncation behavior, ordering, and 404/empty edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->