### PR TITLE
feat(runpod): remote audio delivery via S3 presigned URLs (US-11.x)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,9 +27,10 @@ RUN git clone https://github.com/frankbria/ACE-Step-1.5.git /app/ACE-Step-1.5
 WORKDIR /app/ACE-Step-1.5
 RUN uv venv && uv sync
 
-# Serverless extras: the RunPod SDK plus httpx for the handler's API proxy (httpx is
-# the HTTP client used throughout the platform; the handler reuses it here).
-RUN pip install --no-cache-dir runpod httpx
+# Serverless extras: the RunPod SDK, httpx for the handler's API proxy (httpx is the
+# HTTP client used throughout the platform), and boto3 so the handler can upload
+# generated clips to S3 and return presigned URLs the platform can fetch (US-11.x).
+RUN pip install --no-cache-dir runpod httpx boto3
 
 # Serverless handler (bridges RunPod events to the local ACE-Step API).
 COPY handler.py /app/handler.py

--- a/docker/handler.py
+++ b/docker/handler.py
@@ -29,22 +29,38 @@ Run modes:
   worker loop. ``runpod`` is imported lazily there so this module stays importable
   for unit tests without the runpod SDK installed and never starts a server on import.
 
-Known limitation: the audio URLs returned here point at the worker-local ACE-Step
-server (``http://localhost:8001/v1/audio?...``). Delivering generated audio across
-the internet (S3 upload / presigned URLs) is follow-up infrastructure tracked
-separately; the platform's extractor already tolerates the URL shape emitted here.
+Remote audio delivery (US-11.x): ACE-Step writes clips to the worker-local server
+(``http://localhost:8001/v1/audio?...``), which a remote platform host cannot reach.
+When S3 is configured (``ACEMUSIC_S3_BUCKET`` plus the ``ACEMUSIC_S3_*`` settings the
+platform already uses), the handler downloads each clip on-worker and re-uploads it to
+S3, returning presigned GET URLs the platform can fetch. With no bucket configured it
+returns the worker-local URLs unchanged (local / single-host use, where ``localhost``
+is reachable).
 """
 
 from __future__ import annotations
 
 import json
+import mimetypes
 import os
 import subprocess
 import time
+import urllib.parse
 
 import httpx
 
+try:  # boto3 ships in the worker image; optional so this module imports without it.
+    import boto3
+except ImportError:  # pragma: no cover - exercised only where boto3 is absent
+    boto3 = None
+
 API_BASE_URL = "http://localhost:8001"
+
+# Parsed (scheme, host, port) of the worker-local server. The ACE-Step token is sent
+# only to this exact origin — compared on parsed parts, not a string prefix, so a
+# userinfo-spoofed URL whose real host differs (e.g. ``http://localhost@evil.example/``,
+# which httpx connects to ``evil.example``) cannot slip through and leak the credential.
+_LOCAL_ORIGIN = urllib.parse.urlsplit(API_BASE_URL)
 
 # The ACE-Step project (code + uv venv) is installed in the image at build time. The
 # API server runs from here so ``uv run`` resolves the project's pyproject.toml + venv.
@@ -159,7 +175,8 @@ def _poll_until_complete(task_id: str) -> dict:
         status = _STATUS_MAP.get(raw_status, "pending") if isinstance(raw_status, int) else raw_status
 
         if status == "completed":
-            return {"status": "completed", "audio_urls": _extract_audio_urls(item)}
+            urls = _deliver_audio(_extract_audio_urls(item), task_id)
+            return {"status": "completed", "audio_urls": urls}
         if status == "failed":
             return _failure(item.get("error") or "ACE-Step generation failed")
         if time.monotonic() >= deadline:
@@ -185,6 +202,106 @@ def _extract_audio_urls(item: dict) -> list[str]:
             continue
         urls.append(f"{API_BASE_URL}{file}" if file.startswith("/") else file)
     return urls
+
+
+def _deliver_audio(urls: list[str], task_id: str) -> list[str]:
+    """Make worker-local clips reachable by the platform.
+
+    With ``ACEMUSIC_S3_BUCKET`` set, each clip is downloaded from the worker-local
+    ACE-Step server and re-uploaded to S3, and a presigned GET URL is returned in its
+    place. Without a bucket the worker-local URLs are returned unchanged (local /
+    single-host use, where ``localhost`` is reachable). Raises :class:`HandlerError` if
+    delivery is configured but fails, so the job surfaces a clean failure rather than
+    handing the platform URLs it cannot fetch.
+    """
+    bucket = os.getenv("ACEMUSIC_S3_BUCKET")
+    if not bucket:
+        # Worker-local URLs only reach the platform when it shares the host (local / pod
+        # use). On a RunPod serverless worker the platform is always remote, so missing
+        # storage is a misconfiguration — fail loudly rather than return dead URLs the
+        # client will silently discard.
+        if os.getenv("RUNPOD_ENDPOINT_ID"):
+            raise HandlerError("Serverless audio delivery requires ACEMUSIC_S3_BUCKET to be set")
+        return urls
+    if boto3 is None:
+        raise HandlerError("ACEMUSIC_S3_BUCKET is set but boto3 is not installed")
+
+    prefix = (os.getenv("ACEMUSIC_S3_PREFIX") or "").strip("/")
+    expiry = _s3_url_expiry()
+    try:
+        client = boto3.client(
+            "s3",
+            region_name=os.getenv("ACEMUSIC_S3_REGION") or None,
+            endpoint_url=os.getenv("ACEMUSIC_S3_ENDPOINT_URL") or None,
+        )
+        delivered: list[str] = []
+        for index, url in enumerate(urls):
+            ext = _audio_ext(url)
+            key = "/".join(part for part in (prefix, "runpod", task_id, f"{index}{ext}") if part)
+            # ponytail: the staging object under runpod/<task_id> is left for a bucket
+            # lifecycle policy to expire; the platform stores its own canonical copy on
+            # download, so in-handler deletion would need cross-component coordination.
+            client.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=_download_clip(url),
+                ContentType=_content_type(ext),
+            )
+            delivered.append(
+                client.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=expiry)
+            )
+        return delivered
+    except Exception as exc:  # noqa: BLE001 - any download/upload failure means undeliverable audio
+        raise HandlerError(f"Failed to deliver audio to S3: {exc}") from exc
+
+
+def _download_clip(url: str) -> bytes:
+    """Fetch raw clip bytes from the worker-local ACE-Step server.
+
+    Mirrors :class:`acemusic.client.AceStepClient`: sends the ACE-Step bearer token when
+    ``ACESTEP_API_KEY`` is set. The token is attached *only* for the worker-local server
+    (``API_BASE_URL``) — ACE-Step may return absolute third-party URLs, and the
+    credential must never be disclosed to an external result host.
+    """
+    api_key = os.getenv("ACESTEP_API_KEY")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key and _is_worker_local(url) else {}
+    response = httpx.get(url, headers=headers, timeout=120.0, follow_redirects=True)
+    response.raise_for_status()
+    return response.content
+
+
+def _is_worker_local(url: str) -> bool:
+    """True only if ``url``'s parsed origin matches the worker-local ACE-Step server."""
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except ValueError:
+        return False
+    return (parts.scheme, parts.hostname, parts.port) == (
+        _LOCAL_ORIGIN.scheme,
+        _LOCAL_ORIGIN.hostname,
+        _LOCAL_ORIGIN.port,
+    )
+
+
+def _audio_ext(url: str) -> str:
+    """Best-effort audio file extension from a clip URL (its ``path`` query, else path)."""
+    parsed = urllib.parse.urlparse(url)
+    candidate = urllib.parse.parse_qs(parsed.query).get("path", [""])[0] or parsed.path
+    return os.path.splitext(candidate)[1] or ".wav"
+
+
+def _content_type(ext: str) -> str:
+    """MIME type for an audio extension, defaulting to a generic binary type."""
+    return mimetypes.guess_type(f"clip{ext}")[0] or "application/octet-stream"
+
+
+def _s3_url_expiry() -> int:
+    """Presigned-URL lifetime in seconds (``ACEMUSIC_S3_URL_EXPIRY``, default 3600)."""
+    try:
+        expiry = int(os.getenv("ACEMUSIC_S3_URL_EXPIRY", "3600"))
+    except ValueError:
+        return 3600
+    return expiry if expiry > 0 else 3600
 
 
 def _failure(message: str) -> dict:

--- a/docker/handler.py
+++ b/docker/handler.py
@@ -35,12 +35,15 @@ When S3 is configured (``ACEMUSIC_S3_BUCKET`` plus the ``ACEMUSIC_S3_*`` setting
 platform already uses), the handler downloads each clip on-worker and re-uploads it to
 S3, returning presigned GET URLs the platform can fetch. With no bucket configured it
 returns the worker-local URLs unchanged (local / single-host use, where ``localhost``
-is reachable).
+is reachable). Credentials come from boto3's standard chain (``AWS_ACCESS_KEY_ID`` /
+``AWS_SECRET_ACCESS_KEY`` / instance role) — set those in the RunPod template alongside
+the ``ACEMUSIC_S3_*`` vars.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import mimetypes
 import os
 import subprocess
