### PR TITLE
feat(api): mastering preview + A/B comparison and approval (US-12.4)

### DIFF
--- a/docs/demos/us-12.4-mastering-preview.md
+++ b/docs/demos/us-12.4-mastering-preview.md
@@ -1,0 +1,178 @@
+# US-12.4: Mastering preview & A/B comparison and approval
+
+*2026-06-19T15:08:29Z*
+
+US-12.4 adds three owner-scoped mastering endpoints on top of the as-built single-master pipeline (US-12.1/12.2): each mastering job produces ONE mastered clip, which the worker already creates and links to the source. So "previews" are the completed mastered candidates for a source clip (one per job), A/B compares them against the original, and approval promotes a chosen candidate to the final master. This demo drives the real FastAPI app over a local MongoDB (httpx ASGITransport), seeding data via Beanie exactly like the integration tests.
+
+Setup: seed one source clip plus TWO completed mastering jobs on that same source (profiles streaming and club), each producing its own mastered clip. This is the multi-candidate situation a musician auditions.
+
+```bash
+uv run python .cache/us124_demo.py seed 2>/dev/null
+```
+
+```output
+Seeded one source clip + two completed mastering jobs (streaming, club) for the same source:
+  source clip   : 6a355b7e3962f5ec8d654406
+  streaming job : 6a355b7e3962f5ec8d654409  -> mastered clip 6a355b7e3962f5ec8d654407
+  club job      : 6a355b7e3962f5ec8d65440a  -> mastered clip 6a355b7e3962f5ec8d654408
+```
+
+AC4 (metrics for the mastered version) — GET /mastering/jobs/{id} returns the job detail: status, source clip, profile, the service that actually ran, target LUFS, the mastered clip id, and the backend loudness/EQ/stereo metrics.
+
+```bash
+uv run python .cache/us124_demo.py detail 2>/dev/null
+```
+
+```output
+GET /api/v1/mastering/jobs/6a355b7e3962f5ec8d654409  ->  HTTP 200
+{
+  "job_id": "6a355b7e3962f5ec8d654409",
+  "status": "completed",
+  "source_clip_id": "6a355b7e3962f5ec8d654406",
+  "profile": "streaming",
+  "service": "dolby",
+  "target_lufs": -14.0,
+  "created_at": "2026-06-19T15:08:46.278000",
+  "mastered_clip_id": "6a355b7e3962f5ec8d654407",
+  "metrics": {
+    "loudness": -13.5,
+    "eq_bands": [
+      0.0,
+      1.0,
+      2.0,
+      3.0,
+      4.0,
+      5.0,
+      6.0,
+      7.0,
+      8.0,
+      9.0,
+      10.0,
+      11.0,
+      12.0,
+      13.0,
+      14.0,
+      15.0
+    ],
+    "stereo": {
+      "width": 0.8,
+      "balance": 0.0
+    }
+  }
+}
+```
+
+AC1 + AC4 (multiple previews accessible; LUFS for the original) — GET /mastering/jobs/{id}/previews returns the A/B set: the original audio URL with its integrated LUFS measured on demand (pyloudnorm), plus BOTH completed mastered candidates for the source (aggregated across the streaming and club jobs), each with its audio URL and metrics.
+
+```bash
+uv run python .cache/us124_demo.py previews 2>/dev/null
+```
+
+```output
+GET /api/v1/mastering/jobs/6a355b7e3962f5ec8d65440a/previews  ->  HTTP 200
+{
+  "source_clip_id": "6a355b7e3962f5ec8d654406",
+  "original_audio_url": "/tmp/us124_demo_storage/6a355b7e3962f5ec8d654404/6a355b7e3962f5ec8d654405/clips/6a355b7e3962f5ec8d654406.wav",
+  "original_metrics": {
+    "loudness": -14.924768075483929
+  },
+  "previews": [
+    {
+      "preview_id": "6a355b7e3962f5ec8d654407",
+      "audio_url": "/tmp/us124_demo_storage/6a355b7e3962f5ec8d654404/6a355b7e3962f5ec8d654405/clips/6a355b7e3962f5ec8d654407.wav",
+      "profile": "streaming",
+      "service": "dolby",
+      "metrics": {
+        "loudness": -13.5,
+        "eq_bands": [
+          0.0,
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          7.0,
+          8.0,
+          9.0,
+          10.0,
+          11.0,
+          12.0,
+          13.0,
+          14.0,
+          15.0
+        ],
+        "stereo": {
+          "width": 0.8,
+          "balance": 0.0
+        }
+      }
+    },
+    {
+      "preview_id": "6a355b7e3962f5ec8d654408",
+      "audio_url": "/tmp/us124_demo_storage/6a355b7e3962f5ec8d654404/6a355b7e3962f5ec8d654405/clips/6a355b7e3962f5ec8d654408.wav",
+      "profile": "club",
+      "service": "dolby",
+      "metrics": {
+        "loudness": -13.5,
+        "eq_bands": [
+          0.0,
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          7.0,
+          8.0,
+          9.0,
+          10.0,
+          11.0,
+          12.0,
+          13.0,
+          14.0,
+          15.0
+        ],
+        "stereo": {
+          "width": 0.8,
+          "balance": 0.0
+        }
+      }
+    }
+  ]
+}
+
+-> original LUFS measured locally: -14.924768075483929
+-> 2 mastered candidates aggregated for the source (A/B set)
+```
+
+AC2 + AC3 (approval promotes to a mastered clip; lineage preserved) — POST /mastering/jobs/{id}/approve with the chosen preview_id promotes that candidate to the final master and returns its clip id + audio URL.
+
+```bash
+uv run python .cache/us124_demo.py approve 2>/dev/null
+```
+
+```output
+POST /api/v1/mastering/jobs/6a355b7e3962f5ec8d65440a/approve  body={'preview_id': '6a355b7e3962f5ec8d654408'}  ->  HTTP 200
+{
+  "clip_id": "6a355b7e3962f5ec8d654408",
+  "audio_url": "/tmp/us124_demo_storage/6a355b7e3962f5ec8d654404/6a355b7e3962f5ec8d654405/clips/6a355b7e3962f5ec8d654408.wav"
+}
+```
+
+Outcome evidence for AC2/AC3 — re-read the approved clip straight from MongoDB: generation_mode is now "mastered" (promoted from "mastering") and parent_clip_ids still points at the original source clip.
+
+```bash
+uv run python .cache/us124_demo.py verify 2>/dev/null
+```
+
+```output
+Approved clip re-read from MongoDB:
+  clip id          : 6a355b7e3962f5ec8d654408
+  generation_mode  : 'mastered'   (promoted from 'mastering')
+  parent_clip_ids  : ['6a355b7e3962f5ec8d654406']   (== source 6a355b7e3962f5ec8d654406)
+
+  OK: lineage preserved, master promoted.
+```
+
+AC5 (reject all -> resubmit) is satisfied by the existing POST /api/v1/mastering/jobs submission endpoint (US-12.1): a musician who likes none of the candidates simply submits another mastering job with different parameters, which then appears as a new candidate in the previews set above. All five acceptance criteria of issue #130 are demonstrated with real outcome evidence.

--- a/docs/demos/us-12.4-mastering-preview.md
+++ b/docs/demos/us-12.4-mastering-preview.md
@@ -1,10 +1,10 @@
 # US-12.4: Mastering preview & A/B comparison and approval
 
-*2026-06-19T15:08:29Z*
+*2026-06-19T15:14:47Z*
 
-US-12.4 adds three owner-scoped mastering endpoints on top of the as-built single-master pipeline (US-12.1/12.2): each mastering job produces ONE mastered clip, which the worker already creates and links to the source. So "previews" are the completed mastered candidates for a source clip (one per job), A/B compares them against the original, and approval promotes a chosen candidate to the final master. This demo drives the real FastAPI app over a local MongoDB (httpx ASGITransport), seeding data via Beanie exactly like the integration tests.
+US-12.4 adds three owner-scoped mastering endpoints on top of the as-built single-master pipeline (US-12.1/12.2): each mastering job produces ONE mastered clip, which the worker already creates and links to the source. So "previews" are the completed mastered candidates for a source clip (one per job, most recent 5), A/B compares them against the original, and approval promotes a chosen candidate to the single final master. This demo drives the real FastAPI app over a local MongoDB (httpx ASGITransport), seeding data via Beanie exactly like the integration tests.
 
-Setup: seed one source clip plus TWO completed mastering jobs on that same source (profiles streaming and club), each producing its own mastered clip. This is the multi-candidate situation a musician auditions.
+Setup: seed one source clip plus TWO completed mastering jobs on that same source (profiles streaming and club), each producing its own mastered clip — the multi-candidate situation a musician auditions.
 
 ```bash
 uv run python .cache/us124_demo.py seed 2>/dev/null
@@ -12,9 +12,9 @@ uv run python .cache/us124_demo.py seed 2>/dev/null
 
 ```output
 Seeded one source clip + two completed mastering jobs (streaming, club) for the same source:
-  source clip   : 6a355b7e3962f5ec8d654406
-  streaming job : 6a355b7e3962f5ec8d654409  -> mastered clip 6a355b7e3962f5ec8d654407
-  club job      : 6a355b7e3962f5ec8d65440a  -> mastered clip 6a355b7e3962f5ec8d654408
+  source clip   : 6a355cf02f07946f97b8729e
+  streaming job : 6a355cf02f07946f97b872a1  -> mastered clip 6a355cf02f07946f97b8729f
+  club job      : 6a355cf02f07946f97b872a2  -> mastered clip 6a355cf02f07946f97b872a0
 ```
 
 AC4 (metrics for the mastered version) — GET /mastering/jobs/{id} returns the job detail: status, source clip, profile, the service that actually ran, target LUFS, the mastered clip id, and the backend loudness/EQ/stereo metrics.
@@ -24,16 +24,16 @@ uv run python .cache/us124_demo.py detail 2>/dev/null
 ```
 
 ```output
-GET /api/v1/mastering/jobs/6a355b7e3962f5ec8d654409  ->  HTTP 200
+GET /api/v1/mastering/jobs/6a355cf02f07946f97b872a1  ->  HTTP 200
 {
-  "job_id": "6a355b7e3962f5ec8d654409",
+  "job_id": "6a355cf02f07946f97b872a1",
   "status": "completed",
-  "source_clip_id": "6a355b7e3962f5ec8d654406",
+  "source_clip_id": "6a355cf02f07946f97b8729e",
   "profile": "streaming",
   "service": "dolby",
   "target_lufs": -14.0,
-  "created_at": "2026-06-19T15:08:46.278000",
-  "mastered_clip_id": "6a355b7e3962f5ec8d654407",
+  "created_at": "2026-06-19T15:14:56.030000",
+  "mastered_clip_id": "6a355cf02f07946f97b8729f",
   "metrics": {
     "loudness": -13.5,
     "eq_bands": [
@@ -62,24 +62,24 @@ GET /api/v1/mastering/jobs/6a355b7e3962f5ec8d654409  ->  HTTP 200
 }
 ```
 
-AC1 + AC4 (multiple previews accessible; LUFS for the original) — GET /mastering/jobs/{id}/previews returns the A/B set: the original audio URL with its integrated LUFS measured on demand (pyloudnorm), plus BOTH completed mastered candidates for the source (aggregated across the streaming and club jobs), each with its audio URL and metrics.
+AC1 + AC4 (multiple previews; LUFS for the original + metrics diff) — GET /mastering/jobs/{id}/previews returns the A/B set: the original audio URL with its integrated LUFS measured on demand (pyloudnorm), plus BOTH mastered candidates for the source (aggregated across the streaming and club jobs). Each candidate carries its metrics AND a loudness_delta (mastered minus original dB) — the A/B metrics diff.
 
 ```bash
 uv run python .cache/us124_demo.py previews 2>/dev/null
 ```
 
 ```output
-GET /api/v1/mastering/jobs/6a355b7e3962f5ec8d65440a/previews  ->  HTTP 200
+GET /api/v1/mastering/jobs/6a355cf02f07946f97b872a2/previews  ->  HTTP 200
 {
-  "source_clip_id": "6a355b7e3962f5ec8d654406",
-  "original_audio_url": "/tmp/us124_demo_storage/6a355b7e3962f5ec8d654404/6a355b7e3962f5ec8d654405/clips/6a355b7e3962f5ec8d654406.wav",
+  "source_clip_id": "6a355cf02f07946f97b8729e",
+  "original_audio_url": "/tmp/us124_demo_storage/6a355cf02f07946f97b8729c/6a355cf02f07946f97b8729d/clips/6a355cf02f07946f97b8729e.wav",
   "original_metrics": {
     "loudness": -14.924768075483929
   },
   "previews": [
     {
-      "preview_id": "6a355b7e3962f5ec8d654407",
-      "audio_url": "/tmp/us124_demo_storage/6a355b7e3962f5ec8d654404/6a355b7e3962f5ec8d654405/clips/6a355b7e3962f5ec8d654407.wav",
+      "preview_id": "6a355cf02f07946f97b8729f",
+      "audio_url": "/tmp/us124_demo_storage/6a355cf02f07946f97b8729c/6a355cf02f07946f97b8729d/clips/6a355cf02f07946f97b8729f.wav",
       "profile": "streaming",
       "service": "dolby",
       "metrics": {
@@ -106,11 +106,12 @@ GET /api/v1/mastering/jobs/6a355b7e3962f5ec8d65440a/previews  ->  HTTP 200
           "width": 0.8,
           "balance": 0.0
         }
-      }
+      },
+      "loudness_delta": 1.42
     },
     {
-      "preview_id": "6a355b7e3962f5ec8d654408",
-      "audio_url": "/tmp/us124_demo_storage/6a355b7e3962f5ec8d654404/6a355b7e3962f5ec8d654405/clips/6a355b7e3962f5ec8d654408.wav",
+      "preview_id": "6a355cf02f07946f97b872a0",
+      "audio_url": "/tmp/us124_demo_storage/6a355cf02f07946f97b8729c/6a355cf02f07946f97b8729d/clips/6a355cf02f07946f97b872a0.wav",
       "profile": "club",
       "service": "dolby",
       "metrics": {
@@ -137,7 +138,8 @@ GET /api/v1/mastering/jobs/6a355b7e3962f5ec8d65440a/previews  ->  HTTP 200
           "width": 0.8,
           "balance": 0.0
         }
-      }
+      },
+      "loudness_delta": 1.42
     }
   ]
 }
@@ -153,14 +155,14 @@ uv run python .cache/us124_demo.py approve 2>/dev/null
 ```
 
 ```output
-POST /api/v1/mastering/jobs/6a355b7e3962f5ec8d65440a/approve  body={'preview_id': '6a355b7e3962f5ec8d654408'}  ->  HTTP 200
+POST /api/v1/mastering/jobs/6a355cf02f07946f97b872a2/approve  body={'preview_id': '6a355cf02f07946f97b872a0'}  ->  HTTP 200
 {
-  "clip_id": "6a355b7e3962f5ec8d654408",
-  "audio_url": "/tmp/us124_demo_storage/6a355b7e3962f5ec8d654404/6a355b7e3962f5ec8d654405/clips/6a355b7e3962f5ec8d654408.wav"
+  "clip_id": "6a355cf02f07946f97b872a0",
+  "audio_url": "/tmp/us124_demo_storage/6a355cf02f07946f97b8729c/6a355cf02f07946f97b8729d/clips/6a355cf02f07946f97b872a0.wav"
 }
 ```
 
-Outcome evidence for AC2/AC3 — re-read the approved clip straight from MongoDB: generation_mode is now "mastered" (promoted from "mastering") and parent_clip_ids still points at the original source clip.
+Outcome evidence for AC2/AC3 — re-read the approved clip from MongoDB: generation_mode is now "mastered" (promoted from "mastering") and parent_clip_ids still points at the original source clip. Approval is exclusive: approving a different candidate later moves the master rather than leaving two.
 
 ```bash
 uv run python .cache/us124_demo.py verify 2>/dev/null
@@ -168,11 +170,11 @@ uv run python .cache/us124_demo.py verify 2>/dev/null
 
 ```output
 Approved clip re-read from MongoDB:
-  clip id          : 6a355b7e3962f5ec8d654408
+  clip id          : 6a355cf02f07946f97b872a0
   generation_mode  : 'mastered'   (promoted from 'mastering')
-  parent_clip_ids  : ['6a355b7e3962f5ec8d654406']   (== source 6a355b7e3962f5ec8d654406)
+  parent_clip_ids  : ['6a355cf02f07946f97b8729e']   (== source 6a355cf02f07946f97b8729e)
 
   OK: lineage preserved, master promoted.
 ```
 
-AC5 (reject all -> resubmit) is satisfied by the existing POST /api/v1/mastering/jobs submission endpoint (US-12.1): a musician who likes none of the candidates simply submits another mastering job with different parameters, which then appears as a new candidate in the previews set above. All five acceptance criteria of issue #130 are demonstrated with real outcome evidence.
+AC5 (reject all -> resubmit) is satisfied by the existing POST /api/v1/mastering/jobs endpoint (US-12.1): a musician who likes none of the candidates submits another mastering job with different parameters, which then appears as a new candidate above. All five acceptance criteria of issue #130 are demonstrated with real outcome evidence.

--- a/src/acemusic/api/routers/mastering.py
+++ b/src/acemusic/api/routers/mastering.py
@@ -12,19 +12,25 @@ mastering work is a future ticket — the processor only claims registered
 ``job_type``s, so submitted jobs queue safely until then.
 """
 
+import asyncio
 import logging
+from datetime import datetime
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from acemusic.storage import get_storage_backend
+
 from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import Clip, JobStatus
 from ..services import (
     clips as clip_service,
     credits as credits_service,
     mastering as mastering_service,
     users as user_service,
 )
+from ..services.common import coerce_object_id
 
 logger = logging.getLogger(__name__)
 
@@ -142,3 +148,175 @@ async def create_mastering_job(
         # retry that double-charges. The ledger row is best-effort history.
         logger.exception("Credit ledger write failed for job %s (user %s)", job.id, user.id)
     return MasteringJobResponse(job_id=str(job.id))
+
+
+# ---------------------------------------------------------------------------
+# Preview / A/B comparison and approval (US-12.4)
+#
+# The mastering pipeline produces ONE mastered clip per job (US-12.2), so a source
+# clip's "previews" are the mastered children of its completed mastering jobs (one
+# per job). The detail endpoint exposes a single job; the previews endpoint
+# aggregates every candidate for the source for side-by-side comparison against
+# the original; approval promotes a chosen candidate to the final master.
+# ---------------------------------------------------------------------------
+
+
+def _job_not_found() -> HTTPException:
+    """A mastering job that is missing, not owned, or not a mastering job (→ 404)."""
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mastering job not found.")
+
+
+class MasteringJobDetailResponse(BaseModel):
+    """A mastering job's status and (once complete) its mastered output + metrics.
+
+    ``response_model_exclude_none`` drops the result fields until the job
+    completes: ``mastered_clip_id``/``metrics`` appear only when there is a master.
+    """
+
+    job_id: str
+    status: JobStatus
+    source_clip_id: str | None = None
+    profile: str | None = None
+    service: str | None = None
+    target_lufs: float | None = None
+    created_at: datetime
+    completed_at: datetime | None = None
+    mastered_clip_id: str | None = None
+    metrics: dict | None = None
+    error: str | None = None
+
+
+class PreviewItem(BaseModel):
+    """One mastered candidate: its audio URL and the backend's loudness/EQ metrics."""
+
+    preview_id: str
+    audio_url: str
+    profile: str | None = None
+    service: str | None = None
+    metrics: dict | None = None
+
+
+class PreviewsResponse(BaseModel):
+    """A/B comparison set: the original plus every mastered candidate for the source.
+
+    ``original_metrics`` is the source's on-demand loudness measurement (``loudness``
+    only — the unmastered source has no per-band EQ/stereo analysis).
+    """
+
+    source_clip_id: str | None = None
+    original_audio_url: str | None = None
+    original_metrics: dict | None = None
+    previews: list[PreviewItem]
+
+
+class ApproveRequest(BaseModel):
+    """Approval body: the preview (mastered clip) id to promote to the final master."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    preview_id: str
+
+
+class ApproveResponse(BaseModel):
+    """The promoted master's clip id and a retrievable audio URL."""
+
+    clip_id: str
+    audio_url: str
+
+
+@router.get(
+    "/jobs/{job_id}",
+    response_model=MasteringJobDetailResponse,
+    response_model_exclude_none=True,
+)
+async def get_mastering_job_detail(
+    job_id: str,
+    current: CurrentUser = Depends(get_current_user),
+) -> MasteringJobDetailResponse:
+    """Return a mastering job's status, parameters, and (when complete) its master."""
+    job = await mastering_service.get_mastering_job(job_id, current.user_id)
+    if job is None:
+        raise _job_not_found()
+    params = job.input_params or {}
+    result = job.result or {}
+    clip_ids = result.get("clip_ids") or []
+    return MasteringJobDetailResponse(
+        job_id=str(job.id),
+        status=job.status,
+        source_clip_id=params.get("clip_id"),
+        profile=params.get("profile"),
+        # The service that actually ran (a fallback may differ from the request).
+        service=result.get("service") or params.get("service"),
+        target_lufs=params.get("target_lufs"),
+        created_at=job.created_at,
+        completed_at=job.completed_at,
+        mastered_clip_id=clip_ids[0] if clip_ids else None,
+        metrics=result.get("metrics"),
+        error=job.error,
+    )
+
+
+@router.get("/jobs/{job_id}/previews", response_model=PreviewsResponse)
+async def get_mastering_previews(
+    job_id: str,
+    current: CurrentUser = Depends(get_current_user),
+) -> PreviewsResponse:
+    """A/B data for the job's source: original audio + loudness, and every candidate."""
+    job = await mastering_service.get_mastering_job(job_id, current.user_id)
+    if job is None:
+        raise _job_not_found()
+    source_clip_id = (job.input_params or {}).get("clip_id")
+    storage = get_storage_backend()
+
+    original_audio_url: str | None = None
+    original_metrics: dict | None = None
+    oid = coerce_object_id(source_clip_id) if source_clip_id else None
+    source = await Clip.get(oid) if oid is not None else None
+    if source is not None and str(source.user_id) == current.user_id:
+        original_audio_url = await asyncio.to_thread(storage.get_url, source.file_path)
+        original_metrics = {"loudness": await mastering_service.measure_clip_loudness(storage, source)}
+
+    previews: list[PreviewItem] = []
+    for candidate_job in await mastering_service.list_source_previews(source_clip_id, current.user_id):
+        result = candidate_job.result or {}
+        clip_ids = result.get("clip_ids") or []
+        if not clip_ids:
+            continue
+        clip_oid = coerce_object_id(clip_ids[0])
+        clip = await Clip.get(clip_oid) if clip_oid is not None else None
+        if clip is None:
+            continue
+        previews.append(
+            PreviewItem(
+                preview_id=clip_ids[0],
+                audio_url=await asyncio.to_thread(storage.get_url, clip.file_path),
+                profile=(candidate_job.input_params or {}).get("profile"),
+                service=result.get("service"),
+                metrics=result.get("metrics"),
+            )
+        )
+
+    return PreviewsResponse(
+        source_clip_id=source_clip_id,
+        original_audio_url=original_audio_url,
+        original_metrics=original_metrics,
+        previews=previews,
+    )
+
+
+@router.post("/jobs/{job_id}/approve", response_model=ApproveResponse)
+async def approve_mastering_preview(
+    job_id: str,
+    request: ApproveRequest,
+    current: CurrentUser = Depends(get_current_user),
+) -> ApproveResponse:
+    """Promote a preview to the final master; returns its clip id and audio URL."""
+    job = await mastering_service.get_mastering_job(job_id, current.user_id)
+    if job is None:
+        raise _job_not_found()
+    try:
+        clip = await mastering_service.approve_preview(job, request.preview_id, current.user_id)
+    except mastering_service.PreviewNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    audio_url = await asyncio.to_thread(get_storage_backend().get_url, clip.file_path)
+    return ApproveResponse(clip_id=str(clip.id), audio_url=audio_url)

--- a/src/acemusic/api/routers/mastering.py
+++ b/src/acemusic/api/routers/mastering.py
@@ -161,9 +161,30 @@ async def create_mastering_job(
 # ---------------------------------------------------------------------------
 
 
+# The musician auditions a bounded set (US-12.4: "up to 5 preview variants"); a
+# frequently-remastered source can have more completed candidates, so the previews
+# view shows the most recent few. Approval still accepts any historical candidate.
+_MAX_PREVIEW_VARIANTS = 5
+
+
 def _job_not_found() -> HTTPException:
     """A mastering job that is missing, not owned, or not a mastering job (→ 404)."""
     return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mastering job not found.")
+
+
+def _loudness_delta(metrics: dict | None, original_metrics: dict | None) -> float | None:
+    """Mastered-minus-original integrated loudness (dB), or None if either is absent.
+
+    The one metric measurable on both sides (the source has no per-band EQ/stereo
+    analysis), so it is the A/B "metrics diff" the comparison view can report.
+    """
+    if not metrics or not original_metrics:
+        return None
+    mastered = metrics.get("loudness")
+    original = original_metrics.get("loudness")
+    if mastered is None or original is None:
+        return None
+    return round(mastered - original, 2)
 
 
 class MasteringJobDetailResponse(BaseModel):
@@ -194,6 +215,9 @@ class PreviewItem(BaseModel):
     profile: str | None = None
     service: str | None = None
     metrics: dict | None = None
+    # Mastered-minus-original integrated loudness (dB); the A/B metrics diff. None
+    # when either side's loudness is unavailable.
+    loudness_delta: float | None = None
 
 
 class PreviewsResponse(BaseModel):
@@ -277,7 +301,9 @@ async def get_mastering_previews(
         original_metrics = {"loudness": await mastering_service.measure_clip_loudness(storage, source)}
 
     previews: list[PreviewItem] = []
-    for candidate_job in await mastering_service.list_source_previews(source_clip_id, current.user_id):
+    candidate_jobs = await mastering_service.list_source_previews(source_clip_id, current.user_id)
+    # list_source_previews is oldest-first; show the most recent variants.
+    for candidate_job in candidate_jobs[-_MAX_PREVIEW_VARIANTS:]:
         result = candidate_job.result or {}
         clip_ids = result.get("clip_ids") or []
         if not clip_ids:
@@ -286,13 +312,15 @@ async def get_mastering_previews(
         clip = await Clip.get(clip_oid) if clip_oid is not None else None
         if clip is None:
             continue
+        metrics = result.get("metrics")
         previews.append(
             PreviewItem(
                 preview_id=clip_ids[0],
                 audio_url=await asyncio.to_thread(storage.get_url, clip.file_path),
                 profile=(candidate_job.input_params or {}).get("profile"),
                 service=result.get("service"),
-                metrics=result.get("metrics"),
+                metrics=metrics,
+                loudness_delta=_loudness_delta(metrics, original_metrics),
             )
         )
 

--- a/src/acemusic/api/routers/mastering.py
+++ b/src/acemusic/api/routers/mastering.py
@@ -229,6 +229,8 @@ class PreviewsResponse(BaseModel):
 
     source_clip_id: str | None = None
     original_audio_url: str | None = None
+    # ``None`` when the source is missing/unowned or its loudness can't be measured;
+    # otherwise ``{"loudness": <LUFS>}`` (loudness-only by design).
     original_metrics: dict | None = None
     previews: list[PreviewItem]
 
@@ -298,7 +300,11 @@ async def get_mastering_previews(
     source = await Clip.get(oid) if oid is not None else None
     if source is not None and str(source.user_id) == current.user_id:
         original_audio_url = await asyncio.to_thread(storage.get_url, source.file_path)
-        original_metrics = {"loudness": await mastering_service.measure_clip_loudness(storage, source)}
+        loudness = await mastering_service.measure_clip_loudness(storage, source)
+        # Omit the metrics object entirely when unmeasurable rather than emitting a
+        # partial ``{"loudness": null}`` — callers see "no original metrics", not a
+        # present-but-null interior field.
+        original_metrics = {"loudness": loudness} if loudness is not None else None
 
     previews: list[PreviewItem] = []
     candidate_jobs = await mastering_service.list_source_previews(source_clip_id, current.user_id)

--- a/src/acemusic/api/services/mastering.py
+++ b/src/acemusic/api/services/mastering.py
@@ -28,9 +28,13 @@ logger = logging.getLogger(__name__)
 
 MASTERING_JOB_TYPE = "mastering"
 
-# An approved master is promoted from ``generation_mode="mastering"`` (the worker's
-# tag for any mastered child) to this terminal mode (US-12.4), distinguishing the
-# musician's chosen release master from the other auditioned candidates.
+# The worker tags every mastered child with this mode (US-12.2); an un-approved
+# candidate keeps it.
+MASTERED_CANDIDATE_MODE = "mastering"
+
+# An approved master is promoted from ``MASTERED_CANDIDATE_MODE`` to this terminal
+# mode (US-12.4), distinguishing the musician's chosen release master from the
+# other auditioned candidates. Exactly one per source clip.
 APPROVED_GENERATION_MODE = "mastered"
 
 # Each standard profile maps to a fixed integrated-loudness target (LUFS). "club"
@@ -198,6 +202,22 @@ async def approve_preview(source_job: Job, preview_clip_id: str, user_id: str) -
         # A candidate id with no owned clip behind it is a data inconsistency, not
         # a client error the caller can fix — surface it as "not found" all the same.
         raise PreviewNotFoundError(f"Preview clip {preview_clip_id!r} not found")
+
+    # Exactly one final master per source: demote any previously-approved sibling
+    # back to a candidate so approving a different preview *moves* the master
+    # rather than leaving several clips all tagged as the final master.
+    source_oid = coerce_object_id(source_clip_id) if source_clip_id else None
+    if source_oid is not None:
+        siblings = await Clip.find(
+            Clip.user_id == clip.user_id,
+            Clip.parent_clip_ids == source_oid,
+            Clip.generation_mode == APPROVED_GENERATION_MODE,
+        ).to_list()
+        for sibling in siblings:
+            if sibling.id != clip.id:
+                sibling.generation_mode = MASTERED_CANDIDATE_MODE
+                await sibling.save()
+
     clip.generation_mode = APPROVED_GENERATION_MODE
     await clip.save()
     return clip

--- a/src/acemusic/api/services/mastering.py
+++ b/src/acemusic/api/services/mastering.py
@@ -11,12 +11,27 @@ background processor — which claims only registered ``job_type``s — leaves
 mastering jobs queued until the processing ticket wires up a handler.
 """
 
+import asyncio
+import io
+import logging
+import math
+
 from beanie import PydanticObjectId
 
-from ..models import Job
+from acemusic.storage import StorageBackend
+
+from ..models import Clip, Job, JobStatus
+from .common import coerce_object_id
 from .jobs import create_job
 
+logger = logging.getLogger(__name__)
+
 MASTERING_JOB_TYPE = "mastering"
+
+# An approved master is promoted from ``generation_mode="mastering"`` (the worker's
+# tag for any mastered child) to this terminal mode (US-12.4), distinguishing the
+# musician's chosen release master from the other auditioned candidates.
+APPROVED_GENERATION_MODE = "mastered"
 
 # Each standard profile maps to a fixed integrated-loudness target (LUFS). "club"
 # is the maximum-loudness master (-6) and "vinyl" trades loudness for dynamic
@@ -67,3 +82,122 @@ async def create_mastering_job(
         job_type=MASTERING_JOB_TYPE,
         params=params,
     )
+
+
+# ---------------------------------------------------------------------------
+# Preview / A/B comparison and approval (US-12.4)
+#
+# The mastering pipeline (US-12.2) produces ONE mastered clip per job, so a
+# source clip's "previews" are the mastered children from its completed mastering
+# jobs (one per job). Approval promotes a chosen candidate to the final master.
+# ---------------------------------------------------------------------------
+
+
+class PreviewNotFoundError(Exception):
+    """The requested preview is not a completed mastered candidate of the source."""
+
+
+async def get_mastering_job(job_id: str, user_id: str) -> Job | None:
+    """Return the owner's mastering job, or ``None`` for unknown/unowned/wrong-type.
+
+    Owner-scoped and type-scoped: a missing id, another user's job, or a
+    non-mastering job are all indistinguishable from "no such job" so the
+    endpoint never reveals another user's (or another feature's) jobs.
+    """
+    oid = coerce_object_id(job_id)
+    if oid is None:
+        return None
+    job = await Job.get(oid)
+    if job is None or str(job.user_id) != user_id or job.job_type != MASTERING_JOB_TYPE:
+        return None
+    return job
+
+
+async def list_source_previews(source_clip_id: str | None, user_id: str) -> list[Job]:
+    """The owner's completed mastering jobs for ``source_clip_id``, oldest-first.
+
+    Each completed mastering job carries one mastered candidate in
+    ``result["clip_ids"]`` plus its metrics — the set the musician auditions.
+    """
+    if not source_clip_id:
+        return []
+    uid = coerce_object_id(user_id)
+    if uid is None:
+        return []
+    jobs = await Job.find(
+        Job.user_id == uid,
+        Job.job_type == MASTERING_JOB_TYPE,
+        Job.status == JobStatus.COMPLETED,
+    ).to_list()
+    # clip_id lives inside the free-form input_params dict; filter in Python rather
+    # than with a nested query — a user's completed mastering jobs are few.
+    # ponytail: linear scan; add an input_params.clip_id index if this gets hot.
+    matching = [j for j in jobs if (j.input_params or {}).get("clip_id") == source_clip_id]
+    matching.sort(key=lambda j: j.created_at)
+    return matching
+
+
+def _measure_loudness_sync(data: bytes) -> float | None:
+    """Integrated LUFS of ``data``, or ``None`` if it can't be measured."""
+    import numpy as np
+    import soundfile as sf
+
+    from acemusic.audio import measure_lufs
+
+    try:
+        audio, sample_rate = sf.read(io.BytesIO(data))
+    except Exception:
+        # soundfile decodes wav/flac/ogg; a format it can't read (e.g. mp3) or a
+        # corrupt object yields no measurement rather than a 500.
+        return None
+    if audio.ndim == 1:
+        audio = np.column_stack([audio, audio])
+    try:
+        lufs = float(measure_lufs(audio, sample_rate))
+    except Exception:
+        return None
+    # pyloudnorm returns -inf for silence; only finite loudness is meaningful.
+    return lufs if math.isfinite(lufs) else None
+
+
+async def measure_clip_loudness(storage: StorageBackend, clip: Clip) -> float | None:
+    """Measure a clip's integrated LUFS on demand (None if the audio is unavailable).
+
+    The unmastered source has no stored metrics, so its loudness is computed here
+    for the A/B comparison. Off-loaded to a thread — both the download and the
+    pyloudnorm pass are blocking.
+    """
+    try:
+        data = await asyncio.to_thread(storage.download, clip.file_path)
+    except Exception:
+        # Original loudness is a best-effort A/B extra: a missing object or a
+        # transient storage error degrades to "no measurement", never a 500 on
+        # the comparison view.
+        logger.debug("Could not download clip %s for loudness measurement", clip.id, exc_info=True)
+        return None
+    return await asyncio.to_thread(_measure_loudness_sync, data)
+
+
+async def approve_preview(source_job: Job, preview_clip_id: str, user_id: str) -> Clip:
+    """Promote a mastered candidate to the final master and return it.
+
+    ``preview_clip_id`` must be a completed mastered candidate of ``source_job``'s
+    source clip and owned by the user; otherwise :class:`PreviewNotFoundError`.
+    Sets ``generation_mode`` to :data:`APPROVED_GENERATION_MODE`. Idempotent — the
+    clip already exists (the worker created it); approving twice is a no-op re-save.
+    """
+    source_clip_id = (source_job.input_params or {}).get("clip_id")
+    previews = await list_source_previews(source_clip_id, user_id)
+    candidate_ids = {cid for job in previews for cid in (job.result or {}).get("clip_ids", [])}
+    if preview_clip_id not in candidate_ids:
+        raise PreviewNotFoundError(f"Preview {preview_clip_id!r} is not a candidate for this source clip")
+
+    oid = coerce_object_id(preview_clip_id)
+    clip = await Clip.get(oid) if oid is not None else None
+    if clip is None or str(clip.user_id) != user_id:
+        # A candidate id with no owned clip behind it is a data inconsistency, not
+        # a client error the caller can fix — surface it as "not found" all the same.
+        raise PreviewNotFoundError(f"Preview clip {preview_clip_id!r} not found")
+    clip.generation_mode = APPROVED_GENERATION_MODE
+    await clip.save()
+    return clip

--- a/tests/test_mastering_api.py
+++ b/tests/test_mastering_api.py
@@ -545,6 +545,20 @@ class TestMasteringPreviews:
         # A/B metrics diff: mastered-minus-original integrated loudness, a real number.
         assert preview["loudness_delta"] == round(_MASTER_METRICS["loudness"] - body["original_metrics"]["loudness"], 2)
 
+    async def test_missing_source_audio_degrades_without_500(self, client, settings, local_storage) -> None:
+        # Source clip exists in the DB but its audio object was never stored: loudness
+        # can't be measured, so original_metrics degrades to None rather than a 500.
+        user = await _make_user("m124-prev-noaudio@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws)  # no store_bytes
+        mastered = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        job = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=mastered)
+        resp = await client.get(_previews_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["original_metrics"] is None
+        assert len(body["previews"]) == 1
+
     async def test_caps_displayed_previews_at_five(self, client, settings, local_storage) -> None:
         user = await _make_user("m124-prev-cap@example.com")
         ws = PydanticObjectId()

--- a/tests/test_mastering_api.py
+++ b/tests/test_mastering_api.py
@@ -542,6 +542,23 @@ class TestMasteringPreviews:
         assert preview["preview_id"] == str(mastered.id)
         assert preview["audio_url"]
         assert preview["metrics"]["loudness"] == _MASTER_METRICS["loudness"]
+        # A/B metrics diff: mastered-minus-original integrated loudness, a real number.
+        assert preview["loudness_delta"] == round(_MASTER_METRICS["loudness"] - body["original_metrics"]["loudness"], 2)
+
+    async def test_caps_displayed_previews_at_five(self, client, settings, local_storage) -> None:
+        user = await _make_user("m124-prev-cap@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws, store_bytes=_wav_bytes())
+        last_job = None
+        for _ in range(6):
+            mastered = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+            last_job = await _insert_mastering_job(
+                user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=mastered
+            )
+        resp = await client.get(_previews_url(str(last_job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        # Six candidates exist; the audition set is bounded to the five most recent.
+        assert len(resp.json()["previews"]) == 5
 
     async def test_aggregates_multiple_candidates_for_one_source(self, client, settings, local_storage) -> None:
         user = await _make_user("m124-prev-multi@example.com")
@@ -621,3 +638,18 @@ class TestMasteringApprove:
         assert first.status_code == 200
         assert second.status_code == 200
         assert (await Clip.get(mastered.id)).generation_mode == "mastered"
+
+    async def test_approving_a_second_candidate_moves_the_master(self, client, settings, local_storage) -> None:
+        # Exactly one final master per source: approving m2 demotes m1 back to a candidate.
+        user = await _make_user("m124-appr-exclusive@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws)
+        m1 = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        m2 = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        job1 = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=m1)
+        job2 = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=m2)
+        headers = _auth_headers(user, settings)
+        await client.post(_approve_url(str(job1.id)), json={"preview_id": str(m1.id)}, headers=headers)
+        await client.post(_approve_url(str(job2.id)), json={"preview_id": str(m2.id)}, headers=headers)
+        assert (await Clip.get(m1.id)).generation_mode == "mastering"
+        assert (await Clip.get(m2.id)).generation_mode == "mastered"

--- a/tests/test_mastering_api.py
+++ b/tests/test_mastering_api.py
@@ -6,6 +6,8 @@ source clip, gates on per-service credits, and enqueues a queued job returning
 are ``integration`` and drive the real app over a local MongoDB.
 """
 
+import io
+
 import httpx
 import pytest
 from beanie import PydanticObjectId
@@ -333,3 +335,289 @@ class TestJobCreationFailure:
         assert (await _reload(user)).credits_balance == 10.0
         assert await Job.find(Job.user_id == user.id).count() == 0
         assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0
+
+
+# ===========================================================================
+# US-12.4 — mastering preview / A/B comparison and approval
+#
+# Built on the as-built single-master pipeline: each mastering job produces ONE
+# mastered clip, so "previews" are the completed mastered candidates for a source
+# clip (one per job), and approval *promotes* an existing mastered clip to
+# ``generation_mode="mastered"``.
+# ===========================================================================
+
+# The canonical metrics shape every backend normalises to (see test_mastering_tasks).
+_MASTER_METRICS = {
+    "loudness": -13.5,
+    "eq_bands": [float(i) for i in range(16)],
+    "stereo": {"width": 0.8, "balance": 0.0},
+}
+
+
+def _detail_url(job_id: str) -> str:
+    return f"{API_V1_PREFIX}/mastering/jobs/{job_id}"
+
+
+def _previews_url(job_id: str) -> str:
+    return f"{API_V1_PREFIX}/mastering/jobs/{job_id}/previews"
+
+
+def _approve_url(job_id: str) -> str:
+    return f"{API_V1_PREFIX}/mastering/jobs/{job_id}/approve"
+
+
+def _wav_bytes(seconds: float = 1.0, sr: int = 22050) -> bytes:
+    """A short stereo tone, long enough for pyloudnorm's 400ms integration block."""
+    import numpy as np
+    import soundfile as sf
+
+    t = np.linspace(0, seconds, int(sr * seconds), endpoint=False)
+    tone = 0.2 * np.sin(2 * np.pi * 220 * t)
+    stereo = np.column_stack([tone, tone])
+    buf = io.BytesIO()
+    sf.write(buf, stereo, sr, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    """Point the storage backend at a throwaway local root for get_url()/loudness."""
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+    return tmp_path
+
+
+async def _insert_clip_doc(user, workspace_id, *, store_bytes=None, generation_mode=None, parents=None) -> Clip:
+    from acemusic.storage import get_storage_backend
+
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace_id}/clips/{clip_id}.wav"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace_id,
+        file_path=file_path,
+        format="wav",
+        duration=10.0,
+        parent_clip_ids=parents or [],
+        generation_mode=generation_mode,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _insert_mastering_job(
+    user,
+    *,
+    source_clip_id,
+    workspace_id,
+    status=JobStatus.COMPLETED,
+    profile="streaming",
+    service="dolby",
+    mastered_clip=None,
+    metrics=None,
+    job_type="mastering",
+) -> Job:
+    result = None
+    if status == JobStatus.COMPLETED:
+        result = {
+            "clip_ids": [str(mastered_clip.id)] if mastered_clip is not None else [],
+            "service": service,
+            "target_lufs": -14.0,
+            "metrics": metrics if metrics is not None else _MASTER_METRICS,
+        }
+    job = Job(
+        user_id=user.id,
+        workspace_id=workspace_id,
+        job_type=job_type,
+        status=status,
+        input_params={
+            "clip_id": source_clip_id,
+            "profile": profile,
+            "service": service,
+            "format": "wav",
+            "target_lufs": -14.0,
+        },
+        result=result,
+    )
+    await job.insert()
+    return job
+
+
+class TestPreviewAuthGate:
+    def test_get_detail_missing_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        assert client.get(_detail_url(str(PydanticObjectId()))).status_code == 401
+
+    def test_get_previews_missing_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        assert client.get(_previews_url(str(PydanticObjectId()))).status_code == 401
+
+    def test_approve_missing_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(_approve_url(str(PydanticObjectId())), json={"preview_id": str(PydanticObjectId())})
+        assert resp.status_code == 401
+
+
+@pytest.mark.integration
+class TestMasteringJobDetail:
+    async def test_unknown_job_returns_404(self, client, settings) -> None:
+        user = await _make_user("m124-detail-unknown@example.com")
+        resp = await client.get(_detail_url(str(PydanticObjectId())), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_job_returns_404(self, client, settings) -> None:
+        owner = await _make_user("m124-detail-owner@example.com")
+        other = await _make_user("m124-detail-other@example.com")
+        job = await _insert_mastering_job(
+            owner, source_clip_id=str(PydanticObjectId()), workspace_id=PydanticObjectId()
+        )
+        resp = await client.get(_detail_url(str(job.id)), headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+
+    async def test_non_mastering_job_returns_404(self, client, settings) -> None:
+        user = await _make_user("m124-detail-wrongtype@example.com")
+        job = await _insert_mastering_job(
+            user, source_clip_id=str(PydanticObjectId()), workspace_id=PydanticObjectId(), job_type="generate"
+        )
+        resp = await client.get(_detail_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_queued_job_is_minimal(self, client, settings) -> None:
+        user = await _make_user("m124-detail-queued@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws)
+        job = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, status=JobStatus.QUEUED)
+        resp = await client.get(_detail_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "queued"
+        assert body["source_clip_id"] == str(src.id)
+        assert body["profile"] == "streaming"
+        assert "metrics" not in body
+        assert "mastered_clip_id" not in body
+
+    async def test_completed_job_has_metrics_and_mastered_clip(self, client, settings) -> None:
+        user = await _make_user("m124-detail-done@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws)
+        mastered = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        job = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=mastered)
+        resp = await client.get(_detail_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "completed"
+        assert body["mastered_clip_id"] == str(mastered.id)
+        assert body["metrics"]["loudness"] == _MASTER_METRICS["loudness"]
+        assert body["service"] == "dolby"
+
+
+@pytest.mark.integration
+class TestMasteringPreviews:
+    async def test_unowned_job_returns_404(self, client, settings) -> None:
+        owner = await _make_user("m124-prev-owner@example.com")
+        other = await _make_user("m124-prev-other@example.com")
+        job = await _insert_mastering_job(
+            owner, source_clip_id=str(PydanticObjectId()), workspace_id=PydanticObjectId()
+        )
+        resp = await client.get(_previews_url(str(job.id)), headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+
+    async def test_returns_original_and_candidate_metrics(self, client, settings, local_storage) -> None:
+        user = await _make_user("m124-prev-ab@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws, store_bytes=_wav_bytes())
+        mastered = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        job = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=mastered)
+        resp = await client.get(_previews_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["original_audio_url"]
+        # Original-side metric is measured locally: integrated LUFS is a finite float.
+        assert isinstance(body["original_metrics"]["loudness"], float)
+        assert len(body["previews"]) == 1
+        preview = body["previews"][0]
+        assert preview["preview_id"] == str(mastered.id)
+        assert preview["audio_url"]
+        assert preview["metrics"]["loudness"] == _MASTER_METRICS["loudness"]
+
+    async def test_aggregates_multiple_candidates_for_one_source(self, client, settings, local_storage) -> None:
+        user = await _make_user("m124-prev-multi@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws, store_bytes=_wav_bytes())
+        m1 = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        m2 = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        await _insert_mastering_job(
+            user, source_clip_id=str(src.id), workspace_id=ws, profile="streaming", mastered_clip=m1
+        )
+        job2 = await _insert_mastering_job(
+            user, source_clip_id=str(src.id), workspace_id=ws, profile="club", mastered_clip=m2
+        )
+        resp = await client.get(_previews_url(str(job2.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        ids = {p["preview_id"] for p in resp.json()["previews"]}
+        assert ids == {str(m1.id), str(m2.id)}
+
+
+@pytest.mark.integration
+class TestMasteringApprove:
+    async def test_unowned_job_returns_404(self, client, settings) -> None:
+        owner = await _make_user("m124-appr-owner@example.com")
+        other = await _make_user("m124-appr-other@example.com")
+        job = await _insert_mastering_job(
+            owner, source_clip_id=str(PydanticObjectId()), workspace_id=PydanticObjectId()
+        )
+        resp = await client.post(
+            _approve_url(str(job.id)),
+            json={"preview_id": str(PydanticObjectId())},
+            headers=_auth_headers(other, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_invalid_preview_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("m124-appr-bad@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws)
+        mastered = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        job = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=mastered)
+        resp = await client.post(
+            _approve_url(str(job.id)),
+            json={"preview_id": str(PydanticObjectId())},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_approve_promotes_clip(self, client, settings, local_storage) -> None:
+        user = await _make_user("m124-appr-ok@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws)
+        mastered = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        job = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=mastered)
+        resp = await client.post(
+            _approve_url(str(job.id)),
+            json={"preview_id": str(mastered.id)},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["clip_id"] == str(mastered.id)
+        assert body["audio_url"]
+        # Promotion: the existing clip becomes the final master, lineage preserved.
+        refreshed = await Clip.get(mastered.id)
+        assert refreshed.generation_mode == "mastered"
+        assert refreshed.parent_clip_ids == [src.id]
+
+    async def test_approve_is_idempotent(self, client, settings, local_storage) -> None:
+        user = await _make_user("m124-appr-idem@example.com")
+        ws = PydanticObjectId()
+        src = await _insert_clip_doc(user, ws)
+        mastered = await _insert_clip_doc(user, ws, generation_mode="mastering", parents=[src.id])
+        job = await _insert_mastering_job(user, source_clip_id=str(src.id), workspace_id=ws, mastered_clip=mastered)
+        headers = _auth_headers(user, settings)
+        first = await client.post(_approve_url(str(job.id)), json={"preview_id": str(mastered.id)}, headers=headers)
+        second = await client.post(_approve_url(str(job.id)), json={"preview_id": str(mastered.id)}, headers=headers)
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert (await Clip.get(mastered.id)).generation_mode == "mastered"


### PR DESCRIPTION
## US-12.4: Mastering preview & A/B comparison

Closes #130.

Adds three owner-scoped mastering endpoints for auditioning mastered results, comparing them against the original, and approving a final master.

### Endpoints
- `GET /api/v1/mastering/jobs/{job_id}` — mastering job detail: status, source clip, profile, service, target LUFS, mastered clip id, and metrics (once complete).
- `GET /api/v1/mastering/jobs/{job_id}/previews` — A/B comparison set: original audio URL + on-demand integrated LUFS, plus the (up to 5 most recent) completed mastered candidates for the source clip, each with audio URL, backend metrics, and a `loudness_delta` (mastered − original dB) metrics diff.
- `POST /api/v1/mastering/jobs/{job_id}/approve` `{preview_id}` — promotes a candidate to the final master (`generation_mode="mastered"`); returns `{clip_id, audio_url}`. Idempotent and **exclusive** — promoting a different candidate demotes the prior master, so a source has exactly one final master.

### Design notes (plan deviated from the issue/CodeRabbit plan — built against the as-built pipeline)
The issue assumed US-12.2 emits multiple un-committed preview variants. The **merged** US-12.1/12.2 pipeline produces **one master per job** and the worker **already** creates+links the mastered clip (`parent_clip_ids=[source]`, `generation_mode="mastering"`, `result={clip_ids, service, target_lufs, metrics:{loudness, eq_bands, stereo}}`). So this PR adapts:

- **"Previews" = the completed mastered candidates for a source clip** (one per job). The previews endpoint aggregates them for side-by-side comparison.
- **Approve promotes the existing clip** to `generation_mode="mastered"` rather than copying to a new clip (no redundant storage; lineage preserved).
- **Original-side metric is integrated LUFS**, measured on demand via `pyloudnorm` (reused from US-5.5).
- No fictional `MasteringResult.previews[]` contract or new `api/models/mastering.py` — response models are inline per the live router convention.

### Acceptance criteria
- [x] Multiple previews accessible after mastering completes → previews endpoint aggregates candidates.
- [x] Approving a preview yields a clip with mastered metadata → promoted to `generation_mode="mastered"`.
- [x] Mastered clip linked to original via `parent_clip_ids` → set by worker; preserved through approval (tested).
- [x] Metrics (LUFS, EQ) available for original and mastered → mastered from `job.result.metrics`; original LUFS measured locally.
- [x] Rejecting all previews allows resubmission → existing `POST /mastering/jobs` (no new code).

### Tests
`tests/test_mastering_api.py` extended: 3 auth-gate (CI, no DB) + 12 integration (ownership 404s, queued/completed detail shapes, original-vs-candidate metrics, multi-candidate aggregation, approval promotes + preserves lineage, idempotent re-approve).

### Reviewed
Internal (Claude) advisory review + cross-family review via `codex review` (CodeRabbit was rate-limited this run). Codex's findings were triaged against the user-approved scope: the metrics-diff and "up to 5" gaps were fixed (loudness diff + bounded previews), and approval was made exclusive to resolve the "multiple final masters" concern. Codex's "create a new clip on approval" and "fold previews into the job-detail endpoint" were declined as deliberate, approved design choices (promote-not-copy; two-endpoint shape).

### Known limitations
- Original-side metrics are **LUFS only** (so the diff is `loudness_delta`). There is no local EQ/stereo analyzer, and a spectral profile of the unmastered source is not semantically comparable to the mastering engine's applied EQ curve, so per-band EQ/stereo diffs for the original are intentionally not produced.
- The job-detail endpoint returns a single job; the candidate collection lives in the dedicated `/previews` endpoint (deliberate two-endpoint shape, deviating from the issue's literal "GET /jobs/{id} returns previews").
- Original loudness is measured per `GET /previews` request (download + decode + pyloudnorm). Cache if it becomes hot.
