### PR TITLE
feat(api): RunPod serverless integration (US-11.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,8 @@ ACEMUSIC_API_RUNPOD_API_KEY=
 ACEMUSIC_API_RUNPOD_ENDPOINT_ID=
 ACEMUSIC_API_RUNPOD_TIMEOUT=300
 ACEMUSIC_API_RUNPOD_POLL_INTERVAL=5
+# Override only to point at a staging endpoint or a proxy (default shown).
+# ACEMUSIC_API_RUNPOD_BASE_URL=https://api.runpod.ai/v2
 
 # Async job processor (US-9.2). A background task in the API process polls MongoDB
 # for queued generation jobs and runs them. JOB_CONCURRENCY bounds how many run at

--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,19 @@ ACEMUSIC_API_COMPUTE_PREFERENCE=local_first
 # This is a routing probe URL (independent of the CLI's ACEMUSIC_BASE_URL).
 ACEMUSIC_API_LOCAL_URL=http://localhost:8001
 
+# RunPod serverless remote routing (US-11.2). Enables remote GPU generation: when
+# BOTH the API key and endpoint ID are set, the routing engine probes the endpoint's
+# /health and may route generations to it. Leave either blank to run local-only
+# (remote routing is reported unavailable instead of crashing). These are namespaced
+# under ACEMUSIC_API_ for the Layer-2 API and are independent of the Layer-1
+# RUNPOD_API_KEY/RUNPOD_ENDPOINT_ID used by the CLI's pod-management commands.
+# RUNPOD_TIMEOUT caps how long a remote job may run (seconds, default 300, tolerates
+# cold starts); RUNPOD_POLL_INTERVAL is the gap between status polls (seconds).
+ACEMUSIC_API_RUNPOD_API_KEY=
+ACEMUSIC_API_RUNPOD_ENDPOINT_ID=
+ACEMUSIC_API_RUNPOD_TIMEOUT=300
+ACEMUSIC_API_RUNPOD_POLL_INTERVAL=5
+
 # Async job processor (US-9.2). A background task in the API process polls MongoDB
 # for queued generation jobs and runs them. JOB_CONCURRENCY bounds how many run at
 # once; JOB_POLL_INTERVAL is the idle sleep (seconds) between polls when the queue

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ without the worker — recommended to run a single processor instance),
 default `local_first`), and `LOCAL_URL` (local ACE-Step probe URL, default
 `http://localhost:8001`).
 
+Remote generation runs on a RunPod serverless endpoint (US-11.2). Set
+`RUNPOD_API_KEY` and `RUNPOD_ENDPOINT_ID` (both required) to enable it; remote
+routing is reported available only when both are set and the endpoint's `/health`
+answers, so an unconfigured or down endpoint degrades safely (`*_first` falls back
+to local, `*_only` returns 503) rather than crashing. A remote-routed job submits to
+the endpoint, polls with a cold-start-tolerant cadence (`RUNPOD_POLL_INTERVAL`,
+default 5s) up to `RUNPOD_TIMEOUT` seconds (default 300), retries transient 5xx
+responses, and stores the returned clips exactly like a local job. `RUNPOD_BASE_URL`
+(default `https://api.runpod.ai/v2`) can point at a staging endpoint or proxy.
+
 ### Workspaces
 
 | Endpoint | Purpose |

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -17,6 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from acemusic import __version__
+from acemusic.runpod_client import RunPodClient
 
 from . import database
 from .exceptions import HandleConflictError
@@ -83,10 +84,23 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
         processor: JobProcessor | None = None
         try:
             if settings.job_processor_enabled:
+                # Wire the RunPod backend (US-11.2) only when configured, so a
+                # local-only deployment runs unchanged; routing already reports
+                # remote unavailable when runpod_enabled is False.
+                runpod_factory = None
+                if settings.runpod_enabled:
+                    runpod_factory = lambda: RunPodClient(  # noqa: E731 - small closure over settings
+                        endpoint_id=settings.runpod_endpoint_id,
+                        api_key=settings.runpod_api_key,
+                        base_url=settings.runpod_base_url,
+                    )
                 processor = JobProcessor(
                     concurrency=settings.job_concurrency,
                     poll_interval=settings.job_poll_interval,
                     poll_timeout=settings.job_poll_timeout,
+                    runpod_client_factory=runpod_factory,
+                    runpod_timeout=settings.runpod_timeout,
+                    runpod_poll_interval=settings.runpod_poll_interval,
                 )
                 await processor.start()
             app_.state.job_processor = processor

--- a/src/acemusic/api/routers/generation.py
+++ b/src/acemusic/api/routers/generation.py
@@ -207,6 +207,7 @@ async def create_generation(
             request_target=request.compute_target,
             preference=ComputePreference(settings.compute_preference),
             local_url=settings.local_url,
+            settings=settings,
         )
     except ComputeUnavailableError as exc:
         # Distinguish a request-pinned target from the server preference so the

--- a/src/acemusic/api/services/routing.py
+++ b/src/acemusic/api/services/routing.py
@@ -13,7 +13,7 @@ from enum import Enum
 
 import httpx
 
-from ...runpod_client import RunPodClient, RunPodError
+from ...runpod_client import RunPodClient
 from ..settings import ApiSettings
 
 # The local availability probe must be quick: the issue caps it at a 2-second
@@ -98,7 +98,10 @@ async def check_remote_availability(settings: ApiSettings | None = None) -> bool
     )
     try:
         return await asyncio.to_thread(client.health, REMOTE_AVAILABILITY_TIMEOUT)
-    except RunPodError:
+    except Exception:
+        # A readiness probe must never surface a 500: any failure (probe error,
+        # thread-pool exhaustion, a client constructed with bad config) means
+        # "not ready", so remote routing falls back / 503s rather than crashing.
         return False
 
 

--- a/src/acemusic/api/services/routing.py
+++ b/src/acemusic/api/services/routing.py
@@ -8,14 +8,23 @@ Kept transport-agnostic (raises plain exceptions, never ``HTTPException``) like
 the other service modules, so the router stays free of routing concerns.
 """
 
+import asyncio
 from enum import Enum
 
 import httpx
+
+from ...runpod_client import RunPodClient, RunPodError
+from ..settings import ApiSettings
 
 # The local availability probe must be quick: the issue caps it at a 2-second
 # timeout so a down local server degrades to fallback/503 without stalling the
 # request.
 LOCAL_AVAILABILITY_TIMEOUT = 2.0
+
+# The remote (RunPod) readiness probe gets a slightly longer budget than the local
+# one — a serverless endpoint may be a touch slower to answer /health — but still
+# short enough that an unreachable remote degrades to fallback/503 promptly.
+REMOTE_AVAILABILITY_TIMEOUT = 5.0
 
 # ACE-Step exposes a lightweight stats endpoint used here purely as a health ping.
 LOCAL_STATS_PATH = "/v1/stats"
@@ -69,17 +78,28 @@ async def check_local_availability(url: str, timeout: float = LOCAL_AVAILABILITY
     return response.is_success
 
 
-async def check_remote_availability() -> bool:
-    """Return ``True`` if the remote RunPod endpoint is ready to accept work.
+async def check_remote_availability(settings: ApiSettings | None = None) -> bool:
+    """Return ``True`` if the remote RunPod endpoint is ready to accept work (US-11.2).
 
-    Stub that reports unavailable until US-11.2 wires up the RunPod serverless
-    client. It is a real (overridable) async function rather than an inline
-    constant so remote selection degrades safely in production — ``remote_only``
-    yields 503 and ``*_first`` falls back — while tests can exercise the
-    remote/fallback routing branches by patching it.
+    Remote routing is only available when RunPod is configured (both credentials set)
+    AND its ``/health`` endpoint answers — so a deployment without RunPod, or one
+    whose endpoint is down, degrades safely: ``remote_only`` yields 503 and ``*_first``
+    falls back to local. Any probe error counts as unavailable rather than surfacing a
+    500. ``settings`` is supplied by the router (which holds it on app state); a call
+    without it (``None``) is treated as "remote disabled" — we never read the
+    environment here, to avoid surprising request-time env/.env reads.
     """