@@ -53,6 +56,8 @@ try:  # boto3 ships in the worker image; optional so this module imports without
     import boto3
 except ImportError:  # pragma: no cover - exercised only where boto3 is absent
     boto3 = None
+
+logger = logging.getLogger(__name__)
 
 API_BASE_URL = "http://localhost:8001"
 
@@ -297,11 +302,16 @@ def _content_type(ext: str) -> str:
 
 def _s3_url_expiry() -> int:
     """Presigned-URL lifetime in seconds (``ACEMUSIC_S3_URL_EXPIRY``, default 3600)."""
+    raw = os.getenv("ACEMUSIC_S3_URL_EXPIRY", "3600")
     try:
-        expiry = int(os.getenv("ACEMUSIC_S3_URL_EXPIRY", "3600"))
+        expiry = int(raw)
     except ValueError:
+        logger.warning("Invalid ACEMUSIC_S3_URL_EXPIRY %r; defaulting to 3600s", raw)
         return 3600
-    return expiry if expiry > 0 else 3600
+    if expiry <= 0:
+        logger.warning("Non-positive ACEMUSIC_S3_URL_EXPIRY %r; defaulting to 3600s", raw)
+        return 3600
+    return expiry
 
 
 def _failure(message: str) -> dict:

--- a/docs/demos/us-11.x-runpod-s3-delivery.py
+++ b/docs/demos/us-11.x-runpod-s3-delivery.py
@@ -1,0 +1,167 @@
+"""Demo driver for US-11.x remote audio delivery (issue #150).
+
+Exercises the *real* handler and platform-client logic. Only the genuinely external
+pieces are simulated, because no GPU / RunPod / S3 credentials are available here:
+  - S3 is a real in-memory store (records the bytes actually uploaded, mints a
+    presigned-style URL) so we can show clip bytes moving OFF the worker.
+  - The ACE-Step HTTP server and clip bytes are stubbed.
+The download -> upload -> presign logic, the localhost filtering, the serverless guard,
+and the token-scoping are all the shipped code, run unmodified.
+
+Run a single scenario:  python docs/demos/us-11.x-runpod-s3-delivery.py <scenario>
+where <scenario> in {deliver, filter, serverless, token}.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from acemusic.runpod_client import _extract_audio_urls
+
+_HANDLER_PATH = Path(__file__).resolve().parents[2] / "docker" / "handler.py"
+
+
+def _load_handler():
+    spec = importlib.util.spec_from_file_location("acestep_handler", _HANDLER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class InMemoryS3:
+    """A minimal stand-in for an S3 client backed by a real dict, so the demo can show
+    the exact bytes that landed in the bucket and the URL handed back."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType):
+        self.store[f"{Bucket}/{Key}"] = Body
+
+    def generate_presigned_url(self, op, *, Params, ExpiresIn):
+        # Illustrative placeholder, not a real AWS presigned URL (no signature params).
+        return f"https://{Params['Bucket']}.s3.example.test/{Params['Key']}?demo-presigned&expires={ExpiresIn}"
+
+
+def _http_resp(json_data=None, content=b""):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = json_data or {}
+    resp.content = content
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+_TWO_CLIPS = '[{"file": "/v1/audio?path=track-a.wav"}, {"file": "/v1/audio?path=track-b.wav"}]'
+
+
+def _run_handler(handler_mod, s3_client, clip_bytes=b"FAKE_WAV_AUDIO", result=_TWO_CLIPS):
+    """Run the real handler end-to-end with ACE-Step + S3 simulated."""
+    boto3_mod = MagicMock()
+    boto3_mod.client.return_value = s3_client
+    post = MagicMock(
+        side_effect=[
+            _http_resp({"data": {"task_id": "job-42"}, "code": 200}),
+            _http_resp({"data": [{"status": 1, "result": result, "error": None}], "code": 200}),
+        ]
+    )
+    get = MagicMock(return_value=_http_resp(content=clip_bytes))
+    with (
+        patch.object(handler_mod, "boto3", boto3_mod),
+        patch.object(handler_mod, "start_api_server", return_value=True),
+        patch.object(handler_mod.httpx, "post", post),
+        patch.object(handler_mod.httpx, "get", get),
+        patch.object(handler_mod.time, "sleep"),
+    ):
+        out = handler_mod.handler({"input": {"prompt": "warm analog synthwave, 30s"}})
+    return out, get
+
+
+def scenario_deliver():
+    """AC1: a remote generation returns audio the platform can actually download."""
+    handler_mod = _load_handler()
+    s3 = InMemoryS3()
+    with patch.dict("os.environ", {"ACEMUSIC_S3_BUCKET": "ace-clips", "ACEMUSIC_S3_PREFIX": "renders"}):
+        out, _ = _run_handler(handler_mod, s3)
+
+    print("Handler output status :", out["status"])
+    print("audio_urls returned to the platform:")
+    for url in out["audio_urls"]:
+        print("  -", url)
+    print()
+    print("Bytes actually uploaded into S3 (key -> size):")
+    for key, body in s3.store.items():
+        print(f"  - {key}  ({len(body)} bytes)")
+    print()
+    localhost_leaks = [u for u in out["audio_urls"] if "localhost" in u]
+    print("OUTCOME: clip bytes moved off the worker into S3, presigned URLs returned.")
+    print("         worker-local URLs escaping to platform:", len(localhost_leaks))
+
+
+def scenario_filter():
+    """AC2: no worker-local URLs escape — the platform client drops them."""
+    payload = {
+        "audio_urls": [
+            "http://localhost:8001/v1/audio?path=track-a.wav",
+            "http://127.0.0.1:8001/v1/audio?path=track-b.wav",
+            "https://ace-clips.s3.example.test/renders/runpod/job-42/0.wav?demo-presigned",
+        ]
+    }
+    print("Raw output a stale worker might emit:")
+    for url in payload["audio_urls"]:
+        print("  -", url)
+    print()
+    reachable = _extract_audio_urls(payload)
+    print("After _extract_audio_urls (platform side):")
+    for url in reachable:
+        print("  -", url)
+    print()
+    print("OUTCOME: 2 worker-local URLs dropped, only the platform-reachable S3 URL survives.")
+
+
+def scenario_serverless():
+    """A serverless worker with no bucket fails loudly instead of returning dead URLs."""
+    handler_mod = _load_handler()
+    with patch.dict("os.environ", {"RUNPOD_ENDPOINT_ID": "ep-abc"}, clear=False):
+        import os
+
+        os.environ.pop("ACEMUSIC_S3_BUCKET", None)
+        out, _ = _run_handler(handler_mod, InMemoryS3())
+    print("Serverless worker (RUNPOD_ENDPOINT_ID set), ACEMUSIC_S3_BUCKET unset:")
+    print("  status :", out["status"])
+    print("  error  :", out["error"])
+    print("  audio_urls:", out["audio_urls"])
+    print()
+    print("OUTCOME: misconfiguration surfaces as a clean failure, not a silent 'no audio'.")
+
+
+def scenario_token():
+    """The ACE-Step token is never sent to an external/spoofed result host."""
+    handler_mod = _load_handler()
+    spoof = "http://localhost@attacker.example/x.wav"
+    with patch.dict("os.environ", {"ACEMUSIC_S3_BUCKET": "ace-clips", "ACESTEP_API_KEY": "demo-token"}):
+        out, get = _run_handler(handler_mod, InMemoryS3(), result=f'[{{"file": "{spoof}"}}]')
+    fetched_url = get.call_args.args[0]
+    sent_headers = get.call_args.kwargs["headers"]
+    print("ACE-Step returned an absolute, userinfo-spoofed URL:")
+    print("  ", fetched_url)
+    print("  (httpx would connect to host: attacker.example, NOT the worker)")
+    print()
+    print("Headers the handler attached to that download:", sent_headers)
+    print()
+    leaked = "Authorization" in sent_headers
+    print("OUTCOME: ACESTEP_API_KEY leaked to external host:", leaked)
+
+
+if __name__ == "__main__":
+    {
+        "deliver": scenario_deliver,
+        "filter": scenario_filter,
+        "serverless": scenario_serverless,
+        "token": scenario_token,
+    }[sys.argv[1]]()

