### PR TITLE
feat(api): compute routing engine (US-11.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,16 @@ ACEMUSIC_API_REFRESH_TOKEN_EXPIRE_DAYS=7
 ACEMUSIC_API_OAUTH_COOKIE_SECURE=true
 ACEMUSIC_API_OAUTH_COOKIE_SAMESITE=lax
 
+# Compute routing (US-11.1). Selects where a generation runs when the request does
+# not pin a compute_target. *_first tries the named target then falls back to the
+# other; *_only never falls back (503 when that target is down).
+# Values: local_first (default) | remote_first | local_only | remote_only
+ACEMUSIC_API_COMPUTE_PREFERENCE=local_first
+
+# Base URL of the local ACE-Step REST API server probed by the routing engine.
+# This is a routing probe URL (independent of the CLI's ACEMUSIC_BASE_URL).
+ACEMUSIC_API_LOCAL_URL=http://localhost:8001
+
 # Async job processor (US-9.2). A background task in the API process polls MongoDB
 # for queued generation jobs and runs them. JOB_CONCURRENCY bounds how many run at
 # once; JOB_POLL_INTERVAL is the idle sleep (seconds) between polls when the queue

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ environment variables (see `.env.example`); cookie behavior is tuned via
 | `POST /api/v1/generate` | Submits a generation request and returns a `job_id` for async tracking (HTTP 202) |
 | `GET /api/v1/jobs/{id}/status` | Returns a job's current status; owner-scoped (404 for missing or other users' jobs) |
 
-The request body accepts the full creative parameter set: `prompt` (required), `style`, `lyrics`, `vocal_language`, `instrumental`, `bpm` (60–180 or `"auto"`), `key`, `time_signature`, `duration`, `seed`, `inference_steps`, `model`, `weirdness` (0–100), `style_influence` (0–100), `format` (`wav`/`flac`/`mp3`/`aac`/`opus`), `thinking`, `mode` (`song`|`sound`), `sound_type` (`one-shot`|`loop`, required when `mode` is `sound`), and the optional `preset_id`. When `preset_id` is supplied the saved preset's parameters serve as defaults; any field explicitly included in the request overrides the preset value. The job is created with status `queued` and picked up by the async processor (US-9.2).
+The request body accepts the full creative parameter set: `prompt` (required), `style`, `lyrics`, `vocal_language`, `instrumental`, `bpm` (60–180 or `"auto"`), `key`, `time_signature`, `duration`, `seed`, `inference_steps`, `model`, `weirdness` (0–100), `style_influence` (0–100), `format` (`wav`/`flac`/`mp3`/`aac`/`opus`), `thinking`, `mode` (`song`|`sound`), `sound_type` (`one-shot`|`loop`, required when `mode` is `sound`), the optional `preset_id`, and the optional `compute_target` (`auto`|`local`|`remote`). When `preset_id` is supplied the saved preset's parameters serve as defaults; any field explicitly included in the request overrides the preset value. `compute_target` overrides the server's configured `ACEMUSIC_API_COMPUTE_PREFERENCE` for that request: `auto` (or omitting the field) defers to the server preference with fallback, `local`/`remote` pin the target with no fallback and return `503 Service Unavailable` if that target is unreachable. The job is created with status `queued` and picked up by the async processor (US-9.2).
 
 Invalid parameters return 422 with field-level errors. If the user has insufficient credits for the requested mode (song costs 1.0 credit, sound costs 0.5), the request is rejected with `402 Payment Required` and a JSON body of `{"detail": {"error": "insufficient_credits", "balance": <current>, "required": <cost>}}`. New accounts start with 10.0 credits. The create response includes `job_id`, `status: "queued"`, and `estimated_time_seconds`.
 
-The status endpoint returns `job_id`, `status` (`queued`|`processing`|`completed`|`failed`), `created_at`, and `estimated_time_seconds`. Completed jobs additionally include `clip_ids` and `audio_urls`; failed jobs include an `error` message.
+The status endpoint returns `job_id`, `status` (`queued`|`processing`|`completed`|`failed`), `created_at`, `estimated_time_seconds`, and `compute_target` (`"local"`/`"remote"`, present for routed generation jobs, omitted for edits/exports). Completed jobs additionally include `clip_ids` and `audio_urls`; failed jobs include an `error` message.
 
 #### Async job processor (US-9.2, US-10.1, US-10.3)
 