-    # TODO(US-11.2): query the RunPod serverless endpoint status via the RunPod API.
-    return False
+    if settings is None or not settings.runpod_enabled:
+        return False
+    client = RunPodClient(
+        endpoint_id=settings.runpod_endpoint_id,
+        api_key=settings.runpod_api_key,
+        base_url=settings.runpod_base_url,
+    )
+    try:
+        return await asyncio.to_thread(client.health, REMOTE_AVAILABILITY_TIMEOUT)
+    except RunPodError:
+        return False
 
 
 def _effective_preference(request_target: str | None, preference: ComputePreference) -> ComputePreference:
@@ -104,6 +124,7 @@ async def resolve_compute_target(
     preference: ComputePreference,
     local_url: str,
     timeout: float = LOCAL_AVAILABILITY_TIMEOUT,
+    settings: ApiSettings | None = None,
 ) -> ComputeTarget:
     """Resolve which :class:`ComputeTarget` a generation should run on.
 
@@ -111,6 +132,9 @@ async def resolve_compute_target(
     live availability of each target. Raises :class:`ComputeUnavailableError`
     when the required target is down and no fallback is permitted (``*_only`` and
     explicit overrides) or when neither target is reachable (``*_first``).
+
+    ``settings`` is forwarded to the remote (RunPod) readiness probe so it can read
+    the configured credentials (US-11.2); the router supplies it from app state.
     """
     effective = _effective_preference(request_target, preference)
 
@@ -120,20 +144,20 @@ async def resolve_compute_target(
         raise ComputeUnavailableError(ComputeTarget.LOCAL, effective)
 
     if effective is ComputePreference.REMOTE_ONLY:
-        if await check_remote_availability():
+        if await check_remote_availability(settings):
             return ComputeTarget.REMOTE
         raise ComputeUnavailableError(ComputeTarget.REMOTE, effective)
 
     if effective is ComputePreference.LOCAL_FIRST:
         if await check_local_availability(local_url, timeout):
             return ComputeTarget.LOCAL
-        if await check_remote_availability():
+        if await check_remote_availability(settings):
             return ComputeTarget.REMOTE
         raise ComputeUnavailableError(ComputeTarget.LOCAL, effective)
 
     if effective is ComputePreference.REMOTE_FIRST:
         # Prefer remote, fall back to local.
-        if await check_remote_availability():
+        if await check_remote_availability(settings):
             return ComputeTarget.REMOTE
         if await check_local_availability(local_url, timeout):
             return ComputeTarget.LOCAL

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -91,6 +91,23 @@ class ApiSettings(BaseSettings):
     compute_preference: Literal["local_first", "remote_first", "local_only", "remote_only"] = "local_first"
     local_url: str = "http://localhost:8001"
 
+    # RunPod serverless remote routing (US-11.2). The credentials are optional: a
+    # deployment without them runs local-only — ``runpod_enabled`` is False, so the
+    # routing engine reports remote unavailable (``*_first`` falls back, ``remote_only``
+    # 503s) rather than crashing. ``runpod_timeout`` caps how long a remote job may run
+    # before it is failed; ``runpod_poll_interval`` is the gap between status polls,
+    # defaulted high to tolerate serverless cold starts without hammering the API.
+    runpod_api_key: str | None = None
+    runpod_endpoint_id: str | None = None
+    runpod_base_url: str = "https://api.runpod.ai/v2"
+    runpod_timeout: float = Field(default=300.0, gt=0)
+    runpod_poll_interval: float = Field(default=5.0, gt=0)
+
+    @property
+    def runpod_enabled(self) -> bool:
+        """True only when both RunPod credentials are configured (remote routing is usable)."""
+        return bool(self.runpod_api_key and self.runpod_endpoint_id)
+
     # OAuth ``state`` cookie policy (issue #110, login-CSRF binding). The login
     # flow sets a per-client nonce cookie that the callback requires.
     # ``oauth_cookie_secure`` marks it Secure (HTTPS-only); keep True in

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -29,6 +29,7 @@ from pymongo import ASCENDING, ReturnDocument
 
 from acemusic.client import AceStepClient
 from acemusic.config import load_config
+from acemusic.runpod_client import RunPodClient
 from acemusic.storage import StorageBackend, get_storage_backend
 
 from .. import database
@@ -100,6 +101,9 @@ class JobProcessor:
         ace_poll_interval: float = 2.0,
         stale_after: float | None = None,
         client_factory: Callable[[], AceStepClient] | None = None,
+        runpod_client_factory: Callable[[], RunPodClient] | None = None,
+        runpod_timeout: float = 300.0,
+        runpod_poll_interval: float = 5.0,
         storage_factory: Callable[[], StorageBackend] | None = None,
         handlers: dict[str, JobHandler] | None = None,
     ) -> None:
@@ -108,6 +112,13 @@ class JobProcessor:
         self._poll_interval = poll_interval
         self._poll_timeout = poll_timeout
         self._ace_poll_interval = ace_poll_interval
+        # Remote (RunPod) generation (US-11.2). The factory is None unless RunPod is
+        # configured; a job routed to ``remote`` (US-11.1) without it fails loudly
+        # rather than silently running locally. The remote poll interval defaults
+        # higher than the local one to tolerate serverless cold starts.
+        self._runpod_client_factory = runpod_client_factory
+        self._runpod_timeout = runpod_timeout
+        self._runpod_poll_interval = runpod_poll_interval
         # A job legitimately stays in `processing` for at most poll_timeout (its
         # own worker fails it after that). Only re-queue jobs older than that
         # window plus a margin, so a startup sweep never reclaims a job a live
@@ -292,34 +303,61 @@ class JobProcessor:
         )
 
     async def _handle_generate(self, job: Job) -> dict[str, Any]:
-        """Run an ACE-Step generation job: submit, poll, store clips."""
-        client = self._client_factory()
+        """Run a generation job — locally via ACE-Step or remotely via RunPod.
+
+        US-11.1 records the routing decision on ``job.compute_target``; US-11.2 acts
+        on it here. The two backends share an interface (``submit_task`` /
+        ``query_result`` / ``download_audio``) and the normalised result shape, so
+        only the client and the poll cadence/timeout differ between them.
+        """
         params = dict(job.input_params or {})
+        # "remote" is the Job.compute_target literal the routing engine (US-11.1) writes.
+        remote = job.compute_target == "remote"
+        if remote:
+            if self._runpod_client_factory is None:
+                raise JobProcessingError("Job routed to remote compute but RunPod is not configured")
+            client: AceStepClient | RunPodClient = self._runpod_client_factory()
+            poll_interval, timeout, backend = self._runpod_poll_interval, self._runpod_timeout, "RunPod"
+        else:
+            client = self._client_factory()
+            poll_interval, timeout, backend = self._ace_poll_interval, self._poll_timeout, "ACE-Step"
 
         task_id = await asyncio.to_thread(partial(client.submit_task, **self._build_submit_kwargs(params)))
