### PR TITLE
feat(mastering): LANDR + Bakuage fallback integrations (US-12.3, #129)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,3 +151,21 @@ ACEMUSIC_S3_REGION=
 ACEMUSIC_S3_ENDPOINT_URL=
 # Presigned download-URL lifetime in seconds (default 3600).
 ACEMUSIC_S3_URL_EXPIRY=3600
+
+# Music mastering (Stage 12). Three optional backends; the worker selects the
+# requested service and falls back across the configured ones on failure
+# (Dolby.io -> LANDR -> Bakuage). A backend is enabled only when ALL of its
+# credentials are set; unset backends are skipped in the fallback chain. Leave all
+# blank to run with mastering disabled (mastering jobs then fail with a clear
+# "not configured" error rather than crashing).
+
+# Dolby.io Music Mastering (US-12.2). Exchanges app key/secret for a bearer token.
+ACEMUSIC_API_DOLBY_API_KEY=
+ACEMUSIC_API_DOLBY_API_SECRET=
+
+# LANDR B2B Music Mastering (US-12.3). Partnership-gated B2B API.
+ACEMUSIC_API_LANDR_API_KEY=
+ACEMUSIC_API_LANDR_API_SECRET=
+
+# Bakuage AI Mastering (US-12.3). Open REST API with a single API-key bearer token.
+ACEMUSIC_API_BAKUAGE_API_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AI-powered music generation platform built on **ACE-Step-1.5** (fork: `github.co
 3. **Layer 3 — Web UI** (Stages 15–21): Next.js frontend
 4. **Layer 4 — Advanced Integrations** (Stages 22–28): VST3 plugin, music video, voice models, credits, moderation
 
-**Current progress:** Stages 1–9 complete on `main`; Stage 10 in progress (US-10.1 audio editing, US-10.2 stems/MIDI extraction, US-10.3 iterative generation endpoints implemented). CLI foundation (Stages 1–7): generation, workspace management, audio processing, DAW export. Platform API (Stages 8–9): FastAPI with OAuth2 auth, async job queue, clip audio streaming, workspace/clip/preset CRUD, credit deduction. Audio editing API (US-10.1): crop, speed-adjust, and remaster endpoints enqueue async jobs that create derived clips with lineage tracking. Stems/MIDI extraction API (US-10.2): stem separation (4 child clips) and MIDI extraction (files referenced via `Clip.midi_paths`) run as cache-first, idempotent async jobs. Iterative generation API (US-10.3): extend, cover, remix, repaint, sample, add-vocal, and mashup endpoints enqueue credit-bearing async jobs that create lineage-tagged child clips.
+**Current progress:** Stages 1–9 complete on `main`; Stage 10 in progress (US-10.1 audio editing, US-10.2 stems/MIDI extraction, US-10.3 iterative generation endpoints implemented). CLI foundation (Stages 1–7): generation, workspace management, audio processing, DAW export. Platform API (Stages 8–9): FastAPI with OAuth2 auth, async job queue, clip audio streaming, workspace/clip/preset CRUD, credit deduction. Audio editing API (US-10.1): crop, speed-adjust, and remaster endpoints enqueue async jobs that create derived clips with lineage tracking. Stems/MIDI extraction API (US-10.2): stem separation (4 child clips) and MIDI extraction (files referenced via `Clip.midi_paths`) run as cache-first, idempotent async jobs. Iterative generation API (US-10.3): extend, cover, remix, repaint, sample, add-vocal, and mashup endpoints enqueue credit-bearing async jobs that create lineage-tagged child clips. Mastering pipeline (Stage 12): US-12.1 submission endpoint (per-service credit charge + async job), US-12.2 Dolby.io integration, US-12.3 LANDR + Bakuage fallback integrations with a shared `MasteringService` interface and a `MasteringOrchestrator` that selects the requested backend and falls back (Dolby→LANDR→Bakuage) across configured services on any `MasteringError`.
 
 ## Commands
 
@@ -116,6 +116,11 @@ src/acemusic/
   backends.py       # Backend selector: resolve_backend (auto|ace-step|elevenlabs) + capability map
   cli.py            # Typer CLI app (health, generate, compose, sounds, models, workspace commands)
   client.py         # AceStepClient — HTTP client for ACE-Step REST API
+  dolby_client.py   # Dolby.io Music Mastering client (US-12.2); conforms to MasteringService
+  landr_client.py   # LANDR B2B Music Mastering client (US-12.3); fallback backend
+  bakuage_client.py # Bakuage AI Mastering client (US-12.3); fallback backend
+  mastering_protocol.py  # Shared MasteringService Protocol + MasteringOutput + MasteringError
+  mastering_orchestrator.py  # MasteringOrchestrator: service selection + Dolby->LANDR->Bakuage fallback
   config.py         # Config loading: env > .env > ~/.acemusic/config.yaml
   db.py             # SQLite connection and schema init (~/.acemusic/metadata.db)
   utils.py          # Filename helpers (make_slug, make_filename, get_duration)

--- a/docs/demos/us-12.3-mastering-fallback.md
+++ b/docs/demos/us-12.3-mastering-fallback.md
@@ -1,0 +1,69 @@
+# US-12.3: LANDR + Bakuage mastering with Dolby fallback
+
+*2026-06-18T20:57:49Z*
+
+US-12.3 adds LANDR and Bakuage as fallback mastering backends alongside Dolby.io (US-12.2), with a MasteringOrchestrator that selects the requested service and falls back across configured services on failure. LANDR/Bakuage are credential-gated, so this demo drives the REAL handler + orchestrator against a REAL local MongoDB and on-disk storage, with in-process stubs standing in for the external mastering APIs only — exactly the project's documented discipline for billed/gated endpoints. The result: real lineage-tagged clips, real audio files, and real credit-ledger movements.
+
+```bash
+cd /home/frankbria/projects/auto-music-studio && uv run python /tmp/us123-demo.py
+```
+
+```output
+Mastering service dolby failed (dolby returned an error (simulated outage)); falling back (1 service(s) left)
+Mastering service dolby failed (dolby returned an error (simulated outage)); falling back (1 service(s) left)
+Mastering service bakuage failed (bakuage returned an error (simulated outage)); no configured fallback remains
+
+======================================================================
+AC1 — LANDR mastering produces a mastered audio file
+======================================================================
+requested service : landr
+result service    : landr
+metrics           : {'loudness': -14.2, 'eq_bands': [], 'stereo': {}}
+child clip id     : 6a345bdc6cb22f937958c0a5
+lineage           : parent_clip_ids=[ObjectId('6a345bdc6cb22f937958c0a4')] (source=6a345bdc6cb22f937958c0a4)
+audio on disk     : b'RIFFT\x13\x08\x00WAVEfmt '... (529244 bytes)
+
+======================================================================
+AC2 — Bakuage mastering produces a mastered audio file
+======================================================================
+requested service : bakuage
+result service    : bakuage
+child clip id     : 6a345bdc6cb22f937958c0a9  lineage parent=6a345bdc6cb22f937958c0a8
+audio on disk     : 529244 bytes
+
+======================================================================
+AC3 — Dolby.io error falls back to Bakuage (+ credit reconciliation)
+======================================================================
+requested service : dolby
+dolby attempted?  : True  (failed -> triggered fallback)
+bakuage attempted?: True
+result service    : bakuage   <-- fallback succeeded
+clip created      : 6a345bdc6cb22f937958c0ad
+credit reconcile  : charged 3 (dolby) -> actual 5 (bakuage)
+                    balance 7 -> 5 (top-up +2)
+
+======================================================================
+AC4 — Every service returns the same response format
+======================================================================
+Result keys are identical across landr / bakuage / fallback runs:
+  {'clip_ids': [...], 'service': <str>, 'target_lufs': <float>, 'metrics': {...}}
+(asserted by test_mastering_tasks.py for all three success paths)
+
+======================================================================
+Negative — every backend fails -> job fails (no partial clip)
+======================================================================
+job failed cleanly: Mastering failed: bakuage returned an error (simulated outage)
+orphaned clips for this user: 0 (rollback clean)
+
+======================================================================
+Negative — explicitly-requested but unconfigured service refunds + errors
+======================================================================
+error: Mastering service 'landr' is not configured. Available: dolby. Set mastering credentials to enable a backend: ACEMUSIC_API_DOLBY_API_KEY + ACEMUSIC_API_DOLBY_API_SECRET (Dolby.io), ACEMUSIC_API_LANDR_API_KEY + ACEMUSIC_API_LANDR_API_SECRET (LANDR), or ACEMUSIC_API_BAKUAGE_API_KEY (Bakuage).
+refund: balance 8 -> 10 (restored, no work performed)
+
+======================================================================
+US-12.3 demo complete — all 4 acceptance criteria demonstrated
+======================================================================
+```
+
+Every acceptance criterion is demonstrated with outcome evidence: AC1 (LANDR clip + lineage + 529KB audio file + loudness metrics), AC2 (Bakuage clip + lineage + audio), AC3 (Dolby outage -> Bakuage fallback -> service switched to bakuage + credit reconciliation 3->5), AC4 (identical {clip_ids, service, target_lufs, metrics} shape). The negative paths also hold: an all-backends-fail job leaves zero orphaned clips (rollback clean), and an explicitly-requested-but-unconfigured service refunds the credits charged at enqueue (8 -> 10). The unit + integration suites (1443 tests) cover the full client/orchestrator/handler contract behind these outcomes.

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -38,7 +38,7 @@ from .routers import (
     workspaces,
 )
 from .settings import ApiSettings
-from .tasks.mastering import get_dolby_client
+from .tasks.mastering import get_mastering_orchestrator
 from .tasks.processor import JobProcessor
 
 API_V1_PREFIX = "/api/v1"
@@ -104,10 +104,12 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
                     runpod_client_factory=runpod_factory,
                     runpod_timeout=settings.runpod_timeout,
                     runpod_poll_interval=settings.runpod_poll_interval,
-                    # Dolby.io mastering (US-12.2): the factory returns None when
-                    # credentials are unset, so mastering jobs fail cleanly rather
-                    # than the app crashing on a Dolby-less deployment.
-                    dolby_client_factory=lambda: get_dolby_client(settings),
+                    # Mastering (US-12.2 Dolby.io + US-12.3 LANDR/Bakuage
+                    # fallback): the orchestrator selects the requested backend
+                    # and falls back across the configured services on failure.
+                    # It is always wired so the handler can produce a clear "not
+                    # configured" error when no mastering credentials are set.
+                    mastering_orchestrator_factory=lambda: get_mastering_orchestrator(settings),
                 )
                 await processor.start()
             app_.state.job_processor = processor

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -121,6 +121,19 @@ class ApiSettings(BaseSettings):
     dolby_api_key: str | None = None
     dolby_api_secret: str | None = None
 
+    # LANDR B2B Music Mastering (US-12.3). Optional fallback alongside Dolby.io;
+    # the B2B API exchanges an app key/secret for a session token, mirroring
+    # Dolby.io. ``landr_enabled`` is False unless both are set, so the
+    # orchestrator skips LANDR in the fallback chain on a LANDR-less deployment.
+    landr_api_key: str | None = None
+    landr_api_secret: str | None = None
+
+    # Bakuage AI Mastering (US-12.3). Optional cost-effective fallback (the end of
+    # the Dolby -> LANDR -> Bakuage chain). Bakuage uses a single API-key bearer
+    # token (no OAuth), so only one credential is required; ``bakuage_enabled`` is
+    # False until it is set.
+    bakuage_api_key: str | None = None
+
     # Compute status endpoint (US-11.4). Per-target health-probe budget for
     # ``GET /api/v1/compute/status``; the local and remote checks run in parallel,
     # each bounded by this timeout, so the aggregate response stays well under the
@@ -137,6 +150,16 @@ class ApiSettings(BaseSettings):
     def dolby_enabled(self) -> bool:
         """True only when both Dolby.io credentials are configured (mastering is usable)."""
         return bool(self.dolby_api_key and self.dolby_api_secret)
+
+    @property
+    def landr_enabled(self) -> bool:
+        """True only when both LANDR B2B credentials are configured."""
+        return bool(self.landr_api_key and self.landr_api_secret)
+
+    @property
+    def bakuage_enabled(self) -> bool:
+        """True only when the Bakuage API key is configured."""
+        return bool(self.bakuage_api_key)
 
     # OAuth ``state`` cookie policy (issue #110, login-CSRF binding). The login
     # flow sets a per-client nonce cookie that the callback requires.

--- a/src/acemusic/api/tasks/mastering.py
+++ b/src/acemusic/api/tasks/mastering.py
@@ -1,22 +1,28 @@
-"""Mastering job handler (US-12.2): Dolby.io Music Mastering integration.
+"""Mastering job handler (US-12.2 + US-12.3 fallback integrations).
 
-Runs one claimed mastering :class:`~acemusic.api.models.job.Job` end to end against
-Dolby.io: load the source clip, download its audio from our storage, upload it to
-Dolby's input storage, submit a master *preview* job, poll to completion, read the
-mastering metrics (loudness / EQ / stereo image), download each mastered preview,
-and store it back as a lineage-tagged child :class:`~acemusic.api.models.clip.Clip`.
+Runs one claimed mastering :class:`~acemusic.api.models.job.Job` end to end:
+load the source clip, download its audio from our storage, hand it to the
+:class:`~acemusic.mastering_orchestrator.MasteringOrchestrator` which runs the
+requested backend (Dolby.io / LANDR / Bakuage) and falls back across the
+configured services on failure, then store the mastered audio back as a
+lineage-tagged child :class:`~acemusic.api.models.clip.Clip`.
 
-Each mastered preview becomes a derived clip (``generation_mode="mastering"``,
-``parent_clip_ids=[source]``) so it is immediately auditionable through the existing
+The mastered clip (``generation_mode="mastering"``,
+``parent_clip_ids=[source]``) is immediately auditionable through the existing
 job-status endpoint, which resolves audio URLs from ``result["clip_ids"]``. The
-A/B selection / approval UX is a separate story (US-12.4). The mastering metrics
-ride along in ``result["metrics"]`` so the status endpoint can surface them.
+mastering metrics ride along in ``result["metrics"]`` and the backend that
+actually ran in ``result["service"]`` (which may differ from the requested
+service when a fallback succeeded). The A/B selection / approval UX is a
+separate story (US-12.4).
 
-Like the iterative handlers, this needs an external client in addition to storage,
-so :class:`~acemusic.api.tasks.processor.JobProcessor` adapts it onto the registry
-through ``_run_mastering_handler`` which injects ``storage`` and the Dolby client
-(``None`` when credentials are absent — the handler then fails the job with a clear
-"not configured" message rather than crashing the app).
+Each backend implements the shared
+:class:`~acemusic.mastering_protocol.MasteringService` contract behind a single
+``master()`` entrypoint, so this handler is backend-agnostic: it only knows the
+orchestrator's ``master_with_fallback`` call. An explicitly requested service
+that is not configured raises :class:`ServiceNotConfiguredError`, which the
+handler turns into a refunded pre-flight rejection (no mastering work performed,
+so the user must not pay). Like the iterative handlers, the orchestrator needs
+to be injected alongside storage.
 """
 
 from __future__ import annotations
@@ -27,33 +33,30 @@ from typing import TYPE_CHECKING, Any
 
 from beanie import PydanticObjectId
 
-from acemusic.dolby_client import DolbyClient, DolbyError, master_output_config
+from acemusic.mastering_orchestrator import MasteringOrchestrator, ServiceNotConfiguredError
 from acemusic.storage import StorageBackend
 
 from ..models import Clip, Job
 from ..services import credits as credits_service
 from ..services.clips import native_format
 from ..services.mastering import MASTERING_JOB_TYPE
-from .common import JobProcessingError, download_clip, load_source_clip, rollback_clips, store_clip
+from .common import JobProcessingError, download_clip, load_source_clip, store_clip
 
 if TYPE_CHECKING:  # pragma: no cover - import only for typing
     from ..settings import ApiSettings
 
 logger = logging.getLogger(__name__)
 
-# US-12.2 implements the Dolby.io backend only; ``landr``/``bakuage`` are accepted
-# by the submission endpoint (US-12.1) but handled by later stories.
-_SUPPORTED_SERVICE = "dolby"
-
 
 async def _refund_unperformed(job: Job, service: str) -> None:
     """Refund the credits charged at enqueue when no mastering work was performed.
 
     The submission endpoint (US-12.1) charges per service up front. When the worker
-    rejects a job before any Dolby work begins — an unsupported service, or a
-    deployment with no Dolby credentials — the user must not be left paying for a
-    master that was never produced. Best-effort (mirrors the full-song refund): a
-    refund failure is logged but never masks the original processing error.
+    rejects a job before any mastering work begins — a service requested without
+    configured credentials, or a deployment with no mastering backend at all — the
+    user must not be left paying for a master that was never produced. Best-effort
+    (mirrors the full-song refund): a refund failure is logged but never masks the
+    original processing error.
     """
     try:
         cost = credits_service.get_mastering_cost(service)
@@ -65,17 +68,28 @@ async def _refund_unperformed(job: Job, service: str) -> None:
         logger.exception("Failed to refund mastering job %s after a pre-flight rejection", job.id)
 
 
-def get_dolby_client(settings: "ApiSettings") -> DolbyClient | None:
-    """Build a :class:`DolbyClient` from settings, or ``None`` when creds are absent.
+def get_mastering_orchestrator(settings: "ApiSettings") -> MasteringOrchestrator:
+    """Build the :class:`MasteringOrchestrator` from the configured backends.
 
-    Returning ``None`` (rather than raising) lets the processor register the
-    handler unconditionally: a mastering job submitted on a Dolby-less deployment
-    is claimed and fails with a clear message, satisfying the "missing credentials
-    disable the service (not crash the app)" requirement.
+    Only services whose credentials are present are wired in, so the orchestrator's
+    fallback chain naturally skips unconfigured backends. A deployment with no
+    mastering credentials at all yields an empty orchestrator; the handler then
+    fails a claimed job with a clear "not configured" message rather than crashing.
     """
-    if not settings.dolby_enabled:
-        return None
-    return DolbyClient(api_key=settings.dolby_api_key, api_secret=settings.dolby_api_secret)
+    clients: dict[str, Any] = {}
+    if settings.dolby_enabled:
+        from acemusic.dolby_client import DolbyClient
+
+        clients["dolby"] = DolbyClient(api_key=settings.dolby_api_key, api_secret=settings.dolby_api_secret)
+    if settings.landr_enabled:
+        from acemusic.landr_client import LandrClient
+
+        clients["landr"] = LandrClient(api_key=settings.landr_api_key, api_secret=settings.landr_api_secret)
+    if settings.bakuage_enabled:
+        from acemusic.bakuage_client import BakuageClient
+
+        clients["bakuage"] = BakuageClient(api_key=settings.bakuage_api_key)
+    return MasteringOrchestrator(clients)
 
 
 async def _store_master_clip(
@@ -85,7 +99,7 @@ async def _store_master_clip(
     data: bytes,
     fmt: str,
 ) -> str:
-    """Upload one mastered preview and insert its lineage-tagged child Clip."""
+    """Upload the mastered audio and insert its lineage-tagged child Clip."""
     clip_id = PydanticObjectId()
     clip = Clip(
         id=clip_id,
@@ -106,29 +120,29 @@ async def _store_master_clip(
     return str(clip_id)
 
 
-async def process_mastering_job(job: Job, *, storage: StorageBackend, client: DolbyClient | None) -> dict[str, Any]:
-    """Master the source clip via Dolby.io and store each preview as a child clip.
+async def process_mastering_job(
+    job: Job, *, storage: StorageBackend, orchestrator: MasteringOrchestrator
+) -> dict[str, Any]:
+    """Master the source clip via the orchestrator and store the result as a child clip.
 
-    Returns ``{"clip_ids": [...], "metrics": {...}, "service": "dolby",
-    "target_lufs": <float>}``. ``metrics`` is the loudness / EQ / stereo analysis
-    from Dolby. Raises :class:`JobProcessingError` (which the processor records
-    as the job's failure) when the service is unsupported, credentials are missing,
-    or Dolby reports an error.
+    Returns ``{"clip_ids": [<id>], "metrics": {...}, "service": <str>,
+    "target_lufs": <float>}``. ``service`` is the backend that actually ran
+    (which may differ from the requested service when a fallback succeeded).
+    Raises :class:`JobProcessingError` (recorded as the job's failure) when the
+    requested service is not configured, no backend is configured at all, or
+    every backend in the fallback chain reports an error.
     """
     params = dict(job.input_params or {})
-    service = params.get("service", _SUPPORTED_SERVICE)
+    service = params.get("service", "dolby")
+
     # Pre-flight rejections refund the credits charged at enqueue (US-12.1): no
-    # Dolby work is performed, so the user must not pay for the failed job.
-    if service != _SUPPORTED_SERVICE:
+    # mastering work is performed, so the user must not pay for the failed job.
+    try:
+        orchestrator.get_client(service)
+    except ServiceNotConfiguredError as exc:
         await _refund_unperformed(job, service)
-        raise JobProcessingError(
-            f"Mastering service {service!r} is not yet implemented; only {_SUPPORTED_SERVICE!r} is available"
-        )
-    if client is None:
-        await _refund_unperformed(job, service)
-        raise JobProcessingError(
-            "Dolby.io mastering is not configured: set ACEMUSIC_API_DOLBY_API_KEY and ACEMUSIC_API_DOLBY_API_SECRET"
-        )
+        hint = _configuration_hint()
+        raise JobProcessingError(f"{exc} {hint}") from exc
 
     source = await load_source_clip(job)
     # target_lufs is resolved and stored by the submission endpoint (US-12.1); a
@@ -141,45 +155,47 @@ async def process_mastering_job(job: Job, *, storage: StorageBackend, client: Do
 
     source_bytes = await download_clip(storage, source)
 
-    # Key Dolby's input/output objects by *job* id, not just the source clip, so
-    # concurrent masters (or a retry) on the same clip never overwrite or download
-    # each other's audio.
+    # Key the upload by *job* id, not just the source clip, so concurrent masters
+    # (or a retry) on the same clip never overwrite or download each other's audio.
+    filename = f"{source.id}-{job.id}.{fmt}"
     try:
-        input_url = await asyncio.to_thread(client.upload, source_bytes, f"{source.id}-{job.id}.{fmt}")
-        destination = f"dlb://{source.id}-{job.id}-master.{fmt}"
-        outputs = [master_output_config(profile, target_lufs, destination)]
-        dolby_job_id = await asyncio.to_thread(client.submit_preview, input_url, outputs)
-        status_payload = await asyncio.to_thread(client.wait_for_completion, dolby_job_id)
-        # Pass the already-polled terminal payload so get_results reuses it instead
-        # of issuing a second status request for the same job.
-        results = await asyncio.to_thread(client.get_results, dolby_job_id, status_payload)
-    except DolbyError as exc:
-        raise JobProcessingError(f"Dolby mastering failed: {exc}") from exc
+        output = await asyncio.to_thread(
+            orchestrator.master_with_fallback,
+            source_bytes,
+            filename,
+            profile,
+            target_lufs,
+            fmt,
+            requested_service=service,
+        )
+    except ServiceNotConfiguredError as exc:
+        # Defensive: master_with_fallback raises this only for an unconfigured
+        # *requested* service, which the pre-flight get_client already caught.
+        await _refund_unperformed(job, service)
+        raise JobProcessingError(str(exc)) from exc
+    except Exception as exc:
+        raise JobProcessingError(f"Mastering failed: {exc}") from exc
 
-    preview_handles = [out.get("preview") for out in results.get("outputs", []) if out.get("preview")]
-    if not preview_handles:
-        raise JobProcessingError("Dolby mastering completed but returned no preview outputs")
-
-    clip_ids: list[str] = []
-    try:
-        for handle in preview_handles:
-            try:
-                preview_bytes = await asyncio.to_thread(client.download, handle)
-            except DolbyError as exc:
-                raise JobProcessingError(f"Dolby preview download failed: {exc}") from exc
-            clip_ids.append(await _store_master_clip(job, source, storage, preview_bytes, fmt))
-    except BaseException:
-        # BaseException (not Exception): a shutdown CancelledError must also roll
-        # back, else a requeued retry duplicates the stored previews.
-        await rollback_clips(storage, clip_ids)
-        raise
+    clip_id = await _store_master_clip(job, source, storage, output.audio_bytes, fmt)
+    if output.service != service:
+        logger.info("Mastering job %s fell back from %s to %s", job.id, service, output.service)
 
     return {
-        "clip_ids": clip_ids,
-        "service": service,
+        "clip_ids": [clip_id],
+        "service": output.service,
         "target_lufs": target_lufs,
-        "metrics": results.get("metrics", {}),
+        "metrics": output.metrics,
     }
+
+
+def _configuration_hint() -> str:
+    """A human-readable hint naming the mastering env vars, for error messages."""
+    return (
+        "Set mastering credentials to enable a backend: "
+        "ACEMUSIC_API_DOLBY_API_KEY + ACEMUSIC_API_DOLBY_API_SECRET (Dolby.io), "
+        "ACEMUSIC_API_LANDR_API_KEY + ACEMUSIC_API_LANDR_API_SECRET (LANDR), or "
+        "ACEMUSIC_API_BAKUAGE_API_KEY (Bakuage)."
+    )
 
 
 MASTERING_JOB_HANDLERS = {MASTERING_JOB_TYPE: process_mastering_job}

--- a/src/acemusic/api/tasks/mastering.py
+++ b/src/acemusic/api/tasks/mastering.py
@@ -168,12 +168,11 @@ async def process_mastering_job(
             fmt,
             requested_service=service,
         )
-    except ServiceNotConfiguredError as exc:
-        # Defensive: master_with_fallback raises this only for an unconfigured
-        # *requested* service, which the pre-flight get_client already caught.
-        await _refund_unperformed(job, service)
-        raise JobProcessingError(str(exc)) from exc
     except Exception as exc:
+        # The pre-flight get_client already handled the unconfigured-requested
+        # case (with a refund); any failure reaching here is a backend error from
+        # a configured service that exhausted its fallback chain, so the job fails
+        # without a refund (mirrors the existing runtime-failure behaviour).
         raise JobProcessingError(f"Mastering failed: {exc}") from exc
 
     clip_id = await _store_master_clip(job, source, storage, output.audio_bytes, fmt)

--- a/src/acemusic/api/tasks/mastering.py
+++ b/src/acemusic/api/tasks/mastering.py
@@ -37,7 +37,7 @@ from acemusic.mastering_orchestrator import MasteringOrchestrator, ServiceNotCon
 from acemusic.storage import StorageBackend
 
 from ..models import Clip, Job
-from ..services import credits as credits_service
+from ..services import credits as credits_service, users as user_service
 from ..services.clips import native_format
 from ..services.mastering import MASTERING_JOB_TYPE
 from .common import JobProcessingError, download_clip, load_source_clip, store_clip
@@ -66,6 +66,59 @@ async def _refund_unperformed(job: Job, service: str) -> None:
         await credits_service.refund_credits(job.user_id, cost)
     except Exception:  # pragma: no cover - refund is best-effort; never mask the cause
         logger.exception("Failed to refund mastering job %s after a pre-flight rejection", job.id)
+
+
+async def _reconcile_fallback_credits(job: Job, requested_service: str, actual_service: str) -> None:
+    """Reconcile the pre-charged credits to the cost of the service that actually ran.
+
+    The router (US-12.1) charges the *requested* service at enqueue. When the
+    orchestrator falls back to a differently-priced backend, the user would
+    otherwise be left over- or under-charged relative to the work performed. This
+    adjusts the balance so the final charge equals ``get_mastering_cost(actual)``:
+    a cheaper fallback refunds the difference; a pricier fallback charges the
+    difference (best-effort — an insufficient balance for the top-up is logged,
+    not fatal, since the master is already complete and the job must not fail
+    over a few credits). Best-effort overall: a ledger failure is logged, never
+    masks the mastering result.
+    """
+    if actual_service == requested_service:
+        return
+    try:
+        charged = credits_service.get_mastering_cost(requested_service)
+        actual = credits_service.get_mastering_cost(actual_service)
+    except ValueError:  # pragma: no cover - both services are validated upstream
+        return
+    diff = actual - charged  # >0: undercharged (top up); <0: overcharged (refund)
+    if diff == 0:
+        return
+    try:
+        if diff > 0:
+            balance_after = await credits_service.deduct_credits(job.user_id, diff)
+            if balance_after is None:
+                logger.warning(
+                    "Mastering job %s fell back to pricier %s (+%.1f credits) but the user has "
+                    "insufficient balance for the top-up; result retained.",
+                    job.id,
+                    actual_service,
+                    diff,
+                )
+                return
+        else:
+            await credits_service.refund_credits(job.user_id, -diff)
+            user = await user_service.get_user_by_id(str(job.user_id))
+            balance_after = user.credits_balance if user is not None else 0.0
+        # amount sign matches the router's convention: negative for a charge,
+        # positive for a refund. ``-diff`` is negative when diff>0 (top-up) and
+        # positive when diff<0 (refund).
+        await credits_service.record_transaction(
+            user_id=job.user_id,
+            amount=-diff,
+            action_type=MASTERING_JOB_TYPE,
+            job_id=str(job.id),
+            balance_after=balance_after,
+        )
+    except Exception:  # pragma: no cover - reconciliation is best-effort
+        logger.exception("Failed to reconcile mastering credits for job %s", job.id)
 
 
 def get_mastering_orchestrator(settings: "ApiSettings") -> MasteringOrchestrator:
@@ -178,6 +231,9 @@ async def process_mastering_job(
     clip_id = await _store_master_clip(job, source, storage, output.audio_bytes, fmt)
     if output.service != service:
         logger.info("Mastering job %s fell back from %s to %s", job.id, service, output.service)
+        # The router charged the requested service at enqueue; reconcile to the
+        # actual service's cost so the user pays for the work performed (codex P1).
+        await _reconcile_fallback_credits(job, service, output.service)
 
     return {
         "clip_ids": [clip_id],

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -29,7 +29,7 @@ from pymongo import ASCENDING, ReturnDocument
 
 from acemusic.client import AceStepClient
 from acemusic.config import load_config
-from acemusic.dolby_client import DolbyClient
+from acemusic.mastering_orchestrator import MasteringOrchestrator
 from acemusic.runpod_client import RunPodClient
 from acemusic.storage import StorageBackend, get_storage_backend
 
@@ -103,7 +103,7 @@ class JobProcessor:
         runpod_client_factory: Callable[[], RunPodClient] | None = None,
         runpod_timeout: float = 300.0,
         runpod_poll_interval: float = 5.0,
-        dolby_client_factory: Callable[[], DolbyClient | None] | None = None,
+        mastering_orchestrator_factory: Callable[[], MasteringOrchestrator] | None = None,
         storage_factory: Callable[[], StorageBackend] | None = None,
         handlers: dict[str, JobHandler] | None = None,
     ) -> None:
@@ -119,10 +119,11 @@ class JobProcessor:
         self._runpod_client_factory = runpod_client_factory
         self._runpod_timeout = runpod_timeout
         self._runpod_poll_interval = runpod_poll_interval
-        # Dolby.io mastering (US-12.2). The factory returns None when credentials
-        # are absent; the mastering handler then fails a claimed job with a clear
-        # message rather than crashing, so a Dolby-less deployment degrades cleanly.
-        self._dolby_client_factory = dolby_client_factory
+        # Mastering orchestrator (US-12.3). The factory builds the orchestrator
+        # from the configured backends (Dolby/LANDR/Bakuage); None only when no
+        # mastering credentials are set at all, in which case the mastering handler
+        # fails a claimed job with a clear message rather than crashing.
+        self._mastering_orchestrator_factory = mastering_orchestrator_factory
         # A job legitimately stays in `processing` for at most poll_timeout (its
         # own worker fails it after that). Only re-queue jobs older than that
         # window plus a margin, so a startup sweep never reclaims a job a live
@@ -147,8 +148,9 @@ class JobProcessor:
         # adapted through their own injecting wrapper.
         for job_type, iterative_handler in ITERATIVE_JOB_HANDLERS.items():
             self._handlers[job_type] = partial(self._run_iterative_handler, iterative_handler)
-        # Mastering handlers (US-12.2) need storage plus the Dolby client (or None
-        # when unconfigured), so they get their own injecting wrapper.
+        # Mastering handlers (US-12.2 / US-12.3) need storage plus the mastering
+        # orchestrator (which selects and falls back across Dolby/LANDR/Bakuage),
+        # so they get their own injecting wrapper.
         for job_type, mastering_handler in MASTERING_JOB_HANDLERS.items():
             self._handlers[job_type] = partial(self._run_mastering_handler, mastering_handler)
         if handlers:
@@ -311,9 +313,13 @@ class JobProcessor:
         )
 
     async def _run_mastering_handler(self, mastering_handler: Any, job: Job) -> dict[str, Any]:
-        """Adapt a mastering handler (US-12.2), injecting storage and the Dolby client (or None)."""
-        client = self._dolby_client_factory() if self._dolby_client_factory is not None else None
-        return await mastering_handler(job, storage=self._storage_factory(), client=client)
+        """Adapt a mastering handler (US-12.2/US-12.3), injecting storage and the orchestrator."""
+        if self._mastering_orchestrator_factory is None:
+            raise JobProcessingError(
+                "Mastering is not configured: this processor has no mastering orchestrator factory"
+            )
+        orchestrator = self._mastering_orchestrator_factory()
+        return await mastering_handler(job, storage=self._storage_factory(), orchestrator=orchestrator)
 
     async def _handle_generate(self, job: Job) -> dict[str, Any]:
         """Run a generation job — locally via ACE-Step or remotely via RunPod.

--- a/src/acemusic/bakuage_client.py
+++ b/src/acemusic/bakuage_client.py
@@ -1,0 +1,268 @@
+"""HTTP client for the Bakuage (AI Mastering) REST API (US-12.3).
+
+Bakuage is the cost-effective fallback mastering backend (the end of the
+Dolby -> LANDR -> Bakuage chain). Unlike Dolby and LANDR it exposes a simpler
+open REST API (spec §41.2.3: base ``https://api.bakuage.com:443``, bearer-token
+auth) with no OAuth token dance: the API key is sent directly as a bearer header
+on every call, and a single ``POST /masterings`` request uploads the audio and
+creates the job.
+
+It mirrors the conventions of the other external clients: synchronous
+:mod:`httpx` (the job processor calls it from a worker thread via
+``asyncio.to_thread``), module-level timeouts, a single :class:`BakuageError`
+for every failure mode, and exponential-backoff retries on transient (5xx /
+network) errors while 4xx auth/validation errors fail fast.
+
+It implements the shared :class:`~acemusic.mastering_protocol.MasteringService`
+contract: :meth:`BakuageClient.master` drives create -> poll -> download and
+returns a normalized :class:`~acemusic.mastering_protocol.MasteringOutput`.
+Bakuage reports fewer metrics than Dolby (loudness, no 16-band EQ or stereo
+analysis), so optional fields degrade to ``None`` to keep the shared shape.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Callable
+
+import httpx
+
+from acemusic.mastering_protocol import MasteringError, MasteringOutput
+
+# Bakuage AI Mastering open REST API (spec §41.2.3).
+_BASE_URL = "https://api.bakuage.com:443/v1"
+_MASTERS_URL = f"{_BASE_URL}/masterings"
+
+# Retry policy for transient (5xx) responses, matching Dolby/LANDR/RunPod.
+_MAX_RETRIES = 3
+_BACKOFF_BASE = 1.0
+_BACKOFF_JITTER = 0.5
+
+# Create/poll calls are quick; download streams a whole audio file.
+_API_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=120.0, pool=10.0)
+_DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0)
+
+# Internal mastering profile -> Bakuage mastering level. Bakuage exposes a
+# mastering-level parameter; this maps the platform profile vocabulary onto it.
+# ``custom`` defers to the resolved target_lufs and carries it through explicitly.
+_PROFILE_LEVEL = {
+    "streaming": "low",
+    "soundcloud": "medium",
+    "club": "high",
+    "vinyl": "low",
+}
+_DEFAULT_LEVEL = "low"
+
+# Bakuage reports job state under these lower-cased strings; anything else is
+# treated as still-running so the poll loop keeps waiting until its timeout.
+_SUCCESS_STATES = {"completed", "success"}
+_FAILURE_STATES = {"failed", "cancelled", "error"}
+
+
+class BakuageError(MasteringError):
+    """Raised when the Bakuage API returns an error or is unreachable.
+
+    Subclasses :class:`~acemusic.mastering_protocol.MasteringError` so the
+    orchestrator can fall back (or report the final failure) on any Bakuage error.
+    """
+
+
+def bakuage_master_params(profile: str, target_lufs: float, output_format: str) -> dict[str, Any]:
+    """Map the platform profile onto Bakuage's mastering parameters."""
+    params: dict[str, Any] = {
+        "mastering_level": _PROFILE_LEVEL.get(profile, _DEFAULT_LEVEL),
+        "output_format": output_format,
+    }
+    if profile == "custom":
+        params["target_lufs"] = float(target_lufs)
+    return params
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Exponential backoff (1s, 2s, 4s …) plus jitter for the given retry attempt."""
+    return _BACKOFF_BASE * (2**attempt) + random.uniform(0, _BACKOFF_JITTER)
+
+
+def _as_float(value: Any) -> float | None:
+    """Best-effort float coercion for a metric value, or None when absent/garbage."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class BakuageClient:
+    """Synchronous client for the Bakuage AI Mastering REST workflow."""
+
+    # Canonical service name used for dispatch and result attribution (US-12.3).
+    service = "bakuage"
+
+    def __init__(self, api_key: str) -> None:
+        """Initialise with the Bakuage API key (sent as a bearer header)."""
+        self.api_key = api_key
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+
+    # -- transport ---------------------------------------------------------
+
+    def _send_with_retry(
+        self,
+        method: Callable[..., httpx.Response],
+        url: str,
+        *,
+        timeout: httpx.Timeout | float,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Issue an HTTP request, retrying on 5xx with exponential backoff."""
+        request_headers = self._headers if headers is None else headers
+        response = None
+        for attempt in range(_MAX_RETRIES + 1):
+            response = method(url, headers=request_headers, timeout=timeout, **kwargs)
+            if response.status_code >= 500 and attempt < _MAX_RETRIES:
+                time.sleep(_backoff_delay(attempt))
+                continue
+            return response
+        return response  # pragma: no cover - loop always returns on the last attempt
+
+    # -- create mastering --------------------------------------------------
+
+    def create_mastering(
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+    ) -> str:
+        """Upload ``audio_bytes`` and create a Bakuage mastering job, returning its id.
+
+        Bakuage combines upload + job creation in one ``POST /masterings`` request
+        (multipart form carrying the audio and the mastering parameters).
+        """
+        params = bakuage_master_params(profile, target_lufs, output_format)
+        files = {"audio_file": (filename, audio_bytes)}
+        data = {k: str(v) for k, v in params.items()}
+        try:
+            response = self._send_with_retry(httpx.post, _MASTERS_URL, files=files, data=data, timeout=_API_TIMEOUT)
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise BakuageError(f"Bakuage create failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise BakuageError(f"Bakuage create failed: {exc}") from exc
+        except ValueError as exc:
+            raise BakuageError("Bakuage create failed: invalid JSON response") from exc
+
+        job_id = payload.get("id") if isinstance(payload, dict) else None
+        if not job_id:
+            raise BakuageError("Bakuage create failed: response contains no id")
+        return str(job_id)
+
+    # -- polling -----------------------------------------------------------
+
+    def get_status(self, job_id: str) -> dict[str, Any]:
+        """Fetch the current state of Bakuage job ``job_id`` with a normalised status."""
+        try:
+            response = self._send_with_retry(httpx.get, f"{_MASTERS_URL}/{job_id}", timeout=_API_TIMEOUT)
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise BakuageError(f"Bakuage status check failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise BakuageError(f"Bakuage status check failed: {exc}") from exc
+        except ValueError as exc:
+            raise BakuageError("Bakuage status check failed: invalid JSON response") from exc
+        if not isinstance(payload, dict):
+            raise BakuageError("Bakuage status check failed: unexpected response payload")
+        payload["status"] = str(payload.get("status", "")).lower()
+        payload["progress"] = _as_float(payload.get("progress")) or 0.0
+        return payload
+
+    def wait_for_completion(self, job_id: str, timeout: float = 600.0, poll_interval: float = 2.0) -> dict[str, Any]:
+        """Poll ``job_id`` until it succeeds, returning the final status payload."""
+        deadline = time.monotonic() + timeout
+        interval = poll_interval
+        while True:
+            status_payload = self.get_status(job_id)
+            state = status_payload["status"]
+            if state in _SUCCESS_STATES:
+                return status_payload
+            if state in _FAILURE_STATES:
+                detail = status_payload.get("error") or state
+                raise BakuageError(f"Bakuage mastering job {job_id} failed: {detail}")
+            if time.monotonic() >= deadline:
+                raise BakuageError(f"Bakuage mastering job {job_id} timed out after {timeout:.0f}s")
+            time.sleep(interval)
+            interval = min(interval * 2, 30.0)
+
+    # -- download ----------------------------------------------------------
+
+    def download(self, job_id: str) -> bytes:
+        """Download the mastered audio for ``job_id`` from Bakuage.
+
+        ``GET /masterings/{id}/download`` either streams the bytes directly or
+        redirects to a pre-authorized CDN URL; a redirect is followed manually
+        with *no* bearer header so the token never reaches the CDN host.
+        """
+        try:
+            response = self._send_with_retry(
+                httpx.get,
+                f"{_MASTERS_URL}/{job_id}/download",
+                timeout=_DOWNLOAD_TIMEOUT,
+                follow_redirects=False,
+            )
+            if response.is_redirect and response.headers.get("location"):
+                response = self._send_with_retry(
+                    httpx.get,
+                    response.headers["location"],
+                    timeout=_DOWNLOAD_TIMEOUT,
+                    headers={},
+                    follow_redirects=True,
+                )
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPStatusError as exc:
+            raise BakuageError(f"Bakuage download failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise BakuageError(f"Bakuage download failed: {exc}") from exc
+
+    # -- high-level entrypoint (US-12.3 shared interface) -----------------
+
+    def master(
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+    ) -> MasteringOutput:
+        """Run the full Bakuage mastering workflow and return a normalized output.
+
+        Wraps create -> poll -> download behind the single
+        :meth:`~acemusic.mastering_protocol.MasteringService.master` entrypoint.
+        Bakuage reports fewer metrics than Dolby (loudness only); the metrics dict
+        is built defensively so missing fields degrade to ``None`` / empty.
+        """
+        job_id = self.create_mastering(audio_bytes, filename, profile, target_lufs, output_format)
+        status_payload = self.wait_for_completion(job_id)
+        audio = self.download(job_id)
+        return MasteringOutput(audio_bytes=audio, metrics=_parse_metrics(status_payload), service=self.service)
+
+
+def _parse_metrics(status_payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract the loudness metric Bakuage reports, defensively.
+
+    Bakuage nests analysis under ``result`` and reports loudness only (no 16-band
+    EQ or stereo-image analysis); optional fields degrade to ``None`` / empty to
+    match the shared metrics shape used across all three backends.
+    """
+    result = status_payload.get("result")
+    result = result if isinstance(result, dict) else {}
+    return {
+        "loudness": _as_float(result.get("loudness_lufs")),
+        "eq_bands": [],
+        "stereo": {"width": None, "balance": None},
+    }

--- a/src/acemusic/bakuage_client.py
+++ b/src/acemusic/bakuage_client.py
@@ -238,6 +238,7 @@ class BakuageClient:
         profile: str,
         target_lufs: float,
         output_format: str,
+        timeout: float | None = None,
     ) -> MasteringOutput:
         """Run the full Bakuage mastering workflow and return a normalized output.
 
@@ -245,9 +246,10 @@ class BakuageClient:
         :meth:`~acemusic.mastering_protocol.MasteringService.master` entrypoint.
         Bakuage reports fewer metrics than Dolby (loudness only); the metrics dict
         is built defensively so missing fields degrade to ``None`` / empty.
+        ``timeout`` caps the poll phase (defaults to 600s).
         """
         job_id = self.create_mastering(audio_bytes, filename, profile, target_lufs, output_format)
-        status_payload = self.wait_for_completion(job_id)
+        status_payload = self.wait_for_completion(job_id, timeout=timeout if timeout is not None else 600.0)
         audio = self.download(job_id)
         return MasteringOutput(audio_bytes=audio, metrics=_parse_metrics(status_payload), service=self.service)
 

--- a/src/acemusic/dolby_client.py
+++ b/src/acemusic/dolby_client.py
@@ -28,6 +28,8 @@ from typing import Any, Callable
 
 import httpx
 
+from acemusic.mastering_protocol import MasteringError, MasteringOutput
+
 # Auth lives on api.dolby.io; the Media (mastering/input/output) endpoints live on
 # api.dolby.com — two distinct hosts, mirroring Dolby.io's published API surface.
 _AUTH_URL = "https://api.dolby.io/v1/auth/token"
@@ -75,8 +77,13 @@ _SUCCESS_STATES = {"success"}
 _FAILURE_STATES = {"failed", "cancelled"}
 
 
-class DolbyError(Exception):
-    """Raised when the Dolby.io API returns an error or is unreachable."""
+class DolbyError(MasteringError):
+    """Raised when the Dolby.io API returns an error or is unreachable.
+
+    Subclasses :class:`~acemusic.mastering_protocol.MasteringError` so the
+    mastering orchestrator can catch every backend's failure through one common
+    base when deciding whether to fall back to another service (US-12.3).
+    """
 
 
 def master_output_config(profile: str, target_lufs: float, destination: str) -> dict[str, Any]:
@@ -114,6 +121,9 @@ def _as_float(value: Any) -> float | None:
 
 class DolbyClient:
     """Synchronous client for the Dolby.io Music Mastering workflow."""
+
+    # Canonical service name used for dispatch and result attribution (US-12.3).
+    service = "dolby"
 
     def __init__(self, api_key: str, api_secret: str) -> None:
         """Initialise with the Dolby.io app key/secret used to mint bearer tokens."""
@@ -375,6 +385,40 @@ class DolbyClient:
             raise DolbyError(f"Dolby download failed: {exc.response.status_code}") from exc
         except httpx.RequestError as exc:
             raise DolbyError(f"Dolby download failed: {exc}") from exc
+
+    # -- high-level entrypoint (US-12.3 shared interface) -----------------
+
+    def master(
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+    ) -> MasteringOutput:
+        """Run the full Dolby mastering workflow and return a normalized output.
+
+        Wraps the granular upload -> submit -> poll -> results -> download flow
+        behind the single :meth:`~acemusic.mastering_protocol.MasteringService`
+        entrypoint so the orchestrator can treat Dolby.io, LANDR and Bakuage
+        interchangeably. A single output variant is requested (multi-preview A/B
+        comparison is US-12.4's concern); its mastered audio and metrics are
+        returned in the shared :class:`MasteringOutput` shape.
+
+        ``filename`` carries the job id (supplied by the caller) so concurrent
+        masters on the same clip never collide on Dolby's input/output keys.
+        """
+        input_url = self.upload(audio_bytes, filename)
+        destination = f"dlb://{filename.rsplit('/', 1)[-1].rsplit('.', 1)[0]}-master.{output_format}"
+        outputs = [master_output_config(profile, target_lufs, destination)]
+        job_id = self.submit_preview(input_url, outputs)
+        status_payload = self.wait_for_completion(job_id)
+        results = self.get_results(job_id, status_payload)
+        preview_handles = [out.get("preview") for out in results.get("outputs", []) if out.get("preview")]
+        if not preview_handles:
+            raise DolbyError("Dolby mastering completed but returned no preview outputs")
+        audio = self.download(preview_handles[0])
+        return MasteringOutput(audio_bytes=audio, metrics=results.get("metrics", {}), service=self.service)
 
 
 def _parse_metrics(result: dict[str, Any]) -> dict[str, Any]:

--- a/src/acemusic/dolby_client.py
+++ b/src/acemusic/dolby_client.py
@@ -395,6 +395,7 @@ class DolbyClient:
         profile: str,
         target_lufs: float,
         output_format: str,
+        timeout: float | None = None,
     ) -> MasteringOutput:
         """Run the full Dolby mastering workflow and return a normalized output.
 
@@ -407,12 +408,13 @@ class DolbyClient:
 
         ``filename`` carries the job id (supplied by the caller) so concurrent
         masters on the same clip never collide on Dolby's input/output keys.
+        ``timeout`` caps the poll phase (defaults to 600s when ``None``).
         """
         input_url = self.upload(audio_bytes, filename)
         destination = f"dlb://{filename.rsplit('/', 1)[-1].rsplit('.', 1)[0]}-master.{output_format}"
         outputs = [master_output_config(profile, target_lufs, destination)]
         job_id = self.submit_preview(input_url, outputs)
-        status_payload = self.wait_for_completion(job_id)
+        status_payload = self.wait_for_completion(job_id, timeout=timeout if timeout is not None else 600.0)
         results = self.get_results(job_id, status_payload)
         preview_handles = [out.get("preview") for out in results.get("outputs", []) if out.get("preview")]
         if not preview_handles:

--- a/src/acemusic/landr_client.py
+++ b/src/acemusic/landr_client.py
@@ -1,0 +1,361 @@
+"""HTTP client for the LANDR B2B Music Mastering API (US-12.3).
+
+LANDR is the first fallback mastering backend alongside Dolby.io (US-12.2). It
+mirrors the conventions of the other external clients in this package:
+synchronous :mod:`httpx` (the job processor calls it from a worker thread via
+``asyncio.to_thread``), module-level timeouts, a single :class:`LandrError` for
+every failure mode, and RunPod-style exponential-backoff retries on transient
+(5xx / network) errors while 4xx auth/validation errors fail fast.
+
+It implements the shared :class:`~acemusic.mastering_protocol.MasteringService`
+contract: a single :meth:`LandrClient.master` entrypoint drives the full
+upload -> submit -> poll -> download workflow and returns a normalized
+:class:`~acemusic.mastering_protocol.MasteringOutput`, so the mastering
+orchestrator can treat it interchangeably with Dolby.io and Bakuage.
+
+.. note::
+
+   LANDR's B2B REST API is partnership-gated, so the endpoint shapes below
+   encode the contract this client assumes (auth token, two-step upload to a
+   presigned URL, job submission with loudness/style, status polling, download
+   with redirect handling). They follow LANDR's published B2B model (REST,
+   genre-aware processing, three loudness tiers, multiple mastering styles) per
+   ``ai-music-spec.md`` §41.2.2. A live integration swaps these constants for
+   the partnership's documented URLs without changing the workflow.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Callable
+
+import httpx
+
+from acemusic.mastering_protocol import MasteringError, MasteringOutput
+
+# LANDR B2B API (assumed partnership-gated surface, per spec §41.2.2).
+_BASE_URL = "https://api.landr.com/v1"
+_AUTH_URL = f"{_BASE_URL}/auth/token"
+_UPLOAD_URL = f"{_BASE_URL}/uploads"
+_MASTERS_URL = f"{_BASE_URL}/masters"
+
+# Token lifetime requested from LANDR (30 min) and the buffer before expiry at
+# which we proactively refresh, mirroring the Dolby client.
+_TOKEN_LIFETIME_S = 1800
+_TOKEN_EXPIRY_BUFFER_S = 60.0
+
+# Retry policy for transient (5xx) responses, matching Dolby/RunPod.
+_MAX_RETRIES = 3
+_BACKOFF_BASE = 1.0
+_BACKOFF_JITTER = 0.5
+
+# Auth/JSON calls are quick; upload and download stream whole audio files.
+_AUTH_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=10.0)
+_API_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
+_UPLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=300.0, pool=10.0)
+_DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0)
+
+# Internal mastering profile -> LANDR loudness tier + style preset. LANDR exposes
+# three loudness settings and multiple mastering styles (spec §41.2.2); this maps
+# the platform profile vocabulary onto LANDR's parameters. ``custom`` defers to
+# the resolved target_lufs and carries it through explicitly.
+_PROFILE_LOUDNESS = {
+    "streaming": "low",
+    "soundcloud": "medium",
+    "club": "high",
+    "vinyl": "low",
+}
+_PROFILE_STYLE = {
+    "streaming": "universal",
+    "soundcloud": "warm",
+    "club": "club",
+    "vinyl": "vinyl",
+}
+_DEFAULT_LOUDNESS = "low"
+_DEFAULT_STYLE = "universal"
+
+# LANDR reports job state under these lower-cased strings; anything else is
+# treated as still-running so the poll loop keeps waiting until its timeout.
+_SUCCESS_STATES = {"completed", "success"}
+_FAILURE_STATES = {"failed", "cancelled", "error"}
+
+
+class LandrError(MasteringError):
+    """Raised when the LANDR API returns an error or is unreachable.
+
+    Subclasses :class:`~acemusic.mastering_protocol.MasteringError` so the
+    orchestrator can fall back to the next service on any LANDR failure.
+    """
+
+
+def landr_master_params(profile: str, target_lufs: float, output_format: str) -> dict[str, Any]:
+    """Map the platform profile onto LANDR's loudness/style/output parameters.
+
+    ``custom`` carries the resolved ``target_lufs`` explicitly (LANDR applies the
+    exact loudness target). Kept a free function so the handler/tests can compose
+    and assert the mapping without the client.
+    """
+    params: dict[str, Any] = {
+        "loudness": _PROFILE_LOUDNESS.get(profile, _DEFAULT_LOUDNESS),
+        "style": _PROFILE_STYLE.get(profile, _DEFAULT_STYLE),
+        "output_format": output_format,
+    }
+    if profile == "custom":
+        params["target_lufs"] = float(target_lufs)
+    return params
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Exponential backoff (1s, 2s, 4s …) plus jitter for the given retry attempt."""
+    return _BACKOFF_BASE * (2**attempt) + random.uniform(0, _BACKOFF_JITTER)
+
+
+def _as_float(value: Any) -> float | None:
+    """Best-effort float coercion for a metric value, or None when absent/garbage."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class LandrClient:
+    """Synchronous client for the LANDR B2B Music Mastering workflow."""
+
+    # Canonical service name used for dispatch and result attribution (US-12.3).
+    service = "landr"
+
+    def __init__(self, api_key: str, api_secret: str) -> None:
+        """Initialise with the LANDR B2B key/secret used to mint session tokens."""
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self._token: str | None = None
+        self._token_expiry: float = 0.0
+
+    # -- auth --------------------------------------------------------------
+
+    def _get_token(self) -> str:
+        """Return a valid bearer token, refreshing it when missing or near expiry."""
+        now = time.monotonic()
+        if self._token is not None and now < self._token_expiry - _TOKEN_EXPIRY_BUFFER_S:
+            return self._token
+        try:
+            response = httpx.post(
+                _AUTH_URL,
+                auth=(self.api_key, self.api_secret),
+                data={"grant_type": "client_credentials", "expires_in": _TOKEN_LIFETIME_S},
+                timeout=_AUTH_TIMEOUT,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise LandrError(f"LANDR authentication failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise LandrError(f"LANDR authentication failed: {exc}") from exc
+        except ValueError as exc:
+            raise LandrError("LANDR authentication failed: invalid JSON response") from exc
+
+        token = payload.get("access_token") if isinstance(payload, dict) else None
+        if not token:
+            raise LandrError("LANDR authentication failed: response contains no access_token")
+        raw_expires = _as_float(payload.get("expires_in"))
+        expires_in = raw_expires if raw_expires is not None and raw_expires > 0 else float(_TOKEN_LIFETIME_S)
+        self._token = str(token)
+        self._token_expiry = now + expires_in
+        return self._token
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Bearer auth header carrying a fresh-enough token."""
+        return {"Authorization": f"Bearer {self._get_token()}"}
+
+    # -- transport ---------------------------------------------------------
+
+    def _send_with_retry(
+        self,
+        method: Callable[..., httpx.Response],
+        url: str,
+        *,
+        timeout: httpx.Timeout | float,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Issue an HTTP request, retrying on 5xx with exponential backoff."""
+        request_headers = self._auth_headers() if headers is None else headers
+        response = None
+        for attempt in range(_MAX_RETRIES + 1):
+            response = method(url, headers=request_headers, timeout=timeout, **kwargs)
+            if response.status_code >= 500 and attempt < _MAX_RETRIES:
+                time.sleep(_backoff_delay(attempt))
+                continue
+            return response
+        return response  # pragma: no cover - loop always returns on the last attempt
+
+    # -- upload ------------------------------------------------------------
+
+    def upload(self, audio_bytes: bytes, filename: str) -> str:
+        """Upload ``audio_bytes`` to LANDR, returning the LANDR audio id.
+
+        Two-step presigned workflow: ask ``POST /uploads`` for a presigned PUT URL
+        and an audio id, then PUT the bytes to the presigned URL (no bearer token).
+        """
+        try:
+            response = self._send_with_retry(httpx.post, _UPLOAD_URL, json={"filename": filename}, timeout=_API_TIMEOUT)
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise LandrError(f"LANDR upload request failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise LandrError(f"LANDR upload request failed: {exc}") from exc
+        except ValueError as exc:
+            raise LandrError("LANDR upload request failed: invalid JSON response") from exc
+
+        presigned_url = payload.get("upload_url") if isinstance(payload, dict) else None
+        audio_id = payload.get("audio_id") if isinstance(payload, dict) else None
+        if not audio_id:
+            raise LandrError("LANDR upload request failed: response contains no audio_id")
+        if not presigned_url:
+            raise LandrError("LANDR upload request failed: response contains no upload_url")
+
+        try:
+            put = self._send_with_retry(
+                httpx.put, presigned_url, content=audio_bytes, timeout=_UPLOAD_TIMEOUT, headers={}
+            )
+            put.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise LandrError(f"LANDR upload failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise LandrError(f"LANDR upload failed: {exc}") from exc
+        return str(audio_id)
+
+    # -- submission --------------------------------------------------------
+
+    def submit(self, audio_id: str, profile: str, target_lufs: float, output_format: str) -> str:
+        """Submit a LANDR mastering job and return its ``job_id``."""
+        body = {"audio_id": audio_id, **landr_master_params(profile, target_lufs, output_format)}
+        try:
+            response = self._send_with_retry(httpx.post, _MASTERS_URL, json=body, timeout=_API_TIMEOUT)
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise LandrError(f"LANDR submission failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise LandrError(f"LANDR submission failed: {exc}") from exc
+        except ValueError as exc:
+            raise LandrError("LANDR submission failed: invalid JSON response") from exc
+
+        job_id = payload.get("job_id") if isinstance(payload, dict) else None
+        if not job_id:
+            raise LandrError("LANDR submission failed: response contains no job_id")
+        return str(job_id)
+
+    # -- polling -----------------------------------------------------------
+
+    def get_status(self, job_id: str) -> dict[str, Any]:
+        """Fetch the current state of LANDR job ``job_id`` with a normalised status."""
+        try:
+            response = self._send_with_retry(httpx.get, f"{_MASTERS_URL}/{job_id}", timeout=_API_TIMEOUT)
+            response.raise_for_status()
+            payload = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise LandrError(f"LANDR status check failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise LandrError(f"LANDR status check failed: {exc}") from exc
+        except ValueError as exc:
+            raise LandrError("LANDR status check failed: invalid JSON response") from exc
+        if not isinstance(payload, dict):
+            raise LandrError("LANDR status check failed: unexpected response payload")
+        payload["status"] = str(payload.get("status", "")).lower()
+        payload["progress"] = _as_float(payload.get("progress")) or 0.0
+        return payload
+
+    def wait_for_completion(self, job_id: str, timeout: float = 600.0, poll_interval: float = 2.0) -> dict[str, Any]:
+        """Poll ``job_id`` until it succeeds, returning the final status payload."""
+        deadline = time.monotonic() + timeout
+        interval = poll_interval
+        while True:
+            status_payload = self.get_status(job_id)
+            state = status_payload["status"]
+            if state in _SUCCESS_STATES:
+                return status_payload
+            if state in _FAILURE_STATES:
+                detail = status_payload.get("error") or state
+                raise LandrError(f"LANDR mastering job {job_id} failed: {detail}")
+            if time.monotonic() >= deadline:
+                raise LandrError(f"LANDR mastering job {job_id} timed out after {timeout:.0f}s")
+            time.sleep(interval)
+            interval = min(interval * 2, 30.0)
+
+    # -- download ----------------------------------------------------------
+
+    def download(self, job_id: str) -> bytes:
+        """Download the mastered audio for ``job_id`` from LANDR.
+
+        ``GET /masters/{id}/download`` either streams the bytes directly or
+        redirects to a pre-authorized CDN URL; a redirect is followed manually
+        with *no* bearer header so the token never reaches the CDN host.
+        """
+        try:
+            response = self._send_with_retry(
+                httpx.get,
+                f"{_MASTERS_URL}/{job_id}/download",
+                timeout=_DOWNLOAD_TIMEOUT,
+                follow_redirects=False,
+            )
+            if response.is_redirect and response.headers.get("location"):
+                response = self._send_with_retry(
+                    httpx.get,
+                    response.headers["location"],
+                    timeout=_DOWNLOAD_TIMEOUT,
+                    headers={},
+                    follow_redirects=True,
+                )
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPStatusError as exc:
+            raise LandrError(f"LANDR download failed: {exc.response.status_code}") from exc
+        except httpx.RequestError as exc:
+            raise LandrError(f"LANDR download failed: {exc}") from exc
+
+    # -- high-level entrypoint (US-12.3 shared interface) -----------------
+
+    def master(
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+    ) -> MasteringOutput:
+        """Run the full LANDR mastering workflow and return a normalized output.
+
+        Wraps upload -> submit -> poll -> download behind the single
+        :meth:`~acemusic.mastering_protocol.MasteringService.master` entrypoint.
+        LANDR reports fewer metrics than Dolby (loudness, optional EQ); the
+        metrics dict is built defensively so missing fields degrade to ``None``
+        rather than raising.
+        """
+        audio_id = self.upload(audio_bytes, filename)
+        job_id = self.submit(audio_id, profile, target_lufs, output_format)
+        status_payload = self.wait_for_completion(job_id)
+        audio = self.download(job_id)
+        return MasteringOutput(audio_bytes=audio, metrics=_parse_metrics(status_payload), service=self.service)
+
+
+def _parse_metrics(status_payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract the loudness / EQ metrics LANDR reports, defensively.
+
+    LANDR nests analysis under ``result``; fields are optional, so missing values
+    degrade to ``None`` / empty to match the shared metrics shape.
+    """
+    result = status_payload.get("result")
+    result = result if isinstance(result, dict) else {}
+    raw_bands = result.get("eq_bands") if isinstance(result.get("eq_bands"), list) else []
+    eq_bands = [band for band in (_as_float(v) for v in raw_bands) if band is not None]
+    return {
+        "loudness": _as_float(result.get("loudness_lufs")),
+        "eq_bands": eq_bands,
+        # LANDR does not report stereo-image analysis; keep the shared shape.
+        "stereo": {"width": None, "balance": None},
+    }

--- a/src/acemusic/landr_client.py
+++ b/src/acemusic/landr_client.py
@@ -327,6 +327,7 @@ class LandrClient:
         profile: str,
         target_lufs: float,
         output_format: str,
+        timeout: float | None = None,
     ) -> MasteringOutput:
         """Run the full LANDR mastering workflow and return a normalized output.
 
@@ -334,11 +335,11 @@ class LandrClient:
         :meth:`~acemusic.mastering_protocol.MasteringService.master` entrypoint.
         LANDR reports fewer metrics than Dolby (loudness, optional EQ); the
         metrics dict is built defensively so missing fields degrade to ``None``
-        rather than raising.
+        rather than raising. ``timeout`` caps the poll phase (defaults to 600s).
         """
         audio_id = self.upload(audio_bytes, filename)
         job_id = self.submit(audio_id, profile, target_lufs, output_format)
-        status_payload = self.wait_for_completion(job_id)
+        status_payload = self.wait_for_completion(job_id, timeout=timeout if timeout is not None else 600.0)
         audio = self.download(job_id)
         return MasteringOutput(audio_bytes=audio, metrics=_parse_metrics(status_payload), service=self.service)
 

--- a/src/acemusic/mastering_orchestrator.py
+++ b/src/acemusic/mastering_orchestrator.py
@@ -26,7 +26,6 @@ Fallback policy (see ``tasks/todo.md`` for the rationale):
 from __future__ import annotations
 
 import logging
-from typing import Protocol, runtime_checkable
 
 from acemusic.mastering_protocol import MasteringError, MasteringOutput, MasteringService
 
@@ -45,23 +44,6 @@ class ServiceNotConfiguredError(Exception):
     handler can refund the credits charged at enqueue (no mastering work was
     performed) and report a clear "not configured" failure rather than retrying.
     """
-
-
-# A narrow callable type for the master entrypoint, so the orchestrator doesn't
-# import each concrete client. ``MasteringService`` (the runtime-checkable
-# Protocol) is the public contract; this alias documents the dispatch surface.
-@runtime_checkable
-class _MasterCallable(Protocol):
-    service: str
-
-    def master(
-        self,
-        audio_bytes: bytes,
-        filename: str,
-        profile: str,
-        target_lufs: float,
-        output_format: str,
-    ) -> MasteringOutput: ...
 
 
 class MasteringOrchestrator:

--- a/src/acemusic/mastering_orchestrator.py
+++ b/src/acemusic/mastering_orchestrator.py
@@ -26,6 +26,7 @@ Fallback policy (see ``tasks/todo.md`` for the rationale):
 from __future__ import annotations
 
 import logging
+import time
 
 from acemusic.mastering_protocol import MasteringError, MasteringOutput, MasteringService
 
@@ -35,6 +36,12 @@ logger = logging.getLogger(__name__)
 # -> Bakuage (cost-effective open API, US-12.3). The chain honours this order for
 # fallback candidates regardless of which service was requested.
 DEFAULT_FALLBACK_ORDER: tuple[str, ...] = ("dolby", "landr", "bakuage")
+
+# Overall deadline for one mastering run's full fallback chain. The processor's
+# stale-job threshold defaults to poll_timeout (600s) + 300s = 900s; bounding the
+# whole chain to 600s keeps a multi-backend run comfortably inside that window so
+# a restart-driven re-queue cannot duplicate a still-live job (codex review P2).
+DEFAULT_TOTAL_TIMEOUT_S: float = 600.0
 
 
 class ServiceNotConfiguredError(Exception):
@@ -96,13 +103,20 @@ class MasteringOrchestrator:
         output_format: str,
         *,
         requested_service: str,
+        total_timeout: float = DEFAULT_TOTAL_TIMEOUT_S,
     ) -> MasteringOutput:
         """Master ``audio_bytes`` via the requested service, falling back on failure.
 
         Raises :class:`ServiceNotConfiguredError` if the requested service has no
         configured client (no silent substitution). Raises the last
         :class:`~acemusic.mastering_protocol.MasteringError` if every service in
-        the chain fails.
+        the chain fails (or the overall deadline elapsed before another attempt).
+
+        ``total_timeout`` bounds the *whole* fallback chain: each backend is given
+        the time remaining on the deadline as its poll budget, so a chain of
+        hanging backends cannot run many minutes past the processor's stale-job
+        window (which would let a second processor re-queue and duplicate the
+        job). The default fits within the processor's default stale threshold.
         """
         if not self.is_service_available(requested_service):
             raise ServiceNotConfiguredError(
@@ -111,11 +125,30 @@ class MasteringOrchestrator:
             )
 
         chain = self._fallback_chain(requested_service)
+        deadline = time.monotonic() + total_timeout
         last_error: MasteringError | None = None
         for index, svc in enumerate(chain):
+            if index == 0:
+                # The requested service always gets a full attempt with the whole
+                # budget; only *fallback* attempts are gated by remaining time.
+                remaining_budget = total_timeout
+            else:
+                remaining_budget = deadline - time.monotonic()
+                if remaining_budget <= 0:
+                    # Deadline exhausted by earlier attempts: stop starting
+                    # fallbacks so the chain cannot run far past the processor's
+                    # stale-job window (which would duplicate the job on restart).
+                    logger.error(
+                        "Mastering fallback deadline (%.0fs) elapsed before trying %s; no further attempts",
+                        total_timeout,
+                        svc,
+                    )
+                    break
             client = self._clients[svc]
             try:
-                output = client.master(audio_bytes, filename, profile, target_lufs, output_format)
+                output = client.master(
+                    audio_bytes, filename, profile, target_lufs, output_format, timeout=remaining_budget
+                )
             except MasteringError as exc:
                 last_error = exc
                 remaining = len(chain) - index - 1
@@ -132,6 +165,10 @@ class MasteringOrchestrator:
             if svc != requested_service:
                 logger.info("Mastering fell back from %s to %s", requested_service, svc)
             return output
-        # Every configured service failed; propagate the last backend error.
-        assert last_error is not None  # pragma: no cover - chain is non-empty here
+        # Every configured service failed (or the deadline elapsed); propagate.
+        if last_error is None:
+            # Deadline elapsed before any backend raised an error.
+            raise MasteringError(
+                f"Mastering fallback deadline ({total_timeout:.0f}s) elapsed before any backend completed"
+            )
         raise last_error

--- a/src/acemusic/mastering_orchestrator.py
+++ b/src/acemusic/mastering_orchestrator.py
@@ -1,0 +1,155 @@
+"""Mastering service orchestrator with automatic fallback (US-12.3).
+
+The orchestrator sits between the mastering job handler and the three mastering
+backends (Dolby.io, LANDR, Bakuage). It selects the requested backend via the
+``service`` parameter and, when that backend fails, retries the next *configured*
+backend in the canonical order — so a Dolby.io outage transparently falls back to
+LANDR, then to Bakuage, without the handler knowing which backend ran.
+
+Fallback policy (see ``tasks/todo.md`` for the rationale):
+
+- An explicitly requested service that is **not configured** raises
+  :class:`ServiceNotConfiguredError` rather than silently substituting another
+  backend — the handler refunds the credits charged at enqueue and reports a
+  clear failure. (Request validation happens upstream, so the user's intent is
+  honored: only *available* services are chosen.)
+- A configured service that **fails at runtime** triggers a fallback to the next
+  configured service in :data:`DEFAULT_FALLBACK_ORDER`. Any
+  :class:`~acemusic.mastering_protocol.MasteringError` qualifies: since the
+  request is already validated by the time a backend is called, a backend error
+  is a service-side failure worth retrying elsewhere.
+- Each service is tried at most once. If every service in the chain fails, the
+  last error propagates. The result is tagged with the service that actually
+  succeeded, so a fallback run is distinguishable from the requested one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+from acemusic.mastering_protocol import MasteringError, MasteringOutput, MasteringService
+
+logger = logging.getLogger(__name__)
+
+# Canonical fallback order: Dolby.io (primary, US-12.2) -> LANDR (B2B, US-12.3)
+# -> Bakuage (cost-effective open API, US-12.3). The chain honours this order for
+# fallback candidates regardless of which service was requested.
+DEFAULT_FALLBACK_ORDER: tuple[str, ...] = ("dolby", "landr", "bakuage")
+
+
+class ServiceNotConfiguredError(Exception):
+    """Raised when an explicitly requested mastering service has no configured client.
+
+    Distinct from :class:`~acemusic.mastering_protocol.MasteringError` so the
+    handler can refund the credits charged at enqueue (no mastering work was
+    performed) and report a clear "not configured" failure rather than retrying.
+    """
+
+
+# A narrow callable type for the master entrypoint, so the orchestrator doesn't
+# import each concrete client. ``MasteringService`` (the runtime-checkable
+# Protocol) is the public contract; this alias documents the dispatch surface.
+@runtime_checkable
+class _MasterCallable(Protocol):
+    service: str
+
+    def master(
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+    ) -> MasteringOutput: ...
+
+
+class MasteringOrchestrator:
+    """Selects a mastering backend and falls back across configured services.
+
+    Constructed with the set of configured clients keyed by their canonical
+    service name (only services whose credentials are present appear in the
+    mapping). :meth:`master_with_fallback` runs the requested service first, then
+    retries the remaining configured services in :data:`DEFAULT_FALLBACK_ORDER`.
+    """
+
+    def __init__(self, clients: dict[str, MasteringService]) -> None:
+        # Copy to avoid mutation by callers; only retain services with a client.
+        self._clients: dict[str, MasteringService] = {
+            svc: client for svc, client in clients.items() if client is not None
+        }
+
+    @property
+    def available_services(self) -> tuple[str, ...]:
+        """The configured service names, in canonical fallback order."""
+        return tuple(svc for svc in DEFAULT_FALLBACK_ORDER if svc in self._clients)
+
+    def is_service_available(self, service: str) -> bool:
+        """Return True if ``service`` has a configured client."""
+        return service in self._clients
+
+    def get_client(self, service: str) -> MasteringService:
+        """Return the configured client for ``service`` or raise if unconfigured."""
+        if service not in self._clients:
+            raise ServiceNotConfiguredError(
+                f"Mastering service {service!r} is not configured. "
+                f"Available: {', '.join(self.available_services) or 'none'}."
+            )
+        return self._clients[service]
+
+    def _fallback_chain(self, requested_service: str) -> list[str]:
+        """Build the try-order: requested service first, then configured others."""
+        chain = [requested_service] if requested_service in self._clients else []
+        for svc in DEFAULT_FALLBACK_ORDER:
+            if svc != requested_service and svc in self._clients:
+                chain.append(svc)
+        return chain
+
+    def master_with_fallback(
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+        *,
+        requested_service: str,
+    ) -> MasteringOutput:
+        """Master ``audio_bytes`` via the requested service, falling back on failure.
+
+        Raises :class:`ServiceNotConfiguredError` if the requested service has no
+        configured client (no silent substitution). Raises the last
+        :class:`~acemusic.mastering_protocol.MasteringError` if every service in
+        the chain fails.
+        """
+        if not self.is_service_available(requested_service):
+            raise ServiceNotConfiguredError(
+                f"Mastering service {requested_service!r} is not configured. "
+                f"Available: {', '.join(self.available_services) or 'none'}."
+            )
+
+        chain = self._fallback_chain(requested_service)
+        last_error: MasteringError | None = None
+        for index, svc in enumerate(chain):
+            client = self._clients[svc]
+            try:
+                output = client.master(audio_bytes, filename, profile, target_lufs, output_format)
+            except MasteringError as exc:
+                last_error = exc
+                remaining = len(chain) - index - 1
+                if remaining > 0:
+                    logger.warning(
+                        "Mastering service %s failed (%s); falling back (%d service(s) left)",
+                        svc,
+                        exc,
+                        remaining,
+                    )
+                else:
+                    logger.error("Mastering service %s failed (%s); no configured fallback remains", svc, exc)
+                continue
+            if svc != requested_service:
+                logger.info("Mastering fell back from %s to %s", requested_service, svc)
+            return output
+        # Every configured service failed; propagate the last backend error.
+        assert last_error is not None  # pragma: no cover - chain is non-empty here
+        raise last_error

--- a/src/acemusic/mastering_protocol.py
+++ b/src/acemusic/mastering_protocol.py
@@ -69,7 +69,13 @@ class MasteringService(Protocol):
     service: str
 
     def master(
-        self, audio_bytes: bytes, filename: str, profile: str, target_lufs: float, output_format: str
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+        timeout: float | None = None,
     ) -> MasteringOutput:
         """Master ``audio_bytes`` and return the mastered audio plus metrics.
 
@@ -78,5 +84,9 @@ class MasteringService(Protocol):
         platform profile vocabulary (``streaming``/``soundcloud``/``club``/
         ``vinyl``/``custom``); ``target_lufs`` the resolved loudness target;
         ``output_format`` the container to produce (``wav``/``mp3``/``flac``).
+        ``timeout`` caps the whole mastering run (upload + poll + download) in
+        seconds; ``None`` lets the backend use its own default. The orchestrator
+        passes a shrinking budget so a multi-backend fallback chain stays within
+        an overall deadline (US-12.3).
         """
         ...

--- a/src/acemusic/mastering_protocol.py
+++ b/src/acemusic/mastering_protocol.py
@@ -1,0 +1,82 @@
+"""Shared mastering-service contract (US-12.3).
+
+LANDR and Bakuage are mastered as fallbacks to Dolby.io (US-12.2). To let the
+mastering job handler treat all three backends interchangeably, this module
+defines the contract they share:
+
+- :class:`MasteringOutput` — the unified result of one mastering run (the
+  mastered audio bytes, the analysis metrics, and the name of the service that
+  produced them). The handler wraps this into ``{"clip_ids", "service",
+  "target_lufs", "metrics"}`` after storing the audio.
+- :class:`MasteringError` — the common base for every backend's failure mode, so
+  the orchestrator can catch a single type when deciding whether to fall back.
+- :class:`MasteringService` — the :class:`typing.Protocol` each backend
+  implements: a single :meth:`master` entrypoint that drives the full
+  upload -> submit -> poll -> download workflow and returns a
+  :class:`MasteringOutput`. Keeping the surface to one method hides each
+  provider's different granular steps (Dolby's presigned upload + preview
+  handles, Bakuage's simpler REST flow) behind a uniform call.
+
+Each backend raises its own ``*Error`` subclass (e.g. :class:`DolbyError`) so a
+caller can distinguish the source while the orchestrator catches the shared
+base. Request validation (profile / target_lufs / format) happens in the
+router/service layer *before* a backend is called, so any :class:`MasteringError`
+raised by a backend is a service-side failure eligible for fallback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class MasteringOutput:
+    """The normalized result of one mastering run across any backend.
+
+    ``audio_bytes`` is the mastered audio (to be stored as a clip); ``metrics``
+    is the provider's loudness/EQ/stereo analysis (may be partial for backends
+    that report fewer measurements); ``service`` names the backend that produced
+    it so a fallback run can be distinguished from the requested one.
+    """
+
+    audio_bytes: bytes
+    metrics: dict[str, Any]
+    service: str
+
+
+class MasteringError(Exception):
+    """Base for every mastering-backend failure (Dolby / LANDR / Bakuage).
+
+    Subclassed by each backend's own error (e.g. :class:`DolbyError`) so callers
+    can catch the common base for fallback decisions while still attributing the
+    source. Request validation lives upstream, so a raised :class:`MasteringError`
+    indicates the backend itself failed.
+    """
+
+
+@runtime_checkable
+class MasteringService(Protocol):
+    """The contract every mastering backend implements.
+
+    A single :meth:`master` entrypoint hides each provider's upload/submit/poll/
+    download dance behind one call, returning a normalized
+    :class:`MasteringOutput`. ``service`` is the backend's canonical name
+    (``"dolby"`` / ``"landr"`` / ``"bakuage"``) used for dispatch and result
+    attribution.
+    """
+
+    service: str
+
+    def master(
+        self, audio_bytes: bytes, filename: str, profile: str, target_lufs: float, output_format: str
+    ) -> MasteringOutput:
+        """Master ``audio_bytes`` and return the mastered audio plus metrics.
+
+        ``filename`` disambiguates the upload key (callers include the job id so
+        concurrent masters on the same clip never collide); ``profile`` is the
+        platform profile vocabulary (``streaming``/``soundcloud``/``club``/
+        ``vinyl``/``custom``); ``target_lufs`` the resolved loudness target;
+        ``output_format`` the container to produce (``wav``/``mp3``/``flac``).
+        """
+        ...

--- a/tests/test_bakuage_client.py
+++ b/tests/test_bakuage_client.py
@@ -1,0 +1,228 @@
+"""Unit tests for BakuageClient (US-12.3).
+
+Every HTTP call is mocked (``unittest.mock``), mirroring the Dolby/LANDR client
+tests, so these run in CI without network access. Bakuage exposes a simpler open
+REST API than Dolby/LANDR (API-key auth, no OAuth token dance), so the contract
+tests are correspondingly focused: API-key header injection, the single
+create-mastering call that uploads the audio, status polling (success / failure /
+timeout), download with redirect handling, transient-5xx retry, and the
+high-level ``master()`` entrypoint returning the shared :class:`MasteringOutput`.
+
+Bakuage's REST API is documented publicly (spec §41.2.3: base
+``https://api.bakuage.com:443``, bearer-token auth); the tests pin the workflow
+contract the client implements.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from acemusic.bakuage_client import (
+    BakuageClient,
+    BakuageError,
+    bakuage_master_params,
+)
+from acemusic.mastering_protocol import MasteringOutput, MasteringService
+
+FAKE_AUDIO = b"RIFF" + b"\x00" * 100
+
+
+def _resp(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    content: bytes = b"",
+    headers: dict | None = None,
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.content = content
+    resp.json.return_value = json_data if json_data is not None else {}
+    resp.text = str(json_data or {})
+    resp.raise_for_status.return_value = None
+    resp.is_redirect = status_code in (301, 302, 303, 307, 308)
+    resp.headers = headers if headers is not None else {}
+    return resp
+
+
+def _error_resp(status_code: int, json_data: dict | None = None) -> MagicMock:
+    resp = _resp(status_code, json_data)
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(str(status_code), request=MagicMock(), response=resp)
+    return resp
+
+
+def _client() -> BakuageClient:
+    return BakuageClient(api_key="bakuage-key")
+
+
+# ---------------------------------------------------------------------------
+# Auth (API-key-only — no token dance)
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    def test_api_key_injected_as_bearer_header(self) -> None:
+        client = _client()
+        # Every call carries the bearer header; check via a create() call.
+        with patch("acemusic.bakuage_client.httpx.post", return_value=_resp(json_data={"id": "bk-1"})) as mock_post:
+            client.create_mastering(FAKE_AUDIO, "clip.wav", "streaming", -14.0, "wav")
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer bakuage-key"
+
+
+# ---------------------------------------------------------------------------
+# Create mastering (single upload+submit call)
+# ---------------------------------------------------------------------------
+
+
+class TestCreate:
+    def test_create_returns_job_id(self) -> None:
+        client = _client()
+        with patch("acemusic.bakuage_client.httpx.post", return_value=_resp(json_data={"id": "bk-1"})):
+            assert client.create_mastering(FAKE_AUDIO, "clip.wav", "streaming", -14.0, "wav") == "bk-1"
+
+    def test_create_missing_id_raises(self) -> None:
+        client = _client()
+        with patch("acemusic.bakuage_client.httpx.post", return_value=_resp(json_data={})):
+            with pytest.raises(BakuageError, match="no id"):
+                client.create_mastering(FAKE_AUDIO, "clip.wav", "streaming", -14.0, "wav")
+
+    def test_create_auth_failure_raises(self) -> None:
+        client = _client()
+        with patch("acemusic.bakuage_client.httpx.post", return_value=_error_resp(401)):
+            with pytest.raises(BakuageError):
+                client.create_mastering(FAKE_AUDIO, "clip.wav", "streaming", -14.0, "wav")
+
+
+# ---------------------------------------------------------------------------
+# Polling
+# ---------------------------------------------------------------------------
+
+
+class TestPolling:
+    def test_wait_for_completion_returns_on_success(self) -> None:
+        client = _client()
+        responses = [
+            _resp(json_data={"status": "processing", "progress": 10}),
+            _resp(json_data={"status": "completed", "progress": 100, "result": {"loudness_lufs": -9.0}}),
+        ]
+        with (
+            patch("acemusic.bakuage_client.httpx.get", side_effect=responses),
+            patch("acemusic.bakuage_client.time.sleep") as mock_sleep,
+        ):
+            result = client.wait_for_completion("bk-1", poll_interval=0.01)
+        assert result["status"] == "completed"
+        mock_sleep.assert_called()
+
+    def test_wait_for_completion_failure_raises(self) -> None:
+        client = _client()
+        with patch("acemusic.bakuage_client.httpx.get", return_value=_resp(json_data={"status": "failed"})):
+            with patch("acemusic.bakuage_client.time.sleep"):
+                with pytest.raises(BakuageError, match="failed"):
+                    client.wait_for_completion("bk-1", poll_interval=0.01)
+
+    def test_wait_for_completion_timeout_raises(self) -> None:
+        client = _client()
+        with patch("acemusic.bakuage_client.httpx.get", return_value=_resp(json_data={"status": "processing"})):
+            with patch("acemusic.bakuage_client.time.sleep"):
+                with pytest.raises(BakuageError, match="timed out"):
+                    client.wait_for_completion("bk-1", timeout=0.0, poll_interval=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+
+class TestDownload:
+    def test_download_returns_bytes(self) -> None:
+        client = _client()
+        with patch("acemusic.bakuage_client.httpx.get", return_value=_resp(content=b"MASTERED")):
+            assert client.download("bk-1") == b"MASTERED"
+
+    def test_download_follows_redirect_without_bearer(self) -> None:
+        client = _client()
+        redirect = _resp(status_code=302, headers={"location": "https://cdn.example/m.wav"})
+        direct = _resp(content=b"MASTERED")
+        with patch("acemusic.bakuage_client.httpx.get", side_effect=[redirect, direct]) as mock_get:
+            assert client.download("bk-1") == b"MASTERED"
+        assert mock_get.call_args_list[1].kwargs["headers"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Transient-error retry
+# ---------------------------------------------------------------------------
+
+
+class TestRetry:
+    def test_5xx_retried_then_succeeds(self) -> None:
+        client = _client()
+        responses = [_resp(status_code=503), _resp(json_data={"id": "bk"})]
+        with (
+            patch("acemusic.bakuage_client.httpx.post", side_effect=responses) as mock_post,
+            patch("acemusic.bakuage_client.time.sleep"),
+        ):
+            assert client.create_mastering(FAKE_AUDIO, "clip.wav", "streaming", -14.0, "wav") == "bk"
+        assert mock_post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Profile -> Bakuage params mapping
+# ---------------------------------------------------------------------------
+
+
+class TestBakuageParams:
+    def test_streaming_maps_to_default_level(self) -> None:
+        params = bakuage_master_params("streaming", -14.0, "wav")
+        assert params["output_format"] == "wav"
+        assert "mastering_level" in params
+
+    def test_custom_uses_target_lufs(self) -> None:
+        params = bakuage_master_params("custom", -10.0, "flac")
+        assert params["target_lufs"] == -10.0
+
+
+# ---------------------------------------------------------------------------
+# High-level master() entrypoint (US-12.3 shared interface)
+# ---------------------------------------------------------------------------
+
+
+class TestMasterEntrypoint:
+    def test_master_returns_normalized_output(self) -> None:
+        client = _client()
+        create_resp = _resp(json_data={"id": "bk-1"})
+        status_resp = _resp(
+            json_data={
+                "status": "completed",
+                "progress": 100,
+                "result": {"loudness_lufs": -9.5},
+            }
+        )
+        download_resp = _resp(content=b"MASTERED")
+        with (
+            patch("acemusic.bakuage_client.httpx.post", return_value=create_resp),
+            patch("acemusic.bakuage_client.httpx.get", side_effect=[status_resp, download_resp]),
+            patch("acemusic.bakuage_client.time.sleep"),
+        ):
+            out = client.master(FAKE_AUDIO, "clip-1-job-1.wav", "streaming", -14.0, "wav")
+        assert isinstance(out, MasteringOutput)
+        assert out.audio_bytes == b"MASTERED"
+        assert out.service == "bakuage"
+        assert out.metrics["loudness"] == -9.5
+        assert isinstance(client, MasteringService)
+
+    def test_master_propagates_bakuage_error(self) -> None:
+        client = _client()
+        with (
+            patch("acemusic.bakuage_client.httpx.post", return_value=_resp(status_code=500)),
+            patch("acemusic.bakuage_client.time.sleep"),
+        ):
+            with pytest.raises(BakuageError):
+                client.master(FAKE_AUDIO, "f.wav", "streaming", -14.0, "wav")
+
+    def test_bakuage_error_is_mastering_error_subclass(self) -> None:
+        from acemusic.mastering_protocol import MasteringError
+
+        assert issubclass(BakuageError, MasteringError)

--- a/tests/test_dolby_client.py
+++ b/tests/test_dolby_client.py
@@ -361,3 +361,66 @@ class TestOutputConfig:
         assert cfg["destination"] == "dlb://out.wav"
         assert cfg["master"]["loudness"]["target_level"] == -18.0
         assert cfg["master"]["content"]["type"] == "music"
+
+
+# ---------------------------------------------------------------------------
+# High-level master() entrypoint (US-12.3 shared interface)
+# ---------------------------------------------------------------------------
+
+
+class TestMasterEntrypoint:
+    """The single master() call wraps upload -> submit -> poll -> results -> download."""
+
+    def test_master_returns_normalized_output(self) -> None:
+        from acemusic.mastering_protocol import MasteringOutput, MasteringService
+
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        # upload POST /input -> presigned url; PUT bytes; submit; status(success, w/ result); download.
+        upload_resp = _resp(json_data={"url": "https://put.example/dst"})
+        put_resp = _resp(status_code=200)
+        submit_resp = _resp(json_data={"job_id": "job-1"})
+        # get_results reads metrics + outputs from status_payload["result"], no extra call.
+        status_resp = _resp(
+            json_data={
+                "status": "Success",
+                "result": {
+                    "audio": {
+                        "loudness": {"measured": -14.0},
+                        "eq": {"bands": [float(i) for i in range(16)]},
+                        "stereo": {"width": 0.5, "balance": 0.0},
+                    },
+                    "outputs": [{"destination": "dlb://out.wav", "preview": "dlb://out.wav"}],
+                },
+            }
+        )
+        download_resp = _resp(content=b"MASTERED")
+        with (
+            patch("acemusic.dolby_client.httpx.post", side_effect=[upload_resp, submit_resp]),
+            patch("acemusic.dolby_client.httpx.put", return_value=put_resp),
+            patch("acemusic.dolby_client.httpx.get", side_effect=[status_resp, download_resp]),
+            patch("acemusic.dolby_client.time.sleep"),
+        ):
+            out = client.master(FAKE_AUDIO, "clip-1-job-1.wav", "streaming", -14.0, "wav")
+        assert isinstance(out, MasteringOutput)
+        assert out.audio_bytes == b"MASTERED"
+        assert out.service == "dolby"
+        assert out.metrics["loudness"] == -14.0
+        # DolbyClient conforms to the shared protocol.
+        assert isinstance(client, MasteringService)
+
+    def test_master_propagates_dolby_error(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        with (
+            patch("acemusic.dolby_client.httpx.post", return_value=_resp(status_code=500)),
+            patch("acemusic.dolby_client.httpx.put"),
+            patch("acemusic.dolby_client.time.sleep"),
+        ):
+            with pytest.raises(DolbyError):
+                client.master(FAKE_AUDIO, "f.wav", "streaming", -14.0, "wav")
+
+    def test_dolby_error_is_mastering_error_subclass(self) -> None:
+        from acemusic.mastering_protocol import MasteringError
+
+        assert issubclass(DolbyError, MasteringError)

--- a/tests/test_landr_client.py
+++ b/tests/test_landr_client.py
@@ -1,0 +1,308 @@
+"""Unit tests for LandrClient (US-12.3).
+
+Every HTTP call is mocked (``unittest.mock``), mirroring the Dolby/ElevenLabs
+client tests, so these run in CI without network access. They cover the same
+mastering workflow contract as the Dolby client: token acquisition/caching, the
+two-step upload, job submission (with profile -> LANDR loudness/style mapping),
+status polling (success / failure / timeout), download, transient-5xx retry, and
+the high-level ``master()`` entrypoint that returns the shared
+:class:`MasteringOutput`.
+
+LANDR's B2B REST API is partnership-gated, so the endpoint shapes here encode the
+contract the client assumes (documented in :mod:`acemusic.landr_client`); the
+tests pin that contract rather than the live service.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from acemusic.landr_client import (
+    LandrClient,
+    LandrError,
+    landr_master_params,
+)
+from acemusic.mastering_protocol import MasteringOutput, MasteringService
+
+FAKE_AUDIO = b"RIFF" + b"\x00" * 100
+
+
+def _resp(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    content: bytes = b"",
+    headers: dict | None = None,
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.content = content
+    resp.json.return_value = json_data if json_data is not None else {}
+    resp.text = str(json_data or {})
+    resp.raise_for_status.return_value = None
+    resp.is_redirect = status_code in (301, 302, 303, 307, 308)
+    resp.headers = headers if headers is not None else {}
+    return resp
+
+
+def _error_resp(status_code: int, json_data: dict | None = None) -> MagicMock:
+    resp = _resp(status_code, json_data)
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(str(status_code), request=MagicMock(), response=resp)
+    return resp
+
+
+def _client() -> LandrClient:
+    return LandrClient(api_key="landr-key", api_secret="landr-secret")
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    def test_get_token_returns_access_token(self) -> None:
+        client = _client()
+        with patch("acemusic.landr_client.httpx.post", return_value=_resp(json_data={"access_token": "tok-1"})):
+            assert client._get_token() == "tok-1"
+
+    def test_token_cached_until_near_expiry(self) -> None:
+        client = _client()
+        with patch("acemusic.landr_client.httpx.post", return_value=_resp(json_data={"access_token": "tok-1"})) as m:
+            client._get_token()
+            client._get_token()
+        assert m.call_count == 1
+
+    def test_auth_failure_raises_landr_error(self) -> None:
+        client = _client()
+        with patch("acemusic.landr_client.httpx.post", return_value=_error_resp(401)):
+            with pytest.raises(LandrError, match="authentication failed"):
+                client._get_token()
+
+    def test_missing_access_token_raises(self) -> None:
+        client = _client()
+        with patch("acemusic.landr_client.httpx.post", return_value=_resp(json_data={})):
+            with pytest.raises(LandrError, match="no access_token"):
+                client._get_token()
+
+    def test_transport_error_raises_landr_error(self) -> None:
+        client = _client()
+        with patch("acemusic.landr_client.httpx.post", side_effect=httpx.ConnectError("nope")):
+            with pytest.raises(LandrError, match="authentication failed"):
+                client._get_token()
+
+
+# ---------------------------------------------------------------------------
+# Upload
+# ---------------------------------------------------------------------------
+
+
+class TestUpload:
+    def test_upload_returns_audio_id(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        post_resp = _resp(json_data={"upload_url": "https://put.example/u", "audio_id": "aud-1"})
+        put_resp = _resp(status_code=200)
+        with (
+            patch("acemusic.landr_client.httpx.post", return_value=post_resp),
+            patch("acemusic.landr_client.httpx.put", return_value=put_resp),
+        ):
+            assert client.upload(FAKE_AUDIO, "clip-1.wav") == "aud-1"
+
+    def test_upload_presigned_put_sends_no_bearer(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        post_resp = _resp(json_data={"upload_url": "https://put.example/u", "audio_id": "aud-1"})
+        put_resp = _resp(status_code=200)
+        with (
+            patch("acemusic.landr_client.httpx.post", return_value=post_resp),
+            patch("acemusic.landr_client.httpx.put", return_value=put_resp) as mock_put,
+        ):
+            client.upload(FAKE_AUDIO, "clip-1.wav")
+        # The presigned URL is already authorized; no bearer token leaks to it.
+        assert mock_put.call_args.kwargs["headers"] == {}
+
+    def test_upload_missing_audio_id_raises(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        with patch("acemusic.landr_client.httpx.post", return_value=_resp(json_data={"upload_url": "x"})):
+            with pytest.raises(LandrError, match="no audio_id"):
+                client.upload(FAKE_AUDIO, "clip-1.wav")
+
+
+# ---------------------------------------------------------------------------
+# Submission
+# ---------------------------------------------------------------------------
+
+
+class TestSubmit:
+    def test_submit_returns_job_id(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        with patch("acemusic.landr_client.httpx.post", return_value=_resp(json_data={"job_id": "lj-1"})):
+            assert client.submit("aud-1", "streaming", -14.0, "wav") == "lj-1"
+
+    def test_submit_missing_job_id_raises(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        with patch("acemusic.landr_client.httpx.post", return_value=_resp(json_data={})):
+            with pytest.raises(LandrError, match="no job_id"):
+                client.submit("aud-1", "streaming", -14.0, "wav")
+
+
+# ---------------------------------------------------------------------------
+# Polling
+# ---------------------------------------------------------------------------
+
+
+class TestPolling:
+    def test_wait_for_completion_returns_on_success(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        responses = [
+            _resp(json_data={"status": "processing", "progress": 10}),
+            _resp(json_data={"status": "completed", "progress": 100}),
+        ]
+        with (
+            patch("acemusic.landr_client.httpx.get", side_effect=responses),
+            patch("acemusic.landr_client.time.sleep") as mock_sleep,
+        ):
+            result = client.wait_for_completion("lj-1", poll_interval=0.01)
+        assert result["status"] == "completed"
+        mock_sleep.assert_called()
+
+    def test_wait_for_completion_failure_raises(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        with patch("acemusic.landr_client.httpx.get", return_value=_resp(json_data={"status": "failed"})):
+            with patch("acemusic.landr_client.time.sleep"):
+                with pytest.raises(LandrError, match="failed"):
+                    client.wait_for_completion("lj-1", poll_interval=0.01)
+
+    def test_wait_for_completion_timeout_raises(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        with patch("acemusic.landr_client.httpx.get", return_value=_resp(json_data={"status": "processing"})):
+            with patch("acemusic.landr_client.time.sleep"):
+                with pytest.raises(LandrError, match="timed out"):
+                    client.wait_for_completion("lj-1", timeout=0.0, poll_interval=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+
+class TestDownload:
+    def test_download_returns_bytes(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        with patch("acemusic.landr_client.httpx.get", return_value=_resp(content=b"MASTERED")):
+            assert client.download("lj-1") == b"MASTERED"
+
+    def test_download_follows_redirect_without_bearer(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        redirect = _resp(status_code=302, headers={"location": "https://cdn.example/m.wav"})
+        direct = _resp(content=b"MASTERED")
+        with patch("acemusic.landr_client.httpx.get", side_effect=[redirect, direct]) as mock_get:
+            assert client.download("lj-1") == b"MASTERED"
+        # Second (redirect-following) call must carry no bearer token.
+        assert mock_get.call_args_list[1].kwargs["headers"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Transient-error retry
+# ---------------------------------------------------------------------------
+
+
+class TestRetry:
+    def test_5xx_retried_then_succeeds(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        responses = [_resp(status_code=503), _resp(json_data={"job_id": "lj"})]
+        with (
+            patch("acemusic.landr_client.httpx.post", side_effect=responses) as mock_post,
+            patch("acemusic.landr_client.time.sleep"),
+        ):
+            assert client.submit("aud-1", "streaming", -14.0, "wav") == "lj"
+        assert mock_post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Profile -> LANDR params mapping
+# ---------------------------------------------------------------------------
+
+
+class TestLandrParams:
+    def test_streaming_maps_to_low_loudness(self) -> None:
+        params = landr_master_params("streaming", -14.0, "wav")
+        assert params["loudness"] == "low"
+        assert params["style"] == "universal"
+        assert params["output_format"] == "wav"
+
+    def test_club_maps_to_high_loudness(self) -> None:
+        params = landr_master_params("club", -6.0, "wav")
+        assert params["loudness"] == "high"
+
+    def test_custom_uses_target_lufs(self) -> None:
+        params = landr_master_params("custom", -10.0, "flac")
+        assert params["target_lufs"] == -10.0
+
+    def test_unknown_profile_defaults(self) -> None:
+        params = landr_master_params("mystery", -14.0, "wav")
+        # Unknown profiles fall back to a neutral default rather than raising.
+        assert "loudness" in params
+
+
+# ---------------------------------------------------------------------------
+# High-level master() entrypoint (US-12.3 shared interface)
+# ---------------------------------------------------------------------------
+
+
+class TestMasterEntrypoint:
+    def test_master_returns_normalized_output(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        upload_post = _resp(json_data={"upload_url": "https://put.example/u", "audio_id": "aud-1"})
+        put_resp = _resp(status_code=200)
+        submit_resp = _resp(json_data={"job_id": "lj-1"})
+        # wait_for_completion polls GET /masters/{id}; success on first poll, with metrics.
+        status_resp = _resp(
+            json_data={
+                "status": "completed",
+                "progress": 100,
+                "result": {"loudness_lufs": -14.2, "eq_bands": [0.1, 0.2]},
+            }
+        )
+        download_resp = _resp(content=b"MASTERED")
+        with (
+            patch("acemusic.landr_client.httpx.post", side_effect=[upload_post, submit_resp]),
+            patch("acemusic.landr_client.httpx.put", return_value=put_resp),
+            patch("acemusic.landr_client.httpx.get", side_effect=[status_resp, download_resp]),
+            patch("acemusic.landr_client.time.sleep"),
+        ):
+            out = client.master(FAKE_AUDIO, "clip-1-job-1.wav", "streaming", -14.0, "wav")
+        assert isinstance(out, MasteringOutput)
+        assert out.audio_bytes == b"MASTERED"
+        assert out.service == "landr"
+        assert out.metrics["loudness"] == -14.2
+        assert isinstance(client, MasteringService)
+
+    def test_master_propagates_landr_error(self) -> None:
+        client = _client()
+        client._token, client._token_expiry = "tok", 1e12
+        with (
+            patch("acemusic.landr_client.httpx.post", return_value=_resp(status_code=500)),
+            patch("acemusic.landr_client.httpx.put"),
+            patch("acemusic.landr_client.time.sleep"),
+        ):
+            with pytest.raises(LandrError):
+                client.master(FAKE_AUDIO, "f.wav", "streaming", -14.0, "wav")
+
+    def test_landr_error_is_mastering_error_subclass(self) -> None:
+        from acemusic.mastering_protocol import MasteringError
+
+        assert issubclass(LandrError, MasteringError)

--- a/tests/test_mastering_orchestrator.py
+++ b/tests/test_mastering_orchestrator.py
@@ -31,6 +31,7 @@ class FakeService:
         self._audio = audio
         self._fail = fail
         self.calls = 0
+        self.last_timeout: float | None = None
 
     def master(
         self,
@@ -39,8 +40,10 @@ class FakeService:
         profile: str,
         target_lufs: float,
         output_format: str,
+        timeout: float | None = None,
     ) -> MasteringOutput:
         self.calls += 1
+        self.last_timeout = timeout
         if self._fail:
             raise MasteringError(f"{self.service} unavailable")
         return MasteringOutput(audio_bytes=self._audio, metrics={"loudness": -14.0}, service=self.service)
@@ -143,25 +146,57 @@ class TestFallback:
         class CapturingService:
             service = "dolby"
 
-            def master(self, audio_bytes, filename, profile, target_lufs, output_format):
+            def master(self, audio_bytes, filename, profile, target_lufs, output_format, timeout=None):
                 captured.update(
                     audio_bytes=audio_bytes,
                     filename=filename,
                     profile=profile,
                     target_lufs=target_lufs,
                     output_format=output_format,
+                    timeout=timeout,
                 )
                 return MasteringOutput(audio_bytes=audio_bytes, metrics={}, service="dolby")
 
         orch = MasteringOrchestrator({"dolby": CapturingService()})
         orch.master_with_fallback(b"AUDIO", "clip.wav", "club", -6.0, "flac", requested_service="dolby")
-        assert captured == {
-            "audio_bytes": b"AUDIO",
-            "filename": "clip.wav",
-            "profile": "club",
-            "target_lufs": -6.0,
-            "output_format": "flac",
-        }
+        assert captured["audio_bytes"] == b"AUDIO"
+        assert captured["filename"] == "clip.wav"
+        assert captured["profile"] == "club"
+        assert captured["target_lufs"] == -6.0
+        assert captured["output_format"] == "flac"
+        # The orchestrator hands each backend the remaining time on its deadline.
+        assert captured["timeout"] is not None and captured["timeout"] > 0
+
+
+class TestDeadline:
+    def test_total_timeout_bounds_the_chain_budget(self) -> None:
+        # Each backend receives the *remaining* deadline as its poll budget, so a
+        # later attempt gets a smaller timeout than an earlier one (codex P2).
+        dolby = FakeService(service="dolby", fail=True)
+        landr = FakeService(service="landr", fail=True)
+        bakuage = FakeService(service="bakuage")
+        orch = MasteringOrchestrator({"dolby": dolby, "landr": landr, "bakuage": bakuage})
+        orch.master_with_fallback(
+            b"a", "f.wav", "streaming", -14.0, "wav", requested_service="dolby", total_timeout=300.0
+        )
+        # Budgets shrink monotonically and never exceed the total.
+        budgets = [dolby.last_timeout, landr.last_timeout, bakuage.last_timeout]
+        assert all(b is not None and 0 < b <= 300.0 for b in budgets)
+        assert budgets[0] >= budgets[1] >= budgets[2]
+
+    def test_elapsed_deadline_stops_starting_fallbacks(self) -> None:
+        # The requested (primary) service always runs once; only *fallback*
+        # attempts are gated by the deadline. With a zero deadline, the primary
+        # runs and fails, then no fallback is started (codex P2).
+        dolby = FakeService(service="dolby", fail=True)
+        bakuage = FakeService(service="bakuage")
+        orch = MasteringOrchestrator({"dolby": dolby, "bakuage": bakuage})
+        with pytest.raises(MasteringError):
+            orch.master_with_fallback(
+                b"a", "f.wav", "streaming", -14.0, "wav", requested_service="dolby", total_timeout=0.0
+            )
+        assert dolby.calls == 1  # primary always runs
+        assert bakuage.calls == 0  # deadline elapsed → no fallback
 
 
 class TestProtocolConformance:

--- a/tests/test_mastering_orchestrator.py
+++ b/tests/test_mastering_orchestrator.py
@@ -1,0 +1,169 @@
+"""Unit tests for the MasteringOrchestrator fallback chain (US-12.3).
+
+The orchestrator is the seam between the mastering job handler and the three
+backends: it picks the requested service, and on a backend failure retries the
+next *configured* service in the canonical order (Dolby -> LANDR -> Bakuage).
+These tests pin the fallback contract with lightweight fake services — no HTTP,
+no DB — covering: explicit-service success, primary-failure -> fallback success,
+all-fail propagation, the "explicitly requested but unconfigured" error (no
+silent substitution), and skipping unconfigured services in the chain.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from acemusic.mastering_orchestrator import (
+    DEFAULT_FALLBACK_ORDER,
+    MasteringOrchestrator,
+    ServiceNotConfiguredError,
+)
+from acemusic.mastering_protocol import MasteringError, MasteringOutput, MasteringService
+
+
+class FakeService:
+    """A mastering service that either succeeds with canned output or raises."""
+
+    service: str
+
+    def __init__(self, *, service: str, audio: bytes = b"X", fail: bool = False) -> None:
+        self.service = service
+        self._audio = audio
+        self._fail = fail
+        self.calls = 0
+
+    def master(
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+    ) -> MasteringOutput:
+        self.calls += 1
+        if self._fail:
+            raise MasteringError(f"{self.service} unavailable")
+        return MasteringOutput(audio_bytes=self._audio, metrics={"loudness": -14.0}, service=self.service)
+
+
+# ---------------------------------------------------------------------------
+# Availability / dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability:
+    def test_is_service_available_for_configured_only(self) -> None:
+        orch = MasteringOrchestrator({"dolby": FakeService(service="dolby")})
+        assert orch.is_service_available("dolby")
+        assert not orch.is_service_available("landr")
+        assert not orch.is_service_available("bakuage")
+
+    def test_get_client_returns_configured_client(self) -> None:
+        svc = FakeService(service="dolby")
+        orch = MasteringOrchestrator({"dolby": svc})
+        assert orch.get_client("dolby") is svc
+
+    def test_get_client_unconfigured_raises(self) -> None:
+        orch = MasteringOrchestrator({"dolby": FakeService(service="dolby")})
+        with pytest.raises(ServiceNotConfiguredError):
+            orch.get_client("landr")
+
+    def test_default_fallback_order(self) -> None:
+        assert DEFAULT_FALLBACK_ORDER == ("dolby", "landr", "bakuage")
+
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestFallback:
+    def test_requested_service_succeeds_no_fallback(self) -> None:
+        dolby = FakeService(service="dolby")
+        bakuage = FakeService(service="bakuage")
+        orch = MasteringOrchestrator({"dolby": dolby, "bakuage": bakuage})
+        out = orch.master_with_fallback(b"a", "f.wav", "streaming", -14.0, "wav", requested_service="dolby")
+        assert out.service == "dolby"
+        assert dolby.calls == 1
+        assert bakuage.calls == 0  # no fallback attempted
+
+    def test_primary_failure_falls_back_to_next_configured(self) -> None:
+        dolby = FakeService(service="dolby", fail=True)
+        bakuage = FakeService(service="bakuage")
+        orch = MasteringOrchestrator({"dolby": dolby, "bakuage": bakuage})
+        out = orch.master_with_fallback(b"a", "f.wav", "streaming", -14.0, "wav", requested_service="dolby")
+        assert out.service == "bakuage"  # AC3: Dolby error -> Bakuage succeeds
+        assert dolby.calls == 1
+        assert bakuage.calls == 1
+
+    def test_chain_skips_unconfigured_services(self) -> None:
+        # dolby fails, landr NOT configured, bakuage configured -> falls back to bakuage.
+        dolby = FakeService(service="dolby", fail=True)
+        bakuage = FakeService(service="bakuage")
+        orch = MasteringOrchestrator({"dolby": dolby, "bakuage": bakuage})
+        out = orch.master_with_fallback(b"a", "f.wav", "streaming", -14.0, "wav", requested_service="dolby")
+        assert out.service == "bakuage"
+
+    def test_full_chain_dolby_to_bakuage_through_landr(self) -> None:
+        dolby = FakeService(service="dolby", fail=True)
+        landr = FakeService(service="landr", fail=True)
+        bakuage = FakeService(service="bakuage")
+        orch = MasteringOrchestrator({"dolby": dolby, "landr": landr, "bakuage": bakuage})
+        out = orch.master_with_fallback(b"a", "f.wav", "streaming", -14.0, "wav", requested_service="dolby")
+        assert out.service == "bakuage"
+        assert all(c.calls == 1 for c in (dolby, landr, bakuage))
+
+    def test_all_fail_propagates_last_error(self) -> None:
+        dolby = FakeService(service="dolby", fail=True)
+        bakuage = FakeService(service="bakuage", fail=True)
+        orch = MasteringOrchestrator({"dolby": dolby, "bakuage": bakuage})
+        with pytest.raises(MasteringError, match="bakuage unavailable"):
+            orch.master_with_fallback(b"a", "f.wav", "streaming", -14.0, "wav", requested_service="dolby")
+
+    def test_requested_unconfigured_raises_clear_error_no_silent_substitution(self) -> None:
+        # Explicitly requested landr but only dolby configured -> must NOT silently
+        # run dolby; raise so the handler can refund and report a clear failure.
+        dolby = FakeService(service="dolby")
+        orch = MasteringOrchestrator({"dolby": dolby})
+        with pytest.raises(ServiceNotConfiguredError):
+            orch.master_with_fallback(b"a", "f.wav", "streaming", -14.0, "wav", requested_service="landr")
+        assert dolby.calls == 0
+
+    def test_bakuage_primary_uses_canonical_order_for_fallbacks(self) -> None:
+        # Requesting bakuage explicitly: fallback order still tries dolby then landr first.
+        bakuage = FakeService(service="bakuage", fail=True)
+        dolby = FakeService(service="dolby")
+        orch = MasteringOrchestrator({"dolby": dolby, "bakuage": bakuage})
+        out = orch.master_with_fallback(b"a", "f.wav", "streaming", -14.0, "wav", requested_service="bakuage")
+        assert out.service == "dolby"
+
+    def test_fallback_passes_through_all_master_args(self) -> None:
+        captured: dict = {}
+
+        class CapturingService:
+            service = "dolby"
+
+            def master(self, audio_bytes, filename, profile, target_lufs, output_format):
+                captured.update(
+                    audio_bytes=audio_bytes,
+                    filename=filename,
+                    profile=profile,
+                    target_lufs=target_lufs,
+                    output_format=output_format,
+                )
+                return MasteringOutput(audio_bytes=audio_bytes, metrics={}, service="dolby")
+
+        orch = MasteringOrchestrator({"dolby": CapturingService()})
+        orch.master_with_fallback(b"AUDIO", "clip.wav", "club", -6.0, "flac", requested_service="dolby")
+        assert captured == {
+            "audio_bytes": b"AUDIO",
+            "filename": "clip.wav",
+            "profile": "club",
+            "target_lufs": -6.0,
+            "output_format": "flac",
+        }
+
+
+class TestProtocolConformance:
+    def test_fakes_conform_to_protocol(self) -> None:
+        assert isinstance(FakeService(service="dolby"), MasteringService)

--- a/tests/test_mastering_protocol.py
+++ b/tests/test_mastering_protocol.py
@@ -1,0 +1,88 @@
+"""Tests for the shared mastering-service contract (US-12.3).
+
+The :class:`MasteringService` protocol is the seam that lets the mastering job
+handler treat Dolby.io, LANDR, and Bakuage interchangeably: each backend drives
+the full upload -> master -> poll -> download workflow behind a single
+:meth:`master` entrypoint and returns the same :class:`MasteringOutput` shape.
+These tests pin the contract (dataclass shape, error hierarchy, protocol
+conformance) that the three clients and the orchestrator rely on.
+"""
+
+from __future__ import annotations
+
+from dataclasses import is_dataclass
+
+import pytest
+
+from acemusic.mastering_protocol import (
+    MasteringError,
+    MasteringOutput,
+    MasteringService,
+)
+
+
+class TestMasteringOutput:
+    def test_is_frozen_dataclass(self) -> None:
+        assert is_dataclass(MasteringOutput)
+        out = MasteringOutput(audio_bytes=b"x", metrics={"loudness": -14.0}, service="dolby")
+        with pytest.raises(Exception):
+            out.service = "landr"  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        out = MasteringOutput(audio_bytes=b"\x00\x01", metrics={"loudness": -6.0}, service="bakuage")
+        assert out.audio_bytes == b"\x00\x01"
+        assert out.metrics == {"loudness": -6.0}
+        assert out.service == "bakuage"
+
+    def test_default_metrics_is_required_not_mutable_default(self) -> None:
+        # No mutable default; callers always pass metrics explicitly.
+        out = MasteringOutput(audio_bytes=b"", metrics={}, service="landr")
+        out2 = MasteringOutput(audio_bytes=b"", metrics={}, service="landr")
+        assert out.metrics is not out2.metrics
+
+
+class TestMasteringError:
+    def test_is_exception_subclass(self) -> None:
+        assert issubclass(MasteringError, Exception)
+
+    def test_can_be_raised_and_caught(self) -> None:
+        with pytest.raises(MasteringError, match="boom"):
+            raise MasteringError("boom")
+
+
+class _GoodService:
+    service = "dolby"
+
+    def master(
+        self, audio_bytes: bytes, filename: str, profile: str, target_lufs: float, output_format: str
+    ) -> MasteringOutput:
+        return MasteringOutput(audio_bytes=audio_bytes, metrics={}, service=self.service)
+
+
+class _MissingService:
+    def master(
+        self, audio_bytes: bytes, filename: str, profile: str, target_lufs: float, output_format: str
+    ) -> MasteringOutput:
+        return MasteringOutput(audio_bytes=b"", metrics={}, service="x")
+
+
+class _MissingMaster:
+    service = "dolby"
+
+
+class TestMasteringServiceProtocol:
+    def test_conforming_class_is_recognised(self) -> None:
+        assert isinstance(_GoodService(), MasteringService)
+
+    def test_class_missing_service_attr_is_rejected(self) -> None:
+        assert not isinstance(_MissingService(), MasteringService)
+
+    def test_class_missing_master_method_is_rejected(self) -> None:
+        assert not isinstance(_MissingMaster(), MasteringService)
+
+    def test_master_signature_carries_expected_args(self) -> None:
+        # Structural: a service built ad hoc with the right method works end to end.
+        svc = _GoodService()
+        out = svc.master(b"audio", "f.wav", "streaming", -14.0, "wav")
+        assert isinstance(out, MasteringOutput)
+        assert out.audio_bytes == b"audio"

--- a/tests/test_mastering_tasks.py
+++ b/tests/test_mastering_tasks.py
@@ -58,7 +58,13 @@ class FakeService:
         self.master_calls: list[dict] = []
 
     def master(
-        self, audio_bytes: bytes, filename: str, profile: str, target_lufs: float, output_format: str
+        self,
+        audio_bytes: bytes,
+        filename: str,
+        profile: str,
+        target_lufs: float,
+        output_format: str,
+        timeout: float | None = None,
     ) -> MasteringOutput:
         self.master_calls.append(
             {
@@ -256,6 +262,45 @@ class TestFallback:
 
         with pytest.raises(tasks.JobProcessingError, match="Mastering failed"):
             await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
+
+    async def test_fallback_reconciles_credits_to_actual_service(self, storage) -> None:
+        # codex P1: a fallback that runs a differently-priced service must adjust
+        # the balance so the user pays for the work performed. Dolby (3.0) ->
+        # Bakuage (5.0): the user is topped up by the 2.0 difference.
+        from acemusic.api.services import credits as credits_service
+
+        job, _ = await _make_clip(storage, email="master-reconcile@example.com", service="dolby")
+        # Simulate the router's enqueue charge of the requested service.
+        charged = credits_service.get_mastering_cost("dolby")
+        balance_after_charge = await credits_service.deduct_credits(job.user_id, charged)
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0), fail=True)
+        bakuage = FakeService(service="bakuage", output=_wav_bytes(3.0))
+        orch = _orchestrator(dolby=dolby, bakuage=bakuage)
+
+        await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
+
+        actual = credits_service.get_mastering_cost("bakuage")
+        user = await user_service.get_user_by_id(str(job.user_id))
+        # Final balance reflects the actual service's cost, not the requested one.
+        assert user.credits_balance == balance_after_charge - (actual - charged)
+
+    async def test_cheaper_fallback_refunds_the_difference(self, storage) -> None:
+        # Bakuage (5.0) -> Dolby (3.0): the 2.0 overcharge is refunded.
+        from acemusic.api.services import credits as credits_service
+
+        job, _ = await _make_clip(storage, email="master-refund@example.com", service="bakuage")
+        charged = credits_service.get_mastering_cost("bakuage")
+        balance_after_charge = await credits_service.deduct_credits(job.user_id, charged)
+        bakuage = FakeService(service="bakuage", output=_wav_bytes(3.0), fail=True)
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0))
+        orch = _orchestrator(dolby=dolby, bakuage=bakuage)
+
+        await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
+
+        actual = credits_service.get_mastering_cost("dolby")
+        user = await user_service.get_user_by_id(str(job.user_id))
+        # Cheaper fallback → the difference is refunded.
+        assert user.credits_balance == balance_after_charge + (charged - actual)
 
 
 class TestGracefulDegradation:

--- a/tests/test_mastering_tasks.py
+++ b/tests/test_mastering_tasks.py
@@ -1,15 +1,17 @@
-"""Tests for the mastering job handler (US-12.2, issue #128).
+"""Tests for the mastering job handler (US-12.2 + US-12.3, issue #128/#129).
 
 Exercise ``acemusic.api.tasks.mastering.process_mastering_job`` directly with a
-fake DolbyClient and a local on-disk storage backend: the handler downloads the
-source clip, "uploads" it to Dolby, "submits"/"polls" a master preview, downloads
-the mastered output and stores it as a lineage-tagged child clip. They assert the
-worker contract — preview clips with lineage, metrics in the result, graceful
-degradation without credentials, per-stage error handling, rollback — that the
-real Dolby integration tests cannot cheaply cover.
+fake mastering orchestrator (built from in-process ``FakeService`` stubs) and a
+local on-disk storage backend: the handler downloads the source clip, hands it
+to the orchestrator which runs the requested backend (and falls back on
+failure), downloads the mastered output and stores it as a lineage-tagged child
+clip. They assert the worker contract — lineage + metrics + the service that
+actually ran, graceful degradation without credentials, fallback from Dolby to
+Bakuage, refund-on-rejection, per-stage error handling — that the live Dolby /
+LANDR / Bakuage integration tests cannot cheaply cover.
 
-The ``get_dolby_client`` factory tests run in CI (no DB). The handler tests need a
-local MongoDB (Beanie) and are marked ``integration``.
+The ``get_mastering_orchestrator`` factory tests run in CI (no DB). The handler
+tests need a local MongoDB (Beanie) and are marked ``integration``.
 """
 
 from __future__ import annotations
@@ -26,7 +28,8 @@ from acemusic.api.services import users as user_service
 from acemusic.api.services.mastering import MASTERING_JOB_TYPE
 from acemusic.api.settings import ApiSettings
 from acemusic.api.tasks import mastering as tasks
-from acemusic.dolby_client import DolbyError
+from acemusic.mastering_orchestrator import MasteringOrchestrator
+from acemusic.mastering_protocol import MasteringError, MasteringOutput
 from acemusic.storage import LocalStorage
 
 SR = 44100
@@ -44,68 +47,65 @@ def _wav_bytes(duration_s: float = 3.0, freq: float = 440.0) -> bytes:
 _METRICS = {"loudness": -14.0, "eq_bands": [float(i) for i in range(16)], "stereo": {"width": 0.8, "balance": 0.0}}
 
 
-class FakeDolby:
-    """Records the workflow calls and returns canned previews/metrics."""
+class FakeService:
+    """A MasteringService stub: returns canned output, or raises on master()."""
 
-    def __init__(
-        self,
-        *,
-        output: bytes,
-        previews: list[str] | None = None,
-        fail_on: str | None = None,
-    ) -> None:
-        self.output = output
-        self.previews = previews if previews is not None else ["dlb://preview-1.wav"]
-        self.fail_on = fail_on
-        self.calls: list[str] = []
+    def __init__(self, *, service: str, output: bytes, metrics: dict | None = None, fail: bool = False) -> None:
+        self.service = service
+        self._output = output
+        self._metrics = metrics if metrics is not None else _METRICS
+        self._fail = fail
+        self.master_calls: list[dict] = []
 
-    def _maybe_fail(self, stage: str) -> None:
-        self.calls.append(stage)
-        if self.fail_on == stage:
-            raise DolbyError(f"boom at {stage}")
+    def master(
+        self, audio_bytes: bytes, filename: str, profile: str, target_lufs: float, output_format: str
+    ) -> MasteringOutput:
+        self.master_calls.append(
+            {
+                "audio_bytes": audio_bytes,
+                "filename": filename,
+                "profile": profile,
+                "target_lufs": target_lufs,
+                "output_format": output_format,
+            }
+        )
+        if self._fail:
+            raise MasteringError(f"{self.service} unavailable")
+        return MasteringOutput(audio_bytes=self._output, metrics=dict(self._metrics), service=self.service)
 
-    def upload(self, audio_bytes: bytes, filename: str) -> str:
-        self._maybe_fail("upload")
-        self.upload_filename = filename
-        return f"dlb://{filename}"
 
-    def submit_preview(self, input_url: str, outputs: list[dict]) -> str:
-        self._maybe_fail("submit")
-        self.submitted_outputs = outputs
-        return "dolby-job-1"
-
-    def wait_for_completion(self, job_id: str, *args, **kwargs) -> dict:
-        self._maybe_fail("wait")
-        return {"status": "success"}
-
-    def get_results(self, job_id: str, status_payload: dict | None = None) -> dict:
-        self._maybe_fail("results")
-        return {
-            "metrics": _METRICS,
-            "outputs": [{"destination": p, "preview": p} for p in self.previews],
-        }
-
-    def download(self, dlb_url: str) -> bytes:
-        self._maybe_fail("download")
-        return self.output
+def _orchestrator(**services: FakeService) -> MasteringOrchestrator:
+    """Build an orchestrator from the given FakeService stubs keyed by service name."""
+    return MasteringOrchestrator(dict(services))
 
 
 # ---------------------------------------------------------------------------
-# get_dolby_client factory (CI — no DB)
+# get_mastering_orchestrator factory (CI — no DB)
 # ---------------------------------------------------------------------------
 
 
-class TestGetDolbyClient:
-    def test_returns_none_without_credentials(self) -> None:
+class TestGetMasteringOrchestrator:
+    def test_no_credentials_yields_empty_orchestrator(self) -> None:
         settings = ApiSettings(_env_file=None)
-        assert tasks.get_dolby_client(settings) is None
+        orch = tasks.get_mastering_orchestrator(settings)
+        assert orch.available_services == ()
 
-    def test_returns_client_with_credentials(self) -> None:
+    def test_dolby_only(self) -> None:
         settings = ApiSettings(_env_file=None, dolby_api_key="k", dolby_api_secret="s")
-        client = tasks.get_dolby_client(settings)
-        assert client is not None
-        assert client.api_key == "k"
-        assert client.api_secret == "s"
+        orch = tasks.get_mastering_orchestrator(settings)
+        assert orch.available_services == ("dolby",)
+
+    def test_all_three_backends_wired(self) -> None:
+        settings = ApiSettings(
+            _env_file=None,
+            dolby_api_key="dk",
+            dolby_api_secret="ds",
+            landr_api_key="lk",
+            landr_api_secret="ls",
+            bakuage_api_key="bk",
+        )
+        orch = tasks.get_mastering_orchestrator(settings)
+        assert orch.available_services == ("dolby", "landr", "bakuage")
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +126,7 @@ async def _make_clip(
     duration: float = 3.0,
     bpm: int | None = 120,
     key: str | None = "C",
+    service: str = "dolby",
 ) -> tuple[Job, Clip]:
     user = await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
     workspace = Workspace(name="WS", user_id=user.id)
@@ -152,7 +153,7 @@ async def _make_clip(
         input_params={
             "clip_id": str(clip.id),
             "profile": "streaming",
-            "service": "dolby",
+            "service": service,
             "format": "wav",
             "target_lufs": -14.0,
         },
@@ -165,13 +166,14 @@ pytestmark = pytest.mark.integration
 
 
 class TestSuccess:
-    async def test_creates_master_clip_with_lineage_and_metrics(self, storage) -> None:
+    async def test_dolby_creates_master_clip_with_lineage_and_metrics(self, storage) -> None:
         job, source = await _make_clip(storage, email="master-ok@example.com")
-        client = FakeDolby(output=_wav_bytes(3.0))
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0))
+        orch = _orchestrator(dolby=dolby)
 
-        result = await tasks.process_mastering_job(job, storage=storage, client=client)
+        result = await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
 
-        assert len(result["clip_ids"]) == 1
+        assert result["clip_ids"]  # one clip stored
         assert result["service"] == "dolby"
         assert result["target_lufs"] == -14.0
         assert result["metrics"] == _METRICS
@@ -184,109 +186,122 @@ class TestSuccess:
         # The mastered audio is retrievable from storage.
         assert storage.download(child.file_path)
 
-    async def test_workflow_calls_in_order(self, storage) -> None:
-        job, _ = await _make_clip(storage, email="master-order@example.com")
-        client = FakeDolby(output=_wav_bytes(3.0))
-        await tasks.process_mastering_job(job, storage=storage, client=client)
-        assert client.calls == ["upload", "submit", "wait", "results", "download"]
+    async def test_landr_creates_master_clip(self, storage) -> None:
+        # AC1: LANDR mastering produces a mastered audio file.
+        job, source = await _make_clip(storage, email="master-landr@example.com", service="landr")
+        landr = FakeService(
+            service="landr", output=_wav_bytes(3.0), metrics={"loudness": -14.2, "eq_bands": [], "stereo": {}}
+        )
+        orch = _orchestrator(landr=landr)
 
-    async def test_multiple_previews_each_become_clips(self, storage) -> None:
-        job, _ = await _make_clip(storage, email="master-multi@example.com")
-        client = FakeDolby(output=_wav_bytes(3.0), previews=["dlb://p1.wav", "dlb://p2.wav", "dlb://p3.wav"])
-        result = await tasks.process_mastering_job(job, storage=storage, client=client)
-        assert len(result["clip_ids"]) == 3
+        result = await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
 
-    async def test_dolby_keys_are_unique_per_job(self, storage) -> None:
-        # The input/output keys carry the job id so concurrent masters on the same
-        # clip never collide (codex review P2).
+        assert result["service"] == "landr"
+        assert result["metrics"]["loudness"] == -14.2
+        child = await Clip.get(PydanticObjectId(result["clip_ids"][0]))
+        assert child is not None
+        assert child.parent_clip_ids == [source.id]
+        assert storage.download(child.file_path)
+
+    async def test_bakuage_creates_master_clip(self, storage) -> None:
+        # AC2: Bakuage mastering produces a mastered audio file.
+        job, source = await _make_clip(storage, email="master-bakuage@example.com", service="bakuage")
+        bakuage = FakeService(
+            service="bakuage", output=_wav_bytes(3.0), metrics={"loudness": -9.0, "eq_bands": [], "stereo": {}}
+        )
+        orch = _orchestrator(bakuage=bakuage)
+
+        result = await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
+
+        assert result["service"] == "bakuage"
+        child = await Clip.get(PydanticObjectId(result["clip_ids"][0]))
+        assert child is not None
+        assert child.parent_clip_ids == [source.id]
+
+    async def test_upload_keyed_by_job_id(self, storage) -> None:
+        # The upload filename carries the job id so concurrent masters on the same
+        # clip never collide on the backend's input keys.
         job, source = await _make_clip(storage, email="master-keys@example.com")
-        client = FakeDolby(output=_wav_bytes(3.0))
-        await tasks.process_mastering_job(job, storage=storage, client=client)
-        assert str(job.id) in client.upload_filename
-        assert str(job.id) in client.submitted_outputs[0]["destination"]
-        assert str(source.id) in client.upload_filename
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0))
+        await tasks.process_mastering_job(job, storage=storage, orchestrator=_orchestrator(dolby=dolby))
+        filename = dolby.master_calls[0]["filename"]
+        assert str(job.id) in filename
+        assert str(source.id) in filename
+
+
+class TestFallback:
+    async def test_dolby_failure_falls_back_to_bakuage(self, storage) -> None:
+        # AC3: when Dolby.io returns an error, the job falls back to Bakuage.
+        job, source = await _make_clip(storage, email="master-fb@example.com", service="dolby")
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0), fail=True)
+        bakuage = FakeService(service="bakuage", output=_wav_bytes(3.0))
+        orch = _orchestrator(dolby=dolby, bakuage=bakuage)
+
+        result = await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
+
+        # The fallback backend ran and its service is attributed in the result.
+        assert result["service"] == "bakuage"
+        assert dolby.master_calls and dolby.master_calls[0]  # primary was attempted
+        assert bakuage.master_calls  # fallback was attempted
+        child = await Clip.get(PydanticObjectId(result["clip_ids"][0]))
+        assert child is not None
+        assert child.parent_clip_ids == [source.id]
+        assert storage.download(child.file_path)
+
+    async def test_all_backends_fail_raises(self, storage) -> None:
+        job, _ = await _make_clip(storage, email="master-allfail@example.com", service="dolby")
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0), fail=True)
+        bakuage = FakeService(service="bakuage", output=_wav_bytes(3.0), fail=True)
+        orch = _orchestrator(dolby=dolby, bakuage=bakuage)
+
+        with pytest.raises(tasks.JobProcessingError, match="Mastering failed"):
+            await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
 
 
 class TestGracefulDegradation:
-    async def test_missing_client_raises_clear_error(self, storage) -> None:
-        job, _ = await _make_clip(storage, email="master-nocreds@example.com")
-        with pytest.raises(tasks.JobProcessingError, match="not configured"):
-            await tasks.process_mastering_job(job, storage=storage, client=None)
-
-    async def test_unsupported_service_raises(self, storage) -> None:
-        job, _ = await _make_clip(storage, email="master-landr@example.com")
-        job.input_params = {**job.input_params, "service": "landr"}
-        client = FakeDolby(output=_wav_bytes(3.0))
-        with pytest.raises(tasks.JobProcessingError, match="not yet implemented"):
-            await tasks.process_mastering_job(job, storage=storage, client=client)
-
-    async def test_unsupported_service_refunds_charged_credits(self, storage) -> None:
-        # The router charges per service up front; a pre-flight rejection must
-        # refund so the user is not left paying for a failed job (codex review P2).
+    async def test_requested_service_unconfigured_refunds_and_raises(self, storage) -> None:
+        # Explicitly requesting landr on a dolby-only deployment: clear error +
+        # refund (no silent substitution, no work performed).
         from acemusic.api.services import credits as credits_service
 
-        job, _ = await _make_clip(storage, email="master-refund-landr@example.com")
-        job.input_params = {**job.input_params, "service": "landr"}
+        job, _ = await _make_clip(storage, email="master-unconfigured@example.com", service="landr")
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0))
+        orch = _orchestrator(dolby=dolby)
         cost = credits_service.get_mastering_cost("landr")
         before = await credits_service.deduct_credits(job.user_id, cost)
-        with pytest.raises(tasks.JobProcessingError):
-            await tasks.process_mastering_job(job, storage=storage, client=FakeDolby(output=_wav_bytes(3.0)))
+
+        with pytest.raises(tasks.JobProcessingError, match="not configured"):
+            await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
+
         user = await user_service.get_user_by_id(str(job.user_id))
         assert user.credits_balance == before + cost
 
-    async def test_missing_client_refunds_charged_credits(self, storage) -> None:
+    async def test_no_backends_at_all_refunds_and_raises(self, storage) -> None:
         from acemusic.api.services import credits as credits_service
 
-        job, _ = await _make_clip(storage, email="master-refund-nocreds@example.com")
+        job, _ = await _make_clip(storage, email="master-nobackend@example.com", service="dolby")
+        orch = _orchestrator()  # empty
         cost = credits_service.get_mastering_cost("dolby")
         before = await credits_service.deduct_credits(job.user_id, cost)
+
         with pytest.raises(tasks.JobProcessingError, match="not configured"):
-            await tasks.process_mastering_job(job, storage=storage, client=None)
+            await tasks.process_mastering_job(job, storage=storage, orchestrator=orch)
+
         user = await user_service.get_user_by_id(str(job.user_id))
         assert user.credits_balance == before + cost
 
 
 class TestErrorHandling:
-    @pytest.mark.parametrize("stage", ["upload", "submit", "wait", "results", "download"])
-    async def test_dolby_error_at_each_stage_is_wrapped(self, storage, stage) -> None:
-        job, _ = await _make_clip(storage, email=f"master-fail-{stage}@example.com")
-        client = FakeDolby(output=_wav_bytes(3.0), fail_on=stage)
-        with pytest.raises(tasks.JobProcessingError, match="Dolby"):
-            await tasks.process_mastering_job(job, storage=storage, client=client)
-
     async def test_missing_source_clip_fails(self, storage) -> None:
         job, source = await _make_clip(storage, email="master-gone@example.com")
         await source.delete()
-        client = FakeDolby(output=_wav_bytes(3.0))
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0))
         with pytest.raises(tasks.JobProcessingError, match="no longer exists"):
-            await tasks.process_mastering_job(job, storage=storage, client=client)
+            await tasks.process_mastering_job(job, storage=storage, orchestrator=_orchestrator(dolby=dolby))
 
-    async def test_no_previews_returned_fails(self, storage) -> None:
-        job, _ = await _make_clip(storage, email="master-empty@example.com")
-        client = FakeDolby(output=_wav_bytes(3.0), previews=[])
-        with pytest.raises(tasks.JobProcessingError, match="no preview outputs"):
-            await tasks.process_mastering_job(job, storage=storage, client=client)
-
-    async def test_download_failure_rolls_back_stored_previews(self, storage) -> None:
-        job, _ = await _make_clip(storage, email="master-rollback@example.com")
-        # First preview stores fine; the second download fails — the first must roll back.
-        client = _RollbackDolby(output=_wav_bytes(3.0), previews=["dlb://p1.wav", "dlb://p2.wav"])
-        with pytest.raises(tasks.JobProcessingError):
-            await tasks.process_mastering_job(job, storage=storage, client=client)
-        # No master clip should survive for this job's source.
-        remaining = await Clip.find(Clip.generation_mode == MASTERING_JOB_TYPE).to_list()
-        assert remaining == []
-
-
-class _RollbackDolby(FakeDolby):
-    """Succeeds on the first download, fails on the second to trigger rollback."""
-
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-        self._downloads = 0
-
-    def download(self, dlb_url: str) -> bytes:
-        self._downloads += 1
-        if self._downloads >= 2:
-            raise DolbyError("download blew up")
-        return self.output
+    async def test_missing_target_lufs_fails(self, storage) -> None:
+        job, _ = await _make_clip(storage, email="master-nolufs@example.com")
+        job.input_params = {k: v for k, v in job.input_params.items() if k != "target_lufs"}
+        dolby = FakeService(service="dolby", output=_wav_bytes(3.0))
+        with pytest.raises(tasks.JobProcessingError, match="target_lufs"):
+            await tasks.process_mastering_job(job, storage=storage, orchestrator=_orchestrator(dolby=dolby))


### PR DESCRIPTION
## Summary

Implements **US-12.3** — LANDR and Bakuage as fallback mastering backends alongside Dolby.io (US-12.2), with automatic cross-service fallback.

The coderabbit plan on the issue was substantially outdated (it assumed US-12.1/12.2 and the `MasteringService` interface did not yet exist). In reality US-12.1/12.2 were already merged, but the shared `MasteringService` interface the spec mandates did **not** exist. This PR introduces that interface and wires the two new backends + an orchestrator into the existing mastering pipeline.

## What changed

- **New shared contract** (`mastering_protocol.py`): `MasteringService` Protocol (single `master()` entrypoint), `MasteringOutput` dataclass, `MasteringError` base.
- **Retrofitted** `DolbyClient`: `DolbyError` now subclasses `MasteringError`; added a `master()` method wrapping its granular workflow behind the shared entrypoint (existing methods/tests untouched).
- **New backends**: `LandrClient` (B2B token auth, two-step upload) and `BakuageClient` (API-key bearer auth, single create call) — both mirror `dolby_client.py` conventions (sync httpx, single `*Error(MasteringError)`, 5xx retry/backoff).
- **New orchestrator** (`mastering_orchestrator.py`): selects the requested backend and falls back across configured services (Dolby→LANDR→Bakuage) on any `MasteringError`. Explicitly-requested-but-unconfigured raises `ServiceNotConfiguredError` (no silent substitution).
- **Wiring**: `settings.py` adds `landr_*`/`bakuage_*` credentials + `*_enabled` properties; the handler (`tasks/mastering.py`) drops the `_SUPPORTED_SERVICE = "dolby"` gate and dispatches via the orchestrator; the processor's `dolby_client_factory` became `mastering_orchestrator_factory`.

## Acceptance criteria

- [x] **AC1** — LANDR mastering produces a mastered audio file — `test_landr_client.py` (unit) + `test_mastering_tasks.py::test_landr_creates_master_clip` (integration, real MongoDB + lineage + metrics)
- [x] **AC2** — Bakuage mastering produces a mastered audio file — `test_bakuage_client.py` (unit) + `test_mastering_tasks.py::test_bakuage_creates_master_clip`
- [x] **AC3** — Fallback from Dolby.io to Bakuage works on Dolby error — `test_mastering_orchestrator.py::test_primary_failure_falls_back_to_next_configured` (unit) + `test_mastering_tasks.py::test_dolby_failure_falls_back_to_bakuage` (integration)
- [x] **AC4** — Each service returns results in the same format — shared `MasteringOutput`; handler returns `{"clip_ids","service","target_lufs","metrics"}` for all three (asserted in every success test)

## Key design decisions (deviations from the coderabbit plan)

1. **Created** the `MasteringService` interface (the plan assumed it existed from US-12.2 — it did not).
2. **Sync httpx** (not async) — matches the existing `dolby_client.py`/`elevenlabs_client.py` convention; `asyncio.to_thread` wrapping stays.
3. **Single `master()` entrypoint** per service (hides each provider's upload/submit/poll/download dance) — keeps the orchestrator trivial.
4. **Fallback on any `MasteringError`** (not connection-error-only) — request validation is pre-flight, so any backend failure is a service problem worth retrying. Simpler and more robust than the CLI's message-inspecting `_should_fall_back`.
5. **Skipped** the coderabbit-suggested `backends.py _CAPABILITIES` update — that map is generation-only; mastering service selection isn't routed through it (YAGNI).

## Test plan

- `uv run pytest` — 1424 unit tests pass (including new `test_mastering_protocol`, `test_landr_client`, `test_bakuage_client`, `test_mastering_orchestrator`, updated `test_dolby_client`).
- `uv run pytest tests/test_mastering_tasks.py tests/test_mastering_api.py tests/test_mastering_service.py -m integration` — 33 integration tests pass against local MongoDB (landr/bakuage success, dolby→bakuage fallback, unconfigured refund, router param persistence).
- `uv run ruff check .` and `uv run black --check` (on all 15 changed `.py` files) — clean.

## Known limitations

- **LANDR/Bakuage endpoint shapes are assumed.** Both services are partnership/API-gated; the clients encode a plausible REST contract (documented in each module's docstring) consistent with the spec (§41.2.2/§41.2.3) and the Dolby client pattern. Tests pin that contract with mocked httpx (the established pattern for client unit tests). A live integration swaps the base URLs/constants without changing the workflow.
- **No live-credential tests** in CI — consistent with the Dolby.io US-12.2 precedent (no live creds in CI). The orchestrator + handler are proven end-to-end with in-process fakes against a real MongoDB.
- **Single mastered output per run.** The `master()` contract returns one `MasteringOutput`; multi-preview A/B comparison is US-12.4's scope (the handler previously submitted one output variant anyway).

Closes #129.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audio mastering now supports multiple backends with automatic fallback between services if a primary backend is unavailable or fails.

* **Configuration**
  * Added environment variables for configuring LANDR and Bakuage mastering service credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->