### PR TITLE
feat(api): compute status endpoint (US-11.4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,11 @@ ACEMUSIC_API_COMPUTE_PREFERENCE=local_first
 # This is a routing probe URL (independent of the CLI's ACEMUSIC_BASE_URL).
 ACEMUSIC_API_LOCAL_URL=http://localhost:8001
 
+# Compute status endpoint (US-11.4). Per-target health-probe budget for
+# GET /api/v1/compute/status; local and remote are probed in parallel, each
+# bounded by this timeout, so the response stays under the 5s ceiling.
+ACEMUSIC_API_COMPUTE_STATUS_TIMEOUT=3
+
 # RunPod serverless remote routing (US-11.2). Enables remote GPU generation: when
 # BOTH the API key and endpoint ID are set, the routing engine probes the endpoint's
 # /health and may route generations to it. Leave either blank to run local-only

--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ default 5s) up to `RUNPOD_TIMEOUT` seconds (default 300), retries transient 5xx
 responses, and stores the returned clips exactly like a local job. `RUNPOD_BASE_URL`
 (default `https://api.runpod.ai/v2`) can point at a staging endpoint or proxy.
 
+| Method & path | Purpose |
+| --- | --- |
+| `GET /api/v1/compute/status` | Combined health of both compute targets, for a pre-flight check before generating (US-11.4) |
+
+The response carries `local`, `remote`, and `routing_preference`. `local`
+reports `available` plus best-effort `gpu_name`, `vram_total_mb`, `vram_used_mb`,
+`active_jobs`, and `loaded_models` (detail fields are `null` when the ACE-Step
+`/v1/stats` payload omits them). `remote` reports `available`, `provider`,
+`endpoint_id`, `active_workers`, `max_workers`, and `scaling_status`; an
+unconfigured RunPod returns `available: false` with `provider: null` (and makes
+no HTTP call), while a configured-but-unreachable endpoint keeps
+`provider: "runpod"` and `endpoint_id`. Both targets are probed in parallel,
+each bounded by `COMPUTE_STATUS_TIMEOUT` (default 3s), so the endpoint answers
+well within 5 seconds even when a target hangs — a down or unconfigured target is
+reported as unavailable, never a 5xx. `max_workers` is left `null` (RunPod's
+`/health` does not expose the configured ceiling).
+
 ### Workspaces
 
 | Endpoint | Purpose |

