### PR TITLE
feat(api): RunPod Network Volume setup (US-11.5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,15 @@ ACEMUSIC_API_RUNPOD_POLL_INTERVAL=5
 # Override only to point at a staging endpoint or a proxy (default shown).
 # ACEMUSIC_API_RUNPOD_BASE_URL=https://api.runpod.ai/v2
 
+# RunPod Network Volume (US-11.5). The persisted volume holding ACE-Step model
+# weights, provisioned once by `scripts/runpod-setup.py` (which prints the id to
+# paste here). Workers mount it so weights download only once. Leave blank until
+# the setup script has run — GET /api/v1/compute/remote/volume returns 503 until
+# it is set. RUNPOD_REST_BASE_URL is RunPod's management REST API (volumes/pods),
+# distinct from the serverless RUNPOD_BASE_URL above; override only for staging.
+ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID=
+# ACEMUSIC_API_RUNPOD_REST_BASE_URL=https://rest.runpod.io/v1
+
 # Async job processor (US-9.2). A background task in the API process polls MongoDB
 # for queued generation jobs and runs them. JOB_CONCURRENCY bounds how many run at
 # once; JOB_POLL_INTERVAL is the idle sleep (seconds) between polls when the queue

--- a/README.md
+++ b/README.md
@@ -102,18 +102,25 @@ default `local_first`), and `LOCAL_URL` (local ACE-Step probe URL, default
 `http://localhost:8001`).
 
 Remote generation runs on a RunPod serverless endpoint (US-11.2). Set
-`RUNPOD_API_KEY` and `RUNPOD_ENDPOINT_ID` (both required) to enable it; remote
+`ACEMUSIC_API_RUNPOD_API_KEY` and `ACEMUSIC_API_RUNPOD_ENDPOINT_ID` (both required) to enable it; remote
 routing is reported available only when both are set and the endpoint's `/health`
 answers, so an unconfigured or down endpoint degrades safely (`*_first` falls back
 to local, `*_only` returns 503) rather than crashing. A remote-routed job submits to
-the endpoint, polls with a cold-start-tolerant cadence (`RUNPOD_POLL_INTERVAL`,
-default 5s) up to `RUNPOD_TIMEOUT` seconds (default 300), retries transient 5xx
-responses, and stores the returned clips exactly like a local job. `RUNPOD_BASE_URL`
+the endpoint, polls with a cold-start-tolerant cadence (`ACEMUSIC_API_RUNPOD_POLL_INTERVAL`,
+default 5s) up to `ACEMUSIC_API_RUNPOD_TIMEOUT` seconds (default 300), retries transient 5xx
+responses, and stores the returned clips exactly like a local job. `ACEMUSIC_API_RUNPOD_BASE_URL`
 (default `https://api.runpod.ai/v2`) can point at a staging endpoint or proxy.
+
+The RunPod Network Volume — which holds model weights so each worker skips the
+download — is provisioned once by running `scripts/runpod-setup.py` (US-11.5).
+After the script runs, paste the printed volume id into
+`ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID` in `.env`. Until that variable is set,
+`GET /api/v1/compute/remote/volume` returns 503.
 
 | Method & path | Purpose |
 | --- | --- |
 | `GET /api/v1/compute/status` | Combined health of both compute targets, for a pre-flight check before generating (US-11.4) |
+| `GET /api/v1/compute/remote/volume` | Metadata (size, used, region) for the configured RunPod Network Volume (US-11.5) |
 
 The response carries `local`, `remote`, and `routing_preference`. `local`
 reports `available` plus best-effort `gpu_name`, `vram_total_mb`, `vram_used_mb`,

--- a/docs/demos/us-11.5-runpod-volume.md
+++ b/docs/demos/us-11.5-runpod-volume.md
@@ -1,0 +1,119 @@
+# US-11.5: RunPod Network Volume setup
+
+*2026-06-17T00:48:24Z*
+
+Provisions a persisted RunPod Network Volume holding ACE-Step-1.5 weights (so workers download nothing on cold start) and exposes `GET /api/v1/compute/remote/volume` to inspect it. Every scenario below drives the **real** code; only RunPod's management REST API is mocked (respx), so no paid account, pod, or GPU is touched — the output is exactly what an operator/client observes.
+
+**AC4 (idempotent) + AC1 (create):** first run creates the volume; re-running detects it by name and reuses it, issuing NO duplicate POST.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_runpod_volume.py ac4
+```
+
+```output
+[first run]  created=True  volume_id=vol-new  (POST /networkvolumes called: True)
+[re-run]     created=False  volume_id=vol-new  (POST /networkvolumes called: False)
+
+Outcome: re-running reuses vol-new and issues NO duplicate POST — idempotent (AC4).
+```
+
+**AC1 (download) + AC2 (volume persists):** a full provisioning run — create volume, launch the temporary download pod, wait for it to finish, then stop+terminate the pod. The pod is cleaned up but the volume DELETE is never issued, so the weights persist.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_runpod_volume.py ac2
+```
+
+```output
+RunPod Network Volume setup (ACE-Step-1.5 weights)
+  Volume name : ace-step-models
+  Size        : 100 GB
+  Region      : EU-RO-1
+  Worker image: frankbria/ace-step:latest
+  Download GPU: NVIDIA GeForce RTX 4090 (temporary pod, billed only while downloading)
+  Estimated cost: ~$7.00/month storage (~$0.07/GB/mo) + temporary GPU pod time during download.
+Created volume: vol-new
+Launched temporary download pod: pod-9. Waiting for weights to download...
+Download pod finished.
+
+Done. Verify the pod log shows 'ACE_STEP_WEIGHTS_READY', then configure your API environment with:
+  ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID=vol-new
+
+--- outcome ---  exit_code=0
+temp pod stopped:    True
+temp pod terminated: True
+volume DELETE issued: False  <- volume persists (AC2)
+```
+
+**AC1 (cost estimate):** `--dry-run` prints the cost estimate and the full plan before any spend — a real CLI invocation that needs no API key and makes zero network calls.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_runpod_volume.py ac1-dry
+```
+
+```output
+RunPod Network Volume setup (ACE-Step-1.5 weights)
+  Volume name : ace-step-models
+  Size        : 100 GB
+  Region      : EU-RO-1
+  Worker image: frankbria/ace-step:latest
+  Download GPU: NVIDIA GeForce RTX 4090 (temporary pod, billed only while downloading)
+  Estimated cost: ~$7.00/month storage (~$0.07/GB/mo) + temporary GPU pod time during download.
+
+[dry-run] No resources created. Planned actions:
+  1. Find-or-create volume 'ace-step-models' (100 GB) in EU-RO-1.
+  2. Launch temporary NVIDIA GeForce RTX 4090 pod from frankbria/ace-step:latest with the volume mounted at /workspace.
+  3. Run download command: ['bash', '-lc', 'set -e; export HF_HOME=/workspace/models/.cache; mkdir -p "$HF_HOME"; cd /app/ACE-Step-1.5; uv run acestep-api & SERVER_PID=$!; ready=0; for i in $(seq 1 180); do if curl -sf http://localhost:8001/v1/stats; then ready=1; break; fi; sleep 10; done; kill "$SERVER_PID" 2>/dev/null || true; if [ "$ready" -ne 1 ]; then echo "ACE_STEP_WEIGHTS_FAILED: server never became healthy" >&2; exit 1; fi; echo ACE_STEP_WEIGHTS_READY']
+  4. Wait for completion, then stop and terminate the pod (volume persists).
+
+(exit code 0; no RUNPOD_API_KEY needed, no API calls made)
+```
+
+**AC3 (workers/clients can find the volume):** `GET /api/v1/compute/remote/volume` returns the configured volume's metadata (size/region), confirming it exists and is mountable. `used_gb` is null because RunPod's REST API reports allocated size but not live usage.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_runpod_volume.py ac3
+```
+
+```output
+HTTP 200
+{
+  "id": "vol-abc123",
+  "name": "ace-step-models",
+  "size_gb": 100,
+  "used_gb": null,
+  "region": "EU-RO-1",
+  "available": true
+}
+```
+
+**Endpoint error contract:** auth-gated (401), 503 until the setup script has run, 404 if the configured id is gone from RunPod, 502 if RunPod is unreachable.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_runpod_volume.py states
+```
+
+```output
+# No token -> 401
+HTTP 401
+{
+  "detail": "Not authenticated."
+}
+
+# RunPod/volume not configured -> 503
+HTTP 503
+{
+  "detail": "RunPod is not configured: set ACEMUSIC_API_RUNPOD_API_KEY and ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID (run scripts/runpod-setup.py)."
+}
+
+# Configured volume id absent from RunPod -> 404
+HTTP 404
+{
+  "detail": "Network volume 'vol-abc123' not found on RunPod."
+}
+
+# RunPod API unreachable/5xx -> 502
+HTTP 502
+{
+  "detail": "RunPod volume lookup failed: Server error '500 Internal Server Error' for url 'https://rest.runpod.io/v1/networkvolumes'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500"
+}
+```

--- a/docs/demos/us-11.5-runpod-volume.md
+++ b/docs/demos/us-11.5-runpod-volume.md
@@ -102,7 +102,7 @@ HTTP 401
 # RunPod/volume not configured -> 503
 HTTP 503
 {
-  "detail": "RunPod is not configured: set ACEMUSIC_API_RUNPOD_API_KEY and ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID (run scripts/runpod-setup.py)."
+  "detail": "RunPod is not configured: set ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID (run scripts/runpod-setup.py)."
 }
 
 # Configured volume id absent from RunPod -> 404

--- a/model-deployment.md
+++ b/model-deployment.md
@@ -212,6 +212,24 @@ runpod.stop_pod("pod_id")
 
 **One-time setup — model weights persist indefinitely.**
 
+Use the `scripts/runpod-setup.py` script (US-11.5) to automate the provisioning
+steps below. The script creates the volume, spins up a temporary pod, downloads
+model weights, stops the pod, and prints the volume id to paste into
+`ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID` in `.env`. It is idempotent — re-running
+detects the existing volume and skips creation.
+
+```bash
+# Automated one-time setup (RUNPOD_API_KEY must be set in the environment).
+# Add --dry-run first to preview the cost estimate and plan without spending.
+uv run python scripts/runpod-setup.py \
+  --region US-TX-3 \
+  --size 30
+# → prints: ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID=vol_abc123
+# Paste that id into ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID in .env
+```
+
+Manual equivalent (for reference):
+
 ```bash
 # 1. Create a Network Volume in RunPod dashboard (or via API)
 #    Region: US-TX-3 (or wherever you want pods)

