### PR TITLE
refactor(api): shared task-layer helpers + unify JobProcessingError (US-0.2)

### DIFF
--- a/src/acemusic/api/tasks/common.py
+++ b/src/acemusic/api/tasks/common.py
@@ -1,0 +1,95 @@
+"""Shared task-layer helpers for the job handlers (US-0.2).
+
+Every job-type module (editing, extraction, mastering, export, iterative) runs
+the same clip lifecycle: resolve the source clip, download its audio, store a
+derived clip with rollback-on-failure. These helpers are that lifecycle, factored
+out of the per-module copies so a new job type reuses them instead of cloning.
+
+:class:`JobProcessingError` is the single failure type every handler raises; the
+:class:`~acemusic.api.tasks.processor.JobProcessor` records its message as the
+job's failure (it lived in ``processor`` before US-0.2 and is re-exported there).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from beanie import PydanticObjectId
+
+from acemusic.storage import StorageBackend
+
+from ..models import Clip, Job
+
+logger = logging.getLogger(__name__)
+
+
+class JobProcessingError(Exception):
+    """A job could not be processed (missing source, audio/ML/service failure)."""
+
+
+async def load_clip(clip_id: object) -> Clip:
+    """Resolve a source clip by id, or fail the job with a clear error.
+
+    The clip may legitimately vanish between enqueue and processing (the owner
+    can DELETE it while the job is queued), so a miss is a job failure, not a
+    crash.
+    """
+    try:
+        oid = PydanticObjectId(clip_id)
+    except Exception as exc:
+        raise JobProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
+    clip = await Clip.get(oid)
+    if clip is None:
+        raise JobProcessingError(f"Source clip {clip_id} no longer exists")
+    return clip
+
+
+async def load_source_clip(job: Job) -> Clip:
+    """Resolve the clip referenced by ``job.input_params['clip_id']``."""
+    return await load_clip((job.input_params or {}).get("clip_id"))
+
+
+async def download_clip(storage: StorageBackend, clip: Clip) -> bytes:
+    """Download a clip's audio bytes, failing the job if the object is missing."""
+    try:
+        return await asyncio.to_thread(storage.download, clip.file_path)
+    except FileNotFoundError as exc:
+        raise JobProcessingError(f"Source clip {clip.id} audio object {clip.file_path!r} is missing") from exc
+
+
+async def store_clip(storage: StorageBackend, clip: Clip, data: bytes) -> Clip:
+    """Upload ``data`` to ``clip.file_path`` and insert ``clip``.
+
+    Rolls the just-uploaded object back if the insert fails, so a job that ends up
+    ``failed`` never leaves an orphaned storage object behind.
+    """
+    await asyncio.to_thread(storage.upload, clip.file_path, data)
+    try:
+        await clip.insert()
+    except BaseException:
+        # BaseException (not Exception): a shutdown CancelledError must also clean
+        # up the just-uploaded object, else a requeued retry leaves it orphaned.
+        try:
+            await asyncio.to_thread(storage.delete, clip.file_path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned storage object %s during rollback", clip.file_path)
+        raise
+    return clip
+
+
+async def rollback_clips(storage: StorageBackend, clip_ids: list[str]) -> None:
+    """Best-effort removal of child clips (docs + audio objects) already stored.
+
+    Used by multi-output modes so a failure partway through the batch does not
+    leave earlier children behind for a job that ends up ``failed``.
+    """
+    for clip_id in clip_ids:
+        clip = await Clip.get(PydanticObjectId(clip_id))
+        if clip is None:  # pragma: no cover - already gone
+            continue
+        try:
+            await asyncio.to_thread(storage.delete, clip.file_path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned storage object %s during rollback", clip.file_path)
+        await clip.delete()

--- a/src/acemusic/api/tasks/common.py
+++ b/src/acemusic/api/tasks/common.py
@@ -92,4 +92,9 @@ async def rollback_clips(storage: StorageBackend, clip_ids: list[str]) -> None:
             await asyncio.to_thread(storage.delete, clip.file_path)
         except Exception:  # pragma: no cover - cleanup is best-effort
             logger.exception("Failed to delete orphaned storage object %s during rollback", clip.file_path)
-        await clip.delete()
+        try:
+            await clip.delete()
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            # Best-effort: a delete error here must not mask the original job failure
+            # (callers re-raise that after rollback returns).
+            logger.exception("Failed to delete orphaned clip doc %s during rollback", clip_id)

--- a/src/acemusic/api/tasks/editing.py
+++ b/src/acemusic/api/tasks/editing.py
@@ -16,7 +16,6 @@ propagate and the processor marks the job failed.
 from __future__ import annotations
 
 import asyncio
-import logging
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -29,30 +28,7 @@ from acemusic.storage import StorageBackend
 from ..models import Clip, Job
 from ..services.clips import native_format
 from ..services.editing import CROP_JOB_TYPE, REMASTER_JOB_TYPE, SPEED_JOB_TYPE
-
-logger = logging.getLogger(__name__)
-
-
-class EditProcessingError(Exception):
-    """An editing job could not be processed (missing source, audio failure)."""
-
-
-async def _load_source_clip(job: Job) -> Clip:
-    """Resolve the job's source clip, or fail the job with a clear error.
-
-    The clip may legitimately vanish between enqueue and processing (the owner
-    can DELETE it while the job is queued), so a miss is a job failure, not a
-    crash.
-    """
-    clip_id = (job.input_params or {}).get("clip_id")
-    try:
-        oid = PydanticObjectId(clip_id)
-    except Exception as exc:
-        raise EditProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
-    clip = await Clip.get(oid)
-    if clip is None:
-        raise EditProcessingError(f"Source clip {clip_id} no longer exists")
-    return clip
+from .common import download_clip, load_source_clip, store_clip
 
 
 async def _store_derived_clip(
@@ -64,20 +40,14 @@ async def _store_derived_clip(
     duration: float | None,
     bpm: int | None,
 ) -> Clip:
-    """Upload the edited audio and insert its Clip record (id matches the key).
-
-    An insert failure deletes the just-uploaded object so a failed job never
-    leaves an orphaned file behind (mirrors the generate path's rollback).
-    """
+    """Upload the edited audio and insert its Clip record (id matches the key)."""
     fmt = native_format(source)
     clip_id = PydanticObjectId()
-    path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
-    await asyncio.to_thread(storage.upload, path, data)
     clip = Clip(
         id=clip_id,
         user_id=job.user_id,
         workspace_id=job.workspace_id,
-        file_path=path,
+        file_path=f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}",
         format=fmt,
         duration=duration,
         bpm=bpm,
@@ -85,15 +55,7 @@ async def _store_derived_clip(
         parent_clip_ids=[source.id],
         generation_mode=job.job_type,
     )
-    try:
-        await clip.insert()
-    except BaseException:
-        try:
-            await asyncio.to_thread(storage.delete, path)
-        except Exception:  # pragma: no cover - cleanup is best-effort
-            logger.exception("Failed to delete orphaned storage object %s during rollback", path)
-        raise
-    return clip
+    return await store_clip(storage, clip, data)
 
 
 class _EditWorkspace:
@@ -105,16 +67,12 @@ class _EditWorkspace:
 
 
 async def _download_source(storage: StorageBackend, source: Clip, workspace: _EditWorkspace) -> None:
-    try:
-        data = await asyncio.to_thread(storage.download, source.file_path)
-    except FileNotFoundError as exc:
-        raise EditProcessingError(f"Source clip {source.id} audio object {source.file_path!r} is missing") from exc
-    workspace.input_path.write_bytes(data)
+    workspace.input_path.write_bytes(await download_clip(storage, source))
 
 
 async def process_crop_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
     """Trim the source to ``[start_ms, end_ms]`` (with optional fades)."""
-    source = await _load_source_clip(job)
+    source = await load_source_clip(job)
     params = job.input_params
     start_ms, end_ms = params["start_ms"], params["end_ms"]
 
@@ -145,7 +103,7 @@ async def process_crop_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
 
 async def process_speed_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
     """Time-stretch the source by the resolved ``multiplier`` (pitch preserved)."""
-    source = await _load_source_clip(job)
+    source = await load_source_clip(job)
     multiplier = job.input_params["multiplier"]
 
     with tempfile.TemporaryDirectory(prefix="acemusic-speed-") as tmp_dir:
@@ -172,7 +130,7 @@ async def process_speed_job(job: Job, storage: StorageBackend) -> dict[str, Any]
 
 async def process_remaster_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
     """Loudness-normalise the source to ``target_lufs`` (full remaster pipeline)."""
-    source = await _load_source_clip(job)
+    source = await load_source_clip(job)
     target_lufs = job.input_params["target_lufs"]
 
     with tempfile.TemporaryDirectory(prefix="acemusic-remaster-") as tmp_dir:

--- a/src/acemusic/api/tasks/export.py
+++ b/src/acemusic/api/tasks/export.py
@@ -26,55 +26,24 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from beanie import PydanticObjectId
-
 from acemusic.audio import EXPORT_FORMATS, export_audio
 from acemusic.storage import StorageBackend
 
-from ..models import Clip, Job
+from ..models import Job
 from ..services.clips import native_format
+from .common import JobProcessingError, download_clip, load_source_clip
 
 # Container/extension each export format is written to (wav32 is a wav variant).
 _FORMAT_EXTENSIONS = {"wav": "wav", "wav32": "wav", "flac": "flac", "mp3": "mp3"}
-
-
-class ExportProcessingError(Exception):
-    """An export job could not be processed (missing source, bad format)."""
-
-
-async def _load_source_clip(job: Job) -> Clip:
-    """Resolve the job's source clip, or fail the job with a clear error.
-
-    The clip may legitimately vanish between enqueue and processing (the owner
-    can DELETE it while the job is queued), so a miss is a job failure, not a
-    crash (mirrors the extraction handlers).
-    """
-    clip_id = (job.input_params or {}).get("clip_id")
-    try:
-        oid = PydanticObjectId(clip_id)
-    except Exception as exc:
-        raise ExportProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
-    clip = await Clip.get(oid)
-    if clip is None:
-        raise ExportProcessingError(f"Source clip {clip_id} no longer exists")
-    return clip
-
-
-async def _download_source(storage: StorageBackend, source: Clip, dest: Path) -> None:
-    try:
-        data = await asyncio.to_thread(storage.download, source.file_path)
-    except FileNotFoundError as exc:
-        raise ExportProcessingError(f"Source clip {source.id} audio object {source.file_path!r} is missing") from exc
-    await asyncio.to_thread(dest.write_bytes, data)
 
 
 async def process_export_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
     """Transcode the source clip to the requested format and store the file."""
     fmt = (job.input_params or {}).get("format")
     if fmt not in EXPORT_FORMATS:
-        raise ExportProcessingError(f"Unsupported export format: {fmt!r}. Expected one of {EXPORT_FORMATS}.")
+        raise JobProcessingError(f"Unsupported export format: {fmt!r}. Expected one of {EXPORT_FORMATS}.")
 
-    source = await _load_source_clip(job)
+    source = await load_source_clip(job)
     src_ext = native_format(source)
 
     ext = _FORMAT_EXTENSIONS[fmt]
@@ -82,7 +51,7 @@ async def process_export_job(job: Job, storage: StorageBackend) -> dict[str, Any
         # Keep the source's real extension so export_audio's pydub decode hint
         # (derived from the suffix) matches the actual format.
         input_path = Path(tmp_dir) / f"source.{src_ext}"
-        await _download_source(storage, source, input_path)
+        await asyncio.to_thread(input_path.write_bytes, await download_clip(storage, source))
         dest_path = Path(tmp_dir) / f"export.{ext}"
         await asyncio.to_thread(export_audio, input_path, dest_path, fmt)
         data = await asyncio.to_thread(dest_path.read_bytes)

--- a/src/acemusic/api/tasks/extraction.py
+++ b/src/acemusic/api/tasks/extraction.py
@@ -42,44 +42,13 @@ from acemusic.storage import StorageBackend
 from ..models import Clip, Job
 from ..services.clips import native_format
 from ..services.extraction import MIDI_JOB_TYPE, STEMS_JOB_TYPE
+from .common import JobProcessingError, download_clip, load_source_clip, rollback_clips, store_clip
 
 logger = logging.getLogger(__name__)
 
 # Default sample rate if the stems client does not expose ``model_samplerate``
 # (mirrors acemusic.daw_export); test doubles need not load a real model.
 _DEFAULT_SAMPLE_RATE = 44100
-
-
-class ExtractionProcessingError(Exception):
-    """An extraction job could not be processed (missing source, ML failure)."""
-
-
-async def _load_source_clip(job: Job) -> Clip:
-    """Resolve the job's source clip, or fail the job with a clear error.
-
-    The clip may legitimately vanish between enqueue and processing (the owner
-    can DELETE it while the job is queued), so a miss is a job failure, not a
-    crash (mirrors the editing handlers).
-    """
-    clip_id = (job.input_params or {}).get("clip_id")
-    try:
-        oid = PydanticObjectId(clip_id)
-    except Exception as exc:
-        raise ExtractionProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
-    clip = await Clip.get(oid)
-    if clip is None:
-        raise ExtractionProcessingError(f"Source clip {clip_id} no longer exists")
-    return clip
-
-
-async def _download_source(storage: StorageBackend, source: Clip, dest: Path) -> None:
-    try:
-        data = await asyncio.to_thread(storage.download, source.file_path)
-    except FileNotFoundError as exc:
-        raise ExtractionProcessingError(
-            f"Source clip {source.id} audio object {source.file_path!r} is missing"
-        ) from exc
-    dest.write_bytes(data)
 
 
 def _separate_stems(source_path: Path, output_dir: Path, base_name: str) -> dict[str, Path]:
@@ -105,18 +74,18 @@ async def process_stems_job(job: Job, storage: StorageBackend) -> dict[str, Any]
     leaves orphaned ``Clip`` rows or storage objects behind (mirrors the
     generate path's rollback).
     """
-    source = await _load_source_clip(job)
+    source = await load_source_clip(job)
 
     with tempfile.TemporaryDirectory(prefix="acemusic-stems-") as tmp_dir:
         input_path = Path(tmp_dir) / f"source.{native_format(source)}"
-        await _download_source(storage, source, input_path)
+        input_path.write_bytes(await download_clip(storage, source))
         stem_paths = await asyncio.to_thread(_separate_stems, input_path, Path(tmp_dir), str(source.id))
         # Read the produced stem bytes while the temp dir still exists, in the
         # canonical label order so the result is deterministic.
         produced = [(label, Path(stem_paths[label]).read_bytes()) for label in STEM_LABELS if label in stem_paths]
 
     if not produced:
-        raise ExtractionProcessingError(f"Stem separation produced no output for clip {source.id}")
+        raise JobProcessingError(f"Stem separation produced no output for clip {source.id}")
 
     # Re-extraction (only reached when the cached set is incomplete — a complete
     # set short-circuits in the router) replaces any leftover stem children so
@@ -149,24 +118,19 @@ async def _store_stem_clips(
 ) -> list[str]:
     """Upload each stem and insert its child Clip; roll back on any failure.
 
-    Uploaded paths are tracked the moment the upload returns — *before* the
-    insert — so a clip insert that fails after its object is already stored
-    still has that object cleaned up (not just the earlier, fully-stored ones).
+    ``store_clip`` rolls back a stem whose own insert fails (its object is removed
+    before raising); on that failure the already-inserted earlier stems are rolled
+    back here, so a ``failed`` job leaves no orphaned clips or objects behind.
     """
     clip_ids: list[str] = []
-    inserted: list[Clip] = []
-    uploaded_paths: list[str] = []
     try:
         for label, data in produced:
             clip_id = PydanticObjectId()
-            path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.wav"
-            await asyncio.to_thread(storage.upload, path, data)
-            uploaded_paths.append(path)
             clip = Clip(
                 id=clip_id,
                 user_id=job.user_id,
                 workspace_id=job.workspace_id,
-                file_path=path,
+                file_path=f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.wav",
                 title=label,
                 format="wav",
                 # Stems are the same length as the source mix (time-aligned).
@@ -176,27 +140,12 @@ async def _store_stem_clips(
                 parent_clip_ids=[source.id],
                 generation_mode=STEMS_JOB_TYPE,
             )
-            await clip.insert()
-            inserted.append(clip)
+            await store_clip(storage, clip, data)
             clip_ids.append(str(clip_id))
     except Exception:
-        await _rollback_clips(storage, inserted, uploaded_paths)
+        await rollback_clips(storage, clip_ids)
         raise
     return clip_ids
-
-
-async def _rollback_clips(storage: StorageBackend, inserted: list[Clip], uploaded_paths: list[str]) -> None:
-    """Best-effort cleanup of stem clips/files written before a mid-batch failure."""
-    for clip in inserted:
-        try:
-            await clip.delete()
-        except Exception:  # pragma: no cover - cleanup is best-effort
-            logger.exception("Failed to delete orphaned stem clip %s during rollback", clip.id)
-    for path in uploaded_paths:
-        try:
-            await asyncio.to_thread(storage.delete, path)
-        except Exception:  # pragma: no cover - cleanup is best-effort
-            logger.exception("Failed to delete orphaned storage object %s during rollback", path)
 
 
 async def process_midi_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
@@ -207,19 +156,19 @@ async def process_midi_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
     failure after some uploads cleans them up so a failed job leaves no orphans
     and never half-populates ``midi_paths``.
     """
-    source = await _load_source_clip(job)
+    source = await load_source_clip(job)
     bpm = float(source.bpm) if source.bpm is not None else 120.0
 
     with tempfile.TemporaryDirectory(prefix="acemusic-midi-") as tmp_dir:
         input_path = Path(tmp_dir) / f"source.{native_format(source)}"
-        await _download_source(storage, source, input_path)
+        input_path.write_bytes(await download_clip(storage, source))
         midi_files = await asyncio.to_thread(_extract_midi, input_path, Path(tmp_dir), str(source.id), bpm)
         produced = [
             (label, Path(midi_files[label]).read_bytes()) for label in MIDI_OUTPUT_LABELS if label in midi_files
         ]
 
     if not produced:
-        raise ExtractionProcessingError(f"MIDI extraction produced no output for clip {source.id}")
+        raise JobProcessingError(f"MIDI extraction produced no output for clip {source.id}")
 
     midi_paths = await _store_midi_files(job, source, storage, produced)
     # Record the artifacts on the parent clip: this is the cache + retrieval

--- a/src/acemusic/api/tasks/iterative.py
+++ b/src/acemusic/api/tasks/iterative.py
@@ -62,6 +62,7 @@ from ..services.iterative import (
     REPAINT_JOB_TYPE,
     SAMPLE_JOB_TYPE,
 )
+from .common import JobProcessingError, download_clip, load_clip, rollback_clips, store_clip
 
 logger = logging.getLogger(__name__)
 
@@ -85,38 +86,13 @@ _ROLE_PROMPT_PREFIX = {
 PollFn = Callable[[AceStepClient, str], Awaitable[dict[str, Any]]]
 
 
-class IterativeProcessingError(Exception):
-    """An iterative-generation job could not be processed."""
-
-
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 
 
-async def _load_clip(clip_id: str) -> Clip:
-    """Resolve a source clip by id, or fail the job with a clear error.
-
-    A source clip may legitimately vanish between enqueue and processing (the
-    owner can DELETE it while the job is queued), so a miss is a job failure,
-    not a crash (mirrors the extraction handlers).
-    """
-    try:
-        oid = PydanticObjectId(clip_id)
-    except Exception as exc:
-        raise IterativeProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
-    clip = await Clip.get(oid)
-    if clip is None:
-        raise IterativeProcessingError(f"Source clip {clip_id} no longer exists")
-    return clip
-
-
 async def _download(storage: StorageBackend, clip: Clip, dest: Path) -> None:
-    try:
-        data = await asyncio.to_thread(storage.download, clip.file_path)
-    except FileNotFoundError as exc:
-        raise IterativeProcessingError(f"Source clip {clip.id} audio object {clip.file_path!r} is missing") from exc
-    dest.write_bytes(data)
+    dest.write_bytes(await download_clip(storage, clip))
 
 
 def _source_prompt(clip: Clip, fallback: str) -> str:
@@ -142,10 +118,10 @@ async def _submit_and_download(
     task_id = await asyncio.to_thread(partial(client.submit_task, **submit_kwargs))
     result = await poll(client, task_id)
     if result.get("status") == "failed":
-        raise IterativeProcessingError(result.get("error") or "ACE-Step task failed")
+        raise JobProcessingError(result.get("error") or "ACE-Step task failed")
     audio_urls = result.get("audio_urls") or []
     if len(audio_urls) < expected:
-        raise IterativeProcessingError(f"ACE-Step returned {len(audio_urls)} clip(s) but {expected} were expected")
+        raise JobProcessingError(f"ACE-Step returned {len(audio_urls)} clip(s) but {expected} were expected")
     return [await asyncio.to_thread(client.download_audio, url) for url in audio_urls[:expected]]
 
 
@@ -178,13 +154,11 @@ async def _store_child_clip(
     generate / editing paths' rollback).
     """
     clip_id = PydanticObjectId()
-    path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
-    await asyncio.to_thread(storage.upload, path, data)
     clip = Clip(
         id=clip_id,
         user_id=job.user_id,
         workspace_id=job.workspace_id,
-        file_path=path,
+        file_path=f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}",
         title=title,
         format=fmt,
         duration=duration,
@@ -197,32 +171,8 @@ async def _store_child_clip(
         generation_mode=job.job_type,
         generation_params=dict(job.input_params or {}),
     )
-    try:
-        await clip.insert()
-    except BaseException:
-        try:
-            await asyncio.to_thread(storage.delete, path)
-        except Exception:  # pragma: no cover - cleanup is best-effort
-            logger.exception("Failed to delete orphaned storage object %s during rollback", path)
-        raise
+    await store_clip(storage, clip, data)
     return str(clip_id)
-
-
-async def _rollback_children(storage: StorageBackend, clip_ids: list[str]) -> None:
-    """Best-effort removal of child clips (docs + audio objects) already stored.
-
-    Used by multi-output modes (sample) so a failure partway through the batch
-    does not leave earlier children behind for a job that ends up ``failed``.
-    """
-    for clip_id in clip_ids:
-        clip = await Clip.get(PydanticObjectId(clip_id))
-        if clip is None:  # pragma: no cover - already gone
-            continue
-        try:
-            await asyncio.to_thread(storage.delete, clip.file_path)
-        except Exception:  # pragma: no cover - cleanup is best-effort
-            logger.exception("Failed to delete orphaned storage object %s during rollback", clip.file_path)
-        await clip.delete()
 
 
 def _decode(data: bytes, fmt: str) -> AudioSegment:
@@ -238,9 +188,9 @@ def _decode(data: bytes, fmt: str) -> AudioSegment:
 async def process_extend_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
     """Grow the source by ``duration`` from ``from_point`` (ACE-Step ``repaint``)."""
     params = dict(job.input_params or {})
-    source = await _load_clip(params["clip_id"])
+    source = await load_clip(params["clip_id"])
     if source.duration is None:
-        raise IterativeProcessingError(f"Source clip {source.id} has no duration metadata")
+        raise JobProcessingError(f"Source clip {source.id} has no duration metadata")
     fmt = native_format(source)
     duration_s = parse_time_string(params["duration"]) / 1000.0
     from_point = params.get("from_point", "end")
@@ -303,7 +253,7 @@ async def _process_restyle_job(
 ) -> dict:
     """Shared cover/remix path: ACE-Step ``cover`` at the source's length."""
     params = dict(job.input_params or {})
-    source = await _load_clip(params["clip_id"])
+    source = await load_clip(params["clip_id"])
     fmt = native_format(source)
     effective_lyrics = lyrics if lyrics is not None else source.lyrics
     with tempfile.TemporaryDirectory(prefix="acemusic-restyle-") as tmp:
@@ -371,7 +321,7 @@ async def process_remix_job(job: Job, *, storage: StorageBackend, client: AceSte
 async def process_add_vocal_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
     """Layer vocals onto the source (ACE-Step ``complete``)."""
     params = dict(job.input_params or {})
-    source = await _load_clip(params["clip_id"])
+    source = await load_clip(params["clip_id"])
     fmt = native_format(source)
     with tempfile.TemporaryDirectory(prefix="acemusic-vocal-") as tmp:
         src_path = Path(tmp) / f"source.{fmt}"
@@ -417,7 +367,7 @@ async def process_add_vocal_job(job: Job, *, storage: StorageBackend, client: Ac
 async def process_repaint_job(job: Job, *, storage: StorageBackend, client: AceStepClient, poll: PollFn) -> dict:
     """Regenerate ``[start, end]`` and crossfade it back into the original audio."""
     params = dict(job.input_params or {})
-    source = await _load_clip(params["clip_id"])
+    source = await load_clip(params["clip_id"])
     fmt = native_format(source)
     start_ms = int(params["start_ms"])
     end_ms = int(params["end_ms"])
@@ -448,9 +398,7 @@ async def process_repaint_job(job: Job, *, storage: StorageBackend, client: AceS
     original = _decode(original_bytes, fmt)
     repaint_full = _decode(data[0], fmt)
     if len(repaint_full) < end_ms - 10:
-        raise IterativeProcessingError(
-            f"ACE-Step output is {len(repaint_full)}ms but the repaint window ends at {end_ms}ms"
-        )
+        raise JobProcessingError(f"ACE-Step output is {len(repaint_full)}ms but the repaint window ends at {end_ms}ms")
     before = original[:start_ms]
     middle = repaint_full[start_ms:end_ms]
     after = original[end_ms:]
@@ -489,7 +437,7 @@ async def process_mashup_job(job: Job, *, storage: StorageBackend, client: AceSt
     """
     params = dict(job.input_params or {})
     clip_ids: list[str] = params["clip_ids"]
-    sources = [await _load_clip(cid) for cid in clip_ids]
+    sources = [await load_clip(cid) for cid in clip_ids]
     primary, secondaries = sources[0], sources[1:]
     fmt = native_format(primary)
     style = params.get("style")
@@ -572,7 +520,7 @@ async def _build_mashup_reference(
     # raise explicitly rather than assert: asserts are stripped under ``python -O``,
     # which would turn an unexpected empty list into an opaque AttributeError.
     if mixed is None:
-        raise IterativeProcessingError("mashup has no secondary sources to build a reference from")
+        raise JobProcessingError("mashup has no secondary sources to build a reference from")
     mixed.export(ref_path, format=fmt)
     return ref_path
 
@@ -619,7 +567,7 @@ async def process_sample_job(job: Job, *, storage: StorageBackend, client: AceSt
     a ``failed`` job leaves no orphaned clips or storage objects behind.
     """
     params = dict(job.input_params or {})
-    source = await _load_clip(params["clip_id"])
+    source = await load_clip(params["clip_id"])
     fmt = native_format(source)
     start_ms = int(params["start_ms"])
     end_ms = int(params["end_ms"])
@@ -670,7 +618,7 @@ async def process_sample_job(job: Job, *, storage: StorageBackend, client: AceSt
         except BaseException:
             # BaseException (not Exception): a shutdown CancelledError must also
             # roll back, else a requeued retry duplicates the stored children.
-            await _rollback_children(storage, clip_ids)
+            await rollback_clips(storage, clip_ids)
             raise
     return {"clip_ids": clip_ids}
 
@@ -708,9 +656,9 @@ async def process_full_song_job(job: Job, *, storage: StorageBackend, client: Ac
     the CLI), so a ``failed`` job still exposes the work done so far.
     """
     params = dict(job.input_params or {})
-    seed = await _load_clip(params["clip_id"])
+    seed = await load_clip(params["clip_id"])
     if seed.duration is None:
-        raise IterativeProcessingError(f"Seed clip {seed.id} has no duration metadata")
+        raise JobProcessingError(f"Seed clip {seed.id} has no duration metadata")
     fmt = native_format(seed)
     target_duration = float(params["target_duration"])
     structure_plan = params.get("structure_plan")
@@ -800,7 +748,7 @@ async def process_full_song_job(job: Job, *, storage: StorageBackend, client: Ac
         # plan_sections guarantees a non-empty list (it raises on empty), so this
         # is only reachable if that invariant is ever broken — fail loudly rather
         # than return an invalid {"clip_ids": [None]} result.
-        raise IterativeProcessingError("Full-song planning produced no sections")
+        raise JobProcessingError("Full-song planning produced no sections")
     return {"clip_ids": [final_clip_id]}
 
 

--- a/src/acemusic/api/tasks/mastering.py
+++ b/src/acemusic/api/tasks/mastering.py
@@ -34,6 +34,7 @@ from ..models import Clip, Job
 from ..services import credits as credits_service
 from ..services.clips import native_format
 from ..services.mastering import MASTERING_JOB_TYPE
+from .common import JobProcessingError, download_clip, load_source_clip, rollback_clips, store_clip
 
 if TYPE_CHECKING:  # pragma: no cover - import only for typing
     from ..settings import ApiSettings
@@ -43,10 +44,6 @@ logger = logging.getLogger(__name__)
 # US-12.2 implements the Dolby.io backend only; ``landr``/``bakuage`` are accepted
 # by the submission endpoint (US-12.1) but handled by later stories.
 _SUPPORTED_SERVICE = "dolby"
-
-
-class MasteringProcessingError(Exception):
-    """A mastering job could not be processed (missing source, creds, or Dolby failure)."""
 
 
 async def _refund_unperformed(job: Job, service: str) -> None:
@@ -81,30 +78,6 @@ def get_dolby_client(settings: "ApiSettings") -> DolbyClient | None:
     return DolbyClient(api_key=settings.dolby_api_key, api_secret=settings.dolby_api_secret)
 
 
-async def _load_source_clip(job: Job) -> Clip:
-    """Resolve the job's source clip, or fail the job with a clear error.
-
-    The clip may legitimately vanish between enqueue and processing (the owner can
-    DELETE it while the job is queued), so a miss is a job failure, not a crash.
-    """
-    clip_id = (job.input_params or {}).get("clip_id")
-    try:
-        oid = PydanticObjectId(clip_id)
-    except Exception as exc:
-        raise MasteringProcessingError(f"Job has an invalid source clip id: {clip_id!r}") from exc
-    clip = await Clip.get(oid)
-    if clip is None:
-        raise MasteringProcessingError(f"Source clip {clip_id} no longer exists")
-    return clip
-
-
-async def _download_source(storage: StorageBackend, source: Clip) -> bytes:
-    try:
-        return await asyncio.to_thread(storage.download, source.file_path)
-    except FileNotFoundError as exc:
-        raise MasteringProcessingError(f"Source clip {source.id} audio object {source.file_path!r} is missing") from exc
-
-
 async def _store_master_clip(
     job: Job,
     source: Clip,
@@ -112,20 +85,13 @@ async def _store_master_clip(
     data: bytes,
     fmt: str,
 ) -> str:
-    """Upload one mastered preview and insert its lineage-tagged child Clip.
-
-    Rolls the uploaded object back if the insert fails, so a job that ends up
-    ``failed`` never leaves an orphaned storage object behind (mirrors the editing
-    and iterative handlers' rollback).
-    """
+    """Upload one mastered preview and insert its lineage-tagged child Clip."""
     clip_id = PydanticObjectId()
-    path = f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}"
-    await asyncio.to_thread(storage.upload, path, data)
     clip = Clip(
         id=clip_id,
         user_id=job.user_id,
         workspace_id=job.workspace_id,
-        file_path=path,
+        file_path=f"{job.user_id}/{job.workspace_id}/clips/{clip_id}.{fmt}",
         format=fmt,
         # Mastering is loudness/EQ work: duration, tempo and key are preserved.
         duration=source.duration,
@@ -136,30 +102,8 @@ async def _store_master_clip(
         generation_mode=job.job_type,
         generation_params=dict(job.input_params or {}),
     )
-    try:
-        await clip.insert()
-    except BaseException:
-        # BaseException (not Exception): a shutdown CancelledError must also clean up
-        # the just-uploaded object, else a requeued retry leaves it orphaned.
-        try:
-            await asyncio.to_thread(storage.delete, path)
-        except Exception:  # pragma: no cover - cleanup is best-effort
-            logger.exception("Failed to delete orphaned storage object %s during rollback", path)
-        raise
+    await store_clip(storage, clip, data)
     return str(clip_id)
-
-
-async def _rollback_clips(storage: StorageBackend, clip_ids: list[str]) -> None:
-    """Best-effort removal of preview clips (docs + audio objects) already stored."""
-    for clip_id in clip_ids:
-        clip = await Clip.get(PydanticObjectId(clip_id))
-        if clip is None:  # pragma: no cover - already gone
-            continue
-        try:
-            await asyncio.to_thread(storage.delete, clip.file_path)
-        except Exception:  # pragma: no cover - cleanup is best-effort
-            logger.exception("Failed to delete orphaned storage object %s during rollback", clip.file_path)
-        await clip.delete()
 
 
 async def process_mastering_job(job: Job, *, storage: StorageBackend, client: DolbyClient | None) -> dict[str, Any]:
@@ -167,7 +111,7 @@ async def process_mastering_job(job: Job, *, storage: StorageBackend, client: Do
 
     Returns ``{"clip_ids": [...], "metrics": {...}, "service": "dolby",
     "target_lufs": <float>}``. ``metrics`` is the loudness / EQ / stereo analysis
-    from Dolby. Raises :class:`MasteringProcessingError` (which the processor records
+    from Dolby. Raises :class:`JobProcessingError` (which the processor records
     as the job's failure) when the service is unsupported, credentials are missing,
     or Dolby reports an error.
     """
@@ -177,25 +121,25 @@ async def process_mastering_job(job: Job, *, storage: StorageBackend, client: Do
     # Dolby work is performed, so the user must not pay for the failed job.
     if service != _SUPPORTED_SERVICE:
         await _refund_unperformed(job, service)
-        raise MasteringProcessingError(
+        raise JobProcessingError(
             f"Mastering service {service!r} is not yet implemented; only {_SUPPORTED_SERVICE!r} is available"
         )
     if client is None:
         await _refund_unperformed(job, service)
-        raise MasteringProcessingError(
+        raise JobProcessingError(
             "Dolby.io mastering is not configured: set ACEMUSIC_API_DOLBY_API_KEY and ACEMUSIC_API_DOLBY_API_SECRET"
         )
 
-    source = await _load_source_clip(job)
+    source = await load_source_clip(job)
     # target_lufs is resolved and stored by the submission endpoint (US-12.1); a
     # job missing it (e.g. a legacy/re-queued doc) fails clearly instead of KeyError.
     if params.get("target_lufs") is None:
-        raise MasteringProcessingError("Mastering job is missing the resolved 'target_lufs' parameter")
+        raise JobProcessingError("Mastering job is missing the resolved 'target_lufs' parameter")
     target_lufs = float(params["target_lufs"])
     profile = params.get("profile", "custom")
     fmt = params.get("format") or native_format(source)
 
-    source_bytes = await _download_source(storage, source)
+    source_bytes = await download_clip(storage, source)
 
     # Key Dolby's input/output objects by *job* id, not just the source clip, so
     # concurrent masters (or a retry) on the same clip never overwrite or download
@@ -210,11 +154,11 @@ async def process_mastering_job(job: Job, *, storage: StorageBackend, client: Do
         # of issuing a second status request for the same job.
         results = await asyncio.to_thread(client.get_results, dolby_job_id, status_payload)
     except DolbyError as exc:
-        raise MasteringProcessingError(f"Dolby mastering failed: {exc}") from exc
+        raise JobProcessingError(f"Dolby mastering failed: {exc}") from exc
 
     preview_handles = [out.get("preview") for out in results.get("outputs", []) if out.get("preview")]
     if not preview_handles:
-        raise MasteringProcessingError("Dolby mastering completed but returned no preview outputs")
+        raise JobProcessingError("Dolby mastering completed but returned no preview outputs")
 
     clip_ids: list[str] = []
     try:
@@ -222,12 +166,12 @@ async def process_mastering_job(job: Job, *, storage: StorageBackend, client: Do
             try:
                 preview_bytes = await asyncio.to_thread(client.download, handle)
             except DolbyError as exc:
-                raise MasteringProcessingError(f"Dolby preview download failed: {exc}") from exc
+                raise JobProcessingError(f"Dolby preview download failed: {exc}") from exc
             clip_ids.append(await _store_master_clip(job, source, storage, preview_bytes, fmt))
     except BaseException:
         # BaseException (not Exception): a shutdown CancelledError must also roll
         # back, else a requeued retry duplicates the stored previews.
-        await _rollback_clips(storage, clip_ids)
+        await rollback_clips(storage, clip_ids)
         raise
 
     return {

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -36,6 +36,7 @@ from acemusic.storage import StorageBackend, get_storage_backend
 from .. import database
 from ..models import Clip, Job, JobStatus
 from ..models.common import utcnow
+from .common import JobProcessingError
 from .editing import EDIT_JOB_HANDLERS
 from .export import EXPORT_JOB_HANDLERS
 from .extraction import EXTRACTION_JOB_HANDLERS
@@ -67,10 +68,6 @@ _SUBMIT_FIELDS = (
     "mode",
     "sound_type",
 )
-
-
-class JobProcessingError(Exception):
-    """A job could not be processed (ACE-Step failure, timeout, or no output)."""
 
 
 JobHandler = Callable[[Job], Awaitable[dict[str, Any]]]

--- a/tests/test_clips_full_song_api.py
+++ b/tests/test_clips_full_song_api.py
@@ -26,7 +26,7 @@ from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Clip, CreditTransaction, Job, JobStatus, User, Workspace
 from acemusic.api.services import users as user_service
 from acemusic.api.settings import ApiSettings
-from acemusic.api.tasks.iterative import IterativeProcessingError
+from acemusic.api.tasks.iterative import JobProcessingError
 from acemusic.song_structure import SONG_STRUCTURE
 from acemusic.storage import LocalStorage, get_storage_backend
 
@@ -554,7 +554,7 @@ class TestFullSongHandler:
         # roll children back, unlike the multi-output sample handler.
         user, workspace, clip = await self._seed(storage)
         job = await self._job(user, workspace, clip, structure_plan=["intro", "verse", "chorus", "outro"])
-        with pytest.raises(IterativeProcessingError, match="ace boom"):
+        with pytest.raises(JobProcessingError, match="ace boom"):
             await self._run(job, _FailingAce(_wav_bytes(2.0), fail_on=3), storage)
         # Sections 1 and 2 committed before the third failed.
         children = await Clip.find(Clip.generation_mode == "full_song").to_list()
@@ -566,7 +566,7 @@ class TestFullSongHandler:
         user, workspace, clip = await self._seed(storage)
         start = (await User.get(user.id)).credits_balance
         job = await self._job(user, workspace, clip, structure_plan=["intro", "verse", "chorus", "outro"])
-        with pytest.raises(IterativeProcessingError, match="ace boom"):
+        with pytest.raises(JobProcessingError, match="ace boom"):
             await self._run(job, _FailingAce(_wav_bytes(2.0), fail_on=3), storage)
         assert (await User.get(user.id)).credits_balance == start + 2.0
 

--- a/tests/test_clips_iterative_tasks.py
+++ b/tests/test_clips_iterative_tasks.py
@@ -268,7 +268,7 @@ class TestRepaint:
         client = FakeAce(_wav_bytes(1.0))  # far shorter than end_ms
 
         before = await Clip.count()
-        with pytest.raises(tasks.IterativeProcessingError):
+        with pytest.raises(tasks.JobProcessingError):
             await tasks.process_repaint_job(job, storage=storage, client=client, poll=_make_poll())
         assert await Clip.count() == before  # no orphan child
 
@@ -506,7 +506,7 @@ class TestFailures:
         client = FakeAce(_wav_bytes(3.0))
 
         before = await Clip.count()
-        with pytest.raises(tasks.IterativeProcessingError):
+        with pytest.raises(tasks.JobProcessingError):
             await tasks.process_cover_job(job, storage=storage, client=client, poll=_make_poll("failed", "boom"))
         assert await Clip.count() == before
 
@@ -516,7 +516,7 @@ class TestFailures:
         job.job_type = tasks.COVER_JOB_TYPE
         job.input_params = {"clip_id": str(source.id), "style": "jazz", "lyrics_override": None}
         client = FakeAce(_wav_bytes(3.0))
-        with pytest.raises(tasks.IterativeProcessingError):
+        with pytest.raises(tasks.JobProcessingError):
             await tasks.process_cover_job(job, storage=storage, client=client, poll=_make_poll())
 
 

--- a/tests/test_mastering_tasks.py
+++ b/tests/test_mastering_tasks.py
@@ -210,14 +210,14 @@ class TestSuccess:
 class TestGracefulDegradation:
     async def test_missing_client_raises_clear_error(self, storage) -> None:
         job, _ = await _make_clip(storage, email="master-nocreds@example.com")
-        with pytest.raises(tasks.MasteringProcessingError, match="not configured"):
+        with pytest.raises(tasks.JobProcessingError, match="not configured"):
             await tasks.process_mastering_job(job, storage=storage, client=None)
 
     async def test_unsupported_service_raises(self, storage) -> None:
         job, _ = await _make_clip(storage, email="master-landr@example.com")
         job.input_params = {**job.input_params, "service": "landr"}
         client = FakeDolby(output=_wav_bytes(3.0))
-        with pytest.raises(tasks.MasteringProcessingError, match="not yet implemented"):
+        with pytest.raises(tasks.JobProcessingError, match="not yet implemented"):
             await tasks.process_mastering_job(job, storage=storage, client=client)
 
     async def test_unsupported_service_refunds_charged_credits(self, storage) -> None:
@@ -229,7 +229,7 @@ class TestGracefulDegradation:
         job.input_params = {**job.input_params, "service": "landr"}
         cost = credits_service.get_mastering_cost("landr")
         before = await credits_service.deduct_credits(job.user_id, cost)
-        with pytest.raises(tasks.MasteringProcessingError):
+        with pytest.raises(tasks.JobProcessingError):
             await tasks.process_mastering_job(job, storage=storage, client=FakeDolby(output=_wav_bytes(3.0)))
         user = await user_service.get_user_by_id(str(job.user_id))
         assert user.credits_balance == before + cost
@@ -240,7 +240,7 @@ class TestGracefulDegradation:
         job, _ = await _make_clip(storage, email="master-refund-nocreds@example.com")
         cost = credits_service.get_mastering_cost("dolby")
         before = await credits_service.deduct_credits(job.user_id, cost)
-        with pytest.raises(tasks.MasteringProcessingError, match="not configured"):
+        with pytest.raises(tasks.JobProcessingError, match="not configured"):
             await tasks.process_mastering_job(job, storage=storage, client=None)
         user = await user_service.get_user_by_id(str(job.user_id))
         assert user.credits_balance == before + cost
@@ -251,27 +251,27 @@ class TestErrorHandling:
     async def test_dolby_error_at_each_stage_is_wrapped(self, storage, stage) -> None:
         job, _ = await _make_clip(storage, email=f"master-fail-{stage}@example.com")
         client = FakeDolby(output=_wav_bytes(3.0), fail_on=stage)
-        with pytest.raises(tasks.MasteringProcessingError, match="Dolby"):
+        with pytest.raises(tasks.JobProcessingError, match="Dolby"):
             await tasks.process_mastering_job(job, storage=storage, client=client)
 
     async def test_missing_source_clip_fails(self, storage) -> None:
         job, source = await _make_clip(storage, email="master-gone@example.com")
         await source.delete()
         client = FakeDolby(output=_wav_bytes(3.0))
-        with pytest.raises(tasks.MasteringProcessingError, match="no longer exists"):
+        with pytest.raises(tasks.JobProcessingError, match="no longer exists"):
             await tasks.process_mastering_job(job, storage=storage, client=client)
 
     async def test_no_previews_returned_fails(self, storage) -> None:
         job, _ = await _make_clip(storage, email="master-empty@example.com")
         client = FakeDolby(output=_wav_bytes(3.0), previews=[])
-        with pytest.raises(tasks.MasteringProcessingError, match="no preview outputs"):
+        with pytest.raises(tasks.JobProcessingError, match="no preview outputs"):
             await tasks.process_mastering_job(job, storage=storage, client=client)
 
     async def test_download_failure_rolls_back_stored_previews(self, storage) -> None:
         job, _ = await _make_clip(storage, email="master-rollback@example.com")
         # First preview stores fine; the second download fails — the first must roll back.
         client = _RollbackDolby(output=_wav_bytes(3.0), previews=["dlb://p1.wav", "dlb://p2.wav"])
-        with pytest.raises(tasks.MasteringProcessingError):
+        with pytest.raises(tasks.JobProcessingError):
             await tasks.process_mastering_job(job, storage=storage, client=client)
         # No master clip should survive for this job's source.
         remaining = await Clip.find(Clip.generation_mode == MASTERING_JOB_TYPE).to_list()


### PR DESCRIPTION
## US-0.2: Extract shared API task-layer helpers + unify `JobProcessingError`

Closes #156.

Stage-0 foundation refactor (from the ponytail over-engineering audit). The job task modules copy-pasted the same clip lifecycle helpers and each redefined a near-identical empty `Exception` subclass. This consolidates them so future job types reuse the shared helpers instead of cloning.

### What changed
- **New `api/tasks/common.py`** with one implementation each of:
  - `load_clip(clip_id)` / `load_source_clip(job)` — resolve a source clip, fail the job cleanly if it vanished
  - `download_clip(storage, clip) -> bytes` — download audio, fail the job if the object is missing
  - `store_clip(storage, clip, data)` — upload + insert, rolling the object back if the insert fails
  - `rollback_clips(storage, clip_ids)` — best-effort batch cleanup of already-stored children
- **`JobProcessingError` moved into `common.py`** (was in `processor.py`) and re-imported there, so the job modules import it without a cycle. The five per-module subclasses (`EditProcessingError`, `ExtractionProcessingError`, `MasteringProcessingError`, `ExportProcessingError`, `IterativeProcessingError`) are **deleted** — all raises now use `JobProcessingError`.
- `editing`, `export`, `extraction`, `mastering`, `iterative` refactored to call the shared helpers; each module still builds its own (module-specific) `Clip`.

### Acceptance criteria
- [x] One implementation each of source-clip load / download / store / rollback.
- [x] All raises use `JobProcessingError`; the five subclasses deleted.
- [x] Rollback-on-failure semantics unchanged (`store_clip` rolls back a just-uploaded object on insert failure; `rollback_clips` cleans up earlier children on a mid-batch failure).
- [x] Task tests pass unchanged (26 unit + 196 integration green).
- [x] ~140 lines net removed from production code.

### Testing
- `pytest` task-layer suites (editing/extraction/mastering/export/iterative/full-song): **26 passed**
- `pytest -m integration` same suites: **196 passed**
- `ruff check` + `black --check`: clean

### Known limitations
- `processor._rollback_clips` (the `generate`-path rollback over `(Clip, path)` tuples) is intentionally left as-is — different shape/semantics, out of scope for this issue.
- `editing._download_source` keeps its thin `_EditWorkspace`-aware wrapper (the "workspace wrapper" small-difference the issue called out); it now delegates to `download_clip`.