--- a/docs/demos/us-11.x-runpod-s3.md
+++ b/docs/demos/us-11.x-runpod-s3.md
@@ -1,0 +1,93 @@
+# US-11.x — Remote audio delivery for RunPod serverless (issue #150)
+
+*2026-06-20T19:06:47Z*
+
+Issue #150: a completed *remote* RunPod job used to return worker-local URLs (`http://localhost:8001/v1/audio?...`) that the platform cannot reach, so clip storage failed. This demo exercises the shipped handler + platform-client logic. Only the truly external pieces are simulated (no GPU / RunPod / S3 creds here): S3 is a real in-memory store so we can see the bytes that actually leave the worker; the ACE-Step HTTP server is stubbed. The download→upload→presign, localhost-filtering, serverless-guard, and token-scoping code all run unmodified. (Presigned URLs shown use an illustrative `s3.example.test` placeholder.)
+
+AC1 — A remote generation returns audio the platform can actually download & store. With ACEMUSIC_S3_BUCKET configured, the handler downloads each ACE-Step clip on-worker and re-uploads it to S3, returning presigned GET URLs. Watch both the URLs returned AND the bytes that land in the bucket.
+
+```bash
+uv run python docs/demos/us-11.x-runpod-s3-delivery.py deliver
+```
+
+```output
+Handler output status : completed
+audio_urls returned to the platform:
+  - https://ace-clips.s3.example.test/renders/runpod/job-42/0.wav?demo-presigned&expires=3600
+  - https://ace-clips.s3.example.test/renders/runpod/job-42/1.wav?demo-presigned&expires=3600
+
+Bytes actually uploaded into S3 (key -> size):
+  - ace-clips/renders/runpod/job-42/0.wav  (14 bytes)
+  - ace-clips/renders/runpod/job-42/1.wav  (14 bytes)
+
+OUTCOME: clip bytes moved off the worker into S3, presigned URLs returned.
+         worker-local URLs escaping to platform: 0
+```
+
+The two clips left the worker as raw bytes and now live in S3 under `renders/runpod/job-42/<i>.wav`; the platform receives presigned URLs and **zero** localhost URLs. Criterion met.
+
+AC2 — No worker-local URLs escape to the platform. As a safety net for stale worker images, the platform client `_extract_audio_urls` drops any localhost / 127.0.0.1 / [::1] URL (logging a warning) before the processor ever tries to download it.
+
+```bash
+uv run python docs/demos/us-11.x-runpod-s3-delivery.py filter
+```
+
+```output
+Dropped 2 worker-local audio URL(s) the platform cannot reach; the worker should upload clips to S3 (US-11.x)
+Raw output a stale worker might emit:
+  - http://localhost:8001/v1/audio?path=track-a.wav
+  - http://127.0.0.1:8001/v1/audio?path=track-b.wav
+  - https://ace-clips.s3.example.test/renders/runpod/job-42/0.wav?demo-presigned
+
+After _extract_audio_urls (platform side):
+  - https://ace-clips.s3.example.test/renders/runpod/job-42/0.wav?demo-presigned
+
+OUTCOME: 2 worker-local URLs dropped, only the platform-reachable S3 URL survives.
+```
+
+Both worker-local URLs are dropped (note the warning); only the platform-reachable S3 URL survives. Criterion met from both sides.
+
+Hardening 1 — Fail loudly on a misconfigured serverless worker (RUNPOD_ENDPOINT_ID set, no bucket) instead of returning silently-useless localhost URLs.
+
+```bash
+uv run python docs/demos/us-11.x-runpod-s3-delivery.py serverless
+```
+
+```output
+Serverless worker (RUNPOD_ENDPOINT_ID set), ACEMUSIC_S3_BUCKET unset:
+  status : failed
+  error  : Serverless audio delivery requires ACEMUSIC_S3_BUCKET to be set
+  audio_urls: []
+
+OUTCOME: misconfiguration surfaces as a clean failure, not a silent 'no audio'.
+```
+
+Hardening 2 — Never leak the ACE-Step token. ACE-Step can return an absolute URL whose userinfo spoofs the trusted host; the handler compares the *parsed* origin, so the bearer token is withheld from the real (attacker-controlled) host.
+
+```bash
+uv run python docs/demos/us-11.x-runpod-s3-delivery.py token
+```
+
+```output
+ACE-Step returned an absolute, userinfo-spoofed URL:
+   http://localhost@attacker.example/x.wav
+  (httpx would connect to host: attacker.example, NOT the worker)
+
+Headers the handler attached to that download: {}
+
+OUTCOME: ACESTEP_API_KEY leaked to external host: False
+```
+
+Finally, the automated coverage backing all of the above.
+
+```bash
+uv run pytest tests/test_docker_handler.py tests/test_runpod_client.py -q -p no:cacheprovider 2>&1 | tail -3
+```
+
+```output
+-----------------------------------------------------------------------------
+TOTAL                                            8206   8091     1%
+65 passed in 0.94s
+```
+
+All three acceptance criteria are demonstrated with observable outcomes (bytes in S3, URLs dropped, clean failure, token withheld) and locked in by passing unit tests. **Known limitation:** S3 credentials are provisioned out-of-band (ops config) and staging objects rely on a bucket lifecycle policy for cleanup — see PR #168.