--- a/scripts/runpod-setup.py
+++ b/scripts/runpod-setup.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""One-time RunPod Network Volume setup for ACE-Step-1.5 model weights (US-11.5).
+
+WHAT THIS DOES
+==============
+The platform's serverless workers (US-11.2/11.3) keep model weights *off* the
+Docker image and load them at runtime from a shared RunPod Network Volume mounted
+at ``/workspace`` (``HF_HOME=/workspace/models/.cache`` — see ``docker/Dockerfile``
+and ``model-deployment.md`` §5.3). This script provisions that volume once and
+populates it with weights so every future worker downloads nothing on cold start:
+
+  1. Find-or-create the Network Volume (idempotent — safe to re-run).
+  2. Spin up a *temporary* GPU pod from the US-11.3 image with the volume mounted,
+     running a one-shot command that downloads the ACE-Step-1.5 weights into the
+     volume, then exits.
+  3. Poll the pod until that command finishes, then stop and terminate the pod.
+  4. Print the volume id to configure as ``ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID``.
+
+The volume PERSISTS after the temporary pod is gone (that is the whole point); the
+script never deletes a volume. Re-running it detects the existing volume by name
+and reuses it instead of creating a duplicate.
+
+PREREQUISITES
+=============
+- A RunPod account and API key, exported as ``RUNPOD_API_KEY`` in the environment.
+  (This is the Layer-1 / ops credential, read directly here — the API layer's
+  ``ACEMUSIC_API_RUNPOD_*`` settings are separate.)
+- The US-11.3 worker image published and pullable (default
+  ``frankbria/ace-step:latest``; override with ``--image``).
+
+USAGE
+=====
+    export RUNPOD_API_KEY=...                      # required
+    python scripts/runpod-setup.py --dry-run       # preview cost + plan, no changes
+    python scripts/runpod-setup.py                 # provision (prompts to confirm)
+    python scripts/runpod-setup.py --region US-OR-1 --size 150 --yes
+
+After a successful run the script prints the volume id; set it in your API
+environment:
+
+    ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID=<printed id>
+
+and verify it via ``GET /api/v1/compute/remote/volume``.
+
+NOTE ON THE WEIGHT-DOWNLOAD COMMAND
+===================================
+The default ``--download-cmd`` warms the Hugging Face cache on the volume by
+starting the ACE-Step API server (which downloads weights into ``HF_HOME`` on
+first load) and exiting once it reports healthy. Depending on how the published
+image fetches weights you may need to override ``--download-cmd`` with the exact
+download invocation for your image. The live download requires a paid GPU pod and
+cannot be exercised in CI; ``--dry-run`` prints the full plan without spending.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+import httpx
+
+DEFAULT_REST_BASE_URL = "https://rest.runpod.io/v1"
+DEFAULT_IMAGE = "frankbria/ace-step:latest"
+DEFAULT_VOLUME_NAME = "ace-step-models"
+DEFAULT_REGION = "EU-RO-1"
+DEFAULT_SIZE_GB = 100
+DEFAULT_GPU_TYPE = "NVIDIA GeForce RTX 4090"
+# Where the image expects the weights volume (HF_HOME lives under here).
+VOLUME_MOUNT_PATH = "/workspace"
+# Container scratch disk for the temporary download pod (weights land on the
+# volume, not here, so this only needs to fit the image + runtime).
+CONTAINER_DISK_GB = 50
+
+# Approximate RunPod network-volume storage rate (USD per GB per month). Published
+# pricing changes; this is a planning estimate shown before any spend, not a quote.
+STORAGE_RATE_USD_PER_GB_MONTH = 0.07
+
+# Pod statuses that mean the one-shot download command has finished.
+_TERMINAL_POD_STATUSES = {"EXITED", "TERMINATED", "STOPPED"}
+
+# Default one-shot download: start the ACE-Step API (which pulls weights into
+# HF_HOME on the mounted volume), wait until it is healthy, then exit so the pod
+# stops. Override with --download-cmd if your image downloads weights differently.
+_DEFAULT_DOWNLOAD_SCRIPT = (
+    "set -e; "
+    "export HF_HOME=/workspace/models/.cache; "
+    "mkdir -p \"$HF_HOME\"; "
+    "cd /app/ACE-Step-1.5; "
+    "uv run acestep-api & SERVER_PID=$!; "
+    "for i in $(seq 1 180); do "
+    'curl -sf http://localhost:8001/v1/stats && break || sleep 10; '
+    "done; "
+    "kill \"$SERVER_PID\" 2>/dev/null || true; "
+    "echo ACE_STEP_WEIGHTS_READY"
+)
+DEFAULT_DOWNLOAD_CMD = ["bash", "-lc", _DEFAULT_DOWNLOAD_SCRIPT]
+
+
+class RunPodRestError(RuntimeError):
+    """A RunPod management REST API call failed (transport error or non-2xx)."""
+
+
+class RunPodRestClient:
+    """Thin synchronous wrapper over RunPod's management REST API.
+
+    Uses ``httpx`` (the platform's HTTP client) with Bearer auth, mirroring
+    ``acemusic.runpod_client.RunPodClient`` rather than pulling in the RunPod SDK.
+    """
+
+    def __init__(self, api_key: str, base_url: str = DEFAULT_REST_BASE_URL, timeout: float = 30.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+        self._timeout = timeout
+
+    def _request(self, method: str, path: str, json_body: dict | None = None) -> object:
+        url = f"{self.base_url}{path}"
+        try:
+            response = httpx.request(method, url, headers=self._headers, json=json_body, timeout=self._timeout)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise RunPodRestError(f"RunPod API {method} {path} failed: {exc}") from exc
+        if not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise RunPodRestError(f"RunPod API {method} {path} returned non-JSON body") from exc
+
+    def list_network_volumes(self) -> list[dict]:
+        payload = self._request("GET", "/networkvolumes")
+        if isinstance(payload, list):
+            return [v for v in payload if isinstance(v, dict)]
+        if isinstance(payload, dict):
+            for key in ("networkVolumes", "data", "volumes"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    return [v for v in value if isinstance(v, dict)]
+        return []
+
+    def create_network_volume(self, name: str, size_gb: int, data_center_id: str) -> dict:
+        result = self._request(
+            "POST", "/networkvolumes", json_body={"name": name, "size": size_gb, "dataCenterId": data_center_id}
+        )
+        return result if isinstance(result, dict) else {}
+
+    def create_pod(self, payload: dict) -> dict:
+        result = self._request("POST", "/pods", json_body=payload)
+        return result if isinstance(result, dict) else {}
+
+    def get_pod(self, pod_id: str) -> dict:
+        result = self._request("GET", f"/pods/{pod_id}")
+        return result if isinstance(result, dict) else {}
+
+    def stop_pod(self, pod_id: str) -> None:
+        self._request("POST", f"/pods/{pod_id}/stop")
+
+    def terminate_pod(self, pod_id: str) -> None:
+        self._request("DELETE", f"/pods/{pod_id}")
+
+
+def estimate_storage_cost_usd_per_month(size_gb: int) -> float:
+    """Approximate monthly storage cost for a network volume of ``size_gb``."""
+    return size_gb * STORAGE_RATE_USD_PER_GB_MONTH
+
+
+def find_volume_by_name(client: RunPodRestClient, name: str) -> dict | None:
+    """Return the first existing volume with ``name``, or ``None`` (idempotency check)."""
+    for volume in client.list_network_volumes():
+        if volume.get("name") == name:
+            return volume
+    return None
+
+
+def ensure_volume(
+    client: RunPodRestClient, name: str, size_gb: int, data_center_id: str
+) -> tuple[dict, bool]:
+    """Find-or-create the named volume. Returns ``(volume, created)``.
+
+    Idempotent: an existing volume with the same name is reused (never duplicated),
+    so re-running the setup script is safe.
+    """
+    existing = find_volume_by_name(client, name)
+    if existing is not None:
+        return existing, False
+    created = client.create_network_volume(name=name, size_gb=size_gb, data_center_id=data_center_id)
+    return created, True
+
+
+def build_download_pod_payload(
+    volume_id: str, image: str, gpu_type: str, download_cmd: list[str], name: str
+) -> dict:
+    """Build the POST /pods body for the temporary weight-download pod."""
+    return {
+        "name": name,
+        "imageName": image,
+        "gpuTypeIds": [gpu_type],
+        "gpuCount": 1,
+        "networkVolumeId": volume_id,
+        "volumeMountPath": VOLUME_MOUNT_PATH,
+        "containerDiskInGb": CONTAINER_DISK_GB,
+        "dockerStartCmd": download_cmd,
+    }
+
+
+def pod_is_finished(pod: dict) -> bool:
+    """True once the pod's one-shot download command has exited.
+
+    RunPod reports status under a few keys depending on API version; treat any
+    terminal status as "download done".
+    """
+    for key in ("desiredStatus", "currentStatus", "status", "lastStatus"):
+        value = pod.get(key)
+        if isinstance(value, str) and value.upper() in _TERMINAL_POD_STATUSES:
+            return True
+    return False
+
+
+def wait_for_pod_finish(
+    client: RunPodRestClient, pod_id: str, timeout: float, poll_interval: float, sleep=time.sleep
+) -> bool:
+    """Poll the pod until its download command finishes or ``timeout`` elapses.
+
+    Returns True if the pod reached a terminal status, False on timeout. ``sleep``
+    is injectable so tests can drive the loop without real delays.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pod_is_finished(client.get_pod(pod_id)):
+            return True
+        sleep(poll_interval)
+    return False
+
+
+def _confirm(assume_yes: bool, prompt: str = "Proceed and create RunPod resources? [y/N] ") -> bool:
+    if assume_yes:
+        return True
+    answer = input(prompt).strip().lower()
+    return answer in ("y", "yes")
+
+
+def run_setup(
+    client: RunPodRestClient,
+    *,
+    volume_name: str,
+    size_gb: int,
+    region: str,
+    image: str,
+    gpu_type: str,
+    download_cmd: list[str],
+    timeout: float,
+    poll_interval: float,
+    dry_run: bool,
+    assume_yes: bool,
+) -> int:
+    """Orchestrate the one-time setup. Returns a process exit code (0 = success)."""
+    monthly = estimate_storage_cost_usd_per_month(size_gb)
+    print("RunPod Network Volume setup (ACE-Step-1.5 weights)")
+    print(f"  Volume name : {volume_name}")
+    print(f"  Size        : {size_gb} GB")
+    print(f"  Region      : {region}")
+    print(f"  Worker image: {image}")
+    print(f"  Download GPU: {gpu_type} (temporary pod, billed only while downloading)")
+    print(
+        f"  Estimated cost: ~${monthly:.2f}/month storage "
+        f"(~${STORAGE_RATE_USD_PER_GB_MONTH:.2f}/GB/mo) + temporary GPU pod time during download."
+    )
+
+    if dry_run:
+        print("\n[dry-run] No resources created. Planned actions:")
+        print(f"  1. Find-or-create volume {volume_name!r} ({size_gb} GB) in {region}.")
+        print(f"  2. Launch temporary {gpu_type} pod from {image} with the volume mounted at {VOLUME_MOUNT_PATH}.")
+        print(f"  3. Run download command: {download_cmd}")
+        print("  4. Wait for completion, then stop and terminate the pod (volume persists).")
+        return 0
+
+    if not _confirm(assume_yes):
+        print("Aborted; no resources created.")
+        return 1
+
+    volume, created = ensure_volume(client, name=volume_name, size_gb=size_gb, data_center_id=region)
+    volume_id = volume.get("id")
+    if not volume_id:
+        print("ERROR: RunPod did not return a volume id.", file=sys.stderr)
+        return 1
+    print(f"{'Created' if created else 'Reusing existing'} volume: {volume_id}")
+
+    pod_id = None
+    try:
+        payload = build_download_pod_payload(
+            volume_id=volume_id,
+            image=image,
+            gpu_type=gpu_type,
+            download_cmd=download_cmd,
+            name=f"{volume_name}-weights-download",
+        )
+        pod = client.create_pod(payload)
+        pod_id = pod.get("id")
+        if not pod_id:
+            print("ERROR: RunPod did not return a pod id.", file=sys.stderr)
+            return 1
+        print(f"Launched temporary download pod: {pod_id}. Waiting for weights to download...")
+        finished = wait_for_pod_finish(client, pod_id, timeout=timeout, poll_interval=poll_interval)
+        if not finished:
+            print(
+                f"ERROR: download pod {pod_id} did not finish within {timeout:.0f}s. "
+                "The pod is being terminated; re-run after checking RunPod logs.",
+                file=sys.stderr,
+            )
+            return 1
+        print("Weight download complete.")
+    finally:
+        # Always clean up the temporary pod; the VOLUME is intentionally left intact.
+        if pod_id:
+            _cleanup_pod(client, pod_id)
+
+    print("\nDone. Configure your API environment with:")
+    print(f"  ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID={volume_id}")
+    return 0
+
+
+def _cleanup_pod(client: RunPodRestClient, pod_id: str) -> None:
+    """Stop then terminate the temporary pod, tolerating partial failure."""
+    for action, fn in (("stop", client.stop_pod), ("terminate", client.terminate_pod)):
+        try:
+            fn(pod_id)
+        except RunPodRestError as exc:
+            print(f"WARNING: failed to {action} pod {pod_id}: {exc}", file=sys.stderr)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Provision the RunPod Network Volume with ACE-Step-1.5 weights (idempotent).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--region", default=DEFAULT_REGION, help="RunPod data center id for the volume.")
+    parser.add_argument("--size", type=int, default=DEFAULT_SIZE_GB, help="Volume size in GB.")
+    parser.add_argument("--volume-name", default=DEFAULT_VOLUME_NAME, help="Volume name (used for idempotency).")
+    parser.add_argument("--image", default=DEFAULT_IMAGE, help="Worker image to run in the temporary pod.")
+    parser.add_argument("--gpu-type", default=DEFAULT_GPU_TYPE, help="GPU type id for the temporary download pod.")
+    parser.add_argument(
+        "--download-cmd",
+        default=None,
+        help="Override the weight-download command (run via 'bash -lc'). Defaults to warming the HF cache.",
+    )
+    parser.add_argument(
+        "--timeout", type=float, default=3600.0, help="Max seconds to wait for the download to finish."
+    )
+    parser.add_argument("--poll-interval", type=float, default=15.0, help="Seconds between pod-status polls.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the plan and cost estimate; make no changes.")
+    parser.add_argument("--yes", action="store_true", help="Skip the confirmation prompt.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    api_key = os.environ.get("RUNPOD_API_KEY")
+    if not api_key and not args.dry_run:
+        print("ERROR: RUNPOD_API_KEY is not set in the environment.", file=sys.stderr)
+        return 2
+
+    download_cmd = ["bash", "-lc", args.download_cmd] if args.download_cmd else DEFAULT_DOWNLOAD_CMD
+    client = RunPodRestClient(api_key=api_key or "")
+    return run_setup(
+        client,
+        volume_name=args.volume_name,
+        size_gb=args.size,
+        region=args.region,
+        image=args.image,
+        gpu_type=args.gpu_type,
+        download_cmd=download_cmd,
+        timeout=args.timeout,
+        poll_interval=args.poll_interval,
+        dry_run=args.dry_run,
+        assume_yes=args.yes,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/runpod-setup.py
+++ b/scripts/runpod-setup.py
@@ -83,16 +83,24 @@ _TERMINAL_POD_STATUSES = {"EXITED", "TERMINATED", "STOPPED"}
 # Default one-shot download: start the ACE-Step API (which pulls weights into
 # HF_HOME on the mounted volume), wait until it is healthy, then exit so the pod
 # stops. Override with --download-cmd if your image downloads weights differently.
+#
+# Crucially, this FAILS LOUDLY: if the server never becomes healthy (bad image,
+# crash, OOM, or a failed weight download) the loop falls through with ``ready=0``
+# and the script exits non-zero *without* printing the success marker — so a pod
+# that never populated the volume is not mistaken for a successful run.
 _DEFAULT_DOWNLOAD_SCRIPT = (
     "set -e; "
     "export HF_HOME=/workspace/models/.cache; "
-    "mkdir -p \"$HF_HOME\"; "
+    'mkdir -p "$HF_HOME"; '
     "cd /app/ACE-Step-1.5; "
     "uv run acestep-api & SERVER_PID=$!; "
+    "ready=0; "
     "for i in $(seq 1 180); do "
-    'curl -sf http://localhost:8001/v1/stats && break || sleep 10; '
+    "if curl -sf http://localhost:8001/v1/stats; then ready=1; break; fi; "
+    "sleep 10; "
     "done; "
-    "kill \"$SERVER_PID\" 2>/dev/null || true; "
+    'kill "$SERVER_PID" 2>/dev/null || true; '
+    'if [ "$ready" -ne 1 ]; then echo "ACE_STEP_WEIGHTS_FAILED: server never became healthy" >&2; exit 1; fi; '
     "echo ACE_STEP_WEIGHTS_READY"
 )
 DEFAULT_DOWNLOAD_CMD = ["bash", "-lc", _DEFAULT_DOWNLOAD_SCRIPT]
@@ -173,9 +181,7 @@ def find_volume_by_name(client: RunPodRestClient, name: str) -> dict | None:
     return None
 
 
-def ensure_volume(
-    client: RunPodRestClient, name: str, size_gb: int, data_center_id: str
-) -> tuple[dict, bool]:
+def ensure_volume(client: RunPodRestClient, name: str, size_gb: int, data_center_id: str) -> tuple[dict, bool]:
     """Find-or-create the named volume. Returns ``(volume, created)``.
 
     Idempotent: an existing volume with the same name is reused (never duplicated),
@@ -188,9 +194,7 @@ def ensure_volume(
     return created, True
 
 
-def build_download_pod_payload(
-    volume_id: str, image: str, gpu_type: str, download_cmd: list[str], name: str
-) -> dict:
+def build_download_pod_payload(volume_id: str, image: str, gpu_type: str, download_cmd: list[str], name: str) -> dict:
     """Build the POST /pods body for the temporary weight-download pod."""
     return {
         "name": name,
@@ -309,13 +313,17 @@ def run_setup(
                 file=sys.stderr,
             )
             return 1
-        print("Weight download complete.")
+        print("Download pod finished.")
     finally:
         # Always clean up the temporary pod; the VOLUME is intentionally left intact.
         if pod_id:
             _cleanup_pod(client, pod_id)
 
-    print("\nDone. Configure your API environment with:")
+    # Completion is detected from the pod reaching a terminal state; RunPod's REST
+    # API does not reliably surface the container exit code, so confirm the pod log
+    # shows the success marker before trusting the volume (the default command
+    # prints ACE_STEP_WEIGHTS_READY on success and exits non-zero on failure).
+    print("\nDone. Verify the pod log shows 'ACE_STEP_WEIGHTS_READY', then configure your API environment with:")
     print(f"  ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID={volume_id}")
     return 0
 
@@ -344,9 +352,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Override the weight-download command (run via 'bash -lc'). Defaults to warming the HF cache.",
     )
-    parser.add_argument(
-        "--timeout", type=float, default=3600.0, help="Max seconds to wait for the download to finish."
-    )
+    parser.add_argument("--timeout", type=float, default=3600.0, help="Max seconds to wait for the download to finish.")
     parser.add_argument("--poll-interval", type=float, default=15.0, help="Seconds between pod-status polls.")
     parser.add_argument("--dry-run", action="store_true", help="Print the plan and cost estimate; make no changes.")
     parser.add_argument("--yes", action="store_true", help="Skip the confirmation prompt.")

--- a/scripts/runpod-setup.py
+++ b/scripts/runpod-setup.py
@@ -75,6 +75,7 @@ CONTAINER_DISK_GB = 50
 
 # Approximate RunPod network-volume storage rate (USD per GB per month). Published
 # pricing changes; this is a planning estimate shown before any spend, not a quote.
+# Last verified: 2026-06-16.
 STORAGE_RATE_USD_PER_GB_MONTH = 0.07
 
 # Pod statuses that mean the one-shot download command has finished.
@@ -194,16 +195,30 @@ def ensure_volume(client: RunPodRestClient, name: str, size_gb: int, data_center
     return created, True
 
 
-def build_download_pod_payload(volume_id: str, image: str, gpu_type: str, download_cmd: list[str], name: str) -> dict:
-    """Build the POST /pods body for the temporary weight-download pod."""
+def build_download_pod_payload(
+    volume_id: str,
+    image: str,
+    gpu_type: str,
+    download_cmd: list[str],
+    name: str,
+    data_center_id: str,
+    container_disk_gb: int = CONTAINER_DISK_GB,
+) -> dict:
+    """Build the POST /pods body for the temporary weight-download pod.
+
+    The pod is pinned to ``data_center_id`` — a network volume lives in exactly one
+    data center, and a pod can only attach a volume in the same one, so placing the
+    pod elsewhere would fail to mount it.
+    """
     return {
         "name": name,
         "imageName": image,
         "gpuTypeIds": [gpu_type],
         "gpuCount": 1,
+        "dataCenterIds": [data_center_id],
         "networkVolumeId": volume_id,
         "volumeMountPath": VOLUME_MOUNT_PATH,
-        "containerDiskInGb": CONTAINER_DISK_GB,
+        "containerDiskInGb": container_disk_gb,
         "dockerStartCmd": download_cmd,
     }
 
@@ -222,17 +237,27 @@ def pod_is_finished(pod: dict) -> bool:
 
 
 def wait_for_pod_finish(
-    client: RunPodRestClient, pod_id: str, timeout: float, poll_interval: float, sleep=time.sleep
+    client: RunPodRestClient,
+    pod_id: str,
+    timeout: float,
+    poll_interval: float,
+    sleep=time.sleep,
+    on_poll=None,
 ) -> bool:
     """Poll the pod until its download command finishes or ``timeout`` elapses.
 
     Returns True if the pod reached a terminal status, False on timeout. ``sleep``
-    is injectable so tests can drive the loop without real delays.
+    is injectable so tests can drive the loop without real delays; ``on_poll`` (if
+    given) is called with the elapsed seconds after each non-terminal poll so a
+    long download (20-40 min) shows progress instead of hanging silently.
     """
-    deadline = time.monotonic() + timeout
+    start = time.monotonic()
+    deadline = start + timeout
     while time.monotonic() < deadline:
         if pod_is_finished(client.get_pod(pod_id)):
             return True
+        if on_poll is not None:
+            on_poll(time.monotonic() - start)
         sleep(poll_interval)
     return False
 
@@ -257,6 +282,7 @@ def run_setup(
     poll_interval: float,
     dry_run: bool,
     assume_yes: bool,
+    container_disk_gb: int = CONTAINER_DISK_GB,
 ) -> int:
     """Orchestrate the one-time setup. Returns a process exit code (0 = success)."""
     monthly = estimate_storage_cost_usd_per_month(size_gb)
@@ -298,6 +324,8 @@ def run_setup(
             gpu_type=gpu_type,
             download_cmd=download_cmd,
             name=f"{volume_name}-weights-download",
+            data_center_id=region,
+            container_disk_gb=container_disk_gb,
         )
         pod = client.create_pod(payload)
         pod_id = pod.get("id")
@@ -305,7 +333,13 @@ def run_setup(
             print("ERROR: RunPod did not return a pod id.", file=sys.stderr)
             return 1
         print(f"Launched temporary download pod: {pod_id}. Waiting for weights to download...")
-        finished = wait_for_pod_finish(client, pod_id, timeout=timeout, poll_interval=poll_interval)
+        finished = wait_for_pod_finish(
+            client,
+            pod_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            on_poll=lambda elapsed: print(f"  ...still downloading ({elapsed:.0f}s elapsed)"),
+        )
         if not finished:
             print(
                 f"ERROR: download pod {pod_id} did not finish within {timeout:.0f}s. "
@@ -345,8 +379,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--region", default=DEFAULT_REGION, help="RunPod data center id for the volume.")
     parser.add_argument("--size", type=int, default=DEFAULT_SIZE_GB, help="Volume size in GB.")
     parser.add_argument("--volume-name", default=DEFAULT_VOLUME_NAME, help="Volume name (used for idempotency).")
-    parser.add_argument("--image", default=DEFAULT_IMAGE, help="Worker image to run in the temporary pod.")
+    parser.add_argument(
+        "--image",
+        default=DEFAULT_IMAGE,
+        help="Worker image to run in the temporary pod. Pin to a digest/tag (not ':latest') for reproducible runs.",
+    )
     parser.add_argument("--gpu-type", default=DEFAULT_GPU_TYPE, help="GPU type id for the temporary download pod.")
+    parser.add_argument(
+        "--container-disk",
+        type=int,
+        default=CONTAINER_DISK_GB,
+        help="Container scratch disk (GB) for the temporary pod; raise for heavier custom images.",
+    )
     parser.add_argument(
         "--download-cmd",
         default=None,
@@ -380,6 +424,7 @@ def main(argv: list[str] | None = None) -> int:
         poll_interval=args.poll_interval,
         dry_run=args.dry_run,
         assume_yes=args.yes,
+        container_disk_gb=args.container_disk,
     )
 
 

--- a/src/acemusic/api/routers/compute.py
+++ b/src/acemusic/api/routers/compute.py
@@ -1,15 +1,26 @@
-"""Compute status endpoint (US-11.4).
+"""Compute status + remote volume endpoints (US-11.4, US-11.5).
 
-Exposes ``GET /api/v1/compute/status`` so a client can check, before generating,
-whether the local GPU is busy and whether the remote RunPod endpoint is available.
-Auth-gated like the rest of the API (only ``/health`` and ``/auth`` are public):
-worker counts and the RunPod endpoint id are operational detail for signed-in users.
+``GET /api/v1/compute/status`` lets a client check, before generating, whether the
+local GPU is busy and whether the remote RunPod endpoint is available.
+``GET /api/v1/compute/remote/volume`` reports the persisted RunPod Network Volume
+that holds the model weights (provisioned by ``scripts/runpod-setup.py``).
+
+Both are auth-gated like the rest of the API (only ``/health`` and ``/auth`` are
+public): worker counts, the RunPod endpoint id, and volume metadata are
+operational detail for signed-in users.
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..auth.dependencies import get_current_user, get_settings
 from ..services.compute_status import ComputeStatusResponse, get_compute_status
+from ..services.volume import (
+    VolumeInfoResponse,
+    VolumeNotConfiguredError,
+    VolumeNotFoundError,
+    VolumeUpstreamError,
+    get_remote_volume,
+)
 from ..settings import ApiSettings
 
 router = APIRouter(tags=["compute"], dependencies=[Depends(get_current_user)])
@@ -19,3 +30,20 @@ router = APIRouter(tags=["compute"], dependencies=[Depends(get_current_user)])
 async def compute_status(settings: ApiSettings = Depends(get_settings)) -> ComputeStatusResponse:
     """Return combined local + remote compute status (both probed in parallel)."""
     return await get_compute_status(settings)
+
+
+@router.get("/compute/remote/volume", response_model=VolumeInfoResponse)
+async def remote_volume(settings: ApiSettings = Depends(get_settings)) -> VolumeInfoResponse:
+    """Return the configured RunPod Network Volume's metadata.
+
+    503 when RunPod / the volume id is not configured, 404 when the configured
+    volume is absent from RunPod, 502 when RunPod's API is unreachable.
+    """
+    try:
+        return await get_remote_volume(settings)
+    except VolumeNotConfiguredError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    except VolumeNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except VolumeUpstreamError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc

--- a/src/acemusic/api/services/volume.py
+++ b/src/acemusic/api/services/volume.py
@@ -1,0 +1,113 @@
+"""Remote RunPod Network Volume info (US-11.5).
+
+Backs ``GET /api/v1/compute/remote/volume``: looks up the configured persisted
+weights volume via RunPod's *management* REST API (``rest.runpod.io/v1``) — a
+different host from the serverless API the routing/status code talks to. The
+volume is provisioned once by ``scripts/runpod-setup.py`` and mounted by every
+serverless worker, so this endpoint lets an operator confirm it exists and
+inspect its size/region before relying on remote generation.
+
+Kept transport-agnostic like the sibling ``compute_status`` module: it returns a
+model on success and raises typed domain errors otherwise, so the router stays
+thin and owns the HTTP-status mapping (503 unconfigured / 404 missing / 502
+upstream failure).
+
+RunPod's ``GET /v1/networkvolumes`` returns a bare JSON array of
+``{"id", "name", "size", "dataCenterId"}`` objects (``size`` in GB). The API does
+not expose live usage, so ``used_gb`` is always ``None`` for now.
+"""
+
+import httpx
+from pydantic import BaseModel
+
+from ..settings import ApiSettings
+
+NETWORK_VOLUMES_PATH = "/networkvolumes"
+
+# A volume listing is a quick management call; bound it so a hung RunPod API
+# surfaces as a 502 rather than holding the request open. Separate from the
+# status endpoint's probe budget — this is a resource fetch, not a health probe.
+VOLUME_REQUEST_TIMEOUT = 10.0
+
+
+class VolumeInfoResponse(BaseModel):
+    """Metadata for the configured RunPod Network Volume.
+
+    ``used_gb`` is optional because RunPod's REST API reports allocated ``size``
+    but not live usage; it stays ``None`` until/unless the API exposes it.
+    """
+
+    id: str
+    name: str
+    size_gb: int
+    used_gb: int | None = None
+    region: str
+    available: bool
+
+
+class VolumeNotConfiguredError(Exception):
+    """RunPod credentials or the network volume id are not configured (→ 503)."""
+
+
+class VolumeNotFoundError(Exception):
+    """The configured volume id was not returned by RunPod's API (→ 404)."""
+
+
+class VolumeUpstreamError(Exception):
+    """RunPod's API was unreachable or returned an error response (→ 502)."""
+
+
+def _extract_volumes(payload: object) -> list[dict]:
+    """Return the list of volume objects from a (defensively-typed) response body.
+
+    The documented shape is a bare array; tolerate a dict wrapper under common
+    keys so a future pagination envelope does not silently break the lookup.
+    """
+    if isinstance(payload, list):
+        return [v for v in payload if isinstance(v, dict)]
+    if isinstance(payload, dict):
+        for key in ("networkVolumes", "data", "volumes"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [v for v in value if isinstance(v, dict)]
+    return []
+
+
+async def get_remote_volume(settings: ApiSettings) -> VolumeInfoResponse:
+    """Fetch the configured Network Volume's metadata from RunPod.
+
+    Raises :class:`VolumeNotConfiguredError` when the API key or volume id is
+    unset (no HTTP call is made), :class:`VolumeUpstreamError` when RunPod is
+    unreachable or returns a non-2xx, and :class:`VolumeNotFoundError` when the
+    configured id is absent from the returned list.
+    """
+    api_key = settings.runpod_api_key
+    volume_id = settings.runpod_network_volume_id
+    if not api_key or not volume_id:
+        raise VolumeNotConfiguredError(
+            "RunPod is not configured: set ACEMUSIC_API_RUNPOD_API_KEY and "
+            "ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID (run scripts/runpod-setup.py)."
+        )
+
+    url = f"{settings.runpod_rest_base_url.rstrip('/')}{NETWORK_VOLUMES_PATH}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        async with httpx.AsyncClient(timeout=VOLUME_REQUEST_TIMEOUT) as client:
+            response = await client.get(url, headers=headers)
+        response.raise_for_status()
+        volumes = _extract_volumes(response.json())
+    except (httpx.HTTPError, ValueError) as exc:
+        raise VolumeUpstreamError(f"RunPod volume lookup failed: {exc}") from exc
+
+    volume = next((v for v in volumes if v.get("id") == volume_id), None)
+    if volume is None:
+        raise VolumeNotFoundError(f"Network volume {volume_id!r} not found on RunPod.")
+
+    return VolumeInfoResponse(
+        id=str(volume.get("id")),
+        name=str(volume.get("name", "")),
+        size_gb=int(volume.get("size", 0)),
+        used_gb=None,
+        region=str(volume.get("dataCenterId", "")),
+        available=True,
+    )

--- a/src/acemusic/api/services/volume.py
+++ b/src/acemusic/api/services/volume.py
@@ -42,6 +42,9 @@ class VolumeInfoResponse(BaseModel):
     size_gb: int
     used_gb: int | None = None
     region: str
+    # ``True`` means "the configured volume was found on RunPod". RunPod's REST API
+    # does not report a per-volume health/degraded state, so this is the only
+    # signal available today; the field is kept for forward-compatibility.
     available: bool
 
 
@@ -81,21 +84,32 @@ async def get_remote_volume(settings: ApiSettings) -> VolumeInfoResponse:
     unreachable or returns a non-2xx, and :class:`VolumeNotFoundError` when the
     configured id is absent from the returned list.
     """
+    # Name only the field(s) actually missing so the remediation step is accurate
+    # (an operator who set the key but not the volume id shouldn't be told to set both).
+    missing = [
+        name
+        for name, value in (
+            ("ACEMUSIC_API_RUNPOD_API_KEY", settings.runpod_api_key),
+            ("ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID", settings.runpod_network_volume_id),
+        )
+        if not value
+    ]
+    if missing:
+        raise VolumeNotConfiguredError(
+            "RunPod is not configured: set " + " and ".join(missing) + " (run scripts/runpod-setup.py)."
+        )
     api_key = settings.runpod_api_key
     volume_id = settings.runpod_network_volume_id
-    if not api_key or not volume_id:
-        raise VolumeNotConfiguredError(
-            "RunPod is not configured: set ACEMUSIC_API_RUNPOD_API_KEY and "
-            "ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID (run scripts/runpod-setup.py)."
-        )
 
     url = f"{settings.runpod_rest_base_url.rstrip('/')}{NETWORK_VOLUMES_PATH}"
     headers = {"Authorization": f"Bearer {api_key}"}
     try:
+        # raise_for_status + json() stay inside the context manager for unambiguous
+        # lifetime (httpx has already buffered the body for a non-streaming GET).
         async with httpx.AsyncClient(timeout=VOLUME_REQUEST_TIMEOUT) as client:
             response = await client.get(url, headers=headers)
-        response.raise_for_status()
-        volumes = _extract_volumes(response.json())
+            response.raise_for_status()
+            volumes = _extract_volumes(response.json())
     except (httpx.HTTPError, ValueError) as exc:
         raise VolumeUpstreamError(f"RunPod volume lookup failed: {exc}") from exc
 

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -103,6 +103,16 @@ class ApiSettings(BaseSettings):
     runpod_timeout: float = Field(default=300.0, gt=0)
     runpod_poll_interval: float = Field(default=5.0, gt=0)
 
+    # RunPod Network Volume (US-11.5). ``runpod_network_volume_id`` names the
+    # persisted weights volume that ``scripts/runpod-setup.py`` provisions once and
+    # every serverless worker mounts; it is what ``GET /compute/remote/volume`` looks
+    # up. It stays None on deployments that have not run the setup script (the
+    # endpoint then 503s rather than crashing). ``runpod_rest_base_url`` is RunPod's
+    # *management* REST API (volumes/pods) — a different host from the serverless
+    # ``runpod_base_url`` above — overridable only to point at a staging proxy.
+    runpod_network_volume_id: str | None = None
+    runpod_rest_base_url: str = "https://rest.runpod.io/v1"
+
     # Compute status endpoint (US-11.4). Per-target health-probe budget for
     # ``GET /api/v1/compute/status``; the local and remote checks run in parallel,
     # each bounded by this timeout, so the aggregate response stays well under the

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -209,6 +209,8 @@ class TestRunPodSettings:
             "ACEMUSIC_API_RUNPOD_ENDPOINT_ID",
             "ACEMUSIC_API_RUNPOD_TIMEOUT",
             "ACEMUSIC_API_RUNPOD_POLL_INTERVAL",
+            "ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID",
+            "ACEMUSIC_API_RUNPOD_REST_BASE_URL",
         ):
             monkeypatch.delenv(key, raising=False)
 
@@ -254,3 +256,39 @@ class TestRunPodSettings:
         monkeypatch.setenv("ACEMUSIC_API_RUNPOD_POLL_INTERVAL", value)
         with pytest.raises(ValueError, match="runpod_poll_interval"):
             ApiSettings(_env_file=None)
+
+
+class TestRunPodVolumeSettings:
+    """RunPod Network Volume configuration (US-11.5).
+
+    The serverless credentials (US-11.2) drive job routing; the volume id names
+    the persisted weights volume those workers mount, so it is configured
+    separately and the volume-info endpoint reads it to look the volume up.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_volume_env(self, monkeypatch):
+        for key in (
+            "ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID",
+            "ACEMUSIC_API_RUNPOD_REST_BASE_URL",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_volume_id_defaults_to_none(self):
+        """No volume is configured until the setup script provisions one."""
+        assert ApiSettings(_env_file=None).runpod_network_volume_id is None
+
+    def test_rest_base_url_default(self):
+        """The volume-management REST API is distinct from the serverless base URL."""
+        settings = ApiSettings(_env_file=None)
+        assert settings.runpod_rest_base_url == "https://rest.runpod.io/v1"
+        # The serverless base URL (US-11.2) is a separate endpoint and untouched.
+        assert settings.runpod_base_url == "https://api.runpod.ai/v2"
+
+    def test_volume_id_from_env(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID", "vol-abc123")
+        assert ApiSettings(_env_file=None).runpod_network_volume_id == "vol-abc123"
+
+    def test_rest_base_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_RUNPOD_REST_BASE_URL", "https://staging.runpod.io/v1")
+        assert ApiSettings(_env_file=None).runpod_rest_base_url == "https://staging.runpod.io/v1"

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -1,0 +1,169 @@
+"""Tests for the remote RunPod Network Volume endpoint and service (US-11.5).
+
+Pure-logic / no-DB: RunPod's management REST API is mocked with respx. The
+endpoint is auth-gated (router-level ``get_current_user``), so a signed access
+token is minted directly like the sibling ``test_compute_status`` suite.
+
+RunPod's ``GET /v1/networkvolumes`` returns a bare JSON array of
+``{"id", "name", "size", "dataCenterId"}`` objects (size in GB; no usage field
+is exposed by the API).
+"""
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import create_app
+from acemusic.api.services.volume import (
+    VolumeInfoResponse,
+    VolumeNotConfiguredError,
+    VolumeNotFoundError,
+    VolumeUpstreamError,
+    get_remote_volume,
+)
+from acemusic.api.settings import ApiSettings
+
+JWT_SECRET = "test-secret-key-at-least-32-bytes-long-xx"
+REST_BASE = "https://rest.runpod.io/v1"
+VOLUMES_URL = f"{REST_BASE}/networkvolumes"
+VOLUME_ENDPOINT = "/api/v1/compute/remote/volume"
+
+# A representative RunPod network-volumes payload (the API returns a bare array).
+SAMPLE_VOLUMES = [
+    {"id": "vol-abc123", "name": "ace-step-models", "size": 100, "dataCenterId": "EU-RO-1"},
+    {"id": "vol-other", "name": "scratch", "size": 20, "dataCenterId": "US-OR-1"},
+]
+
+
+def _settings(**overrides) -> ApiSettings:
+    base = {
+        "_env_file": None,
+        "jwt_secret_key": JWT_SECRET,
+        "runpod_api_key": "rp-key",
+        "runpod_endpoint_id": "ep-1",
+        "runpod_network_volume_id": "vol-abc123",
+        "job_processor_enabled": False,
+    }
+    base.update(overrides)
+    return ApiSettings(**base)
+
+
+def _token(settings: ApiSettings) -> str:
+    return create_access_token(
+        user_id="507f1f77bcf86cd799439011",
+        email="user@example.com",
+        subscription_tier="free",
+        settings=settings,
+    )
+
+
+def _auth(settings: ApiSettings) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_token(settings)}"}
+
+
+def _client(settings: ApiSettings) -> TestClient:
+    # No `with`: the endpoint only reads settings off app state (like /health and
+    # /compute/status), so TestClient can skip the DB/job-processor lifespan.
+    return TestClient(create_app(settings))
+
+
+class TestGetRemoteVolumeService:
+    """Direct unit tests of the transport-agnostic service function."""
+
+    async def test_raises_when_api_key_missing(self):
+        with pytest.raises(VolumeNotConfiguredError):
+            await get_remote_volume(_settings(runpod_api_key=None))
+
+    async def test_raises_when_volume_id_missing(self):
+        with pytest.raises(VolumeNotConfiguredError):
+            await get_remote_volume(_settings(runpod_network_volume_id=None))
+
+    @respx.mock
+    async def test_returns_mapped_volume_when_found(self):
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=SAMPLE_VOLUMES))
+        result = await get_remote_volume(_settings())
+        assert isinstance(result, VolumeInfoResponse)
+        assert result.id == "vol-abc123"
+        assert result.name == "ace-step-models"
+        assert result.size_gb == 100
+        assert result.region == "EU-RO-1"
+        assert result.available is True
+        # The REST API does not report usage, so used_gb stays None.
+        assert result.used_gb is None
+
+    @respx.mock
+    async def test_sends_bearer_auth(self):
+        route = respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=SAMPLE_VOLUMES))
+        await get_remote_volume(_settings())
+        assert route.calls.last.request.headers["Authorization"] == "Bearer rp-key"
+
+    @respx.mock
+    async def test_raises_not_found_when_id_absent(self):
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=[SAMPLE_VOLUMES[1]]))
+        with pytest.raises(VolumeNotFoundError):
+            await get_remote_volume(_settings())
+
+    @respx.mock
+    async def test_raises_upstream_on_5xx(self):
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(500, text="boom"))
+        with pytest.raises(VolumeUpstreamError):
+            await get_remote_volume(_settings())
+
+    @respx.mock
+    async def test_raises_upstream_on_connection_error(self):
+        respx.get(VOLUMES_URL).mock(side_effect=httpx.ConnectError("down"))
+        with pytest.raises(VolumeUpstreamError):
+            await get_remote_volume(_settings())
+
+    @respx.mock
+    async def test_uses_configured_rest_base_url(self):
+        staging = "https://staging.runpod.io/v1"
+        route = respx.get(f"{staging}/networkvolumes").mock(
+            return_value=httpx.Response(200, json=SAMPLE_VOLUMES)
+        )
+        await get_remote_volume(_settings(runpod_rest_base_url=staging))
+        assert route.called
+
+
+class TestVolumeEndpoint:
+    """End-to-end through the auth-gated compute router."""
+
+    def test_requires_auth(self):
+        settings = _settings()
+        resp = _client(settings).get(VOLUME_ENDPOINT)
+        assert resp.status_code == 401
+
+    def test_503_when_not_configured(self):
+        # No volume id configured → the deployment never ran the setup script.
+        settings = _settings(runpod_network_volume_id=None)
+        resp = _client(settings).get(VOLUME_ENDPOINT, headers=_auth(settings))
+        assert resp.status_code == 503
+
+    @respx.mock
+    def test_200_with_volume_info(self):
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=SAMPLE_VOLUMES))
+        settings = _settings()
+        resp = _client(settings).get(VOLUME_ENDPOINT, headers=_auth(settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == "vol-abc123"
+        assert body["name"] == "ace-step-models"
+        assert body["size_gb"] == 100
+        assert body["region"] == "EU-RO-1"
+        assert body["available"] is True
+
+    @respx.mock
+    def test_404_when_volume_absent(self):
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=[SAMPLE_VOLUMES[1]]))
+        settings = _settings()
+        resp = _client(settings).get(VOLUME_ENDPOINT, headers=_auth(settings))
+        assert resp.status_code == 404
+
+    @respx.mock
+    def test_502_when_runpod_unreachable(self):
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(500, text="boom"))
+        settings = _settings()
+        resp = _client(settings).get(VOLUME_ENDPOINT, headers=_auth(settings))
+        assert resp.status_code == 502