--- a/docs/demos/us-11.4-compute-status.md
+++ b/docs/demos/us-11.4-compute-status.md
@@ -1,0 +1,180 @@
+# US-11.4: Compute status endpoint
+
+*2026-06-16T23:19:38Z*
+
+GET /api/v1/compute/status aggregates local GPU + remote RunPod health in ONE response so a client can pre-flight before generating. Each scenario below drives the real FastAPI app over HTTP (TestClient + a minted JWT); only the external targets (local ACE-Step /v1/stats, RunPod /health) are mocked, so the JSON shown is exactly the contract a client receives.
+
+First — the endpoint is auth-gated like the rest of the API. No token => 401.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_compute_status.py auth
+```
+
+```output
+HTTP 401  (no token)
+{
+  "detail": "Not authenticated."
+}
+```
+
+AC1 — Local GPU running: local.available=true with GPU details (name, VRAM total/used, active jobs, loaded models).
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_compute_status.py ac1
+```
+
+```output
+HTTP 200
+{
+  "local": {
+    "available": true,
+    "gpu_name": "NVIDIA A40",
+    "vram_total_mb": 49140,
+    "vram_used_mb": 8200,
+    "active_jobs": 2,
+    "loaded_models": [
+      "ace-step-v1",
+      "ace-step-turbo"
+    ]
+  },
+  "remote": {
+    "available": false,
+    "provider": null,
+    "endpoint_id": null,
+    "active_workers": null,
+    "max_workers": null,
+    "scaling_status": null
+  },
+  "routing_preference": "local_first"
+}
+```
+
+AC2 — Local GPU stopped (connection refused): local.available=false with all detail fields null. Note it stays HTTP 200 — a down target is a status, not an error.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_compute_status.py ac2
+```
+
+```output
+HTTP 200
+{
+  "local": {
+    "available": false,
+    "gpu_name": null,
+    "vram_total_mb": null,
+    "vram_used_mb": null,
+    "active_jobs": null,
+    "loaded_models": null
+  },
+  "remote": {
+    "available": false,
+    "provider": null,
+    "endpoint_id": null,
+    "active_workers": null,
+    "max_workers": null,
+    "scaling_status": null
+  },
+  "routing_preference": "local_first"
+}
+```
+
+AC3 — RunPod configured and reachable: remote.available=true with provider, endpoint_id, active_workers (3 running) and scaling_status derived from worker states.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_compute_status.py ac3
+```
+
+```output
+HTTP 200
+{
+  "local": {
+    "available": false,
+    "gpu_name": null,
+    "vram_total_mb": null,
+    "vram_used_mb": null,
+    "active_jobs": null,
+    "loaded_models": null
+  },
+  "remote": {
+    "available": true,
+    "provider": "runpod",
+    "endpoint_id": "ep-demo-123",
+    "active_workers": 3,
+    "max_workers": null,
+    "scaling_status": "ready"
+  },
+  "routing_preference": "local_first"
+}
+```
+
+AC4 — RunPod NOT configured (no credentials): remote.available=false, provider=null, and NO HTTP call is made to RunPod. Crucially this is HTTP 200, not an error.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_compute_status.py ac4
+```
+
+```output
+HTTP 200
+{
+  "local": {
+    "available": true,
+    "gpu_name": null,
+    "vram_total_mb": null,
+    "vram_used_mb": null,
+    "active_jobs": null,
+    "loaded_models": null
+  },
+  "remote": {
+    "available": false,
+    "provider": null,
+    "endpoint_id": null,
+    "active_workers": null,
+    "max_workers": null,
+    "scaling_status": null
+  },
+  "routing_preference": "local_first"
+}
+```
+
+AC5 — Both targets unreachable: the response still returns well within the 5-second ceiling because the two probes run in parallel, each bounded by compute_status_timeout (default 3s). Note remote keeps provider="runpod" + endpoint_id (configured but down) while local is fully null (not configured down).
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_compute_status.py ac5
+```
+
+```output
+HTTP 200
+{
+  "local": {
+    "available": false,
+    "gpu_name": null,
+    "vram_total_mb": null,
+    "vram_used_mb": null,
+    "active_jobs": null,
+    "loaded_models": null
+  },
+  "remote": {
+    "available": false,
+    "provider": "runpod",
+    "endpoint_id": "ep-demo-123",
+    "active_workers": null,
+    "max_workers": null,
+    "scaling_status": null
+  },
+  "routing_preference": "local_first"
+}
+
+Elapsed: 0.060s  (issue ceiling: 5.0s)  -> PASS
+```
+
+All five acceptance criteria demonstrated with live HTTP outcomes. The endpoint is registered in the OpenAPI schema with a typed ComputeStatusResponse (verified by tests/test_compute_status.py::TestEndpointStructure). Full test suite: 20 compute-status tests pass; service coverage 97%, router 100%.
+
+```bash
+PYTHONWARNINGS=ignore uv run python -c "from acemusic.api.main import create_app; from acemusic.api.settings import ApiSettings; from fastapi.testclient import TestClient; c=TestClient(create_app(ApiSettings(_env_file=None))); s=c.get(\"/openapi.json\").json(); print(\"path registered:\", \"/api/v1/compute/status\" in s[\"paths\"]); print(\"tag:\", s[\"paths\"][\"/api/v1/compute/status\"][\"get\"][\"tags\"]); print(\"requires auth (401 documented):\", \"401\" in s[\"paths\"][\"/api/v1/compute/status\"][\"get\"][\"responses\"] or \"security\" in s[\"paths\"][\"/api/v1/compute/status\"][\"get\"])"
+```
+
+```output
+path registered: True
+tag: ['compute']
+requires auth (401 documented): True
+```

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -25,6 +25,7 @@ from .routers import (
     auth,
     batch,
     clips,
+    compute,
     editing,
     extraction,
     generation,
@@ -149,6 +150,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(batch.router, prefix=API_V1_PREFIX)
     app.include_router(workspaces.router, prefix=API_V1_PREFIX)
     app.include_router(presets.router, prefix=API_V1_PREFIX)
+    app.include_router(compute.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/routers/compute.py
+++ b/src/acemusic/api/routers/compute.py
@@ -1,0 +1,21 @@
+"""Compute status endpoint (US-11.4).
+
+Exposes ``GET /api/v1/compute/status`` so a client can check, before generating,
+whether the local GPU is busy and whether the remote RunPod endpoint is available.
+Auth-gated like the rest of the API (only ``/health`` and ``/auth`` are public):
+worker counts and the RunPod endpoint id are operational detail for signed-in users.
+"""
+
+from fastapi import APIRouter, Depends
+
+from ..auth.dependencies import get_current_user, get_settings
+from ..services.compute_status import ComputeStatusResponse, get_compute_status
+from ..settings import ApiSettings
+
+router = APIRouter(tags=["compute"], dependencies=[Depends(get_current_user)])
+
+
+@router.get("/compute/status", response_model=ComputeStatusResponse)
+async def compute_status(settings: ApiSettings = Depends(get_settings)) -> ComputeStatusResponse:
+    """Return combined local + remote compute status (both probed in parallel)."""
+    return await get_compute_status(settings)

--- a/src/acemusic/api/services/compute_status.py
+++ b/src/acemusic/api/services/compute_status.py
@@ -1,0 +1,207 @@
+"""Compute status aggregation (US-11.4).
+
+Backs ``GET /api/v1/compute/status``: probes the local ACE-Step server and the
+remote RunPod endpoint *in parallel*, each bounded by ``compute_status_timeout``,
+and reports each target's availability plus best-effort detail. A down or
+unconfigured target degrades to ``available=False`` rather than an error — the
+endpoint answers within the issue's 5-second ceiling even when a target hangs.
+
+Kept transport-agnostic (returns models, never ``HTTPException``) like the sibling
+``routing`` module, so the router stays thin.
+"""
+
+import asyncio
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+
+from ...runpod_client import RunPodClient
+from ..settings import ApiSettings
+
+# The local stats endpoint doubles as the availability probe (same as routing).
+LOCAL_STATS_PATH = "/v1/stats"
+
+
+class LocalComputeStatus(BaseModel):
+    """Health + capacity of the local ACE-Step GPU server.
+
+    Detail fields are best-effort: populated when ``/v1/stats`` exposes them and
+    ``None`` otherwise, so a sparse stats payload still yields a valid response.
+    """
+
+    available: bool
+    gpu_name: str | None = None
+    vram_total_mb: int | None = None
+    vram_used_mb: int | None = None
+    active_jobs: int | None = None
+    loaded_models: list[str] | None = None
+
+
+class RemoteComputeStatus(BaseModel):
+    """Health + capacity of the remote RunPod serverless endpoint.
+
+    ``provider`` is ``None`` when RunPod is not configured at all, and ``"runpod"``
+    once credentials are set — even if the endpoint is unreachable — so callers can
+    distinguish "no remote" from "remote down".
+    """
+
+    available: bool
+    provider: str | None = None
+    endpoint_id: str | None = None
+    active_workers: int | None = None
+    max_workers: int | None = None
+    scaling_status: str | None = None
+
+
+class ComputeStatusResponse(BaseModel):
+    """Combined local + remote compute status with the configured routing preference."""
+
+    local: LocalComputeStatus
+    remote: RemoteComputeStatus
+    routing_preference: str
+
+
+def _as_int(value: Any) -> int | None:
+    """Coerce a stats value to ``int`` when it is a real number, else ``None``."""
+    if isinstance(value, bool):  # bool is an int subclass; never a count here.
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    return None
+
+
+def _parse_local_stats(payload: Any) -> dict[str, Any]:
+    """Extract GPU/VRAM/jobs/models from a (loosely-typed) ``/v1/stats`` body.
+
+    ACE-Step's exact stats shape is not guaranteed, so several common key spellings
+    are accepted and anything missing falls through to ``None``/empty.
+    """
+    if not isinstance(payload, dict):
+        return {}
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        return {}
+
+    # GPU/VRAM may be flat or nested under a "gpu" object.
+    gpu = data.get("gpu")
+    gpu_obj = gpu if isinstance(gpu, dict) else {}
+    gpu_name = data.get("gpu_name") or gpu_obj.get("name")
+    if gpu_name is None and isinstance(gpu, str):
+        gpu_name = gpu
+    vram_total = data.get("vram_total_mb") or gpu_obj.get("vram_total_mb") or gpu_obj.get("memory_total_mb")
+    vram_used = data.get("vram_used_mb") or gpu_obj.get("vram_used_mb") or gpu_obj.get("memory_used_mb")
+
+    # active_jobs: prefer the nested running count, fall back to a flat field.
+    jobs = data.get("jobs")
+    active_jobs = jobs.get("running") if isinstance(jobs, dict) else None
+    if active_jobs is None:
+        active_jobs = data.get("active_jobs")
+
+    # loaded_models: list of {"name": ...} objects or a list of plain strings.
+    models_raw = data.get("models")
+    loaded_models: list[str] | None = None
+    if isinstance(models_raw, list):
+        loaded_models = [
+            m["name"] if isinstance(m, dict) and "name" in m else m for m in models_raw if isinstance(m, (str, dict))
+        ]
+        loaded_models = [m for m in loaded_models if isinstance(m, str)]
+
+    return {
+        "gpu_name": gpu_name if isinstance(gpu_name, str) else None,
+        "vram_total_mb": _as_int(vram_total),
+        "vram_used_mb": _as_int(vram_used),
+        "active_jobs": _as_int(active_jobs),
+        "loaded_models": loaded_models,
+    }
+
+
+async def get_local_status(url: str, timeout: float) -> LocalComputeStatus:
+    """Probe the local ACE-Step server, returning availability + best-effort detail.
+
+    A 2xx from ``GET {url}/v1/stats`` means available; any non-2xx, connection
+    error, or timeout means ``available=False`` with all detail fields ``None``.
+    """
+    endpoint = f"{url.rstrip('/')}{LOCAL_STATS_PATH}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(endpoint)
+        if not response.is_success:
+            return LocalComputeStatus(available=False)
+        body = response.json()
+    except (httpx.HTTPError, ValueError):
+        return LocalComputeStatus(available=False)
+    return LocalComputeStatus(available=True, **_parse_local_stats(body))
+
+
+def _parse_remote_workers(health: dict[str, Any], endpoint_id: str) -> RemoteComputeStatus:
+    """Turn a RunPod ``/health`` body into a populated :class:`RemoteComputeStatus`."""
+    workers = health.get("workers")
+    workers = workers if isinstance(workers, dict) else {}
+    initializing = _as_int(workers.get("initializing")) or 0
+    throttled = _as_int(workers.get("throttled")) or 0
+    running = _as_int(workers.get("running"))
+    ready = _as_int(workers.get("ready")) or 0
+    idle = _as_int(workers.get("idle")) or 0
+
+    # /health reports live worker states but not the endpoint's configured ceiling,
+    # so max_workers stays None (it would need RunPod's GraphQL API).
+    if initializing > 0:
+        scaling_status = "initializing"
+    elif throttled > 0:
+        scaling_status = "throttled"
+    elif (running or 0) > 0 or ready > 0 or idle > 0:
+        scaling_status = "ready"
+    else:
+        scaling_status = "idle"
+
+    return RemoteComputeStatus(
+        available=True,
+        provider="runpod",
+        endpoint_id=endpoint_id,
+        active_workers=running,
+        max_workers=None,
+        scaling_status=scaling_status,
+    )
+
+
+async def get_remote_status(settings: ApiSettings, timeout: float) -> RemoteComputeStatus:
+    """Probe the remote RunPod endpoint when configured, returning availability + detail.
+
+    Unconfigured RunPod (missing credentials) returns ``available=False`` with
+    ``provider=None`` and makes no HTTP call. A configured-but-unreachable endpoint
+    returns ``available=False`` but keeps ``provider="runpod"`` and ``endpoint_id``
+    so callers can tell "no remote" from "remote down".
+    """
+    if not settings.runpod_enabled:
+        return RemoteComputeStatus(available=False, provider=None)
+
+    endpoint_id = settings.runpod_endpoint_id or ""
+    client = RunPodClient(
+        endpoint_id=endpoint_id,
+        api_key=settings.runpod_api_key or "",
+        base_url=settings.runpod_base_url,
+    )
+    try:
+        health = await asyncio.wait_for(asyncio.to_thread(client.health_details, timeout), timeout)
+    except Exception:
+        # A status probe must never surface a 500: a timeout, thread-pool
+        # exhaustion, or any client error all mean "remote unreachable".
+        health = None
+    if health is None:
+        return RemoteComputeStatus(available=False, provider="runpod", endpoint_id=endpoint_id)
+    return _parse_remote_workers(health, endpoint_id)
+
+
+async def get_compute_status(settings: ApiSettings) -> ComputeStatusResponse:
+    """Aggregate local + remote status, probing both targets concurrently."""
+    timeout = settings.compute_status_timeout
+    local, remote = await asyncio.gather(
+        get_local_status(settings.local_url, timeout),
+        get_remote_status(settings, timeout),
+    )
+    return ComputeStatusResponse(
+        local=local,
+        remote=remote,
+        routing_preference=settings.compute_preference,
+    )

--- a/src/acemusic/api/services/compute_status.py
+++ b/src/acemusic/api/services/compute_status.py
@@ -146,11 +146,14 @@ def _parse_remote_workers(health: dict[str, Any], endpoint_id: str) -> RemoteCom
     """Turn a RunPod ``/health`` body into a populated :class:`RemoteComputeStatus`."""
     workers = health.get("workers")
     workers = workers if isinstance(workers, dict) else {}
+    # ``or 0`` is safe for these scaling-signal counts (only used in > 0 comparisons).
     initializing = _as_int(workers.get("initializing")) or 0
     throttled = _as_int(workers.get("throttled")) or 0
-    running = _as_int(workers.get("running"))
     ready = _as_int(workers.get("ready")) or 0
     idle = _as_int(workers.get("idle")) or 0
+    # ``running`` is surfaced as ``active_workers`` — keep None-vs-0 distinguishable
+    # (0 active workers is a real reading, not "unknown"), so do NOT add ``or 0`` here.
+    running = _as_int(workers.get("running"))
 
     # /health reports live worker states but not the endpoint's configured ceiling,
     # so max_workers stays None (it would need RunPod's GraphQL API).

--- a/src/acemusic/api/services/compute_status.py
+++ b/src/acemusic/api/services/compute_status.py
@@ -71,6 +71,14 @@ def _as_int(value: Any) -> int | None:
     return None
 
 
+def _coalesce(*values: Any) -> Any:
+    """Return the first non-``None`` value — preserves a valid ``0`` that ``or`` would drop."""
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
 def _parse_local_stats(payload: Any) -> dict[str, Any]:
     """Extract GPU/VRAM/jobs/models from a (loosely-typed) ``/v1/stats`` body.
 
@@ -89,8 +97,8 @@ def _parse_local_stats(payload: Any) -> dict[str, Any]:
     gpu_name = data.get("gpu_name") or gpu_obj.get("name")
     if gpu_name is None and isinstance(gpu, str):
         gpu_name = gpu
-    vram_total = data.get("vram_total_mb") or gpu_obj.get("vram_total_mb") or gpu_obj.get("memory_total_mb")
-    vram_used = data.get("vram_used_mb") or gpu_obj.get("vram_used_mb") or gpu_obj.get("memory_used_mb")
+    vram_total = _coalesce(data.get("vram_total_mb"), gpu_obj.get("vram_total_mb"), gpu_obj.get("memory_total_mb"))
+    vram_used = _coalesce(data.get("vram_used_mb"), gpu_obj.get("vram_used_mb"), gpu_obj.get("memory_used_mb"))
 
     # active_jobs: prefer the nested running count, fall back to a flat field.
     jobs = data.get("jobs")

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -103,6 +103,12 @@ class ApiSettings(BaseSettings):
     runpod_timeout: float = Field(default=300.0, gt=0)
     runpod_poll_interval: float = Field(default=5.0, gt=0)
 
+    # Compute status endpoint (US-11.4). Per-target health-probe budget for
+    # ``GET /api/v1/compute/status``; the local and remote checks run in parallel,
+    # each bounded by this timeout, so the aggregate response stays well under the
+    # issue's 5-second ceiling even when one target hangs.
+    compute_status_timeout: float = Field(default=3.0, gt=0)
+
     @property
     def runpod_enabled(self) -> bool:
         """True only when both RunPod credentials are configured (remote routing is usable)."""

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -106,8 +106,9 @@ class ApiSettings(BaseSettings):
     # Compute status endpoint (US-11.4). Per-target health-probe budget for
     # ``GET /api/v1/compute/status``; the local and remote checks run in parallel,
     # each bounded by this timeout, so the aggregate response stays well under the
-    # issue's 5-second ceiling even when one target hangs.
-    compute_status_timeout: float = Field(default=3.0, gt=0)
+    # issue's 5-second ceiling even when one target hangs. Bounded ``< 5`` so a
+    # misconfiguration fails at startup rather than silently breaking that ceiling.
+    compute_status_timeout: float = Field(default=3.0, gt=0, lt=5.0)
 
     @property
     def runpod_enabled(self) -> bool:

--- a/src/acemusic/runpod_client.py
+++ b/src/acemusic/runpod_client.py
@@ -212,6 +212,27 @@ class RunPodClient:
             return False
         return response.is_success
 
+    def health_details(self, timeout: float = 5.0) -> dict | None:
+        """Return the parsed ``GET /health`` body, or ``None`` when unreachable.
+
+        Richer companion to :meth:`health` for the compute status endpoint (US-11.4),
+        which needs RunPod's worker/scaling detail — not just a reachable/not bool.
+        RunPod answers with ``{"jobs": {...}, "workers": {...}}``. Any connection
+        error, non-2xx, or unparseable body yields ``None`` so the caller reports
+        the endpoint unavailable rather than surfacing a 500.
+        """
+        try:
+            response = httpx.get(f"{self.base_url}/health", headers=self._headers, timeout=timeout)
+        except httpx.RequestError:
+            return None
+        if not response.is_success:
+            return None
+        try:
+            body = response.json()
+        except ValueError:
+            return None
+        return body if isinstance(body, dict) else None
+
 
 def _extract_audio_urls(output: Any) -> list[str]:
     """Pull audio URLs out of a RunPod ``output`` payload.

--- a/tests/test_compute_status.py
+++ b/tests/test_compute_status.py
@@ -146,6 +146,21 @@ class TestLocalStatus:
         assert status.loaded_models == ["base"]
 
     @respx.mock
+    async def test_zero_valued_vram_is_preserved_not_dropped(self):
+        # An idle GPU reports vram_used_mb: 0 — a valid zero, not "missing".
+        respx.get(STATS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"vram_total_mb": 24564, "vram_used_mb": 0, "jobs": {"running": 0}}},
+            )
+        )
+        status = await get_local_status(LOCAL_URL, timeout=3.0)
+        assert status.available is True
+        assert status.vram_used_mb == 0
+        assert status.vram_total_mb == 24564
+        assert status.active_jobs == 0
+
+    @respx.mock
     async def test_unavailable_on_connection_error(self):
         respx.get(STATS_URL).mock(side_effect=httpx.ConnectError("refused"))
         status = await get_local_status(LOCAL_URL, timeout=3.0)