--- a/src/acemusic/runpod_client.py
+++ b/src/acemusic/runpod_client.py
@@ -20,11 +20,21 @@ backoff so the processor stays unaware of retry mechanics. 4xx errors fail fast.
 
 from __future__ import annotations
 
+import logging
 import random
 import time
+import urllib.parse
 from typing import Any, Callable
 
 import httpx
+
+logger = logging.getLogger(__name__)
+
+# Hosts that resolve on the worker (or the platform host) rather than across the
+# network. A correctly-configured worker (US-11.x) uploads clips to S3 and never emits
+# these, but a stale worker image might — so they are dropped here as a safety net so
+# the platform never tries to fetch audio it cannot reach.
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 # Retry policy for transient (5xx) responses. ``_MAX_RETRIES`` retries follow the
 # initial attempt, so a persistently-failing endpoint is hit up to 4 times. Delays
@@ -235,12 +245,18 @@ class RunPodClient:
 
 
 def _extract_audio_urls(output: Any) -> list[str]:
-    """Pull audio URLs out of a RunPod ``output`` payload.
+    """Pull reachable audio URLs out of a RunPod ``output`` payload.
 
-    The worker (US-11.3) is not built yet, so this accepts the shapes it is most
-    likely to emit: a bare list of URLs, a list of ``{"url"|"file"|"audio_url": ...}``
-    objects, or a dict carrying any of those under ``audio_urls``/``clips``/``outputs``.
+    Accepts the shapes the worker (US-11.3) may emit: a bare list of URLs, a list of
+    ``{"url"|"file"|"audio_url": ...}`` objects, or a dict carrying any of those under
+    ``audio_urls``/``clips``/``outputs``. Worker-local URLs (``localhost`` etc.) are
+    dropped as a safety net (see :data:`_LOCAL_HOSTS`).
     """
+    return _drop_unreachable(_collect_audio_urls(output))
+
+
+def _collect_audio_urls(output: Any) -> list[str]:
+    """Pull every audio URL out of a RunPod ``output`` payload, reachable or not."""
     if not output:
         return []
     if isinstance(output, dict):
@@ -255,6 +271,28 @@ def _extract_audio_urls(output: Any) -> list[str]:
     if isinstance(output, list):
         return _urls_from_list(output)
     return []
+
+
+def _drop_unreachable(urls: list[str]) -> list[str]:
+    """Filter out worker-local URLs the platform cannot reach, logging any drops."""
+    reachable = [url for url in urls if not _is_localhost_url(url)]
+    dropped = len(urls) - len(reachable)
+    if dropped:
+        logger.warning(
+            "Dropped %d worker-local audio URL(s) the platform cannot reach; "
+            "the worker should upload clips to S3 (US-11.x)",
+            dropped,
+        )
+    return reachable
+
+
+def _is_localhost_url(url: str) -> bool:
+    """True if ``url``'s host is a loopback/worker-local address."""
+    try:
+        host = urllib.parse.urlparse(url).hostname
+    except ValueError:
+        return False
+    return host in _LOCAL_HOSTS
 
 
 def _urls_from_list(items: list) -> list[str]:

