### PR TITLE
US-15.7: Drop speculative voice_id fields from cover/add-vocal requests

### DIFF
--- a/src/acemusic/api/routers/iterative.py
+++ b/src/acemusic/api/routers/iterative.py
@@ -57,9 +57,8 @@ _MAX_MASHUP_CLIPS = 8
 
 # Free-text fields are persisted verbatim in Job.input_params / Clip.generation_params,
 # so bound them (like the generation API) to keep a single oversized request from
-# bloating a Mongo document or exhausting memory. voice_id is an identifier, so a
-# small bound suffices; style/prompt/lyrics reuse the shared generation caps.
-_VOICE_ID_MAX_LENGTH = 128
+# bloating a Mongo document or exhausting memory; style/prompt/lyrics reuse the
+# shared generation caps.
 
 # Full-song (US-10.4): the seed must be a short idea, not an already-long track —
 # the feature grows a clip *into* a song, so cap the seed and bound the section
@@ -145,17 +144,11 @@ class ExtendRequest(BaseModel):
 
 
 class CoverRequest(BaseModel):
-    """Restyle a clip in a different genre/style.
-
-    ``voice_id`` is part of the API contract (US-10.3) but is not yet applied by
-    the ACE-Step backend, which has no voice-selection parameter — it is accepted
-    and recorded for forward compatibility, not honoured. (Known limitation.)
-    """
+    """Restyle a clip in a different genre/style."""
 
     model_config = ConfigDict(extra="forbid")
 
     style: str = Field(min_length=1, max_length=STYLE_MAX_LENGTH)
-    voice_id: str | None = Field(default=None, max_length=_VOICE_ID_MAX_LENGTH)
     lyrics_override: str | None = Field(default=None, max_length=LYRICS_MAX_LENGTH)
 
 
@@ -204,15 +197,12 @@ class SampleRequest(BaseModel):
 class AddVocalRequest(BaseModel):
     """Layer vocals (``lyrics``) onto an existing clip.
 
-    ``vocal_style`` maps to the ACE-Step style control; ``voice_id`` is recorded
-    for forward compatibility but not yet applied by the backend (no voice-
-    selection parameter). (Known limitation.)
+    ``vocal_style`` maps to the ACE-Step style control.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     lyrics: str = Field(min_length=1, max_length=LYRICS_MAX_LENGTH)
-    voice_id: str | None = Field(default=None, max_length=_VOICE_ID_MAX_LENGTH)
     vocal_style: str | None = Field(default=None, max_length=STYLE_MAX_LENGTH)
 
 
@@ -459,7 +449,6 @@ async def cover_clip(
     params = {
         "clip_id": str(clip.id),
         "style": request.style,
-        "voice_id": request.voice_id,
         "lyrics_override": request.lyrics_override,
     }
     return await _enqueue_generation(
@@ -569,7 +558,6 @@ async def add_vocal_clip(
     params = {
         "clip_id": str(clip.id),
         "lyrics": request.lyrics,
-        "voice_id": request.voice_id,
         "vocal_style": request.vocal_style,
     }
     return await _enqueue_generation(

--- a/tests/test_clips_iterative_api.py
+++ b/tests/test_clips_iterative_api.py
@@ -369,6 +369,7 @@ class TestValidation:
             ("extend", {"duration": "30s", "bogus": 1}),  # extra="forbid"
             ("cover", {}),  # missing required style
             ("cover", {"style": ""}),  # empty style
+            ("cover", {"style": "jazz", "voice_id": "v1"}),  # voice_id dropped (US-15.7), extra="forbid"
             ("remix", {}),  # missing required style
             ("repaint", {"start": "1s", "end": "5s"}),  # missing prompt
             ("repaint", {"start": "x", "end": "5s", "prompt": "p"}),  # unparseable start
@@ -377,6 +378,7 @@ class TestValidation:
             ("sample", {"start": "1s", "end": "3s", "role": "loop-bed", "prompt": "p", "num_clips": 0}),  # num < 1
             ("add-vocal", {}),  # missing lyrics
             ("add-vocal", {"lyrics": ""}),  # empty lyrics
+            ("add-vocal", {"lyrics": "la", "voice_id": "v1"}),  # voice_id dropped (US-15.7), extra="forbid"
         ],
     )
     async def test_invalid_body_returns_422(self, client, settings, operation: str, body: dict) -> None:


### PR DESCRIPTION
## US-15.7: Drop speculative `voice_id` fields from cover/add-vocal requests

Closes #161. Ponytail over-engineering cleanup (phase 7 of 7).

### What
`CoverRequest` and `AddVocalRequest` accepted a `voice_id` field that was never
passed to any backend — ACE-Step has no voice-selection parameter. It was
validated and then discarded. Removed:

- `CoverRequest.voice_id` and `AddVocalRequest.voice_id`
- the shared `_VOICE_ID_MAX_LENGTH = 128` constant (only those two fields used it)
- the now-stale "recorded for forward compatibility" docstrings
- `voice_id` from the `cover` / `add-vocal` job `params` dicts

### Acceptance criteria
- [x] `voice_id` removed from both request schemas + the dedicated constant.
- [x] OpenAPI schema no longer advertises the inert field (verified via `model_json_schema()`).
- [x] Router tests updated — no test referenced `voice_id`; 39 iterative/cover/add-vocal tests pass; no behaviour change for existing callers.

### Demo evidence
```
CoverRequest props: ['style', 'lyrics_override']
AddVocalRequest props: ['lyrics', 'vocal_style']
OK: voice_id now rejected (extra=forbid)
```
`uv run pytest tests/test_clips_iterative_api.py tests/test_cover.py tests/test_add_vocal.py` → **39 passed**. ruff + black clean.

### Notes
- No in-flight voice-selection work consumes this field (grepped `src/`); re-add as a real story when voice selection ships.