@@ -95,8 +95,11 @@ processing library. Iterative generation jobs (`extend`, `cover`, `remix`, `repa
 clips. All handlers mark the job `completed` (or `failed` with an
 error). Tunables (all prefixed `ACEMUSIC_API_`): `JOB_CONCURRENCY` (default 2),
 `JOB_POLL_INTERVAL` seconds (default 1.0), `JOB_POLL_TIMEOUT` seconds (default
-600), and `JOB_PROCESSOR_ENABLED` (default `true`; set `false` to run the API
-without the worker — recommended to run a single processor instance).
+600), `JOB_PROCESSOR_ENABLED` (default `true`; set `false` to run the API
+without the worker — recommended to run a single processor instance),
+`COMPUTE_PREFERENCE` (`local_first`/`remote_first`/`local_only`/`remote_only`,
+default `local_first`), and `LOCAL_URL` (local ACE-Step probe URL, default
+`http://localhost:8001`).
 
 ### Workspaces
 

--- a/docs/demos/us-11.1-compute-routing.md
+++ b/docs/demos/us-11.1-compute-routing.md
@@ -1,0 +1,68 @@
+# US-11.1: Compute Routing Engine
+
+*2026-06-16T01:06:43Z*
+
+US-11.1 adds a compute routing engine to `POST /api/v1/generate`. It evaluates the configured `compute_preference` (and an optional per-request `compute_target`) against the live availability of each backend, decides where the job runs, records the resolved target on the Job, and surfaces it in the job status response. Until US-11.2 wires up RunPod, remote availability is a safe stub returning False.
+
+The driver below boots the real FastAPI app (httpx over ASGITransport, real MongoDB) and runs one scenario per acceptance criterion, stubbing local/remote availability per scenario. For each call it prints the HTTP status + body, the persisted `Job.compute_target`, whether the routing hint leaked into `input_params`, and the `compute_target` returned by `GET /jobs/{id}/status`. See `tasks/demo_us_11_1.py` for the driver.
+
+```bash
+ulimit -n 64000 && uv run python tasks/demo_us_11_1.py 2>/dev/null
+```
+
+```output
+
+=== AC1  local_first + local up  -> local ===
+settings.compute_preference = 'local_first'   (local_available=True, remote_available=False)
+request body = {'prompt': 'calm piano'}
+HTTP 202  ->  {'job_id': '6a30a1b1a7ec671636339abf', 'status': 'queued', 'estimated_time_seconds': 60}
+Job.compute_target (persisted)         = 'local'
+'compute_target' in Job.input_params?  = False
+GET /jobs/{id}/status -> compute_target = 'local'
+
+=== AC1  local_first + local down -> falls back to remote ===
+settings.compute_preference = 'local_first'   (local_available=False, remote_available=True)
+request body = {'prompt': 'calm piano'}
+HTTP 202  ->  {'job_id': '6a30a1b1a7ec671636339ac3', 'status': 'queued', 'estimated_time_seconds': 60}
+Job.compute_target (persisted)         = 'remote'
+'compute_target' in Job.input_params?  = False
+GET /jobs/{id}/status -> compute_target = 'remote'
+
+=== AC2  remote_first + remote up -> remote ===
+settings.compute_preference = 'remote_first'   (local_available=True, remote_available=True)
+request body = {'prompt': 'calm piano'}
+HTTP 202  ->  {'job_id': '6a30a1b1a7ec671636339ac7', 'status': 'queued', 'estimated_time_seconds': 60}
+Job.compute_target (persisted)         = 'remote'
+'compute_target' in Job.input_params?  = False
+GET /jobs/{id}/status -> compute_target = 'remote'
+
+=== AC2  remote_first + remote down -> falls back to local ===
+settings.compute_preference = 'remote_first'   (local_available=True, remote_available=False)
+request body = {'prompt': 'calm piano'}
+HTTP 202  ->  {'job_id': '6a30a1b1a7ec671636339acb', 'status': 'queued', 'estimated_time_seconds': 60}
+Job.compute_target (persisted)         = 'local'
+'compute_target' in Job.input_params?  = False
+GET /jobs/{id}/status -> compute_target = 'local'
+
+=== AC3  local_only + local down -> 503 (no fallback) ===
+settings.compute_preference = 'local_only'   (local_available=False, remote_available=True)
+request body = {'prompt': 'calm piano'}
+HTTP 503  ->  {'detail': "Compute target 'local' is unavailable (preference: local_only)."}
+jobs created = 0   credit transactions = 0  (503 must not charge or enqueue)
+
+=== AC4  remote_only + remote down -> 503 (no fallback) ===
+settings.compute_preference = 'remote_only'   (local_available=True, remote_available=False)
+request body = {'prompt': 'calm piano'}
+HTTP 503  ->  {'detail': "Compute target 'remote' is unavailable (preference: remote_only)."}
+jobs created = 0   credit transactions = 0  (503 must not charge or enqueue)
+
+=== AC5  per-request compute_target=local overrides remote_first ===
+settings.compute_preference = 'remote_first'   (local_available=True, remote_available=True)
+request body = {'prompt': 'calm piano', 'compute_target': 'local'}
+HTTP 202  ->  {'job_id': '6a30a1b1a7ec671636339ad1', 'status': 'queued', 'estimated_time_seconds': 60}
+Job.compute_target (persisted)         = 'local'
+'compute_target' in Job.input_params?  = False
+GET /jobs/{id}/status -> compute_target = 'local'
+```
+
+Every acceptance criterion is verified with outcome evidence: `local_first`/`remote_first` route to the preferred backend and fall back when it is down; `local_only`/`remote_only` return **503** with no job created and no credit charged; a per-request `compute_target: "local"` overrides a `remote_first` default; and the resolved target is both persisted on the Job and visible in `GET /jobs/{id}/status` (while never leaking into the creative `input_params`).

--- a/src/acemusic/api/auth/dependencies.py
+++ b/src/acemusic/api/auth/dependencies.py
@@ -30,8 +30,17 @@ class CurrentUser(BaseModel):
     subscription_tier: str
 
 
-def _settings(request: Request) -> ApiSettings:
+def get_settings(request: Request) -> ApiSettings:
+    """FastAPI dependency exposing the app's :class:`ApiSettings`.
+
+    Public so any router can depend on settings without reaching into a private
+    symbol (``Depends(get_settings)``).
+    """
     return request.app.state.settings
+
+
+# Backwards-compatible private alias for this module's internal call sites.
+_settings = get_settings
 
 
 def _unauthorized(detail: str) -> HTTPException:

--- a/src/acemusic/api/models/job.py
+++ b/src/acemusic/api/models/job.py
@@ -7,6 +7,7 @@ job-queue contract used by the Generation API (US-9.2):
 
 from datetime import datetime
 from enum import Enum
+from typing import Literal
 
 from beanie import Document, PydanticObjectId
 from pydantic import Field
@@ -30,8 +31,9 @@ class Job(Document):
     job_type: str
     # Resolved compute target for this job (US-11.1): "local" or "remote", set by
     # the routing engine at enqueue time. None for jobs created before routing
-    # existed or by paths that do not route (e.g. edits/exports).
-    compute_target: str | None = None
+    # existed or by paths that do not route (e.g. edits/exports). Constrained to
+    # lock the document/API contract — only the routing engine writes it.
+    compute_target: Literal["local", "remote"] | None = None
     status: JobStatus = JobStatus.QUEUED
     input_params: dict = Field(default_factory=dict)
     result: dict | None = None

--- a/src/acemusic/api/models/job.py
+++ b/src/acemusic/api/models/job.py
@@ -28,6 +28,10 @@ class Job(Document):
     user_id: PydanticObjectId
     workspace_id: PydanticObjectId
     job_type: str
+    # Resolved compute target for this job (US-11.1): "local" or "remote", set by
+    # the routing engine at enqueue time. None for jobs created before routing
+    # existed or by paths that do not route (e.g. edits/exports).
+    compute_target: str | None = None
     status: JobStatus = JobStatus.QUEUED
     input_params: dict = Field(default_factory=dict)
     result: dict | None = None

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -209,10 +209,13 @@ async def create_generation(
             local_url=settings.local_url,
         )
     except ComputeUnavailableError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=(f"Compute target '{exc.target.value}' is unavailable " f"(preference: {exc.preference.value})."),
-        ) from exc
+        # Distinguish a request-pinned target from the server preference so the
+        # 503 doesn't report a synthetic "preference" the client never set.
+        if request.compute_target in ("local", "remote"):
+            detail = f"Requested compute target '{exc.target.value}' is unavailable."
+        else:
+            detail = f"Compute target '{exc.target.value}' is unavailable (preference: {exc.preference.value})."
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=detail) from exc
     # US-9.6: credits are deducted atomically at queue time. Cost is judged on
     # the merged request, since a preset may supply the mode. The atomic
     # balance-conditioned deduction is the concurrency guard — two requests

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -35,7 +35,7 @@ from acemusic.constants import (
     WEIRDNESS_MIN,
 )
 