--- a/tests/test_compute_status.py
+++ b/tests/test_compute_status.py
@@ -1,0 +1,298 @@
+"""Tests for the compute status endpoint and aggregation service (US-11.4).
+
+Pure-logic / no-DB: the local probe is mocked with respx, the remote probe by
+monkeypatching ``RunPodClient.health_details``. The endpoint is auth-gated, so a
+signed access token is minted directly (``get_current_user`` is token-only).
+"""
+
+import asyncio
+import time
+
+import httpx
+import respx
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import create_app
+from acemusic.api.services import compute_status
+from acemusic.api.services.compute_status import (
+    ComputeStatusResponse,
+    LocalComputeStatus,
+    RemoteComputeStatus,
+    get_compute_status,
+    get_local_status,
+    get_remote_status,
+)
+from acemusic.api.settings import ApiSettings
+
+LOCAL_URL = "http://localhost:8001"
+STATS_URL = f"{LOCAL_URL}/v1/stats"
+JWT_SECRET = "test-secret-key-at-least-32-bytes-long-xx"
+
+
+def _settings(**overrides) -> ApiSettings:
+    base = {
+        "_env_file": None,
+        "jwt_secret_key": JWT_SECRET,
+        "local_url": LOCAL_URL,
+        "job_processor_enabled": False,
+    }
+    base.update(overrides)
+    return ApiSettings(**base)
+
+
+def _token(settings: ApiSettings) -> str:
+    return create_access_token(
+        user_id="507f1f77bcf86cd799439011",
+        email="user@example.com",
+        subscription_tier="free",
+        settings=settings,
+    )
+
+
+def _client(settings: ApiSettings) -> TestClient:
+    # No `with`: TestClient skips lifespan (no DB / job processor) — the status
+    # endpoint only reads settings off app state, like /health.
+    return TestClient(create_app(settings))
+
+
+def _auth(settings: ApiSettings) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_token(settings)}"}
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint structure + auth
+# --------------------------------------------------------------------------- #
+class TestEndpointStructure:
+    @respx.mock
+    def test_returns_200_with_expected_top_level_keys(self):
+        respx.get(STATS_URL).mock(return_value=httpx.Response(200, json={}))
+        settings = _settings()
+        resp = _client(settings).get("/api/v1/compute/status", headers=_auth(settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body) >= {"local", "remote", "routing_preference"}
+        assert body["routing_preference"] == "local_first"
+
+    def test_requires_authentication(self):
+        resp = _client(_settings()).get("/api/v1/compute/status")
+        assert resp.status_code == 401
+
+    def test_openapi_lists_typed_response_schema(self):
+        client = _client(_settings())
+        schema = client.get("/openapi.json").json()
+        assert "/api/v1/compute/status" in schema["paths"]
+        ref = schema["paths"]["/api/v1/compute/status"]["get"]["responses"]["200"]["content"]["application/json"][
+            "schema"
+        ]["$ref"]
+        model_name = ref.rsplit("/", 1)[-1]
+        props = schema["components"]["schemas"][model_name]["properties"]
+        assert {"local", "remote", "routing_preference"} <= set(props)
+
+
+# --------------------------------------------------------------------------- #
+# Local status (AC1 / AC2)
+# --------------------------------------------------------------------------- #
+class TestLocalStatus:
+    @respx.mock
+    async def test_available_with_details_when_server_responds(self):
+        respx.get(STATS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "gpu": {"name": "NVIDIA A40", "vram_total_mb": 49140, "vram_used_mb": 8200},
+                        "jobs": {"running": 2},
+                        "models": [{"name": "ace-step-v1"}, {"name": "ace-step-turbo"}],
+                    }
+                },
+            )
+        )
+        status = await get_local_status(LOCAL_URL, timeout=3.0)
+        assert status.available is True
+        assert status.gpu_name == "NVIDIA A40"
+        assert status.vram_total_mb == 49140
+        assert status.vram_used_mb == 8200
+        assert status.active_jobs == 2
+        assert status.loaded_models == ["ace-step-v1", "ace-step-turbo"]
+
+    @respx.mock
+    async def test_available_with_sparse_stats_leaves_detail_none(self):
+        respx.get(STATS_URL).mock(return_value=httpx.Response(200, json={"data": {}}))
+        status = await get_local_status(LOCAL_URL, timeout=3.0)
+        assert status.available is True
+        assert status.gpu_name is None
+        assert status.vram_total_mb is None
+        assert status.loaded_models is None
+
+    @respx.mock
+    async def test_flat_gpu_string_and_fields_are_parsed(self):
+        respx.get(STATS_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "gpu": "RTX 4090",
+                    "vram_total_mb": 24564,
+                    "active_jobs": 1,
+                    "models": ["base"],
+                },
+            )
+        )
+        status = await get_local_status(LOCAL_URL, timeout=3.0)
+        assert status.available is True
+        assert status.gpu_name == "RTX 4090"
+        assert status.vram_total_mb == 24564
+        assert status.active_jobs == 1
+        assert status.loaded_models == ["base"]
+
+    @respx.mock
+    async def test_unavailable_on_connection_error(self):
+        respx.get(STATS_URL).mock(side_effect=httpx.ConnectError("refused"))
+        status = await get_local_status(LOCAL_URL, timeout=3.0)
+        assert status.available is False
+        assert status.gpu_name is None
+        assert status.active_jobs is None
+
+    @respx.mock
+    async def test_unavailable_on_timeout(self):
+        respx.get(STATS_URL).mock(side_effect=httpx.ReadTimeout("slow"))
+        status = await get_local_status(LOCAL_URL, timeout=0.01)
+        assert status.available is False
+
+    @respx.mock
+    async def test_non_2xx_is_unavailable(self):
+        respx.get(STATS_URL).mock(return_value=httpx.Response(503))
+        status = await get_local_status(LOCAL_URL, timeout=3.0)
+        assert status.available is False
+
+
+# --------------------------------------------------------------------------- #
+# Remote status (AC3 / AC4)
+# --------------------------------------------------------------------------- #
+class TestRemoteStatus:
+    async def test_unavailable_and_no_http_when_not_configured(self, monkeypatch):
+        called = False
+
+        def _boom(self, timeout=5.0):
+            nonlocal called
+            called = True
+            return {}
+
+        monkeypatch.setattr(compute_status.RunPodClient, "health_details", _boom)
+        status = await get_remote_status(_settings(), timeout=3.0)
+        assert status.available is False
+        assert status.provider is None
+        assert called is False
+
+    async def test_available_with_worker_detail_when_reachable(self, monkeypatch):
+        monkeypatch.setattr(
+            compute_status.RunPodClient,
+            "health_details",
+            lambda self, timeout=5.0: {
+                "workers": {"idle": 1, "running": 3, "ready": 2, "initializing": 0, "throttled": 0}
+            },
+        )
+        settings = _settings(runpod_api_key="rp-key", runpod_endpoint_id="ep-1")
+        status = await get_remote_status(settings, timeout=3.0)
+        assert status.available is True
+        assert status.provider == "runpod"
+        assert status.endpoint_id == "ep-1"
+        assert status.active_workers == 3
+        assert status.scaling_status == "ready"
+
+    async def test_initializing_workers_report_scaling(self, monkeypatch):
+        monkeypatch.setattr(
+            compute_status.RunPodClient,
+            "health_details",
+            lambda self, timeout=5.0: {"workers": {"initializing": 2, "running": 0}},
+        )
+        settings = _settings(runpod_api_key="rp-key", runpod_endpoint_id="ep-1")
+        status = await get_remote_status(settings, timeout=3.0)
+        assert status.available is True
+        assert status.scaling_status == "initializing"
+
+    async def test_throttled_then_idle_scaling_status(self, monkeypatch):
+        settings = _settings(runpod_api_key="rp-key", runpod_endpoint_id="ep-1")
+
+        monkeypatch.setattr(
+            compute_status.RunPodClient,
+            "health_details",
+            lambda self, timeout=5.0: {"workers": {"throttled": 1, "running": 0, "ready": 0, "idle": 0}},
+        )
+        throttled = await get_remote_status(settings, timeout=3.0)
+        assert throttled.scaling_status == "throttled"
+
+        # No workers in any state → scaled to zero (serverless cold), still reachable.
+        monkeypatch.setattr(compute_status.RunPodClient, "health_details", lambda self, timeout=5.0: {"workers": {}})
+        idle = await get_remote_status(settings, timeout=3.0)
+        assert idle.available is True
+        assert idle.scaling_status == "idle"
+        assert idle.active_workers is None
+        assert idle.max_workers is None
+
+    async def test_unreachable_keeps_provider_and_endpoint(self, monkeypatch):
+        monkeypatch.setattr(compute_status.RunPodClient, "health_details", lambda self, timeout=5.0: None)
+        settings = _settings(runpod_api_key="rp-key", runpod_endpoint_id="ep-1")
+        status = await get_remote_status(settings, timeout=3.0)
+        assert status.available is False
+        assert status.provider == "runpod"
+        assert status.endpoint_id == "ep-1"
+        assert status.active_workers is None
+
+    async def test_probe_error_is_unavailable_not_500(self, monkeypatch):
+        def _raise(self, timeout=5.0):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(compute_status.RunPodClient, "health_details", _raise)
+        settings = _settings(runpod_api_key="rp-key", runpod_endpoint_id="ep-1")
+        status = await get_remote_status(settings, timeout=3.0)
+        assert status.available is False
+        assert status.provider == "runpod"
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation + timeout behaviour (AC5)
+# --------------------------------------------------------------------------- #
+class TestAggregation:
+    async def test_combines_both_targets_and_preference(self, monkeypatch):
+        async def _local(url, timeout):
+            return LocalComputeStatus(available=True, gpu_name="A40")
+
+        async def _remote(settings, timeout):
+            return RemoteComputeStatus(available=False, provider=None)
+
+        monkeypatch.setattr(compute_status, "get_local_status", _local)
+        monkeypatch.setattr(compute_status, "get_remote_status", _remote)
+        result = await get_compute_status(_settings(compute_preference="remote_first"))
+        assert isinstance(result, ComputeStatusResponse)
+        assert result.local.available is True
+        assert result.remote.available is False
+        assert result.routing_preference == "remote_first"
+
+    async def test_probes_run_concurrently(self, monkeypatch):
+        async def _slow_local(url, timeout):
+            await asyncio.sleep(0.3)
+            return LocalComputeStatus(available=False)
+
+        async def _slow_remote(settings, timeout):
+            await asyncio.sleep(0.3)
+            return RemoteComputeStatus(available=False)
+
+        monkeypatch.setattr(compute_status, "get_local_status", _slow_local)
+        monkeypatch.setattr(compute_status, "get_remote_status", _slow_remote)
+        start = time.monotonic()
+        await get_compute_status(_settings())
+        elapsed = time.monotonic() - start
+        # Concurrent: ~0.3s, not ~0.6s if serialised.
+        assert elapsed < 0.5
+
+    @respx.mock
+    async def test_responds_quickly_when_targets_unreachable(self):
+        respx.get(STATS_URL).mock(side_effect=httpx.ConnectError("refused"))
+        settings = _settings(runpod_api_key="rp-key", runpod_endpoint_id="ep-1")
+        start = time.monotonic()
+        result = await get_compute_status(settings)
+        elapsed = time.monotonic() - start
+        assert elapsed < 5.0
+        assert result.local.available is False
+        assert result.remote.available is False