-        result = await self._poll_until_complete(client, task_id)
+        result = await self._poll_until_complete(client, task_id, poll_interval=poll_interval, timeout=timeout)
         if result.get("status") == "failed":
-            raise JobProcessingError(result.get("error") or "ACE-Step generation failed")
+            raise JobProcessingError(result.get("error") or f"{backend} generation failed")
 
         audio_urls = result.get("audio_urls") or []
         if not audio_urls:
-            raise JobProcessingError("ACE-Step completed but returned no audio")
+            raise JobProcessingError(f"{backend} completed but returned no audio")
 
         clip_ids = await self._store_clips(job, params, client, audio_urls)
         return {"clip_ids": clip_ids}
 
-    async def _poll_until_complete(self, client: AceStepClient, task_id: str) -> dict[str, Any]:
-        """Poll query_result until the task reaches a terminal state or times out."""
+    async def _poll_until_complete(
+        self,
+        client: AceStepClient | RunPodClient,
+        task_id: str,
+        *,
+        poll_interval: float | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Poll query_result until the task reaches a terminal state or times out.
+
+        ``poll_interval``/``timeout`` default to the local ACE-Step cadence so
+        existing callers (the iterative handlers) keep their behaviour; the remote
+        path passes RunPod's longer cadence/budget.
+        """
+        interval = poll_interval if poll_interval is not None else self._ace_poll_interval
+        budget = timeout if timeout is not None else self._poll_timeout
         start = time.monotonic()
         while True:
             result = await asyncio.to_thread(client.query_result, task_id)
             if result.get("status") in _TERMINAL_STATES:
                 return result
-            if time.monotonic() - start > self._poll_timeout:
-                raise JobProcessingError(
-                    f"Timed out after {self._poll_timeout:.0f}s waiting for ACE-Step task {task_id}"
-                )
-            await asyncio.sleep(self._ace_poll_interval)
+            if time.monotonic() - start > budget:
+                raise JobProcessingError(f"Timed out after {budget:.0f}s waiting for task {task_id}")
+            await asyncio.sleep(interval)
 
     async def _store_clips(
         self,

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -363,7 +363,7 @@ class JobProcessor:
         self,
         job: Job,
         params: dict[str, Any],
-        client: AceStepClient,
+        client: AceStepClient | RunPodClient,
         audio_urls: list[str],
     ) -> list[str]:
         """Download each result, store it, and create its Clip record.

--- a/src/acemusic/runpod_client.py
+++ b/src/acemusic/runpod_client.py
@@ -83,7 +83,13 @@ class RunPodClient:
         self._headers = {"Authorization": f"Bearer {api_key}"}
 
     def _send_with_retry(
-        self, method: Callable[..., httpx.Response], url: str, *, timeout: float, **kwargs: Any
+        self,
+        method: Callable[..., httpx.Response],
+        url: str,
+        *,
+        timeout: float,
+        headers: dict | None = None,
+        **kwargs: Any,
     ) -> httpx.Response:
         """Issue an HTTP request, retrying on 5xx with exponential backoff.
 
@@ -92,9 +98,14 @@ class RunPodClient:
         not retried — they propagate so the caller maps them to
         :class:`RunPodConnectionError`. A 5xx that persists past the retry budget is
         returned so the caller surfaces it as a :class:`RunPodError` like any other.
+
+        ``headers`` defaults to the client's auth headers; callers fetching from a
+        pre-authorized URL (e.g. a presigned audio URL) pass ``{}`` to avoid leaking
+        the RunPod bearer token to an external host.
         """
+        request_headers = self._headers if headers is None else headers
         for attempt in range(_MAX_RETRIES + 1):
-            response = method(url, headers=self._headers, timeout=timeout, **kwargs)
+            response = method(url, headers=request_headers, timeout=timeout, **kwargs)
             if response.status_code >= 500 and attempt < _MAX_RETRIES:
                 time.sleep(_backoff_delay(attempt))
                 continue
@@ -167,12 +178,18 @@ class RunPodClient:
     def download_audio(self, url: str, timeout: float = 120.0) -> bytes:
         """Download raw audio bytes from a URL.
 
+        Transient 5xx responses are retried like the other operations — an audio-CDN
+        blip is as recoverable as a status-poll transient. No auth header is sent: the
+        URL comes from RunPod's own output and is already pre-authorized (typically a
+        presigned/public URL), so attaching the bearer token would only risk leaking
+        it to an external host.
+
         Raises:
             RunPodError: on HTTP error.
             RunPodConnectionError: on connection failure or timeout.
         """
         try:
-            response = httpx.get(url, headers=self._headers, timeout=timeout, follow_redirects=True)
+            response = self._send_with_retry(httpx.get, url, timeout=timeout, headers={}, follow_redirects=True)
             response.raise_for_status()
             return response.content
         except httpx.HTTPStatusError as exc:

--- a/src/acemusic/runpod_client.py
+++ b/src/acemusic/runpod_client.py
@@ -1,0 +1,232 @@
+"""HTTP client for RunPod serverless endpoints (US-11.2).
+
+Drives remote GPU generation on a RunPod serverless endpoint running the ACE-Step
+worker image (US-11.3). The endpoint's API contract:
+
+- POST ``/run``                 → submit a job; response ``{"id": ..., "status": ...}``
+- GET  ``/status/{job_id}``     → poll job status; ``{"status": "IN_QUEUE" | "IN_PROGRESS"
+                                   | "COMPLETED" | "FAILED" | ..., "output": ..., "error": ...}``
+- GET  ``/health``              → endpoint readiness (used by the routing engine)
+
+The client deliberately mirrors :class:`acemusic.client.AceStepClient`'s *consumer*
+interface (``submit_task`` / ``query_result`` / ``download_audio``) and its normalised
+``query_result`` return shape so the job processor's existing poll-and-store helpers
+work against either backend unchanged. Status values are normalised to the same
+``"pending" | "completed" | "failed"`` vocabulary the processor already understands.
+
+Transient server errors (HTTP 5xx) are retried inside the client with exponential
+backoff so the processor stays unaware of retry mechanics. 4xx errors fail fast.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Callable
+
+import httpx
+
+# Retry policy for transient (5xx) responses. ``_MAX_RETRIES`` retries follow the
+# initial attempt, so a persistently-failing endpoint is hit up to 4 times. Delays
+# grow as base * 2**attempt (1s, 2s, 4s) with added jitter to avoid synchronised
+# retry storms when many jobs poll at once.
+_MAX_RETRIES = 3
+_BACKOFF_BASE = 1.0
+_BACKOFF_JITTER = 0.5
+
+# RunPod serverless states normalised onto the processor's status vocabulary. Any
+# unknown state is treated as still-pending so the poll loop keeps waiting (and is
+# eventually capped by the caller's timeout) rather than failing on a new state.
+_STATUS_MAP = {
+    "in_queue": "pending",
+    "in_progress": "pending",
+    "completed": "completed",
+    "failed": "failed",
+    "cancelled": "failed",
+    "timed_out": "failed",
+}
+
+DEFAULT_BASE_URL = "https://api.runpod.ai/v2"
+
+
+class RunPodError(Exception):
+    """Raised when the RunPod API returns an error or is unreachable."""
+
+
+class RunPodConnectionError(RunPodError):
+    """Transport-level failure (connection refused, DNS failure, timeout).
+
+    Distinct from API/HTTP-status errors so callers can tell a transient network
+    issue from a real server-side error. ``is_timeout`` is True only for a *read*
+    timeout — the connection was established but the server was slow to respond
+    (e.g. a cold start spinning up a serverless worker). Connect timeouts and
+    refused/DNS failures leave it False so an unreachable host still fast-fails.
+    """
+
+    def __init__(self, message: str, *, is_timeout: bool = False) -> None:
+        super().__init__(message)
+        self.is_timeout = is_timeout
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Exponential backoff (1s, 2s, 4s …) plus jitter for the given retry attempt."""
+    return _BACKOFF_BASE * (2**attempt) + random.uniform(0, _BACKOFF_JITTER)
+
+
+class RunPodClient:
+    """Reusable HTTP client for a RunPod serverless endpoint."""
+
+    def __init__(self, endpoint_id: str, api_key: str, base_url: str = DEFAULT_BASE_URL) -> None:
+        """Initialise the client for ``endpoint_id`` authenticated with ``api_key``."""
+        self.endpoint_id = endpoint_id
+        self.base_url = f"{base_url.rstrip('/')}/{endpoint_id}"
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+
+    def _send_with_retry(
+        self, method: Callable[..., httpx.Response], url: str, *, timeout: float, **kwargs: Any
+    ) -> httpx.Response:
+        """Issue an HTTP request, retrying on 5xx with exponential backoff.
+
+        Returns the response untouched (the caller decides how to interpret a
+        non-5xx status, e.g. ``raise_for_status`` for a 4xx). Connection errors are
+        not retried — they propagate so the caller maps them to
+        :class:`RunPodConnectionError`. A 5xx that persists past the retry budget is
+        returned so the caller surfaces it as a :class:`RunPodError` like any other.
+        """
+        for attempt in range(_MAX_RETRIES + 1):
+            response = method(url, headers=self._headers, timeout=timeout, **kwargs)
+            if response.status_code >= 500 and attempt < _MAX_RETRIES:
+                time.sleep(_backoff_delay(attempt))
+                continue
+            return response
+        return response  # pragma: no cover - loop always returns on the last attempt
+
+    def submit(self, input_params: dict, timeout: float = 30.0) -> str:
+        """Submit a job via POST ``/run`` and return the RunPod job id.
+
+        ``input_params`` is wrapped in the serverless ``{"input": ...}`` envelope the
+        worker expects.
+
+        Raises:
+            RunPodError: on HTTP error or a response missing the job id.
+            RunPodConnectionError: on connection failure or timeout.
+        """
+        try:
+            response = self._send_with_retry(
+                httpx.post, f"{self.base_url}/run", json={"input": input_params}, timeout=timeout
+            )
+            response.raise_for_status()
+            data = response.json()
+            job_id = data.get("id")
+            if not job_id:
+                raise RunPodError(f"No job id in RunPod response: {data}")
+            return job_id
+        except httpx.HTTPStatusError as exc:
+            raise RunPodError(f"RunPod submit failed: {exc.response.status_code} {exc.response.text}") from exc
+        except httpx.RequestError as exc:
+            raise RunPodConnectionError(
+                f"RunPod submit failed: {exc}", is_timeout=isinstance(exc, httpx.ReadTimeout)
+            ) from exc
+
+    def submit_task(self, **kwargs: Any) -> str:
+        """Alias matching :meth:`AceStepClient.submit_task` so the processor can treat
+        both backends uniformly: the keyword generation params become the RunPod input."""
+        return self.submit(kwargs)
+
+    def query_result(self, job_id: str, timeout: float = 10.0) -> dict:
+        """Poll GET ``/status/{job_id}`` and return a normalised result dict.
+
+        Returns:
+            dict with keys (mirroring :meth:`AceStepClient.query_result`):
+              - status: "pending" | "completed" | "failed"
+              - audio_urls: list of audio URLs (empty until completed)
+              - error: error message string or None
+
+        Transient 5xx responses are retried with backoff before failing.
+
+        Raises:
+            RunPodError: on a 4xx, or a 5xx that survives the retry budget.
+            RunPodConnectionError: on connection failure or timeout.
+        """
+        try:
+            response = self._send_with_retry(httpx.get, f"{self.base_url}/status/{job_id}", timeout=timeout)
+            response.raise_for_status()
+            data = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise RunPodError(f"RunPod status failed: {exc.response.status_code} {exc.response.text}") from exc
+        except httpx.RequestError as exc:
+            raise RunPodConnectionError(
+                f"RunPod status failed: {exc}", is_timeout=isinstance(exc, httpx.ReadTimeout)
+            ) from exc
+
+        status = _STATUS_MAP.get(str(data.get("status", "")).lower(), "pending")
+        error = data.get("error")
+        audio_urls = _extract_audio_urls(data.get("output")) if status == "completed" else []
+        return {"status": status, "audio_urls": audio_urls, "error": error}
+
+    def download_audio(self, url: str, timeout: float = 120.0) -> bytes:
+        """Download raw audio bytes from a URL.
+
+        Raises:
+            RunPodError: on HTTP error.
+            RunPodConnectionError: on connection failure or timeout.
+        """
+        try:
+            response = httpx.get(url, headers=self._headers, timeout=timeout, follow_redirects=True)
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPStatusError as exc:
+            raise RunPodError(f"RunPod download failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise RunPodConnectionError(
+                f"RunPod download failed: {exc}", is_timeout=isinstance(exc, httpx.ReadTimeout)
+            ) from exc
+
+    def health(self, timeout: float = 5.0) -> bool:
+        """Return ``True`` if GET ``/health`` answers with a 2xx.
+
+        Used by the routing engine as a readiness probe, so any connection error or
+        non-2xx counts as unavailable rather than raising — remote routing degrades
+        to fallback/503 instead of surfacing a 500.
+        """
+        try:
+            response = httpx.get(f"{self.base_url}/health", headers=self._headers, timeout=timeout)
+        except httpx.RequestError:
+            return False
+        return response.is_success
+
+
+def _extract_audio_urls(output: Any) -> list[str]:
+    """Pull audio URLs out of a RunPod ``output`` payload.
+
+    The worker (US-11.3) is not built yet, so this accepts the shapes it is most
+    likely to emit: a bare list of URLs, a list of ``{"url"|"file"|"audio_url": ...}``
+    objects, or a dict carrying any of those under ``audio_urls``/``clips``/``outputs``.
+    """
+    if not output:
+        return []
+    if isinstance(output, dict):
+        direct = output.get("audio_urls")
+        if isinstance(direct, list):
+            return [url for url in direct if url]
+        for key in ("clips", "outputs", "output"):
+            nested = output.get(key)
+            if isinstance(nested, list):
+                return _urls_from_list(nested)
+        return []
+    if isinstance(output, list):
+        return _urls_from_list(output)
+    return []
+
+
+def _urls_from_list(items: list) -> list[str]:
+    """Extract URL strings from a list of either plain strings or url-bearing dicts."""
+    urls: list[str] = []
+    for item in items:
+        if isinstance(item, str) and item:
+            urls.append(item)
+        elif isinstance(item, dict):
+            url = item.get("url") or item.get("file") or item.get("audio_url")
+            if url:
+                urls.append(url)
+    return urls

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -197,3 +197,60 @@ class TestComputeRoutingSettings:
         monkeypatch.setenv("ACEMUSIC_API_LOCAL_URL", value)
         with pytest.raises(ValueError, match="local_url"):
             ApiSettings(_env_file=None)
+
+
+class TestRunPodSettings:
+    """RunPod serverless remote-routing configuration (US-11.2)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_runpod_env(self, monkeypatch):
+        for key in (
+            "ACEMUSIC_API_RUNPOD_API_KEY",
+            "ACEMUSIC_API_RUNPOD_ENDPOINT_ID",
+            "ACEMUSIC_API_RUNPOD_TIMEOUT",
+            "ACEMUSIC_API_RUNPOD_POLL_INTERVAL",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_defaults_are_unset_and_disabled(self):
+        settings = ApiSettings(_env_file=None)
+        assert settings.runpod_api_key is None
+        assert settings.runpod_endpoint_id is None
+        assert settings.runpod_timeout == 300.0
+        assert settings.runpod_poll_interval == 5.0
+        assert settings.runpod_enabled is False
+
+    def test_enabled_requires_both_credentials(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_API_KEY", "rp-key")
+        assert ApiSettings(_env_file=None).runpod_enabled is False
+
+        monkeypatch.delenv("ACEMUSIC_API_RUNPOD_API_KEY")
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_ENDPOINT_ID", "ep-1")
+        assert ApiSettings(_env_file=None).runpod_enabled is False
+
+    def test_enabled_when_both_credentials_set(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_API_KEY", "rp-key")
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_ENDPOINT_ID", "ep-1")
+        settings = ApiSettings(_env_file=None)
+        assert settings.runpod_enabled is True
+        assert settings.runpod_api_key == "rp-key"
+        assert settings.runpod_endpoint_id == "ep-1"
+
+    def test_timeout_and_poll_interval_from_env(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_TIMEOUT", "600")
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_POLL_INTERVAL", "10")
+        settings = ApiSettings(_env_file=None)
+        assert settings.runpod_timeout == 600.0
+        assert settings.runpod_poll_interval == 10.0
+
+    @pytest.mark.parametrize("value", ["0", "-1"])
+    def test_timeout_rejects_non_positive(self, monkeypatch, value):
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_TIMEOUT", value)
+        with pytest.raises(ValueError, match="runpod_timeout"):
+            ApiSettings(_env_file=None)
+
+    @pytest.mark.parametrize("value", ["0", "-2"])
+    def test_poll_interval_rejects_non_positive(self, monkeypatch, value):
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_POLL_INTERVAL", value)
+        with pytest.raises(ValueError, match="runpod_poll_interval"):
+            ApiSettings(_env_file=None)

--- a/tests/test_generation_api.py
+++ b/tests/test_generation_api.py
@@ -27,7 +27,7 @@ def _set_availability(monkeypatch, *, local: bool, remote: bool = False) -> None
     async def _local(url, timeout=routing.LOCAL_AVAILABILITY_TIMEOUT):
         return local
 
-    async def _remote():
+    async def _remote(settings=None):
         return remote
 
     monkeypatch.setattr(routing, "check_local_availability", _local)

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -92,11 +92,56 @@ class _FakeAceClient:
         return self._audio
 
 
-async def _enqueue(input_params: dict | None = None, *, job_type: str = "generate") -> Job:
+class _FakeRunPodClient:
+    """Synchronous RunPod stand-in mirroring the AceStep consumer interface."""
+
+    def __init__(
+        self,
+        *,
+        audio_urls=None,
+        audio: bytes = b"RUNPOD-WAV-BYTES",
+        status: str = "completed",
+        error: str | None = None,
+        pending_forever: bool = False,
+    ) -> None:
+        self._audio_urls = ["http://runpod/a.wav"] if audio_urls is None else audio_urls
+        self._audio = audio
+        self._status = status
+        self._error = error
+        self._pending_forever = pending_forever
+        self.submitted: list[dict] = []
+
+    def submit_task(self, **kwargs) -> str:
+        self.submitted.append(kwargs)
+        return "runpod-job-1"
+
+    def query_result(self, task_id: str, timeout: float = 10.0) -> dict:
+        if self._pending_forever:
+            time.sleep(0.01)
+            return {"status": "pending", "audio_urls": [], "error": None}
+        if self._status == "failed":
+            return {"status": "failed", "audio_urls": [], "error": self._error or "remote boom"}
+        return {"status": "completed", "audio_urls": list(self._audio_urls), "error": None}
+
+    def download_audio(self, url: str, timeout: float = 120.0) -> bytes:
+        return self._audio
+
+
+class _ExplodingClient:
+    """A client whose every call fails — used to prove the *other* backend ran."""
+
+    def submit_task(self, **kwargs) -> str:  # pragma: no cover - must never be called
+        raise AssertionError("wrong backend: local ACE-Step client was used for a remote job")
+
+
+async def _enqueue(
+    input_params: dict | None = None, *, job_type: str = "generate", compute_target: str | None = None
+) -> Job:
     job = Job(
         user_id=PydanticObjectId(),
         workspace_id=PydanticObjectId(),
         job_type=job_type,
+        compute_target=compute_target,
         status=JobStatus.QUEUED,
         input_params=input_params or {"prompt": "a calm piano ballad", "format": "wav"},
     )
@@ -113,7 +158,16 @@ async def _wait_until(predicate, *, timeout: float = 5.0, interval: float = 0.02
     return False
 
 
-def _make_processor(fake, storage, *, concurrency: int = 2, stale_after: float = 0.0, handlers=None) -> JobProcessor:
+def _make_processor(
+    fake,
+    storage,
+    *,
+    concurrency: int = 2,
+    stale_after: float = 0.0,
+    handlers=None,
+    runpod=None,
+    runpod_timeout: float = 5.0,
+) -> JobProcessor:
     # stale_after=0.0: any `processing` job is treated as immediately orphaned, so
     # the requeue-on-startup test is deterministic (production uses a real window).
     return JobProcessor(
@@ -123,6 +177,9 @@ def _make_processor(fake, storage, *, concurrency: int = 2, stale_after: float =
         ace_poll_interval=0.01,
         stale_after=stale_after,
         client_factory=lambda: fake,
+        runpod_client_factory=(lambda: runpod) if runpod is not None else None,
+        runpod_poll_interval=0.01,
+        runpod_timeout=runpod_timeout,
         storage_factory=lambda: storage,
         handlers=handlers,
     )
@@ -294,6 +351,100 @@ class TestLifecycle:
         assert await Clip.count() == 0, "orphaned clip record not rolled back"
         leftover = [f for _root, _dirs, files in os.walk(tmp_path) for f in files]
         assert leftover == [], "orphaned storage file not rolled back"
+
+
+@pytest.mark.integration
+class TestRemoteRunPod:
+    """Generation jobs routed to remote (RunPod) compute (US-11.2)."""
+
+    async def test_remote_job_runs_via_runpod_and_stores_clips(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        remote = _FakeRunPodClient(audio_urls=["http://runpod/a.wav", "http://runpod/b.wav"])
+        proc = _make_processor(_ExplodingClient(), storage, runpod=remote)
+        job = await _enqueue(compute_target="remote")
+
+        await proc.start()
+        try:
+            done = await _wait_until(lambda: _is_status(job.id, JobStatus.COMPLETED))
+        finally:
+            await proc.stop()
+
+        assert done, "remote job did not reach completed"
+        # The remote client ran (the local _ExplodingClient would have failed the job).
+        assert remote.submitted, "RunPod client was not used for the remote job"
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.COMPLETED
+        assert len(refreshed.result["clip_ids"]) == 2
+        clips = await Clip.find(Clip.user_id == job.user_id).to_list()
+        assert len(clips) == 2
+        for clip in clips:
+            assert storage.download(clip.file_path) == b"RUNPOD-WAV-BYTES"
+
+    async def test_remote_failure_surfaces_error(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        remote = _FakeRunPodClient(status="failed", error="GPU OOM on worker")
+        proc = _make_processor(_ExplodingClient(), storage, runpod=remote)
+        job = await _enqueue(compute_target="remote")
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.FAILED))
+        finally:
+            await proc.stop()
+
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.FAILED
+        assert refreshed.error == "GPU OOM on worker"
+
+    async def test_remote_timeout_surfaces_error(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        remote = _FakeRunPodClient(pending_forever=True)
+        # Tiny runpod_timeout so the poll budget is exhausted quickly.
+        proc = _make_processor(_ExplodingClient(), storage, runpod=remote, runpod_timeout=0.05)
+        job = await _enqueue(compute_target="remote")
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.FAILED))
+        finally:
+            await proc.stop()
+
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.FAILED
+        assert "timed out" in (refreshed.error or "").lower()
+
+    async def test_remote_job_without_factory_fails_clearly(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        # runpod=None → no factory, but a job is still routed remote.
+        proc = _make_processor(_ExplodingClient(), storage, runpod=None)
+        job = await _enqueue(compute_target="remote")
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.FAILED))
+        finally:
+            await proc.stop()
+
+        refreshed = await Job.get(job.id)
+        assert refreshed.status == JobStatus.FAILED
+        assert "runpod is not configured" in (refreshed.error or "").lower()
+
+    async def test_local_job_still_uses_ace_step(self, mongo_db, tmp_path) -> None:
+        # A job with compute_target="local" must ignore the configured RunPod client.
+        storage = LocalStorage(root_dir=tmp_path)
+        local = _FakeAceClient(audio_urls=["http://ace/a.wav"])
+        remote = _FakeRunPodClient()
+        proc = _make_processor(local, storage, runpod=remote)
+        job = await _enqueue(compute_target="local")
+
+        await proc.start()
+        try:
+            await _wait_until(lambda: _is_status(job.id, JobStatus.COMPLETED))
+        finally:
+            await proc.stop()
+
+        assert local.submitted, "local ACE-Step client was not used for the local job"
+        assert remote.submitted == [], "RunPod client must not run a local job"
 
     async def test_two_concurrent_jobs_complete_without_corruption(self, mongo_db, tmp_path) -> None:
         storage = LocalStorage(root_dir=tmp_path)

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -352,6 +352,34 @@ class TestLifecycle:
         leftover = [f for _root, _dirs, files in os.walk(tmp_path) for f in files]
         assert leftover == [], "orphaned storage file not rolled back"
 
+    async def test_two_concurrent_jobs_complete_without_corruption(self, mongo_db, tmp_path) -> None:
+        storage = LocalStorage(root_dir=tmp_path)
+        tracker = _ConcurrencyTracker()
+        fake = _FakeAceClient(audio_urls=["http://ace/a.wav", "http://ace/b.wav"], track=tracker)
+        proc = _make_processor(fake, storage, concurrency=2)
+        job_a = await _enqueue({"prompt": "first", "format": "wav"})
+        job_b = await _enqueue({"prompt": "second", "format": "wav"})
+
+        await proc.start()
+        try:
+            done = await _wait_until(
+                lambda: _all_status([job_a.id, job_b.id], JobStatus.COMPLETED),
+                timeout=8.0,
+            )
+        finally:
+            await proc.stop()
+
+        assert done, "both jobs did not complete"
+        assert tracker.max >= 2, "jobs did not actually run concurrently"
+
+        refreshed_a = await Job.get(job_a.id)
+        refreshed_b = await Job.get(job_b.id)
+        ids_a = set(refreshed_a.result["clip_ids"])
+        ids_b = set(refreshed_b.result["clip_ids"])
+        assert len(ids_a) == 2 and len(ids_b) == 2
+        assert ids_a.isdisjoint(ids_b), "clip ids leaked between jobs"
+        assert await Clip.count() == 4
+
 
 @pytest.mark.integration
 class TestRemoteRunPod:
@@ -445,34 +473,6 @@ class TestRemoteRunPod:
 
         assert local.submitted, "local ACE-Step client was not used for the local job"
         assert remote.submitted == [], "RunPod client must not run a local job"
-
-    async def test_two_concurrent_jobs_complete_without_corruption(self, mongo_db, tmp_path) -> None:
-        storage = LocalStorage(root_dir=tmp_path)
-        tracker = _ConcurrencyTracker()
-        fake = _FakeAceClient(audio_urls=["http://ace/a.wav", "http://ace/b.wav"], track=tracker)
-        proc = _make_processor(fake, storage, concurrency=2)
-        job_a = await _enqueue({"prompt": "first", "format": "wav"})
-        job_b = await _enqueue({"prompt": "second", "format": "wav"})
-
-        await proc.start()
-        try:
-            done = await _wait_until(
-                lambda: _all_status([job_a.id, job_b.id], JobStatus.COMPLETED),
-                timeout=8.0,
-            )
-        finally:
-            await proc.stop()
-
-        assert done, "both jobs did not complete"
-        assert tracker.max >= 2, "jobs did not actually run concurrently"
-
-        refreshed_a = await Job.get(job_a.id)
-        refreshed_b = await Job.get(job_b.id)
-        ids_a = set(refreshed_a.result["clip_ids"])
-        ids_b = set(refreshed_b.result["clip_ids"])
-        assert len(ids_a) == 2 and len(ids_b) == 2
-        assert ids_a.isdisjoint(ids_b), "clip ids leaked between jobs"
-        assert await Clip.count() == 4
 
 
 @pytest.mark.integration

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -88,8 +88,10 @@ class TestCheckRemoteAvailability:
         assert await routing.check_remote_availability(self._settings()) is False
 
     async def test_unavailable_when_probe_raises(self, monkeypatch):
+        # Any probe failure (not just RunPodError) must degrade to unavailable rather
+        # than surfacing a 500 from the routing engine.
         def _boom(self, timeout=5.0):
-            raise routing.RunPodError("endpoint exploded")
+            raise RuntimeError("endpoint exploded")
 
         monkeypatch.setattr(routing.RunPodClient, "health", _boom)
         assert await routing.check_remote_availability(self._settings()) is False

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -27,7 +27,7 @@ def _set_availability(monkeypatch, *, local: bool, remote: bool) -> None:
     async def _local(url: str, timeout: float = routing.LOCAL_AVAILABILITY_TIMEOUT) -> bool:
         return local
 
-    async def _remote() -> bool:
+    async def _remote(settings=None) -> bool:
         return remote
 
     monkeypatch.setattr(routing, "check_local_availability", _local)
@@ -63,9 +63,36 @@ class TestCheckLocalAvailability:
 
 
 class TestCheckRemoteAvailability:
-    async def test_remote_is_unavailable_until_us_11_2(self):
-        # Until US-11.2 wires up RunPod, the remote probe degrades to unavailable.
-        assert await routing.check_remote_availability() is False
+    """RunPod readiness probe (US-11.2)."""
+
+    def _settings(self, **overrides):
+        from acemusic.api.settings import ApiSettings
+
+        base = dict(runpod_api_key="rp-key", runpod_endpoint_id="ep-1")
+        base.update(overrides)
+        return ApiSettings(_env_file=None, **base)
+
+    async def test_unavailable_when_runpod_not_configured(self):
+        # No credentials → remote routing disabled, regardless of any endpoint.
+        from acemusic.api.settings import ApiSettings
+
+        settings = ApiSettings(_env_file=None, runpod_api_key=None, runpod_endpoint_id=None)
+        assert await routing.check_remote_availability(settings) is False
+
+    async def test_available_when_configured_and_health_ok(self, monkeypatch):
+        monkeypatch.setattr(routing.RunPodClient, "health", lambda self, timeout=5.0: True)
+        assert await routing.check_remote_availability(self._settings()) is True
+
+    async def test_unavailable_when_health_probe_fails(self, monkeypatch):
+        monkeypatch.setattr(routing.RunPodClient, "health", lambda self, timeout=5.0: False)
+        assert await routing.check_remote_availability(self._settings()) is False
+
+    async def test_unavailable_when_probe_raises(self, monkeypatch):
+        def _boom(self, timeout=5.0):
+            raise routing.RunPodError("endpoint exploded")
+
+        monkeypatch.setattr(routing.RunPodClient, "health", _boom)
+        assert await routing.check_remote_availability(self._settings()) is False
 
 
 class TestLocalFirst:

--- a/tests/test_runpod_client.py
+++ b/tests/test_runpod_client.py
@@ -201,6 +201,21 @@ class TestDownloadAudio:
                 _client().download_audio("http://x/a.wav")
         assert exc.value.is_timeout is False
 
+    def test_does_not_send_auth_header_to_external_url(self):
+        # The audio URL is pre-authorized (presigned/public); the bearer token must
+        # not leak to an external host.
+        resp = _ok({}, content=b"WAV")
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp) as mock_get:
+            _client().download_audio("https://cdn.example/a.wav")
+        assert mock_get.call_args.kwargs["headers"] == {}
+
+    def test_5xx_is_retried_then_recovers(self):
+        responses = [_err(503), _ok({}, content=b"WAV")]
+        with patch("acemusic.runpod_client.httpx.get", side_effect=responses) as mock_get:
+            with patch("acemusic.runpod_client.time.sleep"):
+                assert _client().download_audio("http://x/a.wav") == b"WAV"
+        assert mock_get.call_count == 2
+
 
 class TestOutputExtraction:
     def test_completed_with_no_output_yields_empty(self):

--- a/tests/test_runpod_client.py
+++ b/tests/test_runpod_client.py
@@ -1,0 +1,236 @@
+"""Unit tests for RunPodClient (US-11.2).
+
+All HTTP is mocked at the module-level ``httpx.get``/``httpx.post`` (the client uses
+module-level calls, mirroring AceStepClient) so these run in CI without the network.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from acemusic.runpod_client import (
+    RunPodClient,
+    RunPodConnectionError,
+    RunPodError,
+)
+
+ENDPOINT = "ep-123"
+API_KEY = "rp-secret"
+
+
+def _ok(json_data: dict, *, content: bytes = b"") -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = json_data
+    resp.text = str(json_data)
+    resp.content = content
+    resp.is_success = True
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _err(status_code: int, *, text: str = "error") -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = text
+    resp.json.return_value = {}
+    resp.content = b""
+    resp.is_success = False
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(text, request=MagicMock(), response=resp)
+    return resp
+
+
+def _client() -> RunPodClient:
+    return RunPodClient(endpoint_id=ENDPOINT, api_key=API_KEY)
+
+
+class TestConstruction:
+    def test_base_url_includes_endpoint_id(self):
+        client = _client()
+        assert client.base_url == f"https://api.runpod.ai/v2/{ENDPOINT}"
+
+    def test_authorization_header_is_bearer_api_key(self):
+        client = _client()
+        assert client._headers == {"Authorization": f"Bearer {API_KEY}"}
+
+    def test_trailing_slash_base_url_is_normalised(self):
+        client = RunPodClient(endpoint_id=ENDPOINT, api_key=API_KEY, base_url="https://x.test/v2/")
+        assert client.base_url == f"https://x.test/v2/{ENDPOINT}"
+
+
+class TestSubmit:
+    def test_returns_job_id(self):
+        resp = _ok({"id": "job-1", "status": "IN_QUEUE"})
+        with patch("acemusic.runpod_client.httpx.post", return_value=resp):
+            assert _client().submit({"prompt": "calm piano"}) == "job-1"
+
+    def test_wraps_params_in_input_envelope(self):
+        resp = _ok({"id": "job-1"})
+        with patch("acemusic.runpod_client.httpx.post", return_value=resp) as mock_post:
+            _client().submit({"prompt": "calm piano", "audio_duration": 30})
+        assert mock_post.call_args.kwargs["json"] == {"input": {"prompt": "calm piano", "audio_duration": 30}}
+
+    def test_sends_bearer_header(self):
+        resp = _ok({"id": "job-1"})
+        with patch("acemusic.runpod_client.httpx.post", return_value=resp) as mock_post:
+            _client().submit({"prompt": "x"})
+        assert mock_post.call_args.kwargs["headers"]["Authorization"] == f"Bearer {API_KEY}"
+
+    def test_missing_id_raises_runpod_error(self):
+        resp = _ok({"status": "IN_QUEUE"})
+        with patch("acemusic.runpod_client.httpx.post", return_value=resp):
+            with pytest.raises(RunPodError, match="No job id"):
+                _client().submit({"prompt": "x"})
+
+    def test_submit_task_alias_wraps_kwargs(self):
+        resp = _ok({"id": "job-7"})
+        with patch("acemusic.runpod_client.httpx.post", return_value=resp) as mock_post:
+            assert _client().submit_task(prompt="x", format="wav") == "job-7"
+        assert mock_post.call_args.kwargs["json"] == {"input": {"prompt": "x", "format": "wav"}}
+
+    def test_connection_timeout_raises_connection_error_with_flag(self):
+        with patch("acemusic.runpod_client.httpx.post", side_effect=httpx.ReadTimeout("slow")):
+            with pytest.raises(RunPodConnectionError) as exc:
+                _client().submit({"prompt": "x"})
+        assert exc.value.is_timeout is True
+
+    def test_connection_refused_is_not_timeout(self):
+        with patch("acemusic.runpod_client.httpx.post", side_effect=httpx.ConnectError("refused")):
+            with pytest.raises(RunPodConnectionError) as exc:
+                _client().submit({"prompt": "x"})
+        assert exc.value.is_timeout is False
+
+
+class TestQueryResult:
+    def test_completed_returns_audio_urls_from_list_output(self):
+        resp = _ok({"status": "COMPLETED", "output": ["http://x/a.wav", "http://x/b.wav"]})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            result = _client().query_result("job-1")
+        assert result == {
+            "status": "completed",
+            "audio_urls": ["http://x/a.wav", "http://x/b.wav"],
+            "error": None,
+        }
+
+    def test_completed_extracts_urls_from_dict_output(self):
+        resp = _ok({"status": "COMPLETED", "output": {"audio_urls": ["http://x/a.wav"]}})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            result = _client().query_result("job-1")
+        assert result["audio_urls"] == ["http://x/a.wav"]
+
+    def test_completed_extracts_urls_from_object_list(self):
+        resp = _ok({"status": "COMPLETED", "output": [{"url": "http://x/a.wav"}, {"file": "http://x/b.wav"}]})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            result = _client().query_result("job-1")
+        assert result["audio_urls"] == ["http://x/a.wav", "http://x/b.wav"]
+
+    @pytest.mark.parametrize("raw_status", ["IN_QUEUE", "IN_PROGRESS"])
+    def test_in_flight_states_normalise_to_pending(self, raw_status):
+        resp = _ok({"status": raw_status})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            result = _client().query_result("job-1")
+        assert result == {"status": "pending", "audio_urls": [], "error": None}
+
+    def test_failed_surfaces_error_message(self):
+        resp = _ok({"status": "FAILED", "error": "worker OOM"})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            result = _client().query_result("job-1")
+        assert result["status"] == "failed"
+        assert result["error"] == "worker OOM"
+
+    def test_4xx_raises_immediately_without_retry(self):
+        resp = _err(404)
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp) as mock_get:
+            with patch("acemusic.runpod_client.time.sleep") as mock_sleep:
+                with pytest.raises(RunPodError):
+                    _client().query_result("job-1")
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_5xx_retries_three_times_then_raises(self):
+        resp = _err(503)
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp) as mock_get:
+            with patch("acemusic.runpod_client.time.sleep") as mock_sleep:
+                with pytest.raises(RunPodError):
+                    _client().query_result("job-1")
+        # Initial attempt + 3 retries == 4 calls; 3 backoff sleeps between them.
+        assert mock_get.call_count == 4
+        assert mock_sleep.call_count == 3
+
+    def test_5xx_then_success_recovers(self):
+        responses = [_err(503), _ok({"status": "COMPLETED", "output": ["http://x/a.wav"]})]
+        with patch("acemusic.runpod_client.httpx.get", side_effect=responses):
+            with patch("acemusic.runpod_client.time.sleep"):
+                result = _client().query_result("job-1")
+        assert result["status"] == "completed"
+
+    def test_exponential_backoff_delays(self):
+        resp = _err(500)
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            with patch("acemusic.runpod_client.random.uniform", return_value=0.0):
+                with patch("acemusic.runpod_client.time.sleep") as mock_sleep:
+                    with pytest.raises(RunPodError):
+                        _client().query_result("job-1")
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [1.0, 2.0, 4.0]
+
+    def test_connection_error_raises_connection_error(self):
+        with patch("acemusic.runpod_client.httpx.get", side_effect=httpx.ReadTimeout("slow")):
+            with pytest.raises(RunPodConnectionError) as exc:
+                _client().query_result("job-1")
+        assert exc.value.is_timeout is True
+
+
+class TestDownloadAudio:
+    def test_returns_bytes(self):
+        resp = _ok({}, content=b"WAV-BYTES")
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            assert _client().download_audio("http://x/a.wav") == b"WAV-BYTES"
+
+    def test_http_error_raises_runpod_error(self):
+        resp = _err(403)
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            with pytest.raises(RunPodError):
+                _client().download_audio("http://x/a.wav")
+
+    def test_connection_error_raises_connection_error(self):
+        with patch("acemusic.runpod_client.httpx.get", side_effect=httpx.ConnectError("refused")):
+            with pytest.raises(RunPodConnectionError) as exc:
+                _client().download_audio("http://x/a.wav")
+        assert exc.value.is_timeout is False
+
+
+class TestOutputExtraction:
+    def test_completed_with_no_output_yields_empty(self):
+        resp = _ok({"status": "COMPLETED"})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            assert _client().query_result("job-1")["audio_urls"] == []
+
+    def test_unknown_status_treated_as_pending(self):
+        resp = _ok({"status": "SOMETHING_NEW"})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            assert _client().query_result("job-1")["status"] == "pending"
+
+    def test_cancelled_status_is_failed(self):
+        resp = _ok({"status": "CANCELLED", "error": "user cancelled"})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            assert _client().query_result("job-1")["status"] == "failed"
+
+
+class TestHealth:
+    def test_2xx_is_healthy(self):
+        resp = _ok({})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            assert _client().health() is True
+
+    def test_non_2xx_is_unhealthy(self):
+        resp = MagicMock(spec=httpx.Response)
+        resp.is_success = False
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            assert _client().health() is False
+
+    def test_connection_error_is_unhealthy(self):
+        with patch("acemusic.runpod_client.httpx.get", side_effect=httpx.ConnectError("refused")):
+            assert _client().health() is False


