### PR TITLE
refactor(cli): fold single-use fallback predicates into _should_fall_back (US-15.5)

### DIFF
--- a/src/acemusic/cli.py
+++ b/src/acemusic/cli.py
@@ -356,25 +356,6 @@ def models() -> None:
     console.print(table)
 
 
-def _is_connection_error(exc: AceStepError) -> bool:
-    """Return True if the AceStepError is a connection/timeout failure (not an API error)."""
-    msg = str(exc).lower()
-    return any(
-        keyword in msg
-        # "timed out" and "timeout" are distinct substrings: httpx renders read/
-        # connect timeouts as "timed out", so both must be matched.
-        for keyword in ("connection refused", "connect", "timeout", "timed out", "unreachable", "name or service")
-    )
-
-
-def _is_timeout_error(exc: AceStepError) -> bool:
-    """Return True if the failure is a timeout (server slow-but-reachable)."""
-    if exc.is_connection:
-        return exc.is_timeout
-    msg = str(exc).lower()
-    return "timed out" in msg or "timeout" in msg
-
-
 def _should_fall_back(exc: AceStepError) -> bool:
     """Whether an ACE-Step failure warrants switching to ElevenLabs.
 
@@ -385,7 +366,16 @@ def _should_fall_back(exc: AceStepError) -> bool:
     """
     if exc.is_connection:
         return not exc.is_timeout
-    return _is_connection_error(exc) and not _is_timeout_error(exc)
+    # Transport flags absent: sniff the message. "timed out" and "timeout" are
+    # distinct substrings (httpx renders read/connect timeouts as "timed out"),
+    # so both must be matched.
+    msg = str(exc).lower()
+    is_connection = any(
+        keyword in msg
+        for keyword in ("connection refused", "connect", "timeout", "timed out", "unreachable", "name or service")
+    )
+    is_timeout = "timed out" in msg or "timeout" in msg
+    return is_connection and not is_timeout
 
 
 _MAX_CONSECUTIVE_POLL_ERRORS = 5


### PR DESCRIPTION
## US-15.5: Fold single-use fallback predicates (`#159`)

Closes #159.

### What changed
Folded `_is_connection_error()` and `_is_timeout_error()` into their **only** caller,
`_should_fall_back()` — a single-use call chain reached only from the `generate`
fallback check. Net **3 functions → 1**, −10 lines. Logic is byte-for-byte
equivalent (same branches, same keyword set, same timeout precedence); the named
predicate stays at the call site (`if not _should_fall_back(exc)`), which reads
better than inlining a multi-line boolean into the `except` block.

### Scope adapted from the issue (stale audit)
The issue's three cuts came from a whole-repo audit dated **2026-06-17**, *before*
US-15.4 (#172) reshaped `cli.py`. Re-checked against current code, two of the three
no longer hold — see **Known Limitations**. The user approved the honest subset
(fallback fold only) over forcing the line-count target.

### Known Limitations / deliberately NOT done
- **`_LANGUAGE_NAMES` kept.** The audit claimed 18 lines / 2 use sites. Current
  reality: a 16-entry ISO-639 → English lookup with **one** use site (`cli.py:216`).
  It's legitimate data; "inlining" it means a 16-entry dict literal mid-function —
  worse, not cleaner.
- **`_fmt_duration` kept as-is.** The audit assumed it was inline-able; it has **8**
  call sites, so it stays a function. Its body already uses `divmod` (stdlib) and is
  clean — the suggested f-string swap is cosmetic, not an improvement.

### Verification
- `ruff check` ✓ · `black --check` ✓
- `pytest -k "generate or cli"` → **631 passed** (incl. all fallback-path tests)
- Fallback behaviour and duration strings unchanged.