--- a/tests/test_compute_api.py
+++ b/tests/test_compute_api.py
@@ -120,11 +120,17 @@ class TestGetRemoteVolumeService:
     @respx.mock
     async def test_uses_configured_rest_base_url(self):
         staging = "https://staging.runpod.io/v1"
-        route = respx.get(f"{staging}/networkvolumes").mock(
-            return_value=httpx.Response(200, json=SAMPLE_VOLUMES)
-        )
+        route = respx.get(f"{staging}/networkvolumes").mock(return_value=httpx.Response(200, json=SAMPLE_VOLUMES))
         await get_remote_volume(_settings(runpod_rest_base_url=staging))
         assert route.called
+
+    @respx.mock
+    async def test_tolerates_dict_wrapped_volume_list(self):
+        # Defensive: if RunPod ever wraps the array in a pagination envelope, the
+        # configured volume is still found rather than silently 404ing.
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json={"networkVolumes": SAMPLE_VOLUMES}))
+        result = await get_remote_volume(_settings())
+        assert result.id == "vol-abc123"
 
 
 class TestVolumeEndpoint:

--- a/tests/test_runpod_setup_script.py
+++ b/tests/test_runpod_setup_script.py
@@ -53,9 +53,7 @@ class TestEnsureVolumeIdempotency:
         list_route = respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=EXISTING_VOLUMES))
         create_route = respx.post(VOLUMES_URL).mock(return_value=httpx.Response(200, json={}))
 