### PR DESCRIPTION
## Summary

Implements **US-11.2: RunPod serverless integration** (closes #123) — remote GPU
generation on RunPod serverless, wired onto the US-11.1 compute-routing engine.

A generation routed to `compute_target="remote"` now submits/polls/retrieves results
from a RunPod serverless endpoint. The work plugs into the routing that already
exists rather than introducing a parallel job type.

## Approach (deviation from the issue's CodeRabbit plan)

The issue's auto-generated plan proposed a separate `generate_runpod` job type and
handler. That predates US-11.1 (merged in d473d9e), which already routes via
`Job.compute_target` and left an explicit `TODO(US-11.2)` in
`routing.check_remote_availability()`. So instead:

- **`RunPodClient`** (new) mirrors `AceStepClient`'s *consumer* interface
  (`submit_task` / `query_result` / `download_audio` + `health`) and its normalised
  status shape (`pending|completed|failed`, `audio_urls`, `error`). This lets the
  JobProcessor's existing `_poll_until_complete` and `_store_clips` helpers be reused
  unchanged. Transient **5xx responses are retried** inside the client with
  exponential backoff (1s/2s/4s + jitter, max 3); **4xx fail fast**.
- **`JobProcessor._handle_generate`** branches on `job.compute_target`: `"remote"`
  uses the RunPod client with a longer, cold-start-tolerant poll cadence; everything
  else stays on local ACE-Step, untouched. A remote job with RunPod unconfigured
  fails with a clear message rather than silently running locally.
- **`routing.check_remote_availability(settings)`** (was a stub) now reports remote
  available only when both credentials are set **and** `/health` answers — so a
  local-only deployment degrades safely (`remote_only` → 503, `*_first` → local).
- **`ApiSettings`** gains `runpod_api_key` / `runpod_endpoint_id` / `runpod_base_url`
  / `runpod_timeout` / `runpod_poll_interval` + a `runpod_enabled` property. The
  lifespan wires the client factory only when configured. `.env.example` documents
  the new vars (`ACEMUSIC_API_RUNPOD_*`).

## Acceptance criteria

- [x] A generation request routed to RunPod returns a completed clip — `TestRemoteRunPod::test_remote_job_runs_via_runpod_and_stores_clips`
- [x] Cold-start latency tolerated without premature timeout — default 5s poll / 300s budget; `test_remote_timeout_surfaces_error` exercises the budget
- [x] RunPod errors surfaced as meaningful messages in job status — `test_remote_failure_surfaces_error`
- [x] Transient (5xx) failures retried before failing — `test_5xx_retries_three_times_then_raises`, `test_5xx_then_success_recovers`
- [x] Missing RunPod configuration disables remote routing without crashing — `test_unavailable_when_runpod_not_configured`, `test_remote_job_without_factory_fails_clearly`

## Testing

- New `tests/test_runpod_client.py` (30 cases): retry/backoff, status normalisation,
  url extraction, timeouts, health.
- Extended settings, processor (remote path), routing, and generation-API tests.
- Full unit suite: **1248 passed**. Integration suites for processor / routing /
  generation API pass against local MongoDB. ruff + black clean.

## Design note / known limitation

The RunPod worker image (US-11.3) is not built yet, so it defines the exact `/status`
`output` payload. `query_result` extracts audio URLs defensively from the likely
shapes (bare URL list, `{"audio_urls": [...]}`, or a list of `{"url"|"file"|...}`
objects) and is documented as such — to be confirmed/narrowed once US-11.3 lands.
No live RunPod credentials in CI, so the remote path is covered by fakes/unit tests.

## Env var naming

API-layer creds use `ACEMUSIC_API_RUNPOD_*` (consistent with every other
`ApiSettings` field), distinct from the Layer-1 CLI's `RUNPOD_*` pod-management vars.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for remote GPU generation routing via RunPod serverless endpoints
  * Introduced configuration options to enable and control RunPod-based remote job submission with API credentials, endpoint settings, and timing controls

* **Tests**
  * Expanded test coverage for remote job processing, availability probes, and RunPod integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->