### PR TITLE
feat(api): mastering job submission (US-12.1)

### DIFF
--- a/docs/demos/us-12.1-mastering.md
+++ b/docs/demos/us-12.1-mastering.md
@@ -1,0 +1,109 @@
+# US-12.1: Mastering job submission
+
+*2026-06-17T19:58:06Z*
+
+`POST /api/v1/mastering/jobs` submits a clip for automated mastering against a target loudness profile. Each scenario below drives the real FastAPI app over HTTP (httpx ASGITransport + a minted JWT) against a live local MongoDB — nothing about the endpoint is mocked, so the JSON shown is exactly the contract a client receives. The persistence scenarios print the actual stored `Job` document.
+
+First — the endpoint is auth-gated like the rest of the API. No token => 401.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_mastering.py auth
+```
+
+```output
+No Authorization header:
+HTTP 401
+{
+  "detail": "Not authenticated."
+}
+```
+
+**AC1 — Submitting a mastering job returns a job_id with status `queued`.** The service defaults to `dolby` and the response is HTTP 202.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_mastering.py ac1
+```
+
+```output
+Submit a mastering job (profile=streaming, service defaults to dolby):
+HTTP 202
+{
+  "job_id": "6a32fc3b43ec8ff43be29279",
+  "status": "queued"
+}
+```
+
+**AC2 — Each profile maps to the correct LUFS target.** The resolved target is persisted on the job; `custom` carries the caller-specified value.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_mastering.py ac2
+```
+
+```output
+Each profile resolves to its loudness target (persisted on the job):
+  streaming  -> target_lufs = -14.0
+  soundcloud -> target_lufs = -12.0
+  club       -> target_lufs = -6.0
+  vinyl      -> target_lufs = -18.0
+  custom     -> target_lufs = -9.0  (caller-specified)
+```
+
+**AC3 — Invalid profile or service returns 422** (and `custom` without a `target_lufs` is also rejected).
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_mastering.py ac3
+```
+
+```output
+Invalid profile 'ultraloud' -> HTTP 422
+Invalid service 'izotope'   -> HTTP 422
+profile=custom without target_lufs -> HTTP 422
+```
+
+**AC4 — Insufficient credits returns 402.** With 1.0 credit and a 3.0-credit dolby master, the request is rejected, the balance is untouched, and no job is created.
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_mastering.py ac4
+```
+
+```output
+Balance 1.0 credit, dolby mastering costs 3.0:
+HTTP 402
+{
+  "detail": {
+    "error": "insufficient_credits",
+    "balance": 1.0,
+    "required": 3.0
+  }
+}
+Balance unchanged: 1.0   Jobs created: 0
+```
+
+**AC5 — Job record is created in MongoDB with all parameters**, and the per-service credits are deducted (bakuage = 5.0).
+
+```bash
+PYTHONWARNINGS=ignore uv run python .cache/demo_mastering.py ac5
+```
+
+```output
+Stored Job document in MongoDB:
+{
+  "id": "6a32fc44596e91ba3481c2f0",
+  "user_id": "6a32fc44596e91ba3481c2ed",
+  "workspace_id": "6a32fc44596e91ba3481c2ee",
+  "job_type": "mastering",
+  "status": "queued",
+  "input_params": {
+    "clip_id": "6a32fc44596e91ba3481c2ef",
+    "profile": "club",
+    "service": "bakuage",
+    "format": "flac",
+    "target_lufs": -6.0
+  }
+}
+Credits: 10.0 -> 5.0  (bakuage = 5.0)
+```
+
+## Known limitation
+
+This ticket is **submission only**. No worker handler is registered for `job_type="mastering"` yet, so submitted jobs stay `queued` until the mastering-processing ticket (the next Stage-12 story) wires up the Dolby/LANDR/Bakuage integration. This is safe by design: `JobProcessor` only claims job types with a registered handler, so a mastering job never crashes the processor or runs partially. The credit charge is the documented behaviour for this story (the 402 acceptance criterion requires it).

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -32,6 +32,7 @@ from .routers import (
     health,
     iterative,
     jobs,
+    mastering,
     presets,
     users,
     workspaces,
@@ -151,6 +152,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(workspaces.router, prefix=API_V1_PREFIX)
     app.include_router(presets.router, prefix=API_V1_PREFIX)
     app.include_router(compute.router, prefix=API_V1_PREFIX)
+    app.include_router(mastering.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/routers/mastering.py
+++ b/src/acemusic/api/routers/mastering.py
@@ -1,0 +1,137 @@
+"""Mastering job submission endpoint (US-12.1).
+
+``POST /api/v1/mastering/jobs`` accepts a source clip, a mastering profile, and
+an optional service/format, then enqueues a credit-bearing mastering job and
+returns 202 with a trackable job id.
+
+The credit-gate flow mirrors the generation/iterative endpoints (these are paid
+operations): the source clip is validated for ownership first (404 before any
+charge), the per-service cost is deducted atomically (the concurrency guard), a
+job-creation failure refunds, and the ledger write is best-effort. The actual
+mastering work is a future ticket — the processor only claims registered
+``job_type``s, so submitted jobs queue safely until then.
+"""
+
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..services import (
+    clips as clip_service,
+    credits as credits_service,
+    mastering as mastering_service,
+    users as user_service,
+)
+
+logger = logging.getLogger(__name__)
+
+# Custom LUFS targets share the remaster bounds: anything above -5 or below -70
+# is a client error, not a master (see editing.RemasterRequest).
+_CUSTOM_LUFS_MIN = -70.0
+_CUSTOM_LUFS_MAX = -5.0
+
+router = APIRouter(prefix="/mastering", tags=["mastering"], dependencies=[Depends(get_current_user)])
+
+
+class MasteringRequest(BaseModel):
+    """A mastering submission: a source clip plus a target profile.
+
+    ``extra="forbid"`` rejects unknown keys with 422 (a client typo surfaces
+    instead of being silently dropped). ``target_lufs`` is required for the
+    ``custom`` profile and forbidden for the standard profiles, which own their
+    own loudness target.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    clip_id: str
+    profile: Literal["streaming", "soundcloud", "club", "vinyl", "custom"]
+    service: Literal["dolby", "landr", "bakuage"] = "dolby"
+    format: Literal["wav", "mp3", "flac"] = "wav"
+    target_lufs: float | None = None
+
+    @model_validator(mode="after")
+    def _check_target_lufs(self) -> "MasteringRequest":
+        if self.profile == "custom":
+            if self.target_lufs is None:
+                raise ValueError("target_lufs is required when profile is 'custom'")
+            if not (_CUSTOM_LUFS_MIN <= self.target_lufs <= _CUSTOM_LUFS_MAX):
+                raise ValueError(f"target_lufs must be between {_CUSTOM_LUFS_MIN} and {_CUSTOM_LUFS_MAX} dB")
+        elif self.target_lufs is not None:
+            raise ValueError("target_lufs is only allowed when profile is 'custom'")
+        return self
+
+
+class MasteringJobResponse(BaseModel):
+    """The accepted-job acknowledgement returned with HTTP 202."""
+
+    job_id: str
+    status: Literal["queued"] = "queued"
+
+
+@router.post("/jobs", response_model=MasteringJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def create_mastering_job(
+    request: MasteringRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> MasteringJobResponse:
+    """Validate the clip, charge credits, and enqueue a queued mastering job.
+
+    Pydantic returns 422 for invalid bodies and the router dependency returns 401
+    for missing/invalid tokens — both before this runs. Raises 404 (stale token
+    or unknown/unowned clip) and 402 (insufficient credits).
+    """
+    user = await user_service.get_user_by_id(current.user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+
+    # Validate ownership before charging: an unknown/unowned clip yields a clean
+    # 404 with no credit movement. The clip's workspace is where the master lands.
+    clip = await clip_service.get_owned_clip(request.clip_id, current.user_id)
+
+    cost = credits_service.get_mastering_cost(request.service)
+    balance_after = await credits_service.deduct_credits(user.id, cost)
+    if balance_after is None:
+        # Re-read the balance for the error payload: the copy on ``user`` was
+        # loaded before the deduction attempt and may be stale under concurrency.
+        fresh = await user_service.get_user_by_id(user.id)
+        balance = fresh.credits_balance if fresh is not None else 0.0
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"error": "insufficient_credits", "balance": balance, "required": cost},
+        )
+
+    target_lufs = mastering_service.resolve_target_lufs(request.profile, request.target_lufs)
+    params = {
+        "clip_id": str(clip.id),
+        "profile": request.profile,
+        "service": request.service,
+        "format": request.format,
+        "target_lufs": target_lufs,
+    }
+    try:
+        job = await mastering_service.create_mastering_job(
+            user_id=user.id,
+            workspace_id=clip.workspace_id,
+            params=params,
+        )
+    except BaseException:
+        # The deduction already landed but no job exists — give the credit back.
+        # BaseException (not Exception): asyncio.CancelledError must also refund.
+        await credits_service.refund_credits(user.id, cost)
+        raise
+    try:
+        await credits_service.record_transaction(
+            user_id=user.id,
+            amount=-cost,
+            action_type=mastering_service.MASTERING_JOB_TYPE,
+            job_id=str(job.id),
+            balance_after=balance_after,
+        )
+    except Exception:
+        # The charge is taken and the job dispatched; failing here would invite a
+        # retry that double-charges. The ledger row is best-effort history.
+        logger.exception("Credit ledger write failed for job %s (user %s)", job.id, user.id)
+    return MasteringJobResponse(job_id=str(job.id))

--- a/src/acemusic/api/routers/mastering.py
+++ b/src/acemusic/api/routers/mastering.py
@@ -75,6 +75,9 @@ class MasteringJobResponse(BaseModel):
 @router.post("/jobs", response_model=MasteringJobResponse, status_code=status.HTTP_202_ACCEPTED)
 async def create_mastering_job(
     request: MasteringRequest,
+    # The router-level dependency already gates auth; declaring it here too gives
+    # the handler the resolved CurrentUser. FastAPI dedupes by callable per
+    # request, so get_current_user runs once (mirrors the iterative router).
     current: CurrentUser = Depends(get_current_user),
 ) -> MasteringJobResponse:
     """Validate the clip, charge credits, and enqueue a queued mastering job.

--- a/src/acemusic/api/routers/mastering.py
+++ b/src/acemusic/api/routers/mastering.py
@@ -106,15 +106,19 @@ async def create_mastering_job(
             detail={"error": "insufficient_credits", "balance": balance, "required": cost},
         )
 
-    target_lufs = mastering_service.resolve_target_lufs(request.profile, request.target_lufs)
-    params = {
-        "clip_id": str(clip.id),
-        "profile": request.profile,
-        "service": request.service,
-        "format": request.format,
-        "target_lufs": target_lufs,
-    }
     try:
+        # Everything after the deduction lives inside the refund guard so the
+        # "charged ⇒ either a job exists or the credit is returned" invariant
+        # holds structurally, not just because resolve_target_lufs happens to be
+        # unreachable today (the Literal profile is Pydantic-validated upstream).
+        target_lufs = mastering_service.resolve_target_lufs(request.profile, request.target_lufs)
+        params = {
+            "clip_id": str(clip.id),
+            "profile": request.profile,
+            "service": request.service,
+            "format": request.format,
+            "target_lufs": target_lufs,
+        }
         job = await mastering_service.create_mastering_job(
             user_id=user.id,
             workspace_id=clip.workspace_id,

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -36,6 +36,18 @@ _COSTS = {
     **{mode: ITERATIVE_COST for mode in _SINGLE_SOURCE_ITERATIVE_MODES},
 }
 
+# US-12.1: mastering is billed per external service, tiered within the
+# documented 2-5 credit band by perceived service value (Dolby is the default).
+MASTERING_DOLBY_COST = 3.0
+MASTERING_LANDR_COST = 2.0
+MASTERING_BAKUAGE_COST = 5.0
+
+_MASTERING_COSTS = {
+    "dolby": MASTERING_DOLBY_COST,
+    "landr": MASTERING_LANDR_COST,
+    "bakuage": MASTERING_BAKUAGE_COST,
+}
+
 # History page size for GET /users/me/credits.
 HISTORY_LIMIT = 50
 
@@ -46,6 +58,14 @@ def get_cost(mode: str) -> float:
         return _COSTS[mode]
     except KeyError:
         raise ValueError(f"Unknown generation mode: {mode!r}") from None
+
+
+def get_mastering_cost(service: str) -> float:
+    """Credit cost of one mastering job on ``service``. Raises for unknown services."""
+    try:
+        return _MASTERING_COSTS[service]
+    except KeyError:
+        raise ValueError(f"Unknown mastering service: {service!r}") from None
 
 
 async def deduct_credits(user_id: PydanticObjectId, cost: float) -> float | None:

--- a/src/acemusic/api/services/mastering.py
+++ b/src/acemusic/api/services/mastering.py
@@ -1,0 +1,81 @@
+"""Mastering service layer (US-12.1).
+
+Persists queued mastering jobs for the mastering endpoint, mirroring
+:func:`acemusic.api.services.editing.create_edit_job`. Profile→LUFS resolution
+lives here too so the router stays thin and the mapping is unit-testable without
+the HTTP surface. Kept transport-agnostic (plain exceptions, never
+``HTTPException``) like the other service modules.
+
+Scope is job *submission* only: no processor handler is registered, so the
+background processor — which claims only registered ``job_type``s — leaves
+mastering jobs queued until the processing ticket wires up a handler.
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import Job, JobStatus
+from ..tasks import dispatch_job
+
+MASTERING_JOB_TYPE = "mastering"
+
+# Each standard profile maps to a fixed integrated-loudness target (LUFS). "club"
+# is the maximum-loudness master (-6) and "vinyl" trades loudness for dynamic
+# range (-18). "custom" is absent: its target comes from the request.
+PROFILE_LUFS_MAP = {
+    "streaming": -14.0,
+    "soundcloud": -12.0,
+    "club": -6.0,
+    "vinyl": -18.0,
+}
+
+CUSTOM_PROFILE = "custom"
+
+
+def resolve_target_lufs(profile: str, custom_lufs: float | None) -> float:
+    """The LUFS target for ``profile``.
+
+    Standard profiles own their target (a stray ``custom_lufs`` is ignored).
+    ``custom`` returns the caller-supplied value, which must be present — range
+    bounds are enforced by the router's request model. Raises ``ValueError`` for
+    an unknown profile or a ``custom`` profile with no value.
+    """
+    if profile in PROFILE_LUFS_MAP:
+        return PROFILE_LUFS_MAP[profile]
+    if profile == CUSTOM_PROFILE:
+        if custom_lufs is None:
+            raise ValueError("custom profile requires a target_lufs value")
+        return custom_lufs
+    raise ValueError(f"Unknown mastering profile: {profile!r}")
+
+
+async def create_mastering_job(
+    *,
+    user_id: PydanticObjectId,
+    workspace_id: PydanticObjectId,
+    params: dict,
+) -> Job:
+    """Persist a queued mastering job and dispatch it.
+
+    ``params`` holds the resolved mastering spec (clip_id, profile, service,
+    format, target_lufs) so the future worker never re-derives anything from the
+    request. ``workspace_id`` is the source clip's workspace — the master lands
+    next to its parent. Returns the saved :class:`Job` (with its id).
+    """
+    job = Job(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        job_type=MASTERING_JOB_TYPE,
+        status=JobStatus.QUEUED,
+        input_params=params,
+    )
+    await job.insert()
+    try:
+        await dispatch_job(str(job.id))
+    except BaseException:
+        # Don't leave the job behind: the processor polls for QUEUED documents,
+        # so an orphan would still run even though the caller saw a failure.
+        # BaseException (not Exception) on purpose: asyncio.CancelledError must
+        # also clean up (mirrors create_edit_job).
+        await job.delete()
+        raise
+    return job

--- a/tests/test_mastering_api.py
+++ b/tests/test_mastering_api.py
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Clip, CreditTransaction, Job, JobStatus, Workspace
-from acemusic.api.services import users as user_service
+from acemusic.api.services import mastering as mastering_service, users as user_service
 from acemusic.api.settings import ApiSettings
 
 MASTERING_URL = f"{API_V1_PREFIX}/mastering/jobs"
@@ -301,3 +301,35 @@ class TestClipOwnership:
             headers=_auth_headers(intruder, settings),
         )
         assert resp.status_code == 404
+        # The IDOR path must not charge the intruder (no credit leak).
+        assert (await _reload(intruder)).credits_balance == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Job-creation failure — credit is refunded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestJobCreationFailure:
+    async def test_credit_refunded_when_job_creation_raises(self, client, settings, monkeypatch) -> None:
+        # If the deduction lands but the job never gets created, the router must
+        # give the credit back rather than charge for work that will never run.
+        user, _ws, clip = await _user_with_clip("master-refund@example.com", balance=10.0)
+
+        async def _boom(**_kwargs):
+            raise RuntimeError("job store down")
+
+        monkeypatch.setattr(mastering_service, "create_mastering_job", _boom)
+        # The ASGI test transport re-raises app exceptions; the refund happens in
+        # the router's ``except`` before the error propagates.
+        with pytest.raises(RuntimeError):
+            await client.post(
+                MASTERING_URL,
+                json={"clip_id": str(clip.id), "profile": "streaming"},
+                headers=_auth_headers(user, settings),
+            )
+        # Deducted (dolby=3) then refunded back to the original balance.
+        assert (await _reload(user)).credits_balance == 10.0
+        assert await Job.find(Job.user_id == user.id).count() == 0
+        assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0

--- a/tests/test_mastering_api.py
+++ b/tests/test_mastering_api.py
@@ -1,0 +1,303 @@
+"""Integration tests for the mastering endpoint (US-12.1).
+
+Covers ``POST /api/v1/mastering/jobs``: each request validates against an owned
+source clip, gates on per-service credits, and enqueues a queued job returning
+202 with a trackable job id. The 401 auth-gate test runs in CI (no DB); the rest
+are ``integration`` and drive the real app over a local MongoDB.
+"""
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, CreditTransaction, Job, JobStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+
+MASTERING_URL = f"{API_V1_PREFIX}/mastering/jobs"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB; plain TestClient does not run the lifespan)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_missing_auth_header_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(MASTERING_URL, json={"clip_id": str(PydanticObjectId()), "profile": "streaming"})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # Disable the background processor: these tests assert on the queued job
+    # record and do not want a worker claiming it out from under them.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str, *, balance: float | None = None):
+    user = await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+    if balance is not None:
+        user.credits_balance = balance
+        await user.save()
+    return user
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(user, workspace: Workspace, *, fmt: str | None = "wav") -> Clip:
+    clip_id = PydanticObjectId()
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt or 'wav'}",
+        format=fmt,
+        duration=10.0,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _user_with_clip(email: str, *, balance: float | None = None):
+    user = await _make_user(email, balance=balance)
+    workspace = await _make_workspace(user)
+    clip = await _insert_clip(user, workspace)
+    return user, workspace, clip
+
+
+def _reload(user):
+    return user_service.get_user_by_id(str(user.id))
+
+
+# ---------------------------------------------------------------------------
+# Success — 202 + queued job persisted with all parameters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestSuccessfulSubmission:
+    async def test_returns_202_with_queued_job_id(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-ok@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "streaming"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["job_id"]
+        assert body["status"] == "queued"
+
+    async def test_job_record_created_in_mongo_with_all_params(self, client, settings) -> None:
+        user, ws, clip = await _user_with_clip("master-persist@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "soundcloud", "service": "landr", "format": "flac"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await Job.get(resp.json()["job_id"])
+        assert job is not None
+        assert job.status is JobStatus.QUEUED
+        assert job.job_type == "mastering"
+        assert job.workspace_id == ws.id
+        assert job.input_params["clip_id"] == str(clip.id)
+        assert job.input_params["profile"] == "soundcloud"
+        assert job.input_params["service"] == "landr"
+        assert job.input_params["format"] == "flac"
+        assert job.input_params["target_lufs"] == -12.0
+
+    @pytest.mark.parametrize(
+        ("profile", "expected_lufs"),
+        [("streaming", -14.0), ("soundcloud", -12.0), ("club", -6.0), ("vinyl", -18.0)],
+    )
+    async def test_each_profile_persists_correct_lufs(self, client, settings, profile, expected_lufs) -> None:
+        user, _ws, clip = await _user_with_clip(f"master-{profile}@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": profile},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await Job.get(resp.json()["job_id"])
+        assert job.input_params["target_lufs"] == expected_lufs
+
+    async def test_custom_profile_uses_supplied_lufs(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-custom@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "custom", "target_lufs": -9.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await Job.get(resp.json()["job_id"])
+        assert job.input_params["target_lufs"] == -9.0
+
+    async def test_service_specific_credits_deducted(self, client, settings) -> None:
+        # bakuage costs 5; a 10-credit balance should drop to 5.
+        user, _ws, clip = await _user_with_clip("master-charge@example.com", balance=10.0)
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "streaming", "service": "bakuage"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload(user)).credits_balance == 5.0
+        txns = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        assert len(txns) == 1
+        assert txns[0].amount == -5.0
+        assert txns[0].action_type == "mastering"
+
+
+# ---------------------------------------------------------------------------
+# Validation — 422
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestValidation:
+    async def test_invalid_profile_returns_422(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-badprofile@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "ultraloud"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_invalid_service_returns_422(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-badservice@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "streaming", "service": "izotope"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_custom_profile_without_target_lufs_returns_422(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-custom-missing@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "custom"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_target_lufs_on_standard_profile_returns_422(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-stray-lufs@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "streaming", "target_lufs": -10.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_custom_lufs_out_of_range_returns_422(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-lufs-range@example.com")
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "custom", "target_lufs": 5.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Credit gating — 402
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestInsufficientCredits:
+    async def test_returns_402_with_balance_payload(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-poor@example.com", balance=1.0)
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "streaming", "service": "dolby"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 402
+        detail = resp.json()["detail"]
+        assert detail["error"] == "insufficient_credits"
+        assert detail["balance"] == 1.0
+        assert detail["required"] == 3.0
+
+    async def test_no_job_or_charge_on_insufficient_credits(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("master-poor-noop@example.com", balance=1.0)
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "streaming"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 402
+        assert (await _reload(user)).credits_balance == 1.0
+        assert await Job.find(Job.user_id == user.id).count() == 0
+        assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Ownership — 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestClipOwnership:
+    async def test_unknown_clip_returns_404_and_no_charge(self, client, settings) -> None:
+        user = await _make_user("master-noclip@example.com", balance=10.0)
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(PydanticObjectId()), "profile": "streaming"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+        assert (await _reload(user)).credits_balance == 10.0
+
+    async def test_other_users_clip_returns_404(self, client, settings) -> None:
+        owner, _ws, clip = await _user_with_clip("master-owner@example.com")
+        intruder = await _make_user("master-intruder@example.com", balance=10.0)
+        resp = await client.post(
+            MASTERING_URL,
+            json={"clip_id": str(clip.id), "profile": "streaming"},
+            headers=_auth_headers(intruder, settings),
+        )
+        assert resp.status_code == 404

--- a/tests/test_mastering_api.py
+++ b/tests/test_mastering_api.py
@@ -105,8 +105,8 @@ async def _user_with_clip(email: str, *, balance: float | None = None):
     return user, workspace, clip
 
 
-def _reload(user):
-    return user_service.get_user_by_id(str(user.id))
+async def _reload(user):
+    return await user_service.get_user_by_id(str(user.id))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mastering_service.py
+++ b/tests/test_mastering_service.py
@@ -1,0 +1,107 @@
+"""Tests for the mastering service layer (US-12.1).
+
+The cost lookup and profile→LUFS resolution are pure functions and run in CI
+(no DB); ``create_mastering_job`` is ``integration`` and drives a real MongoDB
+via the ``mongo_db`` fixture, mirroring ``tests/test_clips_edit_api.py``.
+"""
+
+import pytest
+from beanie import PydanticObjectId
+
+from acemusic.api.models import Job, JobStatus
+from acemusic.api.services import credits as credits_service, mastering as mastering_service
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — credit costs (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestMasteringCost:
+    @pytest.mark.parametrize(
+        ("service", "expected"),
+        [("dolby", 3.0), ("landr", 2.0), ("bakuage", 5.0)],
+    )
+    def test_known_services_map_to_costs(self, service: str, expected: float) -> None:
+        assert credits_service.get_mastering_cost(service) == expected
+
+    def test_costs_stay_within_documented_range(self) -> None:
+        # The issue specifies "2-5 credits"; guard the band so a future tweak
+        # cannot drift outside the contract silently.
+        for service in ("dolby", "landr", "bakuage"):
+            assert 2.0 <= credits_service.get_mastering_cost(service) <= 5.0
+
+    def test_unknown_service_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            credits_service.get_mastering_cost("nope")
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests — profile → LUFS resolution (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTargetLufs:
+    @pytest.mark.parametrize(
+        ("profile", "expected"),
+        [("streaming", -14.0), ("soundcloud", -12.0), ("club", -6.0), ("vinyl", -18.0)],
+    )
+    def test_standard_profiles_map_to_lufs(self, profile: str, expected: float) -> None:
+        assert mastering_service.resolve_target_lufs(profile, None) == expected
+
+    def test_standard_profile_ignores_custom_value(self) -> None:
+        # A standard profile owns its target; a stray custom value must not win.
+        assert mastering_service.resolve_target_lufs("streaming", -3.0) == -14.0
+
+    def test_custom_profile_returns_supplied_value(self) -> None:
+        assert mastering_service.resolve_target_lufs("custom", -9.5) == -9.5
+
+    def test_custom_profile_without_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            mastering_service.resolve_target_lufs("custom", None)
+
+    def test_unknown_profile_raises(self) -> None:
+        with pytest.raises(ValueError):
+            mastering_service.resolve_target_lufs("bogus", None)
+
+
+# ---------------------------------------------------------------------------
+# Integration — create_mastering_job persists + dispatches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestCreateMasteringJob:
+    async def test_persists_queued_job_with_params(self, mongo_db) -> None:
+        user_id = PydanticObjectId()
+        workspace_id = PydanticObjectId()
+        params = {
+            "clip_id": str(PydanticObjectId()),
+            "profile": "streaming",
+            "service": "dolby",
+            "format": "wav",
+            "target_lufs": -14.0,
+        }
+        job = await mastering_service.create_mastering_job(user_id=user_id, workspace_id=workspace_id, params=params)
+
+        stored = await Job.get(job.id)
+        assert stored is not None
+        assert stored.status is JobStatus.QUEUED
+        assert stored.job_type == mastering_service.MASTERING_JOB_TYPE
+        assert stored.user_id == user_id
+        assert stored.workspace_id == workspace_id
+        assert stored.input_params == params
+
+    async def test_dispatch_failure_rolls_back_job(self, mongo_db, monkeypatch) -> None:
+        async def _boom(_job_id: str) -> None:
+            raise RuntimeError("dispatch down")
+
+        monkeypatch.setattr(mastering_service, "dispatch_job", _boom)
+        before = await Job.find_all().count()
+        with pytest.raises(RuntimeError):
+            await mastering_service.create_mastering_job(
+                user_id=PydanticObjectId(),
+                workspace_id=PydanticObjectId(),
+                params={"clip_id": str(PydanticObjectId()), "profile": "streaming"},
+            )
+        # The orphan must be deleted so the processor never runs an un-acked job.
+        assert await Job.find_all().count() == before


### PR DESCRIPTION
## US-12.1: Mastering job submission

Closes #127.

Adds `POST /api/v1/mastering/jobs` — submit a clip for automated mastering against a target loudness profile. Mirrors the existing credit-gated generation/iterative flow and the editing/extraction clip-scoped job pattern.

### What changed
- **`services/credits.py`** — per-service mastering costs (`dolby=3`, `landr=2`, `bakuage=5`, within the documented 2–5 band) + `get_mastering_cost()` (raises for unknown services, mirroring `get_cost()`).
- **`services/mastering.py`** (new) — `PROFILE_LUFS_MAP` (streaming −14, soundcloud −12, club −6, vinyl −18), `resolve_target_lufs()`, and `create_mastering_job()` (insert → dispatch → rollback on `BaseException`, mirroring `create_edit_job`).
- **`routers/mastering.py`** (new) — `MasteringRequest` (`extra="forbid"`; validator requires `target_lufs` for `custom`, forbids it otherwise, bounds it to −70..−5 dB) and the endpoint: resolve user (404) → fetch owned clip (404) → atomic credit deduct (402 with `{error, balance, required}`) → resolve LUFS → create job (refund on failure) → best-effort ledger → 202.
- **`main.py`** — register the router under `/api/v1`.

### Acceptance criteria — all demonstrated
See `docs/demos/us-12.1-mastering.md` (real HTTP responses + stored Mongo documents):
- ✅ Submitting a job returns a `job_id` with status `queued` (202)
- ✅ Each profile maps to the correct LUFS target (persisted on the job)
- ✅ Invalid profile or service returns 422 (plus `custom` without `target_lufs`)
- ✅ Insufficient credits returns 402 (balance untouched, no job created)
- ✅ Job record created in MongoDB with all parameters; per-service credits deducted

### Tests
- `tests/test_mastering_service.py` — unit (cost lookup, profile→LUFS resolution, edge cases) + integration (job persisted/dispatched, dispatch-failure rollback).
- `tests/test_mastering_api.py` — 202 success, per-profile LUFS persistence, custom LUFS, service-specific charge + ledger, 422 (invalid profile/service, custom validator, out-of-range), 402 (no job/charge), 404 (unknown + cross-user clip), 401 auth gate.
- All pass; `ruff` + `black --check` clean on changed files.

### Known limitations
- **Submission only — no worker handler yet.** Jobs are persisted with `job_type="mastering"` and charged, but no processor handler exists for that type, so they stay `queued` until the mastering-processing ticket (next Stage-12 story) wires up the Dolby/LANDR/Bakuage integration. This is safe by design — `JobProcessor` only claims registered job types, so a mastering job never crashes the processor or runs partially. The credit charge is intentional: the 402 acceptance criterion requires deduction at submission. (Raised in cross-family review as a P1; it is the explicitly-approved design per the issue's CodeRabbit plan, Design Choice 3.)
- **`club`/`vinyl` LUFS** use concrete values (−6 / −18) since the job params need a number; the issue described them qualitatively ("maximum loudness" / "wide dynamic range").

### Review
- Cross-family review: `codex review` (primary) — one P1, addressed above as a documented, approved limitation.
- Internal advisory review — no blockers; two minor cleanups applied (`await _reload` in tests, comment on the intentional router/endpoint double-`Depends`).