-        volume, created = rp.ensure_volume(
-            _client(), name="ace-step-models", size_gb=100, data_center_id="EU-RO-1"
-        )
+        volume, created = rp.ensure_volume(_client(), name="ace-step-models", size_gb=100, data_center_id="EU-RO-1")
 
         assert created is False
         assert volume["id"] == "vol-existing"
@@ -69,9 +67,7 @@ class TestEnsureVolumeIdempotency:
         created_volume = {"id": "vol-new", "name": "ace-step-models", "size": 100, "dataCenterId": "EU-RO-1"}
         create_route = respx.post(VOLUMES_URL).mock(return_value=httpx.Response(200, json=created_volume))
 
-        volume, created = rp.ensure_volume(
-            _client(), name="ace-step-models", size_gb=100, data_center_id="EU-RO-1"
-        )
+        volume, created = rp.ensure_volume(_client(), name="ace-step-models", size_gb=100, data_center_id="EU-RO-1")
 
         assert created is True
         assert volume["id"] == "vol-new"

--- a/tests/test_runpod_setup_script.py
+++ b/tests/test_runpod_setup_script.py
@@ -7,6 +7,7 @@ respx — no real RunPod account, pod, or GPU is ever touched.
 """
 
 import importlib.util
+import json
 from pathlib import Path
 
 import httpx
@@ -74,8 +75,6 @@ class TestEnsureVolumeIdempotency:
         assert create_route.called
         sent = create_route.calls.last.request
         assert sent.headers["Authorization"] == "Bearer rp-key"
-        import json
-
         body = json.loads(sent.content)
         assert body == {"name": "ace-step-models", "size": 100, "dataCenterId": "EU-RO-1"}
 
@@ -88,6 +87,8 @@ class TestPodPayload:
             gpu_type="NVIDIA GeForce RTX 4090",
             download_cmd=["bash", "-lc", "echo hi"],
             name="ace-step-weights-download",
+            data_center_id="EU-RO-1",
+            container_disk_gb=80,
         )
         assert payload["networkVolumeId"] == "vol-1"
         assert payload["imageName"] == "frankbria/ace-step:latest"
@@ -95,6 +96,9 @@ class TestPodPayload:
         assert payload["dockerStartCmd"] == ["bash", "-lc", "echo hi"]
         # Volume must mount where the image expects model weights (HF_HOME lives here).
         assert payload["volumeMountPath"] == "/workspace"
+        # The pod must be pinned to the volume's data center to be able to attach it.
+        assert payload["dataCenterIds"] == ["EU-RO-1"]
+        assert payload["containerDiskInGb"] == 80
 
 
 class TestPodFinishedDetection:
@@ -221,3 +225,7 @@ class TestCliParsing:
         assert args.region == "US-OR-1"
         assert args.volume_name == "weights"
         assert args.dry_run is True
+
+    def test_container_disk_flag(self):
+        assert rp.parse_args([]).container_disk == 50
+        assert rp.parse_args(["--container-disk", "120"]).container_disk == 120

--- a/tests/test_runpod_setup_script.py
+++ b/tests/test_runpod_setup_script.py
@@ -1,0 +1,227 @@
+"""Tests for the standalone RunPod Network Volume setup script (US-11.5).
+
+The script lives at ``scripts/runpod-setup.py`` (outside the ``acemusic`` package,
+and the hyphen makes it non-importable by name), so it is loaded here via
+``importlib`` from its file path. RunPod's management REST API is mocked with
+respx — no real RunPod account, pod, or GPU is ever touched.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "runpod-setup.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("runpod_setup", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rp = _load_script()
+
+REST_BASE = "https://rest.runpod.io/v1"
+VOLUMES_URL = f"{REST_BASE}/networkvolumes"
+PODS_URL = f"{REST_BASE}/pods"
+
+EXISTING_VOLUMES = [
+    {"id": "vol-existing", "name": "ace-step-models", "size": 100, "dataCenterId": "EU-RO-1"},
+]
+
+
+def _client() -> "rp.RunPodRestClient":
+    return rp.RunPodRestClient(api_key="rp-key", base_url=REST_BASE)
+
+
+class TestCostEstimate:
+    def test_scales_with_size(self):
+        small = rp.estimate_storage_cost_usd_per_month(50)
+        large = rp.estimate_storage_cost_usd_per_month(100)
+        assert large > small > 0
+        # Linear in size at the published per-GB rate.
+        assert large == pytest.approx(small * 2)
+
+
+class TestEnsureVolumeIdempotency:
+    @respx.mock
+    def test_reuses_existing_volume_without_creating(self):
+        list_route = respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=EXISTING_VOLUMES))
+        create_route = respx.post(VOLUMES_URL).mock(return_value=httpx.Response(200, json={}))
+
+        volume, created = rp.ensure_volume(
+            _client(), name="ace-step-models", size_gb=100, data_center_id="EU-RO-1"
+        )
+
+        assert created is False
+        assert volume["id"] == "vol-existing"
+        assert list_route.called
+        # Idempotency: re-running must NOT POST a duplicate volume.
+        assert not create_route.called
+
+    @respx.mock
+    def test_creates_volume_when_absent(self):
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=[]))
+        created_volume = {"id": "vol-new", "name": "ace-step-models", "size": 100, "dataCenterId": "EU-RO-1"}
+        create_route = respx.post(VOLUMES_URL).mock(return_value=httpx.Response(200, json=created_volume))
+
+        volume, created = rp.ensure_volume(
+            _client(), name="ace-step-models", size_gb=100, data_center_id="EU-RO-1"
+        )
+
+        assert created is True
+        assert volume["id"] == "vol-new"
+        assert create_route.called
+        sent = create_route.calls.last.request
+        assert sent.headers["Authorization"] == "Bearer rp-key"
+        import json
+
+        body = json.loads(sent.content)
+        assert body == {"name": "ace-step-models", "size": 100, "dataCenterId": "EU-RO-1"}
+
+
+class TestPodPayload:
+    def test_includes_volume_image_and_download_command(self):
+        payload = rp.build_download_pod_payload(
+            volume_id="vol-1",
+            image="frankbria/ace-step:latest",
+            gpu_type="NVIDIA GeForce RTX 4090",
+            download_cmd=["bash", "-lc", "echo hi"],
+            name="ace-step-weights-download",
+        )
+        assert payload["networkVolumeId"] == "vol-1"
+        assert payload["imageName"] == "frankbria/ace-step:latest"
+        assert payload["gpuTypeIds"] == ["NVIDIA GeForce RTX 4090"]
+        assert payload["dockerStartCmd"] == ["bash", "-lc", "echo hi"]
+        # Volume must mount where the image expects model weights (HF_HOME lives here).
+        assert payload["volumeMountPath"] == "/workspace"
+
+
+class TestPodFinishedDetection:
+    @pytest.mark.parametrize("status", ["EXITED", "TERMINATED", "STOPPED"])
+    def test_terminal_statuses_are_finished(self, status):
+        assert rp.pod_is_finished({"desiredStatus": status}) is True
+
+    @pytest.mark.parametrize("status", ["RUNNING", "CREATED", "PENDING"])
+    def test_non_terminal_statuses_are_not_finished(self, status):
+        assert rp.pod_is_finished({"desiredStatus": status}) is False
+
+
+class TestDryRun:
+    @respx.mock
+    def test_dry_run_makes_no_api_calls_and_does_not_prompt(self, capsys, monkeypatch):
+        # Any prompt or network call in dry-run is a bug; make them fail loudly.
+        monkeypatch.setattr("builtins.input", lambda *a, **k: pytest.fail("dry-run must not prompt"))
+        list_route = respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=EXISTING_VOLUMES))
+        create_route = respx.post(VOLUMES_URL).mock(return_value=httpx.Response(200, json={}))
+        pod_route = respx.post(PODS_URL).mock(return_value=httpx.Response(200, json={}))
+
+        rc = rp.run_setup(
+            _client(),
+            volume_name="ace-step-models",
+            size_gb=100,
+            region="EU-RO-1",
+            image="frankbria/ace-step:latest",
+            gpu_type="NVIDIA GeForce RTX 4090",
+            download_cmd=["bash", "-lc", "echo hi"],
+            timeout=60.0,
+            poll_interval=5.0,
+            dry_run=True,
+            assume_yes=True,
+        )
+
+        assert rc == 0
+        assert not list_route.called
+        assert not create_route.called
+        assert not pod_route.called
+        out = capsys.readouterr().out
+        # The cost estimate is shown before any resource creation.
+        assert "cost" in out.lower()
+
+
+class TestFullLifecycle:
+    @respx.mock
+    def test_provisions_volume_then_terminates_pod_without_deleting_volume(self, capsys):
+        # Volume absent → created; pod runs then exits; pod is stopped+terminated.
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=[]))
+        respx.post(VOLUMES_URL).mock(
+            return_value=httpx.Response(200, json={"id": "vol-new", "name": "ace-step-models"})
+        )
+        respx.post(PODS_URL).mock(return_value=httpx.Response(200, json={"id": "pod-1"}))
+        get_pod_route = respx.get(f"{PODS_URL}/pod-1").mock(
+            return_value=httpx.Response(200, json={"desiredStatus": "EXITED"})
+        )
+        stop_route = respx.post(f"{PODS_URL}/pod-1/stop").mock(return_value=httpx.Response(200))
+        terminate_route = respx.delete(f"{PODS_URL}/pod-1").mock(return_value=httpx.Response(200))
+        # A volume-DELETE would violate "volume persists after the pod stops".
+        volume_delete = respx.delete(f"{VOLUMES_URL}/vol-new").mock(return_value=httpx.Response(200))
+
+        rc = rp.run_setup(
+            _client(),
+            volume_name="ace-step-models",
+            size_gb=100,
+            region="EU-RO-1",
+            image="frankbria/ace-step:latest",
+            gpu_type="NVIDIA GeForce RTX 4090",
+            download_cmd=["bash", "-lc", "echo hi"],
+            timeout=60.0,
+            poll_interval=0.0,
+            dry_run=False,
+            assume_yes=True,
+        )
+
+        assert rc == 0
+        assert get_pod_route.called
+        assert stop_route.called
+        assert terminate_route.called
+        # AC2: the volume is never deleted.
+        assert not volume_delete.called
+        out = capsys.readouterr().out
+        assert "ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID=vol-new" in out
+
+    @respx.mock
+    def test_timeout_terminates_pod_and_fails(self):
+        respx.get(VOLUMES_URL).mock(return_value=httpx.Response(200, json=EXISTING_VOLUMES))
+        respx.post(PODS_URL).mock(return_value=httpx.Response(200, json={"id": "pod-1"}))
+        # Pod never reaches a terminal status → wait times out.
+        respx.get(f"{PODS_URL}/pod-1").mock(return_value=httpx.Response(200, json={"desiredStatus": "RUNNING"}))
+        stop_route = respx.post(f"{PODS_URL}/pod-1/stop").mock(return_value=httpx.Response(200))
+        terminate_route = respx.delete(f"{PODS_URL}/pod-1").mock(return_value=httpx.Response(200))
+
+        rc = rp.run_setup(
+            _client(),
+            volume_name="ace-step-models",
+            size_gb=100,
+            region="EU-RO-1",
+            image="frankbria/ace-step:latest",
+            gpu_type="NVIDIA GeForce RTX 4090",
+            download_cmd=["bash", "-lc", "echo hi"],
+            timeout=0.0,  # immediate timeout
+            poll_interval=0.0,
+            dry_run=False,
+            assume_yes=True,
+        )
+
+        assert rc == 1
+        # Even on timeout the temporary pod is cleaned up.
+        assert stop_route.called
+        assert terminate_route.called
+
+
+class TestCliParsing:
+    def test_defaults(self):
+        args = rp.parse_args([])
+        assert args.size == 100
+        assert args.volume_name == "ace-step-models"
+        assert args.dry_run is False
+
+    def test_overrides(self):
+        args = rp.parse_args(["--size", "250", "--region", "US-OR-1", "--volume-name", "weights", "--dry-run"])
+        assert args.size == 250
+        assert args.region == "US-OR-1"
+        assert args.volume_name == "weights"
+        assert args.dry_run is True


### PR DESCRIPTION
## Summary
Implements #126 (US-11.5): one-time RunPod Network Volume setup for ACE-Step-1.5 model weights, plus an API endpoint to inspect the configured volume.

- **Settings**: added `runpod_network_volume_id` and `runpod_rest_base_url` to `ApiSettings` (env: `ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID`, `ACEMUSIC_API_RUNPOD_REST_BASE_URL`); documented in `.env.example`.
- **Volume service** (`api/services/volume.py`): transport-agnostic `get_remote_volume()` querying RunPod's management REST API (`rest.runpod.io/v1/networkvolumes`), raising typed domain errors. Mirrors the `compute_status` service pattern.
- **Endpoint**: `GET /api/v1/compute/remote/volume` added to the existing auth-gated compute router; maps to **503** (not configured), **404** (volume absent), **502** (RunPod unreachable), **200** (volume metadata).
- **Setup script** (`scripts/runpod-setup.py`): `argparse` CLI that, idempotently, finds-or-creates the network volume, spins up a temporary GPU pod from the US-11.3 image to download weights, polls to completion, then stops + terminates the pod (volume persists). Shows a cost estimate and confirmation prompt; supports `--dry-run`.

## Adapted from the issue's CodeRabbit plan (which was stale)
The plan predated US-11.1–11.4 and assumed no compute router / RunPod settings existed. Adaptations:
- Reused the **existing** compute router (kept its `get_current_user` auth gate) instead of creating a new unauthenticated one.
- Only **added** `runpod_network_volume_id`/`runpod_rest_base_url`; the api-key/endpoint-id fields already exist.
- **No `runpod` SDK dependency**: both volume and pod operations use direct `httpx` REST, consistent with `runpod_client.py`, keeping the script unit-testable and the runtime lean.