--- a/tests/test_docker_handler.py
+++ b/tests/test_docker_handler.py
@@ -335,6 +335,15 @@ class TestS3Delivery:
         assert port_spoof.startswith(handler_mod.API_BASE_URL)  # the trap a prefix check falls into
         assert handler_mod._is_worker_local(port_spoof) is False
 
+    @pytest.mark.parametrize("value", ["not-an-int", "0", "-5"])
+    def test_invalid_url_expiry_falls_back_to_default(self, handler_mod, monkeypatch, value):
+        monkeypatch.setenv("ACEMUSIC_S3_URL_EXPIRY", value)
+        assert handler_mod._s3_url_expiry() == 3600
+
+    def test_valid_url_expiry_is_used(self, handler_mod, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_S3_URL_EXPIRY", "900")
+        assert handler_mod._s3_url_expiry() == 900
+
     def test_uploads_clips_to_s3_and_returns_presigned_urls(self, handler_mod, monkeypatch):
         monkeypatch.setenv("ACEMUSIC_S3_BUCKET", "clips-bucket")
         monkeypatch.delenv("ACEMUSIC_S3_PREFIX", raising=False)

--- a/tests/test_docker_handler.py
+++ b/tests/test_docker_handler.py
@@ -61,6 +61,25 @@ def _query(status: int, *, result: str = "[]", error=None) -> MagicMock:
 
 
 _RESULT_TWO_CLIPS = '[{"file": "/v1/audio?path=a.wav"}, {"file": "/v1/audio?path=b.wav"}]'
+_RESULT_ONE_CLIP = '[{"file": "/v1/audio?path=a.wav"}]'
+
+
+def _audio_resp(body: bytes) -> MagicMock:
+    """A /v1/audio download response carrying raw clip bytes."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.content = body
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _mock_boto3():
+    """A stand-in boto3 whose S3 client records uploads and mints predictable URLs."""
+    client = MagicMock()
+    client.generate_presigned_url.side_effect = lambda op, Params, ExpiresIn: f"https://s3.test/{Params['Key']}?sig"
+    module = MagicMock()
+    module.client.return_value = client
+    return module, client
 
 
 class TestStartApiServer:
@@ -231,6 +250,188 @@ class TestAudioUrlExtraction:
     def test_absolute_url_passed_through(self, handler_mod):
         item = {"result": '[{"file": "https://cdn.test/x.wav"}]'}
         assert handler_mod._extract_audio_urls(item) == ["https://cdn.test/x.wav"]
+
+
+class TestS3Delivery:
+    """US-11.x: when S3 is configured the handler re-hosts clips and returns presigned URLs."""
+
+    def test_no_bucket_returns_worker_local_urls(self, handler_mod, monkeypatch):
+        # Local / pod use (not a serverless worker): localhost is reachable, so the
+        # worker-local URLs pass through unchanged.
+        monkeypatch.delenv("ACEMUSIC_S3_BUCKET", raising=False)
+        monkeypatch.delenv("RUNPOD_ENDPOINT_ID", raising=False)
+        post = MagicMock(side_effect=[_release("t"), _query(1, result=_RESULT_TWO_CLIPS)])
+        with (
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            out = handler_mod.handler({"input": {}})
+        assert out["audio_urls"] == [
+            "http://localhost:8001/v1/audio?path=a.wav",
+            "http://localhost:8001/v1/audio?path=b.wav",
+        ]
+
+    def test_serverless_without_bucket_fails_loudly(self, handler_mod, monkeypatch):
+        # On a real serverless worker the platform is remote; missing storage is a
+        # misconfiguration, not a silent fall-back to unreachable localhost URLs.
+        monkeypatch.delenv("ACEMUSIC_S3_BUCKET", raising=False)
+        monkeypatch.setenv("RUNPOD_ENDPOINT_ID", "ep-123")
+        post = MagicMock(side_effect=[_release("t"), _query(1, result=_RESULT_ONE_CLIP)])
+        with (
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            out = handler_mod.handler({"input": {}})
+        assert out["status"] == "failed"
+        assert "ACEMUSIC_S3_BUCKET" in out["error"]
+        assert out["audio_urls"] == []
+
+    def test_token_not_sent_to_external_result_host(self, handler_mod, monkeypatch):
+        # ACE-Step can return an absolute third-party URL; the ACE-Step token must not
+        # be disclosed to it (only the worker-local server gets the bearer header).
+        monkeypatch.setenv("ACEMUSIC_S3_BUCKET", "b")
+        monkeypatch.setenv("ACESTEP_API_KEY", "secret")
+        boto3_mod, _ = _mock_boto3()
+        post = MagicMock(side_effect=[_release("job"), _query(1, result='[{"file": "https://cdn.test/x.wav"}]')])
+        get = MagicMock(return_value=_audio_resp(b"x"))
+        with (
+            patch.object(handler_mod, "boto3", boto3_mod),
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.httpx, "get", get),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            handler_mod.handler({"input": {}})
+        assert get.call_args.args[0] == "https://cdn.test/x.wav"
+        assert get.call_args.kwargs["headers"] == {}
+
+    def test_token_not_leaked_via_userinfo_spoofed_host(self, handler_mod, monkeypatch):
+        # A userinfo-spoofed URL parses to an attacker-controlled host, so the parsed
+        # origin (not a string prefix) decides whether the token is attached.
+        monkeypatch.setenv("ACEMUSIC_S3_BUCKET", "b")
+        monkeypatch.setenv("ACESTEP_API_KEY", "secret")
+        boto3_mod, _ = _mock_boto3()
+        spoof = "http://localhost@attacker.example/x.wav"
+        post = MagicMock(side_effect=[_release("job"), _query(1, result=f'[{{"file": "{spoof}"}}]')])
+        get = MagicMock(return_value=_audio_resp(b"x"))
+        with (
+            patch.object(handler_mod, "boto3", boto3_mod),
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.httpx, "get", get),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            handler_mod.handler({"input": {}})
+        assert get.call_args.args[0] == spoof
+        assert get.call_args.kwargs["headers"] == {}
+
+    def test_origin_check_rejects_port_prefixed_spoof(self, handler_mod):
+        # Regression for the codex finding: a string-prefix check would accept a URL of
+        # the form <local-base>@otherhost (it starts with the base) yet httpx connects to
+        # otherhost. Built from parts so no literal credential string is committed.
+        port_spoof = handler_mod.API_BASE_URL + "@attacker.example/x.wav"
+        assert port_spoof.startswith(handler_mod.API_BASE_URL)  # the trap a prefix check falls into
+        assert handler_mod._is_worker_local(port_spoof) is False
+
+    def test_uploads_clips_to_s3_and_returns_presigned_urls(self, handler_mod, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_S3_BUCKET", "clips-bucket")
+        monkeypatch.delenv("ACEMUSIC_S3_PREFIX", raising=False)
+        monkeypatch.delenv("ACESTEP_API_KEY", raising=False)
+        boto3_mod, client = _mock_boto3()
+        post = MagicMock(side_effect=[_release("job7"), _query(1, result=_RESULT_TWO_CLIPS)])
+        get = MagicMock(return_value=_audio_resp(b"RIFFdata"))
+        with (
+            patch.object(handler_mod, "boto3", boto3_mod),
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.httpx, "get", get),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            out = handler_mod.handler({"input": {"prompt": "x"}})
+        assert out["status"] == "completed"
+        # Presigned S3 URLs replace the unreachable worker-local URLs.
+        assert out["audio_urls"] == [
+            "https://s3.test/runpod/job7/0.wav?sig",
+            "https://s3.test/runpod/job7/1.wav?sig",
+        ]
+        # Each clip was fetched from the worker-local ACE-Step server...
+        assert [c.args[0] for c in get.call_args_list] == [
+            "http://localhost:8001/v1/audio?path=a.wav",
+            "http://localhost:8001/v1/audio?path=b.wav",
+        ]
+        # ...then uploaded under runpod/<task_id>/<i><ext> with bytes + audio content type.
+        first = client.put_object.call_args_list[0].kwargs
+        assert [c.kwargs["Key"] for c in client.put_object.call_args_list] == [
+            "runpod/job7/0.wav",
+            "runpod/job7/1.wav",
+        ]
+        assert first["Bucket"] == "clips-bucket"
+        assert first["Body"] == b"RIFFdata"
+        assert first["ContentType"].startswith("audio/")
+
+    def test_prefix_prepended_to_s3_key(self, handler_mod, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_S3_BUCKET", "b")
+        monkeypatch.setenv("ACEMUSIC_S3_PREFIX", "audio/")
+        boto3_mod, client = _mock_boto3()
+        post = MagicMock(side_effect=[_release("job"), _query(1, result=_RESULT_ONE_CLIP)])
+        with (
+            patch.object(handler_mod, "boto3", boto3_mod),
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.httpx, "get", MagicMock(return_value=_audio_resp(b"x"))),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            handler_mod.handler({"input": {}})
+        assert client.put_object.call_args.kwargs["Key"] == "audio/runpod/job/0.wav"
+
+    def test_clip_download_sends_api_key(self, handler_mod, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_S3_BUCKET", "b")
+        monkeypatch.setenv("ACESTEP_API_KEY", "secret")
+        boto3_mod, _ = _mock_boto3()
+        post = MagicMock(side_effect=[_release("job"), _query(1, result=_RESULT_ONE_CLIP)])
+        get = MagicMock(return_value=_audio_resp(b"x"))
+        with (
+            patch.object(handler_mod, "boto3", boto3_mod),
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.httpx, "get", get),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            handler_mod.handler({"input": {}})
+        assert get.call_args.kwargs["headers"] == {"Authorization": "Bearer secret"}
+
+    def test_s3_upload_failure_returns_failed(self, handler_mod, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_S3_BUCKET", "b")
+        boto3_mod, client = _mock_boto3()
+        client.put_object.side_effect = RuntimeError("AccessDenied")
+        post = MagicMock(side_effect=[_release("job"), _query(1, result=_RESULT_ONE_CLIP)])
+        with (
+            patch.object(handler_mod, "boto3", boto3_mod),
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.httpx, "get", MagicMock(return_value=_audio_resp(b"x"))),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            out = handler_mod.handler({"input": {}})
+        assert out["status"] == "failed"
+        assert "deliver audio to s3" in out["error"].lower()
+        assert out["audio_urls"] == []
+
+    def test_bucket_set_but_boto3_missing_returns_failed(self, handler_mod, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_S3_BUCKET", "b")
+        post = MagicMock(side_effect=[_release("job"), _query(1, result=_RESULT_ONE_CLIP)])
+        with (
+            patch.object(handler_mod, "boto3", None),
+            patch.object(handler_mod, "start_api_server", return_value=True),
+            patch.object(handler_mod.httpx, "post", post),
+            patch.object(handler_mod.time, "sleep"),
+        ):
+            out = handler_mod.handler({"input": {}})
+        assert out["status"] == "failed"
+        assert "boto3" in out["error"].lower()
+        assert out["audio_urls"] == []
 
 
 class TestModuleContract:

--- a/tests/test_runpod_client.py
+++ b/tests/test_runpod_client.py
@@ -15,6 +15,7 @@ from acemusic.runpod_client import (
     RunPodClient,
     RunPodConnectionError,
     RunPodError,
+    _extract_audio_urls,
 )
 
 ENDPOINT = "ep-123"
@@ -232,6 +233,42 @@ class TestOutputExtraction:
         resp = _ok({"status": "CANCELLED", "error": "user cancelled"})
         with patch("acemusic.runpod_client.httpx.get", return_value=resp):
             assert _client().query_result("job-1")["status"] == "failed"
+
+
+class TestLocalhostFiltering:
+    """US-11.x: worker-local URLs must never escape to the platform."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:8001/v1/audio?path=a.wav",
+            "http://127.0.0.1:8001/v1/audio?path=a.wav",
+            "http://[::1]:8001/v1/audio?path=a.wav",
+        ],
+    )
+    def test_localhost_urls_are_dropped(self, url):
+        assert _extract_audio_urls({"audio_urls": [url]}) == []
+
+    def test_presigned_s3_url_passes_through_with_query_intact(self):
+        url = "https://bucket.s3.example.test/runpod/job/0.wav?sig=abc&expires=3600"
+        assert _extract_audio_urls({"audio_urls": [url]}) == [url]
+
+    def test_mixed_list_keeps_only_reachable_urls(self):
+        urls = [
+            "http://localhost:8001/v1/audio?path=a.wav",
+            "https://bucket.s3.example.test/b.wav?sig=x",
+        ]
+        assert _extract_audio_urls({"audio_urls": urls}) == ["https://bucket.s3.example.test/b.wav?sig=x"]
+
+    def test_filtering_applies_to_dict_list_shape(self):
+        # The dict/file shape routes through _urls_from_list, not the direct path.
+        output = {"clips": [{"file": "http://127.0.0.1:8001/v1/audio?path=a.wav"}]}
+        assert _extract_audio_urls(output) == []
+
+    def test_completed_job_drops_localhost(self):
+        resp = _ok({"status": "COMPLETED", "output": {"audio_urls": ["http://localhost:8001/x.wav"]}})
+        with patch("acemusic.runpod_client.httpx.get", return_value=resp):
+            assert _client().query_result("job-1")["audio_urls"] == []
 
 
 class TestHealth:


### PR DESCRIPTION
## Summary

Makes generated audio reachable by the platform from a **remote** RunPod serverless worker. Previously the handler returned worker-local URLs (`http://localhost:8001/v1/audio?...`) that a remote platform host cannot reach, so any completed remote job would fail during clip storage (US-11.3 scope deferral, issue #150).

### Handler (`docker/handler.py`, `docker/Dockerfile`)
- When `ACEMUSIC_S3_BUCKET` is configured, each generated clip is **downloaded on-worker** from the ACE-Step server and **re-uploaded to S3**, and a **presigned GET URL** is returned in its place (key `{<ACEMUSIC_S3_PREFIX>/}runpod/<task_id>/<i><ext>`).
- Reuses the platform's existing `ACEMUSIC_S3_*` env vars (`_BUCKET`, `_PREFIX`, `_REGION`, `_ENDPOINT_URL`, `_URL_EXPIRY`). `boto3` added to the worker image.
- With **no bucket** configured, worker-local URLs pass through unchanged (local / single-host use). On an actual serverless worker (`RUNPOD_ENDPOINT_ID` present) a missing bucket **fails loudly** instead of returning unreachable URLs.
- The ACE-Step bearer token is attached **only** for the worker-local origin (compared on parsed scheme/host/port, not a string prefix), so it is never disclosed to an external result host.

### Platform client (`src/acemusic/runpod_client.py`)
- `_extract_audio_urls` now drops any `localhost` / `127.0.0.1` / `[::1]` URLs (with a warning) as a safety net, so stale worker images can never hand the platform URLs it cannot fetch.

## Acceptance criteria
- [x] A remote (RunPod) generation returns audio the platform can actually download & store — handler re-hosts clips to S3 and returns presigned URLs
- [x] No worker-local `localhost` URLs escape to the platform — handler returns presigned URLs; client filters localhost defensively
- [x] Covered by tests — handler S3 path / no-S3 path / serverless-misconfig / token-scoping, and client localhost-filtering / presigned passthrough

## Testing
- `tests/test_docker_handler.py` and `tests/test_runpod_client.py` — 64 passing
- Full suite: 1445 passed, 614 integration deselected
- `black --check`, `ruff`, and a cross-family `codex review` pass clean

## Known limitations
- **S3 provisioning is ops config.** The RunPod serverless deployment must set the `ACEMUSIC_S3_*` env vars; this PR adds the code path, not the credentials (consistent with the issue scope).
- **Staging-object lifecycle.** Each remote generation leaves a staging object under `runpod/<task_id>`; the platform stores its own canonical copy on download. In-handler deletion would need cross-component coordination, so cleanup is left to a **bucket lifecycle policy** (presigned-URL expiry defaults to 1h via `ACEMUSIC_S3_URL_EXPIRY`).
- Base64-inline audio delivery was considered and rejected (no existing patterns, poor fit for large files).

Closes #150