-from ..auth.dependencies import CurrentUser, _settings, get_current_user
+from ..auth.dependencies import CurrentUser, get_current_user, get_settings
 from ..models import PRESET_PARAM_FIELDS, Preset
 from ..services import (
     credits as credits_service,
@@ -183,7 +183,7 @@ def _apply_preset(request: GenerationRequest, preset: Preset) -> GenerationReque
 async def create_generation(
     request: GenerationRequest,
     current: CurrentUser = Depends(get_current_user),
-    settings: ApiSettings = Depends(_settings),
+    settings: ApiSettings = Depends(get_settings),
 ) -> GenerationResponse:
     """Validate the request, persist a queued job, and return its id.
 

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -35,14 +35,17 @@ from acemusic.constants import (
     WEIRDNESS_MIN,
 )
 
-from ..auth.dependencies import CurrentUser, get_current_user
+from ..auth.dependencies import CurrentUser, _settings, get_current_user
 from ..models import PRESET_PARAM_FIELDS, Preset
 from ..services import (
     credits as credits_service,
     generation as generation_service,
     presets as preset_service,
+    routing as routing_service,
     users as user_service,
 )
+from ..services.routing import ComputePreference, ComputeUnavailableError
+from ..settings import ApiSettings
 from ._validators import validate_format, validate_model, validate_time_signature
 
 logger = logging.getLogger(__name__)
@@ -70,6 +73,12 @@ class GenerationRequest(BaseModel):
     # US-9.5: apply a saved preset as parameter defaults; explicitly-sent
     # request fields override preset values. Never forwarded to the job.
     preset_id: str | None = None
+
+    # US-11.1: per-request compute routing override. ``None`` and ``"auto"`` both
+    # defer to the server's configured ``compute_preference`` (with fallback);
+    # ``"local"``/``"remote"`` pin the target with no fallback. This is a routing
+    # hint, not a creative param — never forwarded to the job's input_params.
+    compute_target: Literal["auto", "local", "remote"] | None = None
 
     prompt: Annotated[str, Field(min_length=1, max_length=PROMPT_MAX_LENGTH)]
     style: Annotated[str, Field(max_length=STYLE_MAX_LENGTH)] | None = None
@@ -165,10 +174,16 @@ def _apply_preset(request: GenerationRequest, preset: Preset) -> GenerationReque
         ) from exc
 
 
-@router.post("", response_model=GenerationResponse, status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "",
+    response_model=GenerationResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    responses={status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Compute target unavailable"}},
+)
 async def create_generation(
     request: GenerationRequest,
     current: CurrentUser = Depends(get_current_user),
+    settings: ApiSettings = Depends(_settings),
 ) -> GenerationResponse:
     """Validate the request, persist a queued job, and return its id.
 
@@ -185,6 +200,19 @@ async def create_generation(
         # 404 for unknown/malformed/not-owned ids (never reveals other users' presets).
         preset = await preset_service.get_preset(request.preset_id, current.user_id)
         request = _apply_preset(request, preset)
+    # US-11.1: pick the compute target BEFORE charging credits, so an unavailable
+    # backend yields a clean 503 without ever touching the balance.
+    try:
+        resolved_target = await routing_service.resolve_compute_target(
+            request_target=request.compute_target,
+            preference=ComputePreference(settings.compute_preference),
+            local_url=settings.local_url,
+        )
+    except ComputeUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(f"Compute target '{exc.target.value}' is unavailable " f"(preference: {exc.preference.value})."),
+        ) from exc
     # US-9.6: credits are deducted atomically at queue time. Cost is judged on
     # the merged request, since a preset may supply the mode. The atomic
     # balance-conditioned deduction is the concurrency guard — two requests
@@ -204,7 +232,8 @@ async def create_generation(
     try:
         job = await generation_service.create_generation_job(
             user_id=user.id,
-            params=request.model_dump(exclude_none=True, exclude={"preset_id"}),
+            params=request.model_dump(exclude_none=True, exclude={"preset_id", "compute_target"}),
+            compute_target=resolved_target.value,
         )
     except BaseException:
         # The deduction already landed but no job exists — give the credit back

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -236,7 +236,7 @@ async def create_generation(
         job = await generation_service.create_generation_job(
             user_id=user.id,
             params=request.model_dump(exclude_none=True, exclude={"preset_id", "compute_target"}),
-            compute_target=resolved_target.value,
+            compute_target=resolved_target,
         )
     except BaseException:
         # The deduction already landed but no job exists — give the credit back

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -9,6 +9,7 @@ endpoint never reveals the existence of another user's jobs.
 import asyncio
 import logging
 from datetime import datetime
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -60,7 +61,7 @@ class JobStatusResponse(BaseModel):
     estimated_time_seconds: int
     # Resolved compute target (US-11.1: "local"/"remote"); present for routed
     # generation jobs, dropped (None) for job types that do not route.
-    compute_target: str | None = None
+    compute_target: Literal["local", "remote"] | None = None
     # Per-step progress for long multi-step jobs (US-10.4 full-song); only set
     # while the job is queued/processing, dropped once it completes or fails.
     progress: str | None = None

--- a/src/acemusic/api/routers/jobs.py
+++ b/src/acemusic/api/routers/jobs.py
@@ -58,6 +58,9 @@ class JobStatusResponse(BaseModel):
     status: JobStatus
     created_at: datetime
     estimated_time_seconds: int
+    # Resolved compute target (US-11.1: "local"/"remote"); present for routed
+    # generation jobs, dropped (None) for job types that do not route.
+    compute_target: str | None = None
     # Per-step progress for long multi-step jobs (US-10.4 full-song); only set
     # while the job is queued/processing, dropped once it completes or fails.
     progress: str | None = None
@@ -133,6 +136,7 @@ async def get_job_status(
         status=job.status,
         created_at=job.created_at,
         estimated_time_seconds=_estimate_for(job),
+        compute_target=job.compute_target,
     )
     if job.status in (JobStatus.QUEUED, JobStatus.PROCESSING):
         # Progress is in-flight state; a terminal job exposes its result/error instead.

--- a/src/acemusic/api/services/generation.py
+++ b/src/acemusic/api/services/generation.py
@@ -20,18 +20,21 @@ from .workspaces import DEFAULT_WORKSPACE_NAME, get_or_create_default_workspace 
 GENERATE_JOB_TYPE = "generate"
 
 
-async def create_generation_job(*, user_id: PydanticObjectId, params: dict) -> Job:
+async def create_generation_job(*, user_id: PydanticObjectId, params: dict, compute_target: str | None = None) -> Job:
     """Persist a queued generation job for ``user_id`` and dispatch it.
 
     ``params`` is the validated request snapshot, stored verbatim in
     ``input_params`` so the worker (US-9.2) has the full creative spec regardless
-    of later schema changes. Returns the saved :class:`Job` (with its id).
+    of later schema changes. ``compute_target`` is the resolved routing target
+    (US-11.1: ``"local"``/``"remote"``), recorded on the job for auditability and
+    status reporting. Returns the saved :class:`Job` (with its id).
     """
     workspace = await get_or_create_default_workspace(user_id)
     job = Job(
         user_id=user_id,
         workspace_id=workspace.id,
         job_type=GENERATE_JOB_TYPE,
+        compute_target=compute_target,
         status=JobStatus.QUEUED,
         input_params=params,
     )

--- a/src/acemusic/api/services/generation.py
+++ b/src/acemusic/api/services/generation.py
@@ -10,6 +10,7 @@ from beanie import PydanticObjectId
 
 from ..models import Job, JobStatus
 from ..tasks import dispatch_job
+from .routing import ComputeTarget
 
 # get_or_create_default_workspace moved to the workspaces service (US-9.4); it is
 # re-exported here because generation still uses it as a lazy fallback for
@@ -20,13 +21,15 @@ from .workspaces import DEFAULT_WORKSPACE_NAME, get_or_create_default_workspace 
 GENERATE_JOB_TYPE = "generate"
 
 
-async def create_generation_job(*, user_id: PydanticObjectId, params: dict, compute_target: str | None = None) -> Job:
+async def create_generation_job(
+    *, user_id: PydanticObjectId, params: dict, compute_target: ComputeTarget | None = None
+) -> Job:
     """Persist a queued generation job for ``user_id`` and dispatch it.
 
     ``params`` is the validated request snapshot, stored verbatim in
     ``input_params`` so the worker (US-9.2) has the full creative spec regardless
     of later schema changes. ``compute_target`` is the resolved routing target
-    (US-11.1: ``"local"``/``"remote"``), recorded on the job for auditability and
+    (US-11.1), recorded on the job (as its string value) for auditability and
     status reporting. Returns the saved :class:`Job` (with its id).
     """
     workspace = await get_or_create_default_workspace(user_id)
@@ -34,7 +37,7 @@ async def create_generation_job(*, user_id: PydanticObjectId, params: dict, comp
         user_id=user_id,
         workspace_id=workspace.id,
         job_type=GENERATE_JOB_TYPE,
-        compute_target=compute_target,
+        compute_target=compute_target.value if compute_target is not None else None,
         status=JobStatus.QUEUED,
         input_params=params,
     )

--- a/src/acemusic/api/services/routing.py
+++ b/src/acemusic/api/services/routing.py
@@ -1,0 +1,139 @@
+"""Compute routing engine (US-11.1).
+
+Decides whether a generation runs on the local GPU or a remote RunPod worker,
+based on the configured ``compute_preference`` and each target's live
+availability. A per-request ``compute_target`` can override the preference.
+
+Kept transport-agnostic (raises plain exceptions, never ``HTTPException``) like
+the other service modules, so the router stays free of routing concerns.
+"""
+
+from enum import Enum
+
+import httpx
+
+# The local availability probe must be quick: the issue caps it at a 2-second
+# timeout so a down local server degrades to fallback/503 without stalling the
+# request.
+LOCAL_AVAILABILITY_TIMEOUT = 2.0
+
+# ACE-Step exposes a lightweight stats endpoint used here purely as a health ping.
+LOCAL_STATS_PATH = "/v1/stats"
+
+
+class ComputeTarget(str, Enum):
+    """Where a generation actually runs."""
+
+    LOCAL = "local"
+    REMOTE = "remote"
+
+
+class ComputePreference(str, Enum):
+    """Configured routing strategy (``ACEMUSIC_API_COMPUTE_PREFERENCE``).
+
+    Values mirror the ``ApiSettings.compute_preference`` literal so a settings
+    string maps directly onto a member (``ComputePreference(settings.value)``).
+    """
+
+    LOCAL_FIRST = "local_first"
+    REMOTE_FIRST = "remote_first"
+    LOCAL_ONLY = "local_only"
+    REMOTE_ONLY = "remote_only"
+
+
+class ComputeUnavailableError(RuntimeError):
+    """No compute target could satisfy the request.
+
+    Carries the ``target`` that was being attempted and the ``preference`` in
+    play so the router can render an informative 503 detail.
+    """
+
+    def __init__(self, target: ComputeTarget, preference: ComputePreference) -> None:
+        self.target = target
+        self.preference = preference
+        super().__init__(f"compute target {target.value!r} is unavailable (preference {preference.value!r})")
+
+
+async def check_local_availability(url: str, timeout: float = LOCAL_AVAILABILITY_TIMEOUT) -> bool:
+    """Return ``True`` if the local ACE-Step server answers ``GET {url}/v1/stats``.
+
+    Any non-2xx response, connection error, or timeout counts as unavailable —
+    the caller falls back or fails closed rather than dispatching to a dead host.
+    """
+    endpoint = f"{url.rstrip('/')}{LOCAL_STATS_PATH}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(endpoint)
+    except httpx.HTTPError:
+        return False
+    return response.is_success
+
+
+async def check_remote_availability() -> bool:
+    """Return ``True`` if the remote RunPod endpoint is ready to accept work.
+
+    Stub that reports unavailable until US-11.2 wires up the RunPod serverless
+    client. It is a real (overridable) async function rather than an inline
+    constant so remote selection degrades safely in production — ``remote_only``
+    yields 503 and ``*_first`` falls back — while tests can exercise the
+    remote/fallback routing branches by patching it.
+    """
+    # TODO(US-11.2): query the RunPod serverless endpoint status via the RunPod API.
+    return False
+
+
+def _effective_preference(request_target: str | None, preference: ComputePreference) -> ComputePreference:
+    """Collapse a per-request override into the preference that governs routing.
+
+    ``"auto"``/``None`` defer to the configured ``preference``. An explicit
+    ``"local"``/``"remote"`` forces that target with no fallback — the same
+    semantics as ``local_only``/``remote_only``.
+    """
+    if request_target in (None, "auto"):
+        return preference
+    if request_target == ComputeTarget.LOCAL.value:
+        return ComputePreference.LOCAL_ONLY
+    if request_target == ComputeTarget.REMOTE.value:
+        return ComputePreference.REMOTE_ONLY
+    raise ValueError(f"unknown compute_target {request_target!r}")
+
+
+async def resolve_compute_target(
+    *,
+    request_target: str | None,
+    preference: ComputePreference,
+    local_url: str,
+    timeout: float = LOCAL_AVAILABILITY_TIMEOUT,
+) -> ComputeTarget:
+    """Resolve which :class:`ComputeTarget` a generation should run on.
+
+    Applies the effective preference (after any per-request override) against the
+    live availability of each target. Raises :class:`ComputeUnavailableError`
+    when the required target is down and no fallback is permitted (``*_only`` and
+    explicit overrides) or when neither target is reachable (``*_first``).
+    """
+    effective = _effective_preference(request_target, preference)
+
+    if effective is ComputePreference.LOCAL_ONLY:
+        if await check_local_availability(local_url, timeout):
+            return ComputeTarget.LOCAL
+        raise ComputeUnavailableError(ComputeTarget.LOCAL, effective)
+
+    if effective is ComputePreference.REMOTE_ONLY:
+        if await check_remote_availability():
+            return ComputeTarget.REMOTE
+        raise ComputeUnavailableError(ComputeTarget.REMOTE, effective)
+
+    if effective is ComputePreference.LOCAL_FIRST:
+        if await check_local_availability(local_url, timeout):
+            return ComputeTarget.LOCAL
+        if await check_remote_availability():
+            return ComputeTarget.REMOTE
+        raise ComputeUnavailableError(ComputeTarget.LOCAL, effective)
+
+    # REMOTE_FIRST: prefer remote, fall back to local.
+    if await check_remote_availability():
+        return ComputeTarget.REMOTE
+    if await check_local_availability(local_url, timeout):
+        return ComputeTarget.LOCAL
+    raise ComputeUnavailableError(ComputeTarget.REMOTE, effective)

--- a/src/acemusic/api/services/routing.py
+++ b/src/acemusic/api/services/routing.py
@@ -131,9 +131,14 @@ async def resolve_compute_target(
             return ComputeTarget.REMOTE
         raise ComputeUnavailableError(ComputeTarget.LOCAL, effective)
 
-    # REMOTE_FIRST: prefer remote, fall back to local.
-    if await check_remote_availability():
-        return ComputeTarget.REMOTE
-    if await check_local_availability(local_url, timeout):
-        return ComputeTarget.LOCAL
-    raise ComputeUnavailableError(ComputeTarget.REMOTE, effective)
+    if effective is ComputePreference.REMOTE_FIRST:
+        # Prefer remote, fall back to local.
+        if await check_remote_availability():
+            return ComputeTarget.REMOTE
+        if await check_local_availability(local_url, timeout):
+            return ComputeTarget.LOCAL
+        raise ComputeUnavailableError(ComputeTarget.REMOTE, effective)
+
+    # Unreachable: every ComputePreference member is handled above. Explicit so a
+    # future enum addition fails loudly instead of silently returning None.
+    raise ValueError(f"unhandled compute preference {effective!r}")  # pragma: no cover

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -6,6 +6,7 @@ not collide with CLI or ACE-Step server variables.
 """
 
 from typing import Annotated, Literal
+from urllib.parse import urlsplit
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -100,6 +101,21 @@ class ApiSettings(BaseSettings):
     # cross-site callback.
     oauth_cookie_secure: bool = True
     oauth_cookie_samesite: str = "lax"
+
+    @field_validator("local_url")
+    @classmethod
+    def _check_local_url(cls, value: str) -> str:
+        """Reject a malformed local_url at startup, not at probe time.
+
+        Without a scheme/host the availability probe would raise an
+        ``httpx.InvalidURL`` (not an ``httpx.HTTPError``, so it escapes the
+        probe's catch) and surface as a 500. Validating here turns a
+        misconfiguration into a clear startup error instead.
+        """
+        parsed = urlsplit(value.strip())
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError(f"local_url {value!r} must be an absolute http(s):// URL")
+        return value.strip()
 
     @field_validator("oauth_cookie_samesite")
     @classmethod

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -5,7 +5,7 @@ All API settings are namespaced under the ``ACEMUSIC_API_`` env prefix so they d
 not collide with CLI or ACE-Step server variables.
 """
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -79,6 +79,16 @@ class ApiSettings(BaseSettings):
     job_poll_interval: float = Field(default=1.0, gt=0)
     job_poll_timeout: float = Field(default=600.0, gt=0)
     job_processor_enabled: bool = Field(default=True)
+
+    # Compute routing (US-11.1). ``compute_preference`` selects where a generation
+    # runs when the request does not pin a ``compute_target``: ``*_first`` tries
+    # the named target then falls back to the other; ``*_only`` never falls back
+    # (a 503 surfaces when that target is down). ``local_url`` is the local
+    # ACE-Step base URL whose ``/v1/stats`` endpoint is the availability probe;
+    # it defaults to the conventional local port and is independent of the CLI's
+    # ACE-Step config (which drives actual job execution).
+    compute_preference: Literal["local_first", "remote_first", "local_only", "remote_only"] = "local_first"
+    local_url: str = "http://localhost:8001"
 
     # OAuth ``state`` cookie policy (issue #110, login-CSRF binding). The login
     # flow sets a per-client nonce cookie that the callback requires.

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -190,3 +190,10 @@ class TestComputeRoutingSettings:
     def test_local_url_from_env(self, monkeypatch):
         monkeypatch.setenv("ACEMUSIC_API_LOCAL_URL", "http://gpu-box:9000")
         assert ApiSettings(_env_file=None).local_url == "http://gpu-box:9000"
+
+    @pytest.mark.parametrize("value", ["localhost:8001", "ftp://host:1", "not a url", ""])
+    def test_local_url_rejects_malformed(self, monkeypatch, value):
+        """A scheme-less or non-http(s) value is rejected at startup, not at probe time."""
+        monkeypatch.setenv("ACEMUSIC_API_LOCAL_URL", value)
+        with pytest.raises(ValueError, match="local_url"):
+            ApiSettings(_env_file=None)

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -161,3 +161,32 @@ class TestAuthSettings:
         monkeypatch.setenv("ACEMUSIC_API_JWT_ALGORITHM", algorithm)
         with pytest.raises(ValueError, match="jwt_algorithm"):
             ApiSettings(_env_file=None)
+
+
+class TestComputeRoutingSettings:
+    """Compute routing configuration (US-11.1)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_routing_env(self, monkeypatch):
+        for key in ("ACEMUSIC_API_COMPUTE_PREFERENCE", "ACEMUSIC_API_LOCAL_URL"):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_defaults(self):
+        """Compute defaults to local-first against the conventional local port."""
+        settings = ApiSettings(_env_file=None)
+        assert settings.compute_preference == "local_first"
+        assert settings.local_url == "http://localhost:8001"
+
+    @pytest.mark.parametrize("preference", ["local_first", "remote_first", "local_only", "remote_only"])
+    def test_compute_preference_accepts_each_mode(self, monkeypatch, preference):
+        monkeypatch.setenv("ACEMUSIC_API_COMPUTE_PREFERENCE", preference)
+        assert ApiSettings(_env_file=None).compute_preference == preference
+
+    def test_compute_preference_rejects_unknown(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_COMPUTE_PREFERENCE", "bogus")
+        with pytest.raises(ValueError, match="compute_preference"):
+            ApiSettings(_env_file=None)
+
+    def test_local_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_LOCAL_URL", "http://gpu-box:9000")
+        assert ApiSettings(_env_file=None).local_url == "http://gpu-box:9000"

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -20,11 +20,23 @@ from fastapi.testclient import TestClient
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import CreditTransaction, Job, User
-from acemusic.api.services import credits as credits_service, users as user_service
+from acemusic.api.services import credits as credits_service, routing, users as user_service
 from acemusic.api.settings import ApiSettings
 
 GENERATE_URL = f"{API_V1_PREFIX}/generate"
 CREDITS_URL = f"{API_V1_PREFIX}/users/me/credits"
+
+
+@pytest.fixture(autouse=True)
+def _local_compute_available(monkeypatch):
+    """Make the generation router's routing probe (US-11.1) see a reachable local
+    backend, so these credit tests exercise the deduction/refund contract rather
+    than 503ing on compute availability."""
+
+    async def _available(url, timeout=routing.LOCAL_AVAILABILITY_TIMEOUT):
+        return True
+
+    monkeypatch.setattr(routing, "check_local_availability", _available)
 
 
 class TestAuthGate:

--- a/tests/test_generation_api.py
+++ b/tests/test_generation_api.py
@@ -12,12 +12,37 @@ import pytest
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Job, JobStatus, Workspace
-from acemusic.api.services import users as user_service
+from acemusic.api.services import routing, users as user_service
 from acemusic.api.settings import ApiSettings
 
 pytestmark = pytest.mark.integration
 
 GENERATE_URL = f"{API_V1_PREFIX}/generate"
+JOBS_URL = f"{API_V1_PREFIX}/jobs"
+
+
+def _set_availability(monkeypatch, *, local: bool, remote: bool = False) -> None:
+    """Stub the routing probes so endpoint tests control where a request routes."""
+
+    async def _local(url, timeout=routing.LOCAL_AVAILABILITY_TIMEOUT):
+        return local
+
+    async def _remote():
+        return remote
+
+    monkeypatch.setattr(routing, "check_local_availability", _local)
+    monkeypatch.setattr(routing, "check_remote_availability", _remote)
+
+
+@pytest.fixture(autouse=True)
+def _local_compute_available(monkeypatch):
+    """Default the routing probe (US-11.1) to a reachable local backend.
+
+    Most generation tests assert the job-creation contract, not compute
+    availability; without a stub they would 503 (no local server runs in CI).
+    Routing-specific tests below re-stub availability per case.
+    """
+    _set_availability(monkeypatch, local=True, remote=False)
 
 
 def _async_client(app) -> httpx.AsyncClient:
@@ -265,3 +290,131 @@ class TestStaleToken:
             headers=self._token_headers(str(ghost), settings),
         )
         assert await Workspace.find(Workspace.user_id == ghost).to_list() == []
+
+
+class TestComputeRouting:
+    """Compute routing engine (US-11.1).
+
+    Availability is stubbed (no ACE-Step/RunPod runs in CI); each test asserts
+    the routing decision the engine makes and how it surfaces on the job record
+    and status response.
+    """
+
+    @staticmethod
+    async def _client_for(settings: ApiSettings):
+        return _async_client(create_app(settings))
+
+    async def test_local_first_routes_local_when_available(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=True, remote=False)
+        s = settings.model_copy(update={"compute_preference": "local_first"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-lf-local@example.com")
+            resp = await client.post(GENERATE_URL, json={"prompt": "x"}, headers=_auth_headers(user, s))
+            assert resp.status_code == 202
+            job = await Job.get(resp.json()["job_id"])
+            assert job.compute_target == "local"
+
+    async def test_local_first_falls_back_to_remote_when_local_down(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=False, remote=True)
+        s = settings.model_copy(update={"compute_preference": "local_first"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-lf-remote@example.com")
+            resp = await client.post(GENERATE_URL, json={"prompt": "x"}, headers=_auth_headers(user, s))
+            assert resp.status_code == 202
+            job = await Job.get(resp.json()["job_id"])
+            assert job.compute_target == "remote"
+
+    async def test_remote_first_routes_remote_when_available(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=True, remote=True)
+        s = settings.model_copy(update={"compute_preference": "remote_first"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-rf-remote@example.com")
+            resp = await client.post(GENERATE_URL, json={"prompt": "x"}, headers=_auth_headers(user, s))
+            assert resp.status_code == 202
+            job = await Job.get(resp.json()["job_id"])
+            assert job.compute_target == "remote"
+
+    async def test_remote_first_falls_back_to_local_when_remote_down(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=True, remote=False)
+        s = settings.model_copy(update={"compute_preference": "remote_first"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-rf-local@example.com")
+            resp = await client.post(GENERATE_URL, json={"prompt": "x"}, headers=_auth_headers(user, s))
+            assert resp.status_code == 202
+            job = await Job.get(resp.json()["job_id"])
+            assert job.compute_target == "local"
+
+    async def test_local_only_returns_503_when_local_unavailable(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=False, remote=True)
+        s = settings.model_copy(update={"compute_preference": "local_only"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-local-only@example.com")
+            before = user.credits_balance
+            resp = await client.post(GENERATE_URL, json={"prompt": "x"}, headers=_auth_headers(user, s))
+            assert resp.status_code == 503
+            assert "local" in resp.json()["detail"]
+            # No job created and no credit charged for an unavailable backend.
+            assert await Job.find(Job.user_id == user.id).to_list() == []
+            fresh = await user_service.get_user_by_id(str(user.id))
+            assert fresh.credits_balance == before
+
+    async def test_remote_only_returns_503_when_remote_unavailable(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=True, remote=False)
+        s = settings.model_copy(update={"compute_preference": "remote_only"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-remote-only@example.com")
+            resp = await client.post(GENERATE_URL, json={"prompt": "x"}, headers=_auth_headers(user, s))
+            assert resp.status_code == 503
+            assert "remote" in resp.json()["detail"]
+
+    async def test_per_request_local_overrides_remote_first_preference(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=True, remote=True)
+        s = settings.model_copy(update={"compute_preference": "remote_first"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-override-local@example.com")
+            resp = await client.post(
+                GENERATE_URL,
+                json={"prompt": "x", "compute_target": "local"},
+                headers=_auth_headers(user, s),
+            )
+            assert resp.status_code == 202
+            job = await Job.get(resp.json()["job_id"])
+            assert job.compute_target == "local"
+
+    async def test_per_request_local_503s_when_local_down_no_fallback(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=False, remote=True)
+        s = settings.model_copy(update={"compute_preference": "local_first"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-override-local-down@example.com")
+            resp = await client.post(
+                GENERATE_URL,
+                json={"prompt": "x", "compute_target": "local"},
+                headers=_auth_headers(user, s),
+            )
+            assert resp.status_code == 503
+
+    async def test_resolved_target_visible_in_job_status(self, monkeypatch, settings):
+        _set_availability(monkeypatch, local=True, remote=False)
+        s = settings.model_copy(update={"compute_preference": "local_first"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-status@example.com")
+            headers = _auth_headers(user, s)
+            job_id = (await client.post(GENERATE_URL, json={"prompt": "x"}, headers=headers)).json()["job_id"]
+            status_resp = await client.get(f"{JOBS_URL}/{job_id}/status", headers=headers)
+            assert status_resp.status_code == 200
+            assert status_resp.json()["compute_target"] == "local"
+
+    async def test_compute_target_not_leaked_into_input_params(self, monkeypatch, settings):
+        # The routing hint is not a creative param; it must not pollute the job
+        # snapshot forwarded to the worker.
+        _set_availability(monkeypatch, local=True, remote=True)
+        s = settings.model_copy(update={"compute_preference": "remote_first"})
+        async with await self._client_for(s) as client:
+            user = await _make_user("route-no-leak@example.com")
+            resp = await client.post(
+                GENERATE_URL,
+                json={"prompt": "x", "compute_target": "local"},
+                headers=_auth_headers(user, s),
+            )
+            job = await Job.get(resp.json()["job_id"])
+            assert "compute_target" not in job.input_params

--- a/tests/test_generation_api.py
+++ b/tests/test_generation_api.py
@@ -392,6 +392,8 @@ class TestComputeRouting:
                 headers=_auth_headers(user, s),
             )
             assert resp.status_code == 503
+            # The 503 names the *requested* target, not a synthetic preference.
+            assert resp.json()["detail"] == "Requested compute target 'local' is unavailable."
 
     async def test_resolved_target_visible_in_job_status(self, monkeypatch, settings):
         _set_availability(monkeypatch, local=True, remote=False)

--- a/tests/test_presets_api.py
+++ b/tests/test_presets_api.py
@@ -14,11 +14,24 @@ from fastapi.testclient import TestClient
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Job, Preset
-from acemusic.api.services import users as user_service
+from acemusic.api.services import routing, users as user_service
 from acemusic.api.settings import ApiSettings
 
 PRESETS_URL = f"{API_V1_PREFIX}/presets"
 GENERATE_URL = f"{API_V1_PREFIX}/generate"
+
+
+@pytest.fixture(autouse=True)
+def _local_compute_available(monkeypatch):
+    """Make the generation router's routing probe (US-11.1) see a reachable local
+    backend, so preset-aware generation tests assert the merge/job contract
+    rather than 503ing on compute availability."""
+
+    async def _available(url, timeout=routing.LOCAL_AVAILABILITY_TIMEOUT):
+        return True
+
+    monkeypatch.setattr(routing, "check_local_availability", _available)
+
 
 # A representative full parameter snapshot used across tests.
 FULL_PARAMS = {

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -182,6 +182,15 @@ class TestPerRequestOverride:
         )
         assert target is ComputeTarget.LOCAL
 
+    async def test_unknown_request_target_raises_value_error(self, monkeypatch):
+        # The router's Literal guards this, but the service fails loudly rather
+        # than silently defaulting if ever called with a bad value directly.
+        _set_availability(monkeypatch, local=True, remote=True)
+        with pytest.raises(ValueError, match="unknown compute_target"):
+            await resolve_compute_target(
+                request_target="banana", preference=ComputePreference.LOCAL_FIRST, local_url=LOCAL_URL
+            )
+
 
 class TestEnums:
     def test_compute_preference_values_match_settings_literal(self):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,196 @@
+"""Unit tests for the compute routing engine (US-11.1).
+
+Pure-logic tests with no DB: availability checks are monkeypatched (routing
+branches) or mocked with respx (the HTTP probe itself), so these run in CI
+without the ``integration`` marker.
+"""
+
+import httpx
+import pytest
+import respx
+
+from acemusic.api.services import routing
+from acemusic.api.services.routing import (
+    ComputePreference,
+    ComputeTarget,
+    ComputeUnavailableError,
+    resolve_compute_target,
+)
+
+LOCAL_URL = "http://localhost:8001"
+STATS_URL = f"{LOCAL_URL}/v1/stats"
+
+
+def _set_availability(monkeypatch, *, local: bool, remote: bool) -> None:
+    """Stub both availability probes so routing logic can be tested in isolation."""
+
+    async def _local(url: str, timeout: float = routing.LOCAL_AVAILABILITY_TIMEOUT) -> bool:
+        return local
+
+    async def _remote() -> bool:
+        return remote
+
+    monkeypatch.setattr(routing, "check_local_availability", _local)
+    monkeypatch.setattr(routing, "check_remote_availability", _remote)
+
+
+class TestCheckLocalAvailability:
+    @respx.mock
+    async def test_2xx_response_is_available(self):
+        respx.get(STATS_URL).mock(return_value=httpx.Response(200, json={"ok": True}))
+        assert await routing.check_local_availability(LOCAL_URL) is True
+
+    @respx.mock
+    async def test_trailing_slash_url_is_normalised(self):
+        route = respx.get(STATS_URL).mock(return_value=httpx.Response(200))
+        assert await routing.check_local_availability(LOCAL_URL + "/") is True
+        assert route.called
+
+    @respx.mock
+    async def test_server_error_is_unavailable(self):
+        respx.get(STATS_URL).mock(return_value=httpx.Response(503))
+        assert await routing.check_local_availability(LOCAL_URL) is False
+
+    @respx.mock
+    async def test_connection_error_is_unavailable(self):
+        respx.get(STATS_URL).mock(side_effect=httpx.ConnectError("refused"))
+        assert await routing.check_local_availability(LOCAL_URL) is False
+
+    @respx.mock
+    async def test_timeout_is_unavailable(self):
+        respx.get(STATS_URL).mock(side_effect=httpx.ReadTimeout("slow"))
+        assert await routing.check_local_availability(LOCAL_URL, timeout=0.01) is False
+
+
+class TestCheckRemoteAvailability:
+    async def test_remote_is_unavailable_until_us_11_2(self):
+        # Until US-11.2 wires up RunPod, the remote probe degrades to unavailable.
+        assert await routing.check_remote_availability() is False
+
+
+class TestLocalFirst:
+    async def test_routes_local_when_local_available(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=False)
+        target = await resolve_compute_target(
+            request_target="auto", preference=ComputePreference.LOCAL_FIRST, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.LOCAL
+
+    async def test_falls_back_to_remote_when_local_down(self, monkeypatch):
+        _set_availability(monkeypatch, local=False, remote=True)
+        target = await resolve_compute_target(
+            request_target="auto", preference=ComputePreference.LOCAL_FIRST, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.REMOTE
+
+    async def test_raises_when_neither_available(self, monkeypatch):
+        _set_availability(monkeypatch, local=False, remote=False)
+        with pytest.raises(ComputeUnavailableError):
+            await resolve_compute_target(
+                request_target="auto", preference=ComputePreference.LOCAL_FIRST, local_url=LOCAL_URL
+            )
+
+
+class TestRemoteFirst:
+    async def test_routes_remote_when_remote_available(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=True)
+        target = await resolve_compute_target(
+            request_target="auto", preference=ComputePreference.REMOTE_FIRST, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.REMOTE
+
+    async def test_falls_back_to_local_when_remote_down(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=False)
+        target = await resolve_compute_target(
+            request_target="auto", preference=ComputePreference.REMOTE_FIRST, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.LOCAL
+
+    async def test_raises_when_neither_available(self, monkeypatch):
+        _set_availability(monkeypatch, local=False, remote=False)
+        with pytest.raises(ComputeUnavailableError):
+            await resolve_compute_target(
+                request_target="auto", preference=ComputePreference.REMOTE_FIRST, local_url=LOCAL_URL
+            )
+
+
+class TestLocalOnly:
+    async def test_routes_local_when_available(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=True)
+        target = await resolve_compute_target(
+            request_target="auto", preference=ComputePreference.LOCAL_ONLY, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.LOCAL
+
+    async def test_raises_without_falling_back_when_local_down(self, monkeypatch):
+        # Even though remote is "available", local_only never falls back.
+        _set_availability(monkeypatch, local=False, remote=True)
+        with pytest.raises(ComputeUnavailableError) as exc:
+            await resolve_compute_target(
+                request_target="auto", preference=ComputePreference.LOCAL_ONLY, local_url=LOCAL_URL
+            )
+        assert exc.value.target is ComputeTarget.LOCAL
+        assert exc.value.preference is ComputePreference.LOCAL_ONLY
+
+
+class TestRemoteOnly:
+    async def test_routes_remote_when_available(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=True)
+        target = await resolve_compute_target(
+            request_target="auto", preference=ComputePreference.REMOTE_ONLY, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.REMOTE
+
+    async def test_raises_without_falling_back_when_remote_down(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=False)
+        with pytest.raises(ComputeUnavailableError) as exc:
+            await resolve_compute_target(
+                request_target="auto", preference=ComputePreference.REMOTE_ONLY, local_url=LOCAL_URL
+            )
+        assert exc.value.target is ComputeTarget.REMOTE
+        assert exc.value.preference is ComputePreference.REMOTE_ONLY
+
+
+class TestPerRequestOverride:
+    async def test_explicit_local_overrides_remote_first_preference(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=True)
+        target = await resolve_compute_target(
+            request_target="local", preference=ComputePreference.REMOTE_FIRST, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.LOCAL
+
+    async def test_explicit_remote_overrides_local_first_preference(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=True)
+        target = await resolve_compute_target(
+            request_target="remote", preference=ComputePreference.LOCAL_FIRST, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.REMOTE
+
+    async def test_explicit_local_does_not_fall_back(self, monkeypatch):
+        # An explicit target is honoured with *_only semantics: no silent fallback.
+        _set_availability(monkeypatch, local=False, remote=True)
+        with pytest.raises(ComputeUnavailableError) as exc:
+            await resolve_compute_target(
+                request_target="local", preference=ComputePreference.LOCAL_FIRST, local_url=LOCAL_URL
+            )
+        assert exc.value.target is ComputeTarget.LOCAL
+
+    async def test_none_request_target_uses_preference(self, monkeypatch):
+        _set_availability(monkeypatch, local=True, remote=False)
+        target = await resolve_compute_target(
+            request_target=None, preference=ComputePreference.LOCAL_FIRST, local_url=LOCAL_URL
+        )
+        assert target is ComputeTarget.LOCAL
+
+
+class TestEnums:
+    def test_compute_preference_values_match_settings_literal(self):
+        assert {p.value for p in ComputePreference} == {
+            "local_first",
+            "remote_first",
+            "local_only",
+            "remote_only",
+        }
+
+    def test_compute_target_values(self):
+        assert {t.value for t in ComputeTarget} == {"local", "remote"}


### PR DESCRIPTION
## Summary

Implements #122 (US-11.1): a compute routing engine that decides whether a
generation runs on the local GPU or a remote RunPod worker, based on a configured
preference and each target's live availability, with an optional per-request
override.

- **`settings.py`** — `compute_preference` (`local_first` / `remote_first` /
  `local_only` / `remote_only`, env `ACEMUSIC_API_COMPUTE_PREFERENCE`, default
  `local_first`) and `local_url` (env `ACEMUSIC_API_LOCAL_URL`, default
  `http://localhost:8001`) for the `/v1/stats` availability probe.
- **`services/routing.py`** (new) — `ComputeTarget` / `ComputePreference` enums,
  `ComputeUnavailableError`, async `check_local_availability` (httpx GET
  `{local_url}/v1/stats`, 2s timeout, fails closed) and `check_remote_availability`
  (stub, see below), and `resolve_compute_target()` implementing fallback +
  `*_only` semantics. Transport-agnostic — raises plain exceptions, never
  `HTTPException`, like the other services.
- **`routers/generation.py`** — `POST /api/v1/generate` accepts an optional
  `compute_target` (`auto` / `local` / `remote`). The target is resolved **before**
  credits are deducted, so an unavailable backend yields a clean **503** without
  ever charging the user. `compute_target` is a routing hint and is excluded from
  the job's `input_params`.
- **`models/job.py` + `services/generation.py`** — the *resolved* target is
  persisted on `Job.compute_target`.
- **`routers/jobs.py`** — `JobStatusResponse.compute_target` surfaces it in
  `GET /api/v1/jobs/{id}/status`.

## Acceptance Criteria

- [x] `local_first` routes to local GPU when available and falls back to remote when not
- [x] `remote_first` routes to RunPod when available and falls back to local when not
- [x] `local_only` returns 503 when local GPU is unavailable (no fallback)
- [x] `remote_only` returns 503 when RunPod is unavailable (no fallback)
- [x] Per-request `compute_target: "local"` overrides the default preference
- [x] The chosen target is recorded in the job record and visible in status responses

## Test Plan

- [x] Unit tests written first (TDD): `tests/test_routing.py` (23 cases — every
  routing branch, probe success/5xx/connect-error/timeout, enum parity, override
  semantics) and compute-routing settings cases in `tests/test_api_settings.py`.
- [x] Integration tests: `tests/test_generation_api.py::TestComputeRouting`
  (10 cases — each criterion end-to-end, no-charge-on-503, no-leak-into-input_params,
  status visibility).
- [x] All tests passing (1202 CI + affected integration suites green).
- [x] Diff coverage ≥85% on changed lines — new code (`routing.py`, service/router
  wiring) at 98–100%.
- [x] Linting clean (ruff + black).
- [x] Internal code review (advisory) — no Critical/Major; all 6 criteria confirmed met.
- [x] Cross-family review pass: **codex** (see rebuttals under Known Limitations).
- [x] Test mutation sanity check (Phase 7d) — probe and routing-branch mutations both
  caught by the new tests.

## Known Limitations / Intentionally Deferred

- **Worker does not yet dispatch by `compute_target`.** This PR makes and *records*
  the routing decision; actual execution still runs through the existing
  `JobProcessor` (CLI-config ACE-Step client). Wiring the processor to honor the
  resolved target — and to use `local_url` for the local client — is part of
  **US-11.2** (which also introduces the real remote path). If an operator sets
  `ACEMUSIC_API_LOCAL_URL` to a different host than the worker's `ACEMUSIC_BASE_URL`,
  the probe and execution endpoints can diverge. Tracked for US-11.2.
  *(Codex P1 "route local jobs through the probed local URL" — acknowledged, deferred
  to US-11.2 per the issue's dependency note; out of scope for the routing-decision
  acceptance criteria.)*
- **Remote availability is a stub returning `False` until US-11.2.** Until RunPod
  serverless integration lands, `remote_only` yields 503 and `*_first` falls back to
  local — the safe degradation called for by the issue. The stub is a real,
  monkeypatchable async function (not an inline constant) so every routing branch is
  testable now.
- **No SSRF allowlist on the `local_url` probe — intentional.** *(Codex P2)*
  `local_url` is operator-only configuration (`ApiSettings` / env var), never
  request-controlled — the per-request `compute_target` is a `Literal["auto","local",
  "remote"]`, not a URL. This matches how every other outbound URL in settings
  (`mongodb_url`, OAuth redirect URIs) is handled, and an allowlist would break valid
  deployments where the local ACE-Step runs on another internal host. The probe also
  fails closed on any error. No request-driven SSRF vector exists.

## Implementation Notes

The CodeRabbit auto-plan was adapted to the live API rather than followed literally.
The one substantive deviation: `check_remote_availability` is a module-level
overridable stub rather than an inline `return False`, so the `local_first → remote`
fallback and `remote_first` acceptance criteria are actually testable.

Closes #122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-request compute routing via `compute_target` for generation (`auto/local/remote`).
  * Introduced configurable compute routing preference (`local_first/remote_first/local_only/remote_only`) plus `local_url` probe setting.
  * Job status for routed generations now reports the resolved `compute_target`.

* **API Behavior**
  * Generation returns **503** when the required backend is unavailable, without charging credits.

* **Documentation**
  * Updated API docs, README, `.env.example`, and added a compute-routing demo.

* **Tests**
  * Expanded routing, generation, presets, credits, and settings validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->