## Acceptance Criteria
- [x] Setup script creates a Network Volume and downloads model weights (idempotent create + temp-pod download; `--dry-run` + mocked tests; live run is integration-only — see Known Limitations)
- [x] Volume persists after the temporary pod is stopped (script terminates the pod, never deletes the volume; asserted by `test_provisions_volume_then_terminates_pod_without_deleting_volume`)
- [x] Future serverless workers/pods can mount the volume (id printed for `ACEMUSIC_API_RUNPOD_NETWORK_VOLUME_ID`; `GET /compute/remote/volume` confirms it)
- [x] Script is idempotent (re-run reuses the existing volume by name, no duplicate POST; asserted by `test_reuses_existing_volume_without_creating`)

## Test Plan
- [x] Unit tests written first (TDD: RED→GREEN per step)
- [x] All tests passing (1318 passed, 0 failed)
- [x] Diff coverage ≥85% on new code (`volume.py` 98%, `compute.py` 95%)
- [x] Linting clean (`ruff`) and formatting clean (`black --check`)
- [x] Internal review (advisory) — superseded by cross-family pass
- [x] Cross-family review pass: **codex** (one P2 found and fixed — see below)

## Known Limitations / Intentionally Deferred
- **Live RunPod provisioning is not exercised in CI.** Creating a real volume + GPU pod requires a paid RunPod account and GPU; all tests mock RunPod's REST API via `respx`. The `--dry-run` mode prints the full plan + cost estimate without spending.
- **Weight-download command is best-effort and configurable.** The default `--download-cmd` warms the HF cache by starting the ACE-Step server until healthy; depending on how the published image fetches weights, operators may need to override `--download-cmd`. It now fails loudly (non-zero, no success marker) if the server never becomes healthy.
- **`used_gb` is always `None`.** RunPod's REST API reports allocated `size` but not live usage, so the field is present (forward-compatible) but unpopulated.
- **Completion is detected from the pod's terminal state**, not its container exit code (RunPod REST does not reliably expose it); the success message directs operators to confirm `ACE_STEP_WEIGHTS_READY` in the pod log.

## Implementation Notes
- codex review flagged a P2 silent-success bug: the original download loop exited 0 and printed the success marker even if the server never became healthy. Fixed in a dedicated commit — the loop now tracks readiness and exits non-zero without the marker on failure, and `run_setup` no longer over-claims completion.

Closes #126