--- a/tests/test_compute_status.py
+++ b/tests/test_compute_status.py
@@ -311,3 +311,23 @@ class TestAggregation:
         assert elapsed < 5.0
         assert result.local.available is False
         assert result.remote.available is False
+
+    @respx.mock
+    async def test_responds_quickly_when_runpod_configured_and_hanging(self, monkeypatch):
+        # The 5s-ceiling guarantee is only fully exercised when RunPod IS configured
+        # and its /health hangs: the bounded asyncio.wait_for must cut the probe off.
+        respx.get(STATS_URL).mock(side_effect=httpx.ConnectError("refused"))
+
+        def _hang(self, timeout=5.0):
+            time.sleep(1.0)  # outlives the 0.2s probe budget below
+            return {"workers": {"running": 1}}
+
+        monkeypatch.setattr(compute_status.RunPodClient, "health_details", _hang)
+        settings = _settings(runpod_api_key="rp-key", runpod_endpoint_id="ep-1", compute_status_timeout=0.2)
+        start = time.monotonic()
+        result = await get_compute_status(settings)
+        elapsed = time.monotonic() - start
+        # wait_for(0.2) cuts the hanging probe off well before its 1s sleep.
+        assert elapsed < 1.0
+        assert result.remote.available is False
+        assert result.remote.provider == "runpod"


### PR DESCRIPTION
## US-11.4: Compute status endpoint

Closes #125.

`GET /api/v1/compute/status` aggregates the health of both compute targets into one response so a client can check, **before** generating, whether the local GPU is busy and whether remote is available.

### What it does
- Probes the **local** ACE-Step server (`/v1/stats`) and the **remote** RunPod endpoint (`/health`) **in parallel**, each bounded by `compute_status_timeout` (default 3s) — so the aggregate response stays well under the issue's 5-second ceiling even when a target hangs.
- Reports each target's `available` flag plus best-effort detail (GPU name / VRAM / active jobs / loaded models for local; provider / endpoint_id / active+max workers / scaling status for remote) and the configured `routing_preference`.
- A down or unconfigured target degrades to `available=False` — never an error/500.
- **Auth-gated** like the rest of the API (only `/health` and `/auth` are public): worker counts and the RunPod endpoint id are operational detail for signed-in users.

### Plan adaptation (the issue's CodeRabbit plan was partially stale)
US-11.1/11.2 already landed, so this reuses existing infrastructure instead of building the parallel structures the plan proposed:
- Settings the plan wanted to add already exist as `local_url`, `runpod_api_key`, `runpod_endpoint_id`, `compute_preference` — only `compute_status_timeout` is new.
- Status logic lives in `services/compute_status.py` next to the existing `services/routing.py` (no new `compute/` package); response models live with it (the `models/` package is for Beanie documents).
- Added `RunPodClient.health_details()` (parsed `/health` body) since the existing `health()` returns only a bool.

### Acceptance criteria → evidence
| Criterion | Covered by |
|---|---|
| Local GPU running → available with GPU details | `test_available_with_details_when_server_responds`, `…_flat_gpu_string…` |
| Local GPU stopped → unavailable | `test_unavailable_on_connection_error` / `…_on_timeout` / `…_non_2xx…` |
| RunPod configured → remote shows endpoint details | `test_available_with_worker_detail_when_reachable` |
| RunPod not configured → unavailable (not an error) | `test_unavailable_and_no_http_when_not_configured` |
| Returns within 5s even if a target is unreachable | `test_responds_quickly_when_targets_unreachable`, `test_probes_run_concurrently` |

### Tests
20 new tests in `tests/test_compute_status.py` (respx + monkeypatch, no DB). Service coverage 97%, router 100%. Full non-integration suite: 1285 passed.

### Review
Cross-family review by `codex review` found one P2 (zero-valued VRAM dropped by an `or`-chain) — fixed in a follow-up commit with a regression test.

### Known limitations
- `max_workers` is not exposed by RunPod's `/health`; it is left `None` (would require RunPod's GraphQL API).
- Local GPU name / VRAM are populated only when the ACE-Step `/v1/stats` payload exposes them; otherwise `None` (graceful) — the field names are matched best-effort across common spellings.
