### PR TITLE
US-13.2: SoundCloud OAuth 2.1 + track upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,14 @@ ACEMUSIC_API_DISCORD_CLIENT_ID=
 ACEMUSIC_API_DISCORD_CLIENT_SECRET=
 ACEMUSIC_API_DISCORD_REDIRECT_URI=
 
+# SoundCloud distribution account-linking (US-13.2). OAuth 2.1 + PKCE; register an
+# app at https://soundcloud.com/you/apps . Unlike the providers above, this links
+# an already-authenticated user's account so the platform can upload tracks on
+# their behalf (not a login provider). Unused until all three are set.
+ACEMUSIC_API_SOUNDCLOUD_CLIENT_ID=
+ACEMUSIC_API_SOUNDCLOUD_CLIENT_SECRET=
+ACEMUSIC_API_SOUNDCLOUD_REDIRECT_URI=
+
 # JWT signing. jwt_secret_key MUST be set before auth is used (generate a strong
 # random value, e.g. `python -c "import secrets; print(secrets.token_urlsafe(64))"`).
 ACEMUSIC_API_JWT_SECRET_KEY=

--- a/README.md
+++ b/README.md
@@ -219,6 +219,18 @@ Each request fans out into one sub-job per clip, tracked under a `BatchJob`. The
 
 Generation is async: poll `GET /api/v1/jobs/{id}/status`, whose completed response lists `artwork_options` as `{artwork_id, url}` pairs. Each option is generated at 1024×1024 and upscaled to a 3000×3000 distribution master (PNG). Uploads are validated for format (JPG/PNG only), minimum resolution (≥3000×3000, else `422` with a descriptive error), byte size (≤25 MB), and pixel-bomb safety; corrupt files are rejected with `422`. Generation requires `ACEMUSIC_API_OPENAI_API_KEY` (DALL-E); without it the worker fails the job with a clear "not configured" message, and `ACEMUSIC_API_ARTWORK_GENERATION_ENABLED=false` is a kill-switch. No credits are deducted.
 
+### Distribution — SoundCloud (US-13.2)
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/distribution/soundcloud/connect` | Begin the OAuth 2.1 + PKCE account link; returns `authorization_url` and sets per-flow HttpOnly cookies |
+| `POST /api/v1/distribution/soundcloud/callback` | Validate `{code, state}` against the cookies, exchange the code, persist the connection |
+| `GET /api/v1/distribution/soundcloud/status` | Report link status (`connected`, `soundcloud_username`, `connected_at`, `token_valid`) |
+| `POST /api/v1/distribution/soundcloud/upload` | Upload an owned clip (`{clip_id, metadata_overrides}`) as a SoundCloud track; returns `{track_id, permalink_url}` |
+| `DELETE /api/v1/distribution/soundcloud/connect` | Unlink the SoundCloud account (idempotent, 204) |
+
+Account-linking is distinct from login: it connects an already-authenticated user's SoundCloud account so the platform can upload on their behalf, with PKCE (S256), a `uid`-bound signed `state`, and the PKCE verifier held in a per-flow HttpOnly cookie. Upload maps clip metadata (`title`, `bpm`, `key`→`key_signature`, first style tag→`genre`) onto the track, lets `metadata_overrides` (`title`, `genre`, `description`, `bpm`, `key_signature`, `isrc`, `sharing`) take precedence, and attaches the clip's own cover art (US-13.1) when present. Access tokens are refreshed transparently on expiry; a rejected refresh (revoked grant) unlinks the account, while a transient failure preserves it for retry. Uploads over 500 MB are rejected. Requires `ACEMUSIC_API_SOUNDCLOUD_CLIENT_ID/SECRET/REDIRECT_URI`.
+
 ### Presets
 
 | Endpoint | Purpose |

--- a/docs/demos/us-13.2-soundcloud.md
+++ b/docs/demos/us-13.2-soundcloud.md
@@ -1,0 +1,61 @@
+# US-13.2: SoundCloud OAuth 2.1 + Track Upload
+
+*2026-06-21T20:31:50Z*
+
+This demo exercises the full SoundCloud distribution feature (#133) end-to-end against the **real** FastAPI app, MongoDB, JWT auth, and local storage. The only stubbed parts are the outbound calls to SoundCloud itself — this environment has no SoundCloud developer credentials, so those HTTP calls are replaced at the service seam (mirroring the Dolby/ElevenLabs precedent in this repo). Every step below prints actual API responses and database state as outcome evidence for the acceptance criteria.
+
+Acceptance criteria being verified: (1) OAuth flow completes and stores access/refresh tokens; (2) uploading a clip creates a SoundCloud track; (3) metadata (title, genre, BPM) is set on the track; (4) the cover art is uploaded alongside the audio; (5) token refresh works transparently when the access token expires.
+
+Run the end-to-end driver. It seeds a user and an owned clip (with audio + US-13.1 cover art in storage), then walks connect → callback → status → upload → token-refresh → disconnect, printing the real HTTP responses and persisted MongoDB documents at each step.
+
+```bash
+ulimit -n 64000; uv run python .cache/sc_demo.py
+```
+
+```output
+INFO:     acemusic.api.database - Connected to MongoDB database 'acemusic_demo_3aa0a3d5' at mongodb://localhost:27017
+INFO:     acemusic.api.database - Closed MongoDB connection
+========================================================================
+STEP 1 — Begin the OAuth link (POST /soundcloud/connect)
+========================================================================
+  HTTP 200
+  authorization_url: https://secure.soundcloud.com/authorize?client_id=demo-client-id&redirect_uri=https%3A%2F%2Fapp....
+  PKCE S256 in URL : True
+  per-flow cookies : ['sc_link_nonce_MlrReb36C3M=EoAVAmwqAqPNy0eZ6F2AyhcJnb88qdgxwsWqsc1_kjQ; HttpOnly; Max-Age=600; Path=/api/v1/distribution; SameSite=lax']
+
+========================================================================
+STEP 2 — Complete the link (POST /soundcloud/callback)  [AC: tokens stored]
+========================================================================
+  HTTP 200  ->  {'connected': True, 'soundcloud_username': 'demo_artist', 'connected_at': '2026-06-21T20:32:13.235950Z', 'token_valid': True}
+  DB connection persisted: username='demo_artist' access_token='sc-access-1' refresh_token='sc-refresh-1'
+
+========================================================================
+STEP 3 — Connection status (GET /soundcloud/status)
+========================================================================
+  HTTP 200  ->  {'connected': True, 'soundcloud_username': 'demo_artist', 'connected_at': '2026-06-21T20:32:13.235000', 'token_valid': True}
+
+========================================================================
+STEP 4 — Upload the clip (POST /soundcloud/upload)  [AC: track + metadata + art]
+========================================================================
+  HTTP 200  ->  {'track_id': '555123', 'permalink_url': 'https://soundcloud.com/demo_artist/midnight-drive'}
+  audio bytes sent     : b'RIFF....demo-audio-bytes'
+  cover art sent       : b'\x89PNG demo-cover-art'   (the clip's own US-13.1 artwork)
+  metadata to SoundCloud: {'title': 'Midnight Drive', 'bpm': 124, 'key_signature': 'Am', 'genre': 'synthwave', 'description': 'Released from AceMusic', 'sharing': 'public'}
+    -> title/bpm/key from the clip; sharing/description from the request overrides
+
+========================================================================
+STEP 5 — Transparent token refresh on expiry  [AC: refresh works]
+========================================================================
+  refresh called with refresh_token='sc-refresh-1'
+  HTTP 200  ->  upload used token='sc-access-2' (rotated, not the expired one)
+  DB now holds rotated tokens: access='sc-access-2' refresh='sc-refresh-2'
+
+========================================================================
+STEP 6 — Unlink the account (DELETE /soundcloud/connect)
+========================================================================
+  HTTP 204  ->  connection in DB after disconnect: None
+
+All acceptance criteria demonstrated with real API responses + DB state.
+```
+
+Outcome evidence mapped to acceptance criteria: **(1)** STEP 2 — callback returns `connected: true` and the DB shows the persisted `access_token`/`refresh_token`. **(2)** STEP 4 — upload returns a real `track_id` and `permalink_url`. **(3)** STEP 4 — the metadata sent to SoundCloud carries `title=Midnight Drive, bpm=124, genre=synthwave` (clip-derived) plus request overrides. **(4)** STEP 4 — the clip cover-art bytes are sent in the same multipart upload as the audio. **(5)** STEP 5 — an expired token triggers a transparent refresh; the upload uses the rotated token and the DB stores the new pair. Disconnect (STEP 6) removes the connection (204).

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -27,6 +27,7 @@ from .routers import (
     batch,
     clips,
     compute,
+    distribution,
     editing,
     extraction,
     generation,
@@ -167,6 +168,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(presets.router, prefix=API_V1_PREFIX)
     app.include_router(compute.router, prefix=API_V1_PREFIX)
     app.include_router(mastering.router, prefix=API_V1_PREFIX)
+    app.include_router(distribution.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -10,10 +10,22 @@ from .credit_transaction import CreditTransaction
 from .job import Job, JobStatus
 from .preset import PRESET_PARAM_FIELDS, Preset
 from .refresh_token import RefreshToken
+from .soundcloud_connection import SoundCloudConnection
 from .user import User
 from .workspace import Workspace
 
-ALL_MODELS = [User, Workspace, Clip, Job, RefreshToken, Preset, CreditTransaction, BatchJob, ArtworkOption]
+ALL_MODELS = [
+    User,
+    Workspace,
+    Clip,
+    Job,
+    RefreshToken,
+    Preset,
+    CreditTransaction,
+    BatchJob,
+    ArtworkOption,
+    SoundCloudConnection,
+]
 
 __all__ = [
     "User",
@@ -28,5 +40,6 @@ __all__ = [
     "RefreshToken",
     "Preset",
     "PRESET_PARAM_FIELDS",
+    "SoundCloudConnection",
     "ALL_MODELS",
 ]

--- a/src/acemusic/api/models/soundcloud_connection.py
+++ b/src/acemusic/api/models/soundcloud_connection.py
@@ -1,0 +1,38 @@
+"""SoundCloud account-link document model (US-13.2).
+
+Persists the OAuth tokens for a user's linked SoundCloud account so the platform
+can upload tracks on their behalf. One connection per user (unique ``user_id``);
+linking again upserts the same row. Tokens are stored as-is — they are
+short-lived third-party credentials behind the DB's access controls, matching how
+the platform stores other provider credentials.
+"""
+
+from datetime import datetime
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+
+class SoundCloudConnection(Document):
+    """A user's linked SoundCloud account with its OAuth tokens."""
+
+    user_id: PydanticObjectId
+    soundcloud_user_id: str
+    soundcloud_username: str | None = None
+    access_token: str
+    refresh_token: str
+    token_expires_at: datetime
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime | None = None
+
+    class Settings:
+        name = "soundcloud_connections"
+        indexes = [
+            # One SoundCloud link per user: re-linking upserts this row, and the
+            # unique index makes a concurrent double-connect race-safe.
+            IndexModel([("user_id", ASCENDING)], unique=True),
+            IndexModel([("soundcloud_user_id", ASCENDING)]),
+        ]

--- a/src/acemusic/api/routers/distribution.py
+++ b/src/acemusic/api/routers/distribution.py
@@ -14,17 +14,18 @@ this router is the HTTP surface (cookies, status codes, request/response shapes)
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, ConfigDict, Field
 from pymongo.errors import DuplicateKeyError
 
-from acemusic.storage import get_storage_backend
+from acemusic.storage import StorageBackend, get_storage_backend
 
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import Clip, SoundCloudConnection
+from ..models.common import utcnow
 from ..services import clips as clip_service, soundcloud as sc
 from ..settings import ApiSettings
 
@@ -106,7 +107,7 @@ def _set_link_cookie(response: Response, request: Request, settings: ApiSettings
 
 
 @router.post("/soundcloud/connect", response_model=ConnectResponse)
-def soundcloud_connect(
+async def soundcloud_connect(
     request: Request,
     response: Response,
     current: CurrentUser = Depends(get_current_user),
@@ -115,9 +116,8 @@ def soundcloud_connect(
     settings = _settings(request)
     try:
         link = sc.build_connect_request(current.user_id, settings)
-    except sc.SoundCloudNotConfiguredError as exc:
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
     except sc.SoundCloudError as exc:
+        # SoundCloudNotConfiguredError is a subclass, so this covers both.
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
 
     _set_link_cookie(response, request, settings, link.nonce_cookie_name, link.state_nonce)
@@ -200,7 +200,7 @@ async def _apply_tokens(connection: SoundCloudConnection, tokens: dict, profile:
     connection.access_token = tokens["access_token"]
     connection.refresh_token = tokens.get("refresh_token") or connection.refresh_token
     connection.token_expires_at = sc.token_expiry(tokens.get("expires_in"))
-    connection.updated_at = _now()
+    connection.updated_at = utcnow()
     await connection.save()
     return connection
 
@@ -228,6 +228,18 @@ async def soundcloud_upload(
     """Upload an owned clip to the user's linked SoundCloud account."""
     clip = await clip_service.get_owned_clip(body.clip_id, current.user_id)
 
+    # Validate the SoundCloud link first so the common "not connected" / revoked
+    # case fast-fails before paying for a (potentially large) storage download.
+    try:
+        connection = await sc.get_valid_connection(current.user_id, _settings(request))
+    except sc.SoundCloudNotConnectedError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except sc.SoundCloudAuthError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+    except sc.SoundCloudError as exc:
+        # Transient refresh failure — the connection is preserved; ask to retry.
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
     storage = get_storage_backend()
     try:
         audio = await asyncio.to_thread(storage.download, clip.file_path)
@@ -240,16 +252,6 @@ async def soundcloud_upload(
             status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"Audio exceeds SoundCloud's {sc.MAX_UPLOAD_BYTES}-byte upload limit.",
         )
-
-    try:
-        connection = await sc.get_valid_connection(current.user_id, _settings(request))
-    except sc.SoundCloudNotConnectedError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-    except sc.SoundCloudAuthError as exc:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
-    except sc.SoundCloudError as exc:
-        # Transient refresh failure — the connection is preserved; ask to retry.
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
 
     metadata = _merge_metadata(clip, body.metadata_overrides)
     artwork = await _resolve_artwork(clip, storage)
@@ -280,7 +282,7 @@ def _merge_metadata(clip: Clip, overrides: MetadataOverrides) -> dict[str, objec
     return metadata
 
 
-async def _resolve_artwork(clip: Clip, storage) -> bytes | None:
+async def _resolve_artwork(clip: Clip, storage: StorageBackend) -> bytes | None:
     """Return the clip's own cover art (US-13.1 ``artwork_path``) to upload, or None.
 
     Only the clip's stored, already-validated artwork is uploaded — there is no
@@ -303,7 +305,3 @@ async def soundcloud_disconnect(current: CurrentUser = Depends(get_current_user)
     if connection is not None:
         await connection.delete()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
-
-
-def _now() -> datetime:
-    return datetime.now(timezone.utc)

--- a/src/acemusic/api/routers/distribution.py
+++ b/src/acemusic/api/routers/distribution.py
@@ -1,0 +1,279 @@
+"""Distribution endpoints — SoundCloud account-linking and upload (US-13.2).
+
+Mounted under ``/api/v1/distribution`` and gated behind a valid Bearer token:
+
+* ``POST   /soundcloud/connect``   → start the OAuth link, return the authorize URL
+* ``POST   /soundcloud/callback``  → finish the link, persist the connection
+* ``GET    /soundcloud/status``    → report whether the user is linked
+* ``POST   /soundcloud/upload``    → upload an owned clip as a SoundCloud track
+* ``DELETE /soundcloud/connect``   → unlink the SoundCloud account (idempotent)
+
+The OAuth/PKCE/token mechanics live in :mod:`acemusic.api.services.soundcloud`;
+this router is the HTTP surface (cookies, status codes, request/response shapes).
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from beanie import PydanticObjectId
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from acemusic.storage import get_storage_backend
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import Clip, SoundCloudConnection
+from ..services import clips as clip_service, soundcloud as sc
+from ..settings import ApiSettings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/distribution", tags=["distribution"], dependencies=[Depends(get_current_user)])
+
+
+# --- request / response models ----------------------------------------------
+class ConnectResponse(BaseModel):
+    authorization_url: str
+
+
+class CallbackRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    state: str
+
+
+class StatusResponse(BaseModel):
+    connected: bool
+    soundcloud_username: str | None = None
+    connected_at: datetime | None = None
+    token_valid: bool | None = None
+
+
+class MetadataOverrides(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = None
+    genre: str | None = None
+    description: str | None = None
+    bpm: int | None = None
+    key_signature: str | None = None
+    isrc: str | None = None
+    sharing: str | None = Field(default=None, pattern="^(public|private)$")
+    artwork_url: str | None = None
+
+
+class UploadRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    clip_id: str
+    metadata_overrides: MetadataOverrides = Field(default_factory=MetadataOverrides)
+
+
+class UploadResponse(BaseModel):
+    track_id: str
+    permalink_url: str | None = None
+
+
+def _settings(request: Request) -> ApiSettings:
+    return request.app.state.settings
+
+
+def _cookie_path(request: Request) -> str:
+    """Scope the link cookies to the distribution prefix (e.g. ``/api/v1/distribution``).
+
+    Both ``/soundcloud/connect`` and ``/soundcloud/callback`` resolve to the same
+    path, so a cookie set at connect is sent to (and cleared by) the callback.
+    """
+    path = request.url.path
+    marker = "/soundcloud/"
+    if marker in path:
+        return path.rsplit(marker, 1)[0] or "/"
+    return "/"
+
+
+def _set_link_cookie(response: Response, request: Request, settings: ApiSettings, name: str, value: str) -> None:
+    response.set_cookie(
+        key=name,
+        value=value,
+        max_age=sc.LINK_STATE_EXPIRE_MINUTES * 60,
+        httponly=True,
+        secure=settings.oauth_cookie_secure,
+        samesite=settings.oauth_cookie_samesite,
+        path=_cookie_path(request),
+    )
+
+
+@router.post("/soundcloud/connect", response_model=ConnectResponse)
+def soundcloud_connect(
+    request: Request,
+    response: Response,
+    current: CurrentUser = Depends(get_current_user),
+) -> ConnectResponse:
+    """Begin the SoundCloud OAuth link; return the URL the client redirects to."""
+    settings = _settings(request)
+    try:
+        link = sc.build_connect_request(current.user_id, settings)
+    except sc.SoundCloudNotConfiguredError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    except sc.SoundCloudError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    _set_link_cookie(response, request, settings, link.nonce_cookie_name, link.state_nonce)
+    _set_link_cookie(response, request, settings, link.verifier_cookie_name, link.code_verifier)
+    return ConnectResponse(authorization_url=link.url)
+
+
+@router.post("/soundcloud/callback", response_model=StatusResponse)
+async def soundcloud_callback(
+    body: CallbackRequest,
+    request: Request,
+    response: Response,
+    current: CurrentUser = Depends(get_current_user),
+) -> StatusResponse:
+    """Complete the link: validate state, exchange the code, persist the tokens."""
+    settings = _settings(request)
+    try:
+        validated = sc.validate_link_state(body.state, current.user_id, settings, request.cookies)
+    except sc.SoundCloudError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid SoundCloud state.") from exc
+
+    # Single-use: clear the per-flow cookies now that they've served their purpose.
+    response.delete_cookie(validated.nonce_cookie_name, path=_cookie_path(request))
+    response.delete_cookie(validated.verifier_cookie_name, path=_cookie_path(request))
+
+    try:
+        tokens = await sc.exchange_code(body.code, validated.code_verifier, settings)
+        profile = await sc.get_soundcloud_user(tokens["access_token"])
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail="SoundCloud returned no access token."
+        ) from exc
+    except sc.SoundCloudError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+    connection = await _upsert_connection(current.user_id, tokens, profile)
+    return StatusResponse(
+        connected=True,
+        soundcloud_username=connection.soundcloud_username,
+        connected_at=connection.created_at,
+        token_valid=sc.token_valid(connection.token_expires_at),
+    )
+
+
+async def _upsert_connection(user_id: str, tokens: dict, profile: dict) -> SoundCloudConnection:
+    """Create or update the user's single SoundCloud connection."""
+    oid = PydanticObjectId(user_id)
+    connection = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == oid)
+    expires_at = sc.token_expiry(tokens.get("expires_in"))
+    username = profile.get("username") or profile.get("full_name")
+    sc_user_id = str(profile.get("id", ""))
+    if connection is None:
+        connection = SoundCloudConnection(
+            user_id=oid,
+            soundcloud_user_id=sc_user_id,
+            soundcloud_username=username,
+            access_token=tokens["access_token"],
+            refresh_token=tokens.get("refresh_token", ""),
+            token_expires_at=expires_at,
+        )
+        await connection.insert()
+        return connection
+
+    connection.soundcloud_user_id = sc_user_id
+    connection.soundcloud_username = username
+    connection.access_token = tokens["access_token"]
+    connection.refresh_token = tokens.get("refresh_token") or connection.refresh_token
+    connection.token_expires_at = expires_at
+    connection.updated_at = _now()
+    await connection.save()
+    return connection
+
+
+@router.get("/soundcloud/status", response_model=StatusResponse)
+async def soundcloud_status(current: CurrentUser = Depends(get_current_user)) -> StatusResponse:
+    """Report whether the user has a linked SoundCloud account."""
+    connection = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == PydanticObjectId(current.user_id))
+    if connection is None:
+        return StatusResponse(connected=False)
+    return StatusResponse(
+        connected=True,
+        soundcloud_username=connection.soundcloud_username,
+        connected_at=connection.created_at,
+        token_valid=sc.token_valid(connection.token_expires_at),
+    )
+
+
+@router.post("/soundcloud/upload", response_model=UploadResponse)
+async def soundcloud_upload(
+    body: UploadRequest,
+    request: Request,
+    current: CurrentUser = Depends(get_current_user),
+) -> UploadResponse:
+    """Upload an owned clip to the user's linked SoundCloud account."""
+    clip = await clip_service.get_owned_clip(body.clip_id, current.user_id)
+
+    storage = get_storage_backend()
+    try:
+        audio = await asyncio.to_thread(storage.download, clip.file_path)
+    except FileNotFoundError as exc:
+        logger.warning("Clip %s audio object %r is missing", clip.id, clip.file_path)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio file not found.") from exc
+
+    if len(audio) > sc.MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=f"Audio exceeds SoundCloud's {sc.MAX_UPLOAD_BYTES}-byte upload limit.",
+        )
+
+    try:
+        connection = await sc.get_valid_connection(current.user_id, _settings(request))
+    except sc.SoundCloudNotConnectedError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except sc.SoundCloudAuthError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+
+    metadata = _merge_metadata(clip, body.metadata_overrides)
+    artwork = None
+    if body.metadata_overrides.artwork_url:
+        try:
+            artwork = await sc.fetch_artwork(body.metadata_overrides.artwork_url)
+        except sc.SoundCloudError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    filename = f"{clip.title or clip.id}.{clip.format or 'wav'}"
+    try:
+        track = await sc.upload_track(connection.access_token, audio, filename, metadata, artwork)
+    except sc.SoundCloudError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+    track_id = track.get("id")
+    if track_id is None:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="SoundCloud returned no track id.")
+    return UploadResponse(track_id=str(track_id), permalink_url=track.get("permalink_url"))
+
+
+def _merge_metadata(clip: Clip, overrides: MetadataOverrides) -> dict[str, object]:
+    """Derive track metadata from the clip, letting overrides take precedence."""
+    metadata: dict[str, object] = {
+        "title": clip.title,
+        "bpm": clip.bpm,
+        "key_signature": clip.key,
+        "genre": clip.style_tags[0] if clip.style_tags else None,
+    }
+    metadata.update({k: v for k, v in overrides.model_dump().items() if k != "artwork_url" and v is not None})
+    return metadata
+
+
+@router.delete("/soundcloud/connect", status_code=status.HTTP_204_NO_CONTENT)
+async def soundcloud_disconnect(current: CurrentUser = Depends(get_current_user)) -> Response:
+    """Unlink the user's SoundCloud account; idempotent (204 even if not linked)."""
+    connection = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == PydanticObjectId(current.user_id))
+    if connection is not None:
+        await connection.delete()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)

--- a/src/acemusic/api/routers/distribution.py
+++ b/src/acemusic/api/routers/distribution.py
@@ -233,14 +233,12 @@ async def soundcloud_upload(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except sc.SoundCloudAuthError as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+    except sc.SoundCloudError as exc:
+        # Transient refresh failure — the connection is preserved; ask to retry.
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
 
     metadata = _merge_metadata(clip, body.metadata_overrides)
-    artwork = None
-    if body.metadata_overrides.artwork_url:
-        try:
-            artwork = await sc.fetch_artwork(body.metadata_overrides.artwork_url)
-        except sc.SoundCloudError as exc:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    artwork = await _resolve_artwork(clip, body.metadata_overrides, storage)
 
     filename = f"{clip.title or clip.id}.{clip.format or 'wav'}"
     try:
@@ -257,13 +255,35 @@ async def soundcloud_upload(
 def _merge_metadata(clip: Clip, overrides: MetadataOverrides) -> dict[str, object]:
     """Derive track metadata from the clip, letting overrides take precedence."""
     metadata: dict[str, object] = {
-        "title": clip.title,
+        # SoundCloud requires a title; an untitled clip falls back to its id so the
+        # upload never fails upstream for a missing ``track[title]``.
+        "title": clip.title or str(clip.id),
         "bpm": clip.bpm,
         "key_signature": clip.key,
         "genre": clip.style_tags[0] if clip.style_tags else None,
     }
     metadata.update({k: v for k, v in overrides.model_dump().items() if k != "artwork_url" and v is not None})
     return metadata
+
+
+async def _resolve_artwork(clip: Clip, overrides: MetadataOverrides, storage) -> bytes | None:
+    """Return the cover-art bytes to upload, or None.
+
+    An explicit ``artwork_url`` override wins; otherwise the clip's own selected
+    cover art (US-13.1 ``artwork_path``) is uploaded so a track carries its art by
+    default. A missing stored object is non-fatal — the track uploads without art.
+    """
+    if overrides.artwork_url:
+        try:
+            return await sc.fetch_artwork(overrides.artwork_url)
+        except sc.SoundCloudError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    if clip.artwork_path:
+        try:
+            return await asyncio.to_thread(storage.download, clip.artwork_path)
+        except FileNotFoundError:
+            logger.warning("Clip %s artwork object %r is missing; uploading without art", clip.id, clip.artwork_path)
+    return None
 
 
 @router.delete("/soundcloud/connect", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/acemusic/api/routers/distribution.py
+++ b/src/acemusic/api/routers/distribution.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from beanie import PydanticObjectId
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, ConfigDict, Field
+from pymongo.errors import DuplicateKeyError
 
 from acemusic.storage import get_storage_backend
 
@@ -61,7 +62,6 @@ class MetadataOverrides(BaseModel):
     key_signature: str | None = None
     isrc: str | None = None
     sharing: str | None = Field(default=None, pattern="^(public|private)$")
-    artwork_url: str | None = None
 
 
 class UploadRequest(BaseModel):
@@ -163,29 +163,43 @@ async def soundcloud_callback(
 
 
 async def _upsert_connection(user_id: str, tokens: dict, profile: dict) -> SoundCloudConnection:
-    """Create or update the user's single SoundCloud connection."""
-    oid = PydanticObjectId(user_id)
-    connection = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == oid)
-    expires_at = sc.token_expiry(tokens.get("expires_in"))
-    username = profile.get("username") or profile.get("full_name")
-    sc_user_id = str(profile.get("id", ""))
-    if connection is None:
-        connection = SoundCloudConnection(
-            user_id=oid,
-            soundcloud_user_id=sc_user_id,
-            soundcloud_username=username,
-            access_token=tokens["access_token"],
-            refresh_token=tokens.get("refresh_token", ""),
-            token_expires_at=expires_at,
-        )
-        await connection.insert()
-        return connection
+    """Create or update the user's single SoundCloud connection (race-safe).
 
-    connection.soundcloud_user_id = sc_user_id
-    connection.soundcloud_username = username
+    The unique ``user_id`` index makes a find-then-insert racy: two concurrent
+    first-time links both see no row and one insert would 500 on the duplicate
+    key. So a fresh insert that loses the race re-resolves and updates instead
+    (mirrors ``users.get_or_create_user``).
+    """
+    oid = PydanticObjectId(user_id)
+    existing = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == oid)
+    if existing is not None:
+        return await _apply_tokens(existing, tokens, profile)
+
+    new_connection = SoundCloudConnection(
+        user_id=oid,
+        soundcloud_user_id=str(profile.get("id", "")),
+        soundcloud_username=profile.get("username") or profile.get("full_name"),
+        access_token=tokens["access_token"],
+        refresh_token=tokens.get("refresh_token", ""),
+        token_expires_at=sc.token_expiry(tokens.get("expires_in")),
+    )
+    try:
+        await new_connection.insert()
+        return new_connection
+    except DuplicateKeyError:
+        racer = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == oid)
+        if racer is None:
+            raise
+        return await _apply_tokens(racer, tokens, profile)
+
+
+async def _apply_tokens(connection: SoundCloudConnection, tokens: dict, profile: dict) -> SoundCloudConnection:
+    """Overwrite ``connection`` with the latest tokens/profile and persist it."""
+    connection.soundcloud_user_id = str(profile.get("id", ""))
+    connection.soundcloud_username = profile.get("username") or profile.get("full_name")
     connection.access_token = tokens["access_token"]
     connection.refresh_token = tokens.get("refresh_token") or connection.refresh_token
-    connection.token_expires_at = expires_at
+    connection.token_expires_at = sc.token_expiry(tokens.get("expires_in"))
     connection.updated_at = _now()
     await connection.save()
     return connection
@@ -238,7 +252,7 @@ async def soundcloud_upload(
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
 
     metadata = _merge_metadata(clip, body.metadata_overrides)
-    artwork = await _resolve_artwork(clip, body.metadata_overrides, storage)
+    artwork = await _resolve_artwork(clip, storage)
 
     filename = f"{clip.title or clip.id}.{clip.format or 'wav'}"
     try:
@@ -262,28 +276,24 @@ def _merge_metadata(clip: Clip, overrides: MetadataOverrides) -> dict[str, objec
         "key_signature": clip.key,
         "genre": clip.style_tags[0] if clip.style_tags else None,
     }
-    metadata.update({k: v for k, v in overrides.model_dump().items() if k != "artwork_url" and v is not None})
+    metadata.update({k: v for k, v in overrides.model_dump().items() if v is not None})
     return metadata
 
 
-async def _resolve_artwork(clip: Clip, overrides: MetadataOverrides, storage) -> bytes | None:
-    """Return the cover-art bytes to upload, or None.
+async def _resolve_artwork(clip: Clip, storage) -> bytes | None:
+    """Return the clip's own cover art (US-13.1 ``artwork_path``) to upload, or None.
 
-    An explicit ``artwork_url`` override wins; otherwise the clip's own selected
-    cover art (US-13.1 ``artwork_path``) is uploaded so a track carries its art by
-    default. A missing stored object is non-fatal — the track uploads without art.
+    Only the clip's stored, already-validated artwork is uploaded — there is no
+    arbitrary-URL fetch path (that would be an SSRF surface for no real gain). A
+    missing stored object is non-fatal: the track uploads without art.
     """
-    if overrides.artwork_url:
-        try:
-            return await sc.fetch_artwork(overrides.artwork_url)
-        except sc.SoundCloudError as exc:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-    if clip.artwork_path:
-        try:
-            return await asyncio.to_thread(storage.download, clip.artwork_path)
-        except FileNotFoundError:
-            logger.warning("Clip %s artwork object %r is missing; uploading without art", clip.id, clip.artwork_path)
-    return None
+    if not clip.artwork_path:
+        return None
+    try:
+        return await asyncio.to_thread(storage.download, clip.artwork_path)
+    except FileNotFoundError:
+        logger.warning("Clip %s artwork object %r is missing; uploading without art", clip.id, clip.artwork_path)
+        return None
 
 
 @router.delete("/soundcloud/connect", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/acemusic/api/routers/distribution.py
+++ b/src/acemusic/api/routers/distribution.py
@@ -250,7 +250,7 @@ async def soundcloud_upload(
     if len(audio) > sc.MAX_UPLOAD_BYTES:
         raise HTTPException(
             status_code=status.HTTP_413_CONTENT_TOO_LARGE,
-            detail=f"Audio exceeds SoundCloud's {sc.MAX_UPLOAD_BYTES}-byte upload limit.",
+            detail=f"Audio exceeds SoundCloud's {sc.MAX_UPLOAD_BYTES // (1024 * 1024)} MB upload limit.",
         )
 
     metadata = _merge_metadata(clip, body.metadata_overrides)

--- a/src/acemusic/api/services/soundcloud.py
+++ b/src/acemusic/api/services/soundcloud.py
@@ -55,6 +55,9 @@ _VERIFIER_BYTES = 64
 #: Refresh slightly before the real expiry so an in-flight call isn't rejected.
 _REFRESH_BUFFER_SECONDS = 60
 _HTTP_TIMEOUT = 30.0
+#: Uploads can be large, so reads/writes get a generous window — but never
+#: unbounded, so a stalled SoundCloud connection eventually releases the worker.
+_UPLOAD_TIMEOUT = httpx.Timeout(connect=30.0, read=600.0, write=600.0, pool=30.0)
 
 
 class SoundCloudError(Exception):
@@ -391,7 +394,7 @@ async def upload_track(
     if artwork is not None:
         files["track[artwork_data]"] = ("artwork", artwork, "application/octet-stream")
     try:
-        async with httpx.AsyncClient(timeout=None) as client:
+        async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT) as client:
             resp = await client.post(
                 SOUNDCLOUD_UPLOAD_URL,
                 headers={"Authorization": f"OAuth {access_token}"},

--- a/src/acemusic/api/services/soundcloud.py
+++ b/src/acemusic/api/services/soundcloud.py
@@ -18,17 +18,14 @@ A single cohesive module (PKCE + state + HTTP + the token-refreshing
 is split only if a second distribution platform ever needs to share pieces.
 """
 
-import asyncio
 import base64
 import hashlib
 import hmac
-import ipaddress
 import secrets
-import socket
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 
 import httpx
 import jwt
@@ -321,7 +318,8 @@ async def get_valid_connection(user_id: str, settings: ApiSettings):
 
     from ..models import SoundCloudConnection
 
-    connection = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == PydanticObjectId(user_id))
+    oid = PydanticObjectId(user_id)
+    connection = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == oid)
     if connection is None:
         raise SoundCloudNotConnectedError("No SoundCloud account is linked.")
 
@@ -331,8 +329,15 @@ async def get_valid_connection(user_id: str, settings: ApiSettings):
     try:
         tokens = await refresh_access_token(connection.refresh_token, settings)
     except SoundCloudAuthError as exc:
-        # Confirmed dead grant — the link is unusable; drop it so the user re-links.
-        await connection.delete()
+        # A rejected grant *usually* means a dead link — but two uploads racing on
+        # an expiring token both refresh the same rotating token, and the loser
+        # gets invalid_grant. Re-read before deleting: if a concurrent refresh
+        # already produced a fresh token, use it instead of unlinking the user.
+        refreshed = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == oid)
+        if refreshed is not None and not _is_expired(refreshed.token_expires_at):
+            return refreshed
+        if refreshed is not None:
+            await refreshed.delete()
         raise SoundCloudAuthError("SoundCloud re-authorization is required.") from exc
 
     connection.access_token = tokens.get("access_token") or connection.access_token
@@ -397,51 +402,3 @@ async def upload_track(
             return resp.json()
     except httpx.HTTPError as exc:
         raise SoundCloudError("SoundCloud track upload failed.") from exc
-
-
-async def _assert_public_url(url: str) -> None:
-    """Reject non-http(s) URLs or hosts resolving to a private/internal address.
-
-    Guards the user-supplied ``artwork_url`` against SSRF (cloud metadata,
-    internal services). ponytail: this validates the *resolved* host then lets
-    httpx connect, so there's a small TOCTOU window and DNS-rebind gap; pin the
-    connection to the checked IP if this ever fronts untrusted high-value infra.
-    """
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise SoundCloudError("Artwork URL must use http or https.")
-    host = parsed.hostname
-    if not host:
-        raise SoundCloudError("Artwork URL has no host.")
-    try:
-        infos = await asyncio.to_thread(socket.getaddrinfo, host, parsed.port or 443, 0, socket.SOCK_STREAM)
-    except socket.gaierror as exc:
-        raise SoundCloudError("Artwork URL host could not be resolved.") from exc
-    for info in infos:
-        ip = ipaddress.ip_address(info[4][0])
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-            or ip.is_unspecified
-        ):
-            raise SoundCloudError("Artwork URL resolves to a non-public address.")
-
-
-async def fetch_artwork(url: str) -> bytes:
-    """Download cover-art bytes from a public ``url`` for an upload.
-
-    Redirects are *not* followed: a public URL that 30x-redirects to an internal
-    address would bypass the pre-flight host check, so a redirect is treated as a
-    failed fetch rather than chased.
-    """
-    await _assert_public_url(url)
-    try:
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=False) as client:
-            resp = await client.get(url)
-            resp.raise_for_status()
-            return resp.content
-    except httpx.HTTPError as exc:
-        raise SoundCloudError("Fetching the artwork failed.") from exc

--- a/src/acemusic/api/services/soundcloud.py
+++ b/src/acemusic/api/services/soundcloud.py
@@ -18,14 +18,17 @@ A single cohesive module (PKCE + state + HTTP + the token-refreshing
 is split only if a second distribution platform ever needs to share pieces.
 """
 
+import asyncio
 import base64
 import hashlib
 import hmac
+import ipaddress
 import secrets
+import socket
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 import httpx
 import jwt
@@ -225,14 +228,26 @@ def validate_link_state(state: str, user_id: str, settings: ApiSettings, cookies
 
 
 async def _post_token(data: dict[str, str], settings: ApiSettings) -> dict:
-    """POST to SoundCloud's token endpoint and return the parsed token response."""
+    """POST to SoundCloud's token endpoint and return the parsed token response.
+
+    A 400/401 is a rejected grant (invalid/expired/revoked) and surfaces as a
+    :class:`SoundCloudAuthError` — the caller must re-authorize, not retry. Every
+    other failure (network error, 429, 5xx) is transient and surfaces as a plain
+    :class:`SoundCloudError` so callers can keep the connection and retry later.
+    """
     try:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
             resp = await client.post(SOUNDCLOUD_TOKEN_URL, data=data)
-            resp.raise_for_status()
-            return resp.json()
     except httpx.HTTPError as exc:
         raise SoundCloudError("SoundCloud token request failed.") from exc
+
+    if resp.status_code in (400, 401):
+        raise SoundCloudAuthError("SoundCloud rejected the authorization grant.")
+    try:
+        resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise SoundCloudError("SoundCloud token request failed.") from exc
+    return resp.json()
 
 
 async def exchange_code(code: str, code_verifier: str, settings: ApiSettings) -> dict:
@@ -294,9 +309,10 @@ async def get_valid_connection(user_id: str, settings: ApiSettings):
     """Return the user's connection with a guaranteed-fresh access token.
 
     Refreshes (and persists) the token when it is within
-    :data:`_REFRESH_BUFFER_SECONDS` of expiry. A failed refresh means the link is
-    no longer usable, so the connection is deleted and
-    :class:`SoundCloudAuthError` is raised — the user must re-connect.
+    :data:`_REFRESH_BUFFER_SECONDS` of expiry. Only a *rejected* refresh (the
+    refresh token was revoked/expired → :class:`SoundCloudAuthError`) deletes the
+    connection; a transient failure (network/5xx → :class:`SoundCloudError`) is
+    re-raised with the connection intact so a later call can retry.
 
     Imports the model locally to avoid a circular import at module load
     (router → service → model → …).
@@ -314,7 +330,8 @@ async def get_valid_connection(user_id: str, settings: ApiSettings):
 
     try:
         tokens = await refresh_access_token(connection.refresh_token, settings)
-    except SoundCloudError as exc:
+    except SoundCloudAuthError as exc:
+        # Confirmed dead grant — the link is unusable; drop it so the user re-links.
         await connection.delete()
         raise SoundCloudAuthError("SoundCloud re-authorization is required.") from exc
 
@@ -382,10 +399,47 @@ async def upload_track(
         raise SoundCloudError("SoundCloud track upload failed.") from exc
 
 
-async def fetch_artwork(url: str) -> bytes:
-    """Download cover-art bytes from ``url`` for an upload."""
+async def _assert_public_url(url: str) -> None:
+    """Reject non-http(s) URLs or hosts resolving to a private/internal address.
+
+    Guards the user-supplied ``artwork_url`` against SSRF (cloud metadata,
+    internal services). ponytail: this validates the *resolved* host then lets
+    httpx connect, so there's a small TOCTOU window and DNS-rebind gap; pin the
+    connection to the checked IP if this ever fronts untrusted high-value infra.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise SoundCloudError("Artwork URL must use http or https.")
+    host = parsed.hostname
+    if not host:
+        raise SoundCloudError("Artwork URL has no host.")
     try:
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True) as client:
+        infos = await asyncio.to_thread(socket.getaddrinfo, host, parsed.port or 443, 0, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise SoundCloudError("Artwork URL host could not be resolved.") from exc
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise SoundCloudError("Artwork URL resolves to a non-public address.")
+
+
+async def fetch_artwork(url: str) -> bytes:
+    """Download cover-art bytes from a public ``url`` for an upload.
+
+    Redirects are *not* followed: a public URL that 30x-redirects to an internal
+    address would bypass the pre-flight host check, so a redirect is treated as a
+    failed fetch rather than chased.
+    """
+    await _assert_public_url(url)
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=False) as client:
             resp = await client.get(url)
             resp.raise_for_status()
             return resp.content

--- a/src/acemusic/api/services/soundcloud.py
+++ b/src/acemusic/api/services/soundcloud.py
@@ -25,12 +25,16 @@ import secrets
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 import httpx
 import jwt
 
 from ..settings import ApiSettings
+
+if TYPE_CHECKING:
+    from ..models import SoundCloudConnection
 
 # --- SoundCloud endpoints ---------------------------------------------------
 SOUNDCLOUD_AUTHORIZE_URL = "https://secure.soundcloud.com/authorize"
@@ -305,7 +309,7 @@ def token_expiry(expires_in: object) -> datetime:
     return datetime.now(timezone.utc) + timedelta(seconds=seconds)
 
 
-async def get_valid_connection(user_id: str, settings: ApiSettings):
+async def get_valid_connection(user_id: str, settings: ApiSettings) -> "SoundCloudConnection":
     """Return the user's connection with a guaranteed-fresh access token.
 
     Refreshes (and persists) the token when it is within

--- a/src/acemusic/api/services/soundcloud.py
+++ b/src/acemusic/api/services/soundcloud.py
@@ -1,0 +1,393 @@
+"""SoundCloud OAuth 2.1 (PKCE) account-linking and track upload (US-13.2).
+
+This is the distribution-side SoundCloud client. It is deliberately separate from
+the *login* OAuth in :mod:`acemusic.api.auth.oauth`: that flow authenticates a
+person and creates/looks-up a platform user, whereas this one links an *already
+authenticated* user's SoundCloud account so the platform can upload on their
+behalf. SoundCloud mandates PKCE (no exceptions), so the code-for-token exchange
+carries a ``code_verifier`` rather than going through Authlib's login client.
+
+CSRF for the connect→callback round trip reuses the login flow's stateless
+double-submit pattern (a short-lived signed ``state`` JWT committing the SHA-256
+of a per-flow nonce that the client echoes back via an HttpOnly cookie), adding a
+``uid`` claim so a state minted for one user cannot complete another user's link.
+The PKCE ``code_verifier`` rides alongside in its own per-flow HttpOnly cookie.
+
+A single cohesive module (PKCE + state + HTTP + the token-refreshing
+``get_valid_connection``) keeps the SoundCloud-specific surface in one place; it
+is split only if a second distribution platform ever needs to share pieces.
+"""
+
+import base64
+import hashlib
+import hmac
+import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+import jwt
+
+from ..settings import ApiSettings
+
+# --- SoundCloud endpoints ---------------------------------------------------
+SOUNDCLOUD_AUTHORIZE_URL = "https://secure.soundcloud.com/authorize"
+SOUNDCLOUD_TOKEN_URL = "https://secure.soundcloud.com/oauth/token"
+SOUNDCLOUD_API_BASE = "https://api.soundcloud.com"
+SOUNDCLOUD_ME_URL = f"{SOUNDCLOUD_API_BASE}/me"
+SOUNDCLOUD_UPLOAD_URL = f"{SOUNDCLOUD_API_BASE}/tracks"
+
+#: SoundCloud caps uploads far higher (4 GB) but US-13.2 enforces a 500 MB ceiling.
+MAX_UPLOAD_BYTES = 500 * 1024 * 1024
+
+#: Marks the CSRF ``state`` JWT so it cannot be confused with an access token.
+LINK_STATE_TOKEN_TYPE = "soundcloud_link_state"
+LINK_STATE_EXPIRE_MINUTES = 10
+#: Per-flow cookies (namespaced by a flow id named in the state's ``sid`` claim)
+#: so concurrent link attempts don't clobber each other.
+NONCE_COOKIE_PREFIX = "sc_link_nonce_"
+VERIFIER_COOKIE_PREFIX = "sc_link_verifier_"
+_NONCE_BYTES = 32
+_FLOW_ID_BYTES = 8
+_VERIFIER_BYTES = 64
+#: Refresh slightly before the real expiry so an in-flight call isn't rejected.
+_REFRESH_BUFFER_SECONDS = 60
+_HTTP_TIMEOUT = 30.0
+
+
+class SoundCloudError(Exception):
+    """A SoundCloud OAuth/API call failed. The message is safe to surface."""
+
+
+class SoundCloudNotConfiguredError(SoundCloudError):
+    """SoundCloud client credentials are not configured."""
+
+
+class SoundCloudNotConnectedError(SoundCloudError):
+    """The user has no linked SoundCloud account."""
+
+
+class SoundCloudAuthError(SoundCloudError):
+    """Re-authorization is required (e.g. the refresh token was revoked)."""
+
+
+@dataclass
+class LinkAuthorizationRequest:
+    """The connect step's output: the authorize URL plus the secrets to cookie.
+
+    ``state_nonce`` and ``code_verifier`` must be set in their respective
+    HttpOnly cookies (``nonce_cookie_name`` / ``verifier_cookie_name``); only the
+    nonce's SHA-256 is committed inside the signed ``state``, and the verifier
+    never leaves the client until the token exchange.
+    """
+
+    url: str
+    state_nonce: str
+    code_verifier: str
+    nonce_cookie_name: str
+    verifier_cookie_name: str
+
+
+def nonce_cookie_name(flow_id: str) -> str:
+    return f"{NONCE_COOKIE_PREFIX}{flow_id}"
+
+
+def verifier_cookie_name(flow_id: str) -> str:
+    return f"{VERIFIER_COOKIE_PREFIX}{flow_id}"
+
+
+def _require_credentials(settings: ApiSettings) -> dict[str, str]:
+    """Return the SoundCloud client credentials or raise if any are unset."""
+    config = {
+        "client_id": settings.soundcloud_client_id,
+        "client_secret": settings.soundcloud_client_secret,
+        "redirect_uri": settings.soundcloud_redirect_uri,
+    }
+    missing = [k for k, v in config.items() if not v]
+    if missing:
+        raise SoundCloudNotConfiguredError(f"SoundCloud is not configured (missing: {', '.join(missing)}).")
+    return config  # type: ignore[return-value]
+
+
+def _require_secret(settings: ApiSettings) -> str:
+    if not settings.jwt_secret_key:
+        raise SoundCloudError("ACEMUSIC_API_JWT_SECRET_KEY is not set; cannot sign the SoundCloud state token.")
+    return settings.jwt_secret_key
+
+
+def _b64url(raw: bytes) -> str:
+    """base64url without padding, per RFC 7636."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Return ``(code_verifier, code_challenge)`` for a PKCE S256 exchange."""
+    verifier = _b64url(secrets.token_bytes(_VERIFIER_BYTES))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+def _hash_nonce(nonce: str) -> str:
+    return hashlib.sha256(nonce.encode("utf-8")).hexdigest()
+
+
+def _create_link_state(user_id: str, nonce: str, flow_id: str, settings: ApiSettings) -> str:
+    """Mint the short-lived signed CSRF ``state`` for an account-link flow."""
+    secret = _require_secret(settings)
+    now = datetime.now(timezone.utc)
+    payload = {
+        "type": LINK_STATE_TOKEN_TYPE,
+        "uid": user_id,
+        "cnf": _hash_nonce(nonce),
+        "sid": flow_id,
+        "iat": now,
+        "exp": now + timedelta(minutes=LINK_STATE_EXPIRE_MINUTES),
+    }
+    return jwt.encode(payload, secret, algorithm=settings.jwt_algorithm)
+
+
+def build_connect_request(user_id: str, settings: ApiSettings) -> LinkAuthorizationRequest:
+    """Build the SoundCloud authorize URL plus the per-flow client-binding secrets.
+
+    Raises :class:`SoundCloudNotConfiguredError` if credentials are unset.
+    """
+    config = _require_credentials(settings)
+    nonce = secrets.token_urlsafe(_NONCE_BYTES)
+    flow_id = secrets.token_urlsafe(_FLOW_ID_BYTES)
+    verifier, challenge = generate_pkce_pair()
+    params = {
+        "client_id": config["client_id"],
+        "redirect_uri": config["redirect_uri"],
+        "response_type": "code",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": _create_link_state(user_id, nonce, flow_id, settings),
+    }
+    return LinkAuthorizationRequest(
+        url=f"{SOUNDCLOUD_AUTHORIZE_URL}?{urlencode(params)}",
+        state_nonce=nonce,
+        code_verifier=verifier,
+        nonce_cookie_name=nonce_cookie_name(flow_id),
+        verifier_cookie_name=verifier_cookie_name(flow_id),
+    )
+
+
+@dataclass
+class ValidatedLink:
+    """The result of validating a callback's ``state`` against the cookies."""
+
+    code_verifier: str
+    nonce_cookie_name: str
+    verifier_cookie_name: str
+
+
+def validate_link_state(state: str, user_id: str, settings: ApiSettings, cookies: Mapping[str, str]) -> ValidatedLink:
+    """Verify the link ``state`` for ``user_id`` and return the PKCE verifier.
+
+    Confirms the state is a non-expired, untampered link-state JWT bound to this
+    user, whose committed nonce hash matches the client's cookie, and returns the
+    ``code_verifier`` from the per-flow cookie plus the consumed cookie names so
+    the caller can clear them. Raises :class:`SoundCloudError` otherwise.
+    """
+    secret = _require_secret(settings)
+    try:
+        payload = jwt.decode(state, secret, algorithms=[settings.jwt_algorithm])
+    except jwt.PyJWTError as exc:
+        raise SoundCloudError(f"Invalid SoundCloud state: {exc}") from exc
+
+    if payload.get("type") != LINK_STATE_TOKEN_TYPE:
+        raise SoundCloudError("Invalid SoundCloud state: not a link-state token.")
+    if payload.get("uid") != user_id:
+        raise SoundCloudError("SoundCloud state does not belong to this user.")
+
+    committed = payload.get("cnf")
+    flow_id = payload.get("sid")
+    if not committed or not flow_id:
+        raise SoundCloudError("SoundCloud state is not bound to a client.")
+
+    nonce = cookies.get(nonce_cookie_name(flow_id))
+    if not nonce:
+        raise SoundCloudError("Missing SoundCloud state cookie.")
+    if not hmac.compare_digest(committed, _hash_nonce(nonce)):
+        raise SoundCloudError("SoundCloud state does not match the initiating client.")
+
+    verifier = cookies.get(verifier_cookie_name(flow_id))
+    if not verifier:
+        raise SoundCloudError("Missing SoundCloud PKCE cookie.")
+
+    return ValidatedLink(
+        code_verifier=verifier,
+        nonce_cookie_name=nonce_cookie_name(flow_id),
+        verifier_cookie_name=verifier_cookie_name(flow_id),
+    )
+
+
+async def _post_token(data: dict[str, str], settings: ApiSettings) -> dict:
+    """POST to SoundCloud's token endpoint and return the parsed token response."""
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.post(SOUNDCLOUD_TOKEN_URL, data=data)
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPError as exc:
+        raise SoundCloudError("SoundCloud token request failed.") from exc
+
+
+async def exchange_code(code: str, code_verifier: str, settings: ApiSettings) -> dict:
+    """Exchange an authorization ``code`` (+ PKCE verifier) for a token response."""
+    config = _require_credentials(settings)
+    return await _post_token(
+        {
+            "grant_type": "authorization_code",
+            "client_id": config["client_id"],
+            "client_secret": config["client_secret"],
+            "redirect_uri": config["redirect_uri"],
+            "code_verifier": code_verifier,
+            "code": code,
+        },
+        settings,
+    )
+
+
+async def refresh_access_token(refresh_token: str, settings: ApiSettings) -> dict:
+    """Exchange a ``refresh_token`` for a fresh token response."""
+    config = _require_credentials(settings)
+    return await _post_token(
+        {
+            "grant_type": "refresh_token",
+            "client_id": config["client_id"],
+            "client_secret": config["client_secret"],
+            "refresh_token": refresh_token,
+        },
+        settings,
+    )
+
+
+async def get_soundcloud_user(access_token: str) -> dict:
+    """Fetch the linked SoundCloud account's profile (``GET /me``)."""
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.get(SOUNDCLOUD_ME_URL, headers={"Authorization": f"OAuth {access_token}"})
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPError as exc:
+        raise SoundCloudError("Fetching the SoundCloud profile failed.") from exc
+
+
+def token_expiry(expires_in: object) -> datetime:
+    """Translate SoundCloud's ``expires_in`` seconds into an absolute UTC instant.
+
+    Defaults to one hour (SoundCloud's documented access-token lifetime) when the
+    field is missing or unparseable, so a usable connection is never persisted
+    with an expiry in the past.
+    """
+    try:
+        seconds = int(expires_in)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        seconds = 3600
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+async def get_valid_connection(user_id: str, settings: ApiSettings):
+    """Return the user's connection with a guaranteed-fresh access token.
+
+    Refreshes (and persists) the token when it is within
+    :data:`_REFRESH_BUFFER_SECONDS` of expiry. A failed refresh means the link is
+    no longer usable, so the connection is deleted and
+    :class:`SoundCloudAuthError` is raised — the user must re-connect.
+
+    Imports the model locally to avoid a circular import at module load
+    (router → service → model → …).
+    """
+    from beanie import PydanticObjectId
+
+    from ..models import SoundCloudConnection
+
+    connection = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == PydanticObjectId(user_id))
+    if connection is None:
+        raise SoundCloudNotConnectedError("No SoundCloud account is linked.")
+
+    if not _is_expired(connection.token_expires_at):
+        return connection
+
+    try:
+        tokens = await refresh_access_token(connection.refresh_token, settings)
+    except SoundCloudError as exc:
+        await connection.delete()
+        raise SoundCloudAuthError("SoundCloud re-authorization is required.") from exc
+
+    connection.access_token = tokens.get("access_token") or connection.access_token
+    # SoundCloud rotates the refresh token on each use; keep the old one if absent.
+    connection.refresh_token = tokens.get("refresh_token") or connection.refresh_token
+    connection.token_expires_at = token_expiry(tokens.get("expires_in"))
+    connection.updated_at = datetime.now(timezone.utc)
+    await connection.save()
+    return connection
+
+
+def _is_expired(expires_at: datetime) -> bool:
+    """True if ``expires_at`` is within the refresh buffer of now (UTC-aware)."""
+    return _as_utc(expires_at) <= datetime.now(timezone.utc) + timedelta(seconds=_REFRESH_BUFFER_SECONDS)
+
+
+def token_valid(expires_at: datetime) -> bool:
+    """True if ``expires_at`` is still in the future.
+
+    Tolerates the naive UTC datetimes MongoDB returns (Beanie drops tzinfo), so
+    callers can compare a freshly-built or a round-tripped expiry uniformly.
+    """
+    return _as_utc(expires_at) > datetime.now(timezone.utc)
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Treat a tz-naive datetime as UTC (MongoDB stores/returns naive UTC)."""
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+
+
+#: SoundCloud track[...] form fields we forward, in a stable order.
+_TRACK_FIELDS = ("title", "genre", "description", "bpm", "key_signature", "isrc", "sharing")
+
+
+async def upload_track(
+    access_token: str,
+    audio: bytes,
+    filename: str,
+    metadata: Mapping[str, object],
+    artwork: bytes | None = None,
+) -> dict:
+    """Upload ``audio`` as a SoundCloud track and return the created track JSON.
+
+    ``metadata`` keys in :data:`_TRACK_FIELDS` become ``track[<field>]`` form
+    parts (omitting None/empty); ``artwork`` (when given) is sent as
+    ``track[artwork_data]``. Returns the SoundCloud response (includes ``id`` and
+    ``permalink_url``).
+    """
+    data = {f"track[{field}]": str(metadata[field]) for field in _TRACK_FIELDS if metadata.get(field) not in (None, "")}
+    files: dict[str, tuple] = {"track[asset_data]": (filename, audio, "application/octet-stream")}
+    if artwork is not None:
+        files["track[artwork_data]"] = ("artwork", artwork, "application/octet-stream")
+    try:
+        async with httpx.AsyncClient(timeout=None) as client:
+            resp = await client.post(
+                SOUNDCLOUD_UPLOAD_URL,
+                headers={"Authorization": f"OAuth {access_token}"},
+                data=data,
+                files=files,
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPError as exc:
+        raise SoundCloudError("SoundCloud track upload failed.") from exc
+
+
+async def fetch_artwork(url: str) -> bytes:
+    """Download cover-art bytes from ``url`` for an upload."""
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            return resp.content
+    except httpx.HTTPError as exc:
+        raise SoundCloudError("Fetching the artwork failed.") from exc

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -61,6 +61,14 @@ class ApiSettings(BaseSettings):
     discord_client_secret: str | None = None
     discord_redirect_uri: str | None = None
 
+    # SoundCloud OAuth 2.1 + PKCE for distribution account-linking (US-13.2).
+    # Separate from the login providers above: these link an *already
+    # authenticated* user's SoundCloud account so the platform can upload tracks
+    # on their behalf. Unusable until all three are set via the environment.
+    soundcloud_client_id: str | None = None
+    soundcloud_client_secret: str | None = None
+    soundcloud_redirect_uri: str | None = None
+
     # JWT signing (US-8.3). ``jwt_secret_key`` has no default on purpose: the auth
     # layer raises a clear error if a token is minted while it is unset, rather
     # than silently signing with a guessable key. Lifetimes follow the common

--- a/tests/test_distribution_api.py
+++ b/tests/test_distribution_api.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 import httpx
 import pytest
 from beanie import PydanticObjectId
+from pymongo.errors import DuplicateKeyError
 
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
@@ -434,4 +435,43 @@ class TestRelink:
         assert again.access_token == "at-2"
         assert again.refresh_token == "rt-2"
         assert again.soundcloud_username == "second"
+        assert await SoundCloudConnection.find(SoundCloudConnection.user_id == user.id).count() == 1
+
+    async def test_concurrent_insert_race_falls_back_to_update(self, settings, monkeypatch) -> None:
+        """The insert loser (DuplicateKeyError) re-resolves and updates the winner row.
+
+        The patched ``insert`` lands a 'winner' row first, then raises — simulating
+        a concurrent link that landed between our find_one and our insert. This
+        leaves ``find_one``/``save`` real, so the fallback's re-resolve + update run
+        against the actual DB.
+        """
+        user = await _make_user("upsert-race@example.com")
+        real_insert = SoundCloudConnection.insert
+        fired = {"done": False}
+
+        async def fake_insert(self):
+            if not fired["done"]:
+                fired["done"] = True
+                winner = SoundCloudConnection(
+                    user_id=self.user_id,
+                    soundcloud_user_id="winner",
+                    soundcloud_username="winner",
+                    access_token="winner-at",
+                    refresh_token="winner-rt",
+                    token_expires_at=self.token_expires_at,
+                )
+                await real_insert(winner)
+                raise DuplicateKeyError("duplicate user_id")
+            return await real_insert(self)
+
+        monkeypatch.setattr(SoundCloudConnection, "insert", fake_insert)
+
+        result = await dist._upsert_connection(
+            str(user.id),
+            {"access_token": "mine-at", "refresh_token": "mine-rt", "expires_in": 3600},
+            {"id": 9, "username": "mine"},
+        )
+        # The fallback updated the winner row in place — no duplicate, my tokens win.
+        assert result.access_token == "mine-at"
+        assert result.refresh_token == "mine-rt"
         assert await SoundCloudConnection.find(SoundCloudConnection.user_id == user.id).count() == 1

--- a/tests/test_distribution_api.py
+++ b/tests/test_distribution_api.py
@@ -310,31 +310,17 @@ class TestUpload:
         assert resp.status_code == 401
         assert await SoundCloudConnection.find_one(SoundCloudConnection.user_id == user.id) is None
 
-    async def test_artwork_url_is_fetched_and_forwarded(self, client, settings, local_storage, monkeypatch) -> None:
-        user = await _make_user("up-art@example.com")
+    async def test_unknown_override_field_rejected(self, client, settings, local_storage) -> None:
+        # ``artwork_url`` was removed; extra keys are forbidden by the schema.
+        user = await _make_user("up-extra@example.com")
         clip = await _make_clip(user, b"audio")
         await _make_connection(user)
-
-        captured = {}
-
-        async def _fetch_artwork(url):
-            assert url == "https://img.test/cover.png"
-            return b"PNGBYTES"
-
-        async def _upload(token, audio, filename, metadata, artwork=None):
-            captured["artwork"] = artwork
-            return {"id": 1}
-
-        monkeypatch.setattr(sc, "fetch_artwork", _fetch_artwork)
-        monkeypatch.setattr(sc, "upload_track", _upload)
-
         resp = await client.post(
             _url("/soundcloud/upload"),
             headers=_auth_headers(user, settings),
             json={"clip_id": str(clip.id), "metadata_overrides": {"artwork_url": "https://img.test/cover.png"}},
         )
-        assert resp.status_code == 200
-        assert captured["artwork"] == b"PNGBYTES"
+        assert resp.status_code == 422
 
     async def test_token_refreshed_when_expired(self, client, settings, local_storage, monkeypatch) -> None:
         user = await _make_user("up-refresh@example.com")

--- a/tests/test_distribution_api.py
+++ b/tests/test_distribution_api.py
@@ -1,0 +1,331 @@
+"""Integration tests for the SoundCloud distribution router (US-13.2).
+
+These drive the real app over ``httpx.AsyncClient`` against a local MongoDB
+(``mongo_db``) and real LocalStorage. The outbound SoundCloud HTTP calls are
+monkeypatched at the service seam (the pattern ``tests/test_auth_routes.py`` uses
+for route tests, since ``respx`` does not intercept the in-process ASGITransport).
+The HTTP wire format of those calls is covered by ``tests/test_soundcloud_service.py``.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, SoundCloudConnection
+from acemusic.api.services import soundcloud as sc, users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+pytestmark = pytest.mark.integration
+
+
+def _url(path: str) -> str:
+    return f"{API_V1_PREFIX}/distribution{path}"
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+            "soundcloud_client_id": "sc-id",
+            "soundcloud_client_secret": "sc-secret",
+            "soundcloud_redirect_uri": "https://app.test/distribution/soundcloud/callback",
+            "oauth_cookie_secure": False,  # allow cookies over http in tests
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), email=user.email, subscription_tier=user.subscription_tier, settings=settings
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_clip(user, audio: bytes, *, fmt: str = "wav", title: str | None = "Tune", store: bool = True):
+    clip_id = PydanticObjectId()
+    workspace_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace_id}/clips/{clip_id}.{fmt}"
+    if store:
+        get_storage_backend().upload(file_path, audio)
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace_id,
+        file_path=file_path,
+        format=fmt,
+        title=title,
+        bpm=120,
+        key="Am",
+        style_tags=["techno"],
+    )
+    await clip.insert()
+    return clip
+
+
+async def _make_connection(user, *, expires_in_seconds: int = 3600) -> SoundCloudConnection:
+    conn = SoundCloudConnection(
+        user_id=user.id,
+        soundcloud_user_id="sc-42",
+        soundcloud_username="dj",
+        access_token="at",
+        refresh_token="rt",
+        token_expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds),
+    )
+    await conn.insert()
+    return conn
+
+
+# --- connect ----------------------------------------------------------------
+class TestConnect:
+    async def test_returns_authorization_url_and_sets_cookies(self, client, settings) -> None:
+        user = await _make_user("connect@example.com")
+        resp = await client.post(_url("/soundcloud/connect"), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["authorization_url"].startswith(sc.SOUNDCLOUD_AUTHORIZE_URL)
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert sc.NONCE_COOKIE_PREFIX in set_cookie
+        assert sc.VERIFIER_COOKIE_PREFIX in set_cookie
+
+    async def test_unconfigured_returns_503(self, client, settings) -> None:
+        # Rebuild the app without SoundCloud credentials.
+        bare = settings.model_copy(update={"soundcloud_client_id": None})
+        async with _async_client(create_app(bare)) as ac:
+            user = await _make_user("connect-503@example.com")
+            resp = await ac.post(_url("/soundcloud/connect"), headers=_auth_headers(user, bare))
+        assert resp.status_code == 503
+
+    async def test_requires_auth(self, client) -> None:
+        resp = await client.post(_url("/soundcloud/connect"))
+        assert resp.status_code == 401
+
+
+# --- callback (AC: OAuth completes and stores tokens) -----------------------
+class TestCallback:
+    async def test_completes_flow_and_persists_connection(self, client, settings, monkeypatch) -> None:
+        user = await _make_user("cb@example.com")
+        headers = _auth_headers(user, settings)
+
+        # Start the flow so the client holds the nonce/verifier cookies, then
+        # extract the signed state from the returned URL.
+        started = await client.post(_url("/soundcloud/connect"), headers=headers)
+        state = httpx.URL(started.json()["authorization_url"]).params["state"]
+
+        async def _exchange(code, verifier, _settings):
+            assert code == "auth-code"
+            return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+        async def _me(token):
+            assert token == "at"
+            return {"id": 42, "username": "dj"}
+
+        monkeypatch.setattr(sc, "exchange_code", _exchange)
+        monkeypatch.setattr(sc, "get_soundcloud_user", _me)
+
+        resp = await client.post(
+            _url("/soundcloud/callback"), headers=headers, json={"code": "auth-code", "state": state}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["connected"] is True
+        assert resp.json()["soundcloud_username"] == "dj"
+
+        stored = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == user.id)
+        assert stored is not None
+        assert stored.access_token == "at"
+        assert stored.refresh_token == "rt"
+
+    async def test_bad_state_returns_400(self, client, settings) -> None:
+        user = await _make_user("cb-bad@example.com")
+        resp = await client.post(
+            _url("/soundcloud/callback"),
+            headers=_auth_headers(user, settings),
+            json={"code": "c", "state": "not-a-jwt"},
+        )
+        assert resp.status_code == 400
+
+
+# --- status -----------------------------------------------------------------
+class TestStatus:
+    async def test_not_connected(self, client, settings) -> None:
+        user = await _make_user("status-off@example.com")
+        resp = await client.get(_url("/soundcloud/status"), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "connected": False,
+            "soundcloud_username": None,
+            "connected_at": None,
+            "token_valid": None,
+        }
+
+    async def test_connected_reports_username_and_token_valid(self, client, settings) -> None:
+        user = await _make_user("status-on@example.com")
+        await _make_connection(user)
+        resp = await client.get(_url("/soundcloud/status"), headers=_auth_headers(user, settings))
+        body = resp.json()
+        assert body["connected"] is True
+        assert body["soundcloud_username"] == "dj"
+        assert body["token_valid"] is True
+
+
+# --- upload (AC: creates track, sets metadata, cover art, token refresh) -----
+class TestUpload:
+    async def test_happy_path_uploads_with_merged_metadata(self, client, settings, local_storage, monkeypatch) -> None:
+        user = await _make_user("up@example.com")
+        clip = await _make_clip(user, b"RIFFaudio")
+        await _make_connection(user)
+
+        captured = {}
+
+        async def _upload(token, audio, filename, metadata, artwork=None):
+            captured.update(token=token, audio=audio, filename=filename, metadata=metadata, artwork=artwork)
+            return {"id": 777, "permalink_url": "https://snd.sc/x"}
+
+        monkeypatch.setattr(sc, "upload_track", _upload)
+
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(user, settings),
+            json={"clip_id": str(clip.id), "metadata_overrides": {"genre": "house"}},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"track_id": "777", "permalink_url": "https://snd.sc/x"}
+        # Clip-derived metadata with the override taking precedence.
+        assert captured["metadata"]["title"] == "Tune"
+        assert captured["metadata"]["bpm"] == 120
+        assert captured["metadata"]["key_signature"] == "Am"
+        assert captured["metadata"]["genre"] == "house"  # override beat the style_tag default
+        assert captured["audio"] == b"RIFFaudio"
+
+    async def test_artwork_url_is_fetched_and_forwarded(self, client, settings, local_storage, monkeypatch) -> None:
+        user = await _make_user("up-art@example.com")
+        clip = await _make_clip(user, b"audio")
+        await _make_connection(user)
+
+        captured = {}
+
+        async def _fetch_artwork(url):
+            assert url == "https://img.test/cover.png"
+            return b"PNGBYTES"
+
+        async def _upload(token, audio, filename, metadata, artwork=None):
+            captured["artwork"] = artwork
+            return {"id": 1}
+
+        monkeypatch.setattr(sc, "fetch_artwork", _fetch_artwork)
+        monkeypatch.setattr(sc, "upload_track", _upload)
+
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(user, settings),
+            json={"clip_id": str(clip.id), "metadata_overrides": {"artwork_url": "https://img.test/cover.png"}},
+        )
+        assert resp.status_code == 200
+        assert captured["artwork"] == b"PNGBYTES"
+
+    async def test_token_refreshed_when_expired(self, client, settings, local_storage, monkeypatch) -> None:
+        user = await _make_user("up-refresh@example.com")
+        clip = await _make_clip(user, b"audio")
+        await _make_connection(user, expires_in_seconds=-10)  # already expired
+
+        async def _refresh(refresh_token, _settings):
+            assert refresh_token == "rt"
+            return {"access_token": "fresh-at", "refresh_token": "fresh-rt", "expires_in": 3600}
+
+        used_token = {}
+
+        async def _upload(token, audio, filename, metadata, artwork=None):
+            used_token["token"] = token
+            return {"id": 2}
+
+        monkeypatch.setattr(sc, "refresh_access_token", _refresh)
+        monkeypatch.setattr(sc, "upload_track", _upload)
+
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(user, settings),
+            json={"clip_id": str(clip.id)},
+        )
+        assert resp.status_code == 200
+        assert used_token["token"] == "fresh-at"  # refreshed token used for upload
+        stored = await SoundCloudConnection.find_one(SoundCloudConnection.user_id == user.id)
+        assert stored.access_token == "fresh-at"
+        assert stored.refresh_token == "fresh-rt"
+
+    async def test_not_owned_clip_returns_404(self, client, settings, local_storage, monkeypatch) -> None:
+        owner = await _make_user("up-owner@example.com")
+        other = await _make_user("up-other@example.com")
+        clip = await _make_clip(owner, b"audio")
+        await _make_connection(other)
+        monkeypatch.setattr(sc, "upload_track", lambda *a, **k: {"id": 1})
+
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(other, settings),
+            json={"clip_id": str(clip.id)},
+        )
+        assert resp.status_code == 404
+
+    async def test_not_connected_returns_400(self, client, settings, local_storage) -> None:
+        user = await _make_user("up-noconn@example.com")
+        clip = await _make_clip(user, b"audio")
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(user, settings),
+            json={"clip_id": str(clip.id)},
+        )
+        assert resp.status_code == 400
+
+    async def test_oversized_audio_returns_413(self, client, settings, local_storage, monkeypatch) -> None:
+        user = await _make_user("up-big@example.com")
+        clip = await _make_clip(user, b"x" * 100)
+        await _make_connection(user)
+        monkeypatch.setattr(sc, "MAX_UPLOAD_BYTES", 10)  # shrink the cap to trip the guard
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(user, settings),
+            json={"clip_id": str(clip.id)},
+        )
+        assert resp.status_code == 413
+
+
+# --- disconnect -------------------------------------------------------------
+class TestDisconnect:
+    async def test_deletes_connection_and_is_idempotent(self, client, settings) -> None:
+        user = await _make_user("disc@example.com")
+        await _make_connection(user)
+        headers = _auth_headers(user, settings)
+
+        first = await client.delete(_url("/soundcloud/connect"), headers=headers)
+        assert first.status_code == 204
+        assert await SoundCloudConnection.find_one(SoundCloudConnection.user_id == user.id) is None
+
+        second = await client.delete(_url("/soundcloud/connect"), headers=headers)
+        assert second.status_code == 204  # idempotent

--- a/tests/test_distribution_api.py
+++ b/tests/test_distribution_api.py
@@ -70,12 +70,24 @@ async def _make_user(email: str):
     return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
 
 
-async def _make_clip(user, audio: bytes, *, fmt: str = "wav", title: str | None = "Tune", store: bool = True):
+async def _make_clip(
+    user,
+    audio: bytes,
+    *,
+    fmt: str = "wav",
+    title: str | None = "Tune",
+    store: bool = True,
+    artwork: bytes | None = None,
+):
     clip_id = PydanticObjectId()
     workspace_id = PydanticObjectId()
     file_path = f"{user.id}/{workspace_id}/clips/{clip_id}.{fmt}"
     if store:
         get_storage_backend().upload(file_path, audio)
+    artwork_path = None
+    if artwork is not None:
+        artwork_path = f"{user.id}/{workspace_id}/clips/{clip_id}.png"
+        get_storage_backend().upload(artwork_path, artwork)
     clip = Clip(
         id=clip_id,
         user_id=user.id,
@@ -86,6 +98,7 @@ async def _make_clip(user, audio: bytes, *, fmt: str = "wav", title: str | None 
         bpm=120,
         key="Am",
         style_tags=["techno"],
+        artwork_path=artwork_path,
     )
     await clip.insert()
     return clip
@@ -223,6 +236,79 @@ class TestUpload:
         assert captured["metadata"]["key_signature"] == "Am"
         assert captured["metadata"]["genre"] == "house"  # override beat the style_tag default
         assert captured["audio"] == b"RIFFaudio"
+
+    async def test_untitled_clip_falls_back_to_clip_id_as_title(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        user = await _make_user("up-untitled@example.com")
+        clip = await _make_clip(user, b"audio", title=None)
+        await _make_connection(user)
+
+        captured = {}
+
+        async def _upload(token, audio, filename, metadata, artwork=None):
+            captured["metadata"] = metadata
+            return {"id": 5}
+
+        monkeypatch.setattr(sc, "upload_track", _upload)
+        resp = await client.post(
+            _url("/soundcloud/upload"), headers=_auth_headers(user, settings), json={"clip_id": str(clip.id)}
+        )
+        assert resp.status_code == 200
+        assert captured["metadata"]["title"] == str(clip.id)  # never empty for SoundCloud
+
+    async def test_clip_artwork_uploaded_by_default(self, client, settings, local_storage, monkeypatch) -> None:
+        user = await _make_user("up-defaultart@example.com")
+        clip = await _make_clip(user, b"audio", artwork=b"COVERPNG")
+        await _make_connection(user)
+
+        captured = {}
+
+        async def _upload(token, audio, filename, metadata, artwork=None):
+            captured["artwork"] = artwork
+            return {"id": 6}
+
+        monkeypatch.setattr(sc, "upload_track", _upload)
+        resp = await client.post(
+            _url("/soundcloud/upload"), headers=_auth_headers(user, settings), json={"clip_id": str(clip.id)}
+        )
+        assert resp.status_code == 200
+        assert captured["artwork"] == b"COVERPNG"  # the clip's own cover art, no override needed
+
+    async def test_transient_refresh_failure_preserves_connection(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        user = await _make_user("up-transient@example.com")
+        clip = await _make_clip(user, b"audio")
+        await _make_connection(user, expires_in_seconds=-10)  # expired → triggers refresh
+
+        async def _refresh(refresh_token, _settings):
+            raise sc.SoundCloudError("SoundCloud token request failed.")
+
+        monkeypatch.setattr(sc, "refresh_access_token", _refresh)
+        resp = await client.post(
+            _url("/soundcloud/upload"), headers=_auth_headers(user, settings), json={"clip_id": str(clip.id)}
+        )
+        assert resp.status_code == 502
+        # The link survives a transient outage so a later retry can succeed.
+        assert await SoundCloudConnection.find_one(SoundCloudConnection.user_id == user.id) is not None
+
+    async def test_revoked_refresh_token_unlinks_and_returns_401(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        user = await _make_user("up-revoked@example.com")
+        clip = await _make_clip(user, b"audio")
+        await _make_connection(user, expires_in_seconds=-10)
+
+        async def _refresh(refresh_token, _settings):
+            raise sc.SoundCloudAuthError("SoundCloud rejected the authorization grant.")
+
+        monkeypatch.setattr(sc, "refresh_access_token", _refresh)
+        resp = await client.post(
+            _url("/soundcloud/upload"), headers=_auth_headers(user, settings), json={"clip_id": str(clip.id)}
+        )
+        assert resp.status_code == 401
+        assert await SoundCloudConnection.find_one(SoundCloudConnection.user_id == user.id) is None
 
     async def test_artwork_url_is_fetched_and_forwarded(self, client, settings, local_storage, monkeypatch) -> None:
         user = await _make_user("up-art@example.com")

--- a/tests/test_distribution_api.py
+++ b/tests/test_distribution_api.py
@@ -16,6 +16,7 @@ from beanie import PydanticObjectId
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Clip, SoundCloudConnection
+from acemusic.api.routers import distribution as dist
 from acemusic.api.services import soundcloud as sc, users as user_service
 from acemusic.api.settings import ApiSettings
 from acemusic.storage import get_storage_backend
@@ -356,7 +357,11 @@ class TestUpload:
         other = await _make_user("up-other@example.com")
         clip = await _make_clip(owner, b"audio")
         await _make_connection(other)
-        monkeypatch.setattr(sc, "upload_track", lambda *a, **k: {"id": 1})
+
+        async def _upload(*a, **k):  # async to match the real signature; never reached
+            return {"id": 1}
+
+        monkeypatch.setattr(sc, "upload_track", _upload)
 
         resp = await client.post(
             _url("/soundcloud/upload"),
@@ -401,3 +406,32 @@ class TestDisconnect:
 
         second = await client.delete(_url("/soundcloud/connect"), headers=headers)
         assert second.status_code == 204  # idempotent
+
+
+# --- re-link / upsert update path -------------------------------------------
+class TestRelink:
+    async def test_relink_updates_existing_connection_in_place(self, settings) -> None:
+        """A second successful link for an already-connected user updates in place.
+
+        Exercises ``_upsert_connection``'s update branch + ``_apply_tokens`` (the
+        same update the DuplicateKeyError race fallback runs) against a real DB —
+        the unique ``user_id`` index means no second row is created.
+        """
+        user = await _make_user("relink@example.com")
+        updated = await dist._upsert_connection(
+            str(user.id),
+            {"access_token": "at-1", "refresh_token": "rt-1", "expires_in": 3600},
+            {"id": 1, "username": "first"},
+        )
+        assert updated.access_token == "at-1"
+
+        again = await dist._upsert_connection(
+            str(user.id),
+            {"access_token": "at-2", "refresh_token": "rt-2", "expires_in": 3600},
+            {"id": 1, "username": "second"},
+        )
+        assert again.id == updated.id  # same row, updated in place
+        assert again.access_token == "at-2"
+        assert again.refresh_token == "rt-2"
+        assert again.soundcloud_username == "second"
+        assert await SoundCloudConnection.find(SoundCloudConnection.user_id == user.id).count() == 1

--- a/tests/test_soundcloud_service.py
+++ b/tests/test_soundcloud_service.py
@@ -1,0 +1,191 @@
+"""Unit tests for the SoundCloud distribution service (US-13.2).
+
+Pure helpers (PKCE, state) run with no I/O; the OAuth/upload HTTP calls are
+mocked with ``respx`` (the same library the login OAuth tests use). The
+DB-backed ``get_valid_connection`` is exercised end-to-end in
+``tests/test_distribution_api.py``.
+"""
+
+import base64
+import hashlib
+
+import httpx
+import pytest
+import respx
+
+from acemusic.api.services import soundcloud as sc
+from acemusic.api.settings import ApiSettings
+
+
+def _settings(**overrides) -> ApiSettings:
+    base = {
+        "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+        "soundcloud_client_id": "sc-id",
+        "soundcloud_client_secret": "sc-secret",
+        "soundcloud_redirect_uri": "https://app.test/distribution/soundcloud/callback",
+    }
+    base.update(overrides)
+    return ApiSettings(_env_file=None, **base)
+
+
+class TestPkce:
+    def test_pair_is_base64url_and_challenge_matches_verifier(self) -> None:
+        verifier, challenge = sc.generate_pkce_pair()
+        # base64url, no padding
+        assert "=" not in verifier and "=" not in challenge
+        assert "+" not in verifier and "/" not in verifier
+        expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+        assert challenge == expected
+
+    def test_pairs_are_unique(self) -> None:
+        assert sc.generate_pkce_pair()[0] != sc.generate_pkce_pair()[0]
+
+
+class TestBuildConnectRequest:
+    def test_url_carries_pkce_and_state(self) -> None:
+        settings = _settings()
+        link = sc.build_connect_request("user-1", settings)
+        assert link.url.startswith(sc.SOUNDCLOUD_AUTHORIZE_URL + "?")
+        assert "code_challenge_method=S256" in link.url
+        assert "response_type=code" in link.url
+        # The raw nonce/verifier are returned for cookies, never placed in the URL.
+        assert link.state_nonce not in link.url
+        assert link.code_verifier not in link.url
+        assert link.nonce_cookie_name.startswith(sc.NONCE_COOKIE_PREFIX)
+        assert link.verifier_cookie_name.startswith(sc.VERIFIER_COOKIE_PREFIX)
+
+    def test_unconfigured_raises(self) -> None:
+        settings = _settings(soundcloud_client_id=None)
+        with pytest.raises(sc.SoundCloudNotConfiguredError):
+            sc.build_connect_request("user-1", settings)
+
+
+class TestStateRoundTrip:
+    def test_valid_state_returns_verifier(self) -> None:
+        settings = _settings()
+        link = sc.build_connect_request("user-1", settings)
+        cookies = {link.nonce_cookie_name: link.state_nonce, link.verifier_cookie_name: link.code_verifier}
+        state = link.url.split("state=", 1)[1].split("&", 1)[0]
+        # urlencode percent-encodes nothing JWT-relevant here, but decode to be safe.
+        from urllib.parse import unquote
+
+        validated = sc.validate_link_state(unquote(state), "user-1", settings, cookies)
+        assert validated.code_verifier == link.code_verifier
+
+    def test_wrong_user_rejected(self) -> None:
+        settings = _settings()
+        link = sc.build_connect_request("user-1", settings)
+        cookies = {link.nonce_cookie_name: link.state_nonce, link.verifier_cookie_name: link.code_verifier}
+        from urllib.parse import unquote
+
+        state = unquote(link.url.split("state=", 1)[1].split("&", 1)[0])
+        with pytest.raises(sc.SoundCloudError):
+            sc.validate_link_state(state, "user-2", settings, cookies)
+
+    def test_missing_nonce_cookie_rejected(self) -> None:
+        settings = _settings()
+        link = sc.build_connect_request("user-1", settings)
+        from urllib.parse import unquote
+
+        state = unquote(link.url.split("state=", 1)[1].split("&", 1)[0])
+        cookies = {link.verifier_cookie_name: link.code_verifier}  # nonce missing
+        with pytest.raises(sc.SoundCloudError):
+            sc.validate_link_state(state, "user-1", settings, cookies)
+
+    def test_tampered_nonce_rejected(self) -> None:
+        settings = _settings()
+        link = sc.build_connect_request("user-1", settings)
+        from urllib.parse import unquote
+
+        state = unquote(link.url.split("state=", 1)[1].split("&", 1)[0])
+        cookies = {link.nonce_cookie_name: "not-the-nonce", link.verifier_cookie_name: link.code_verifier}
+        with pytest.raises(sc.SoundCloudError):
+            sc.validate_link_state(state, "user-1", settings, cookies)
+
+
+@respx.mock
+async def test_exchange_code_posts_pkce_params() -> None:
+    settings = _settings()
+    route = respx.post(sc.SOUNDCLOUD_TOKEN_URL).mock(
+        return_value=httpx.Response(200, json={"access_token": "at", "refresh_token": "rt", "expires_in": 3600})
+    )
+    tokens = await sc.exchange_code("the-code", "the-verifier", settings)
+    assert tokens["access_token"] == "at"
+    sent = route.calls.last.request
+    body = sent.content.decode()
+    assert "grant_type=authorization_code" in body
+    assert "code_verifier=the-verifier" in body
+    assert "code=the-code" in body
+
+
+@respx.mock
+async def test_refresh_access_token_uses_refresh_grant() -> None:
+    settings = _settings()
+    route = respx.post(sc.SOUNDCLOUD_TOKEN_URL).mock(
+        return_value=httpx.Response(200, json={"access_token": "at2", "refresh_token": "rt2", "expires_in": 3600})
+    )
+    tokens = await sc.refresh_access_token("old-refresh", settings)
+    assert tokens["access_token"] == "at2"
+    body = route.calls.last.request.content.decode()
+    assert "grant_type=refresh_token" in body
+    assert "refresh_token=old-refresh" in body
+
+
+@respx.mock
+async def test_token_request_error_is_wrapped() -> None:
+    settings = _settings()
+    respx.post(sc.SOUNDCLOUD_TOKEN_URL).mock(return_value=httpx.Response(401, json={"error": "invalid_grant"}))
+    with pytest.raises(sc.SoundCloudError):
+        await sc.refresh_access_token("bad", settings)
+
+
+@respx.mock
+async def test_get_soundcloud_user_uses_oauth_header() -> None:
+    route = respx.get(sc.SOUNDCLOUD_ME_URL).mock(return_value=httpx.Response(200, json={"id": 42, "username": "dj"}))
+    profile = await sc.get_soundcloud_user("tok")
+    assert profile["username"] == "dj"
+    assert route.calls.last.request.headers["Authorization"] == "OAuth tok"
+
+
+@respx.mock
+async def test_upload_track_sends_multipart_metadata_and_audio() -> None:
+    route = respx.post(sc.SOUNDCLOUD_UPLOAD_URL).mock(
+        return_value=httpx.Response(201, json={"id": 999, "permalink_url": "https://snd.sc/x"})
+    )
+    metadata = {"title": "My Song", "genre": "house", "bpm": 128, "key_signature": "Am", "sharing": "public"}
+    track = await sc.upload_track("tok", b"RIFFxxxx", "song.wav", metadata, artwork=b"\x89PNGdata")
+    assert track["id"] == 999
+    request = route.calls.last.request
+    assert request.headers["Authorization"] == "OAuth tok"
+    body = request.content  # multipart body bytes
+    assert b'name="track[title]"' in body and b"My Song" in body
+    assert b'name="track[genre]"' in body and b"house" in body
+    assert b'name="track[bpm]"' in body and b"128" in body
+    assert b'name="track[key_signature]"' in body and b"Am" in body
+    assert b'name="track[sharing]"' in body and b"public" in body
+    assert b'name="track[asset_data]"' in body and b"RIFFxxxx" in body
+    assert b'name="track[artwork_data]"' in body and b"PNGdata" in body
+
+
+@respx.mock
+async def test_upload_track_omits_absent_optional_fields() -> None:
+    route = respx.post(sc.SOUNDCLOUD_UPLOAD_URL).mock(return_value=httpx.Response(201, json={"id": 1}))
+    await sc.upload_track("tok", b"audio", "a.wav", {"title": "T"}, artwork=None)
+    body = route.calls.last.request.content
+    assert b"track[genre]" not in body
+    assert b"track[artwork_data]" not in body
+
+
+class TestTokenExpiry:
+    def test_uses_expires_in_seconds(self) -> None:
+        from datetime import datetime, timezone
+
+        before = datetime.now(timezone.utc)
+        expiry = sc.token_expiry(3600)
+        assert 3500 < (expiry - before).total_seconds() < 3700
+
+    def test_defaults_to_one_hour_when_unparseable(self) -> None:
+        from datetime import datetime, timezone
+
+        expiry = sc.token_expiry(None)
+        assert expiry > datetime.now(timezone.utc)

--- a/tests/test_soundcloud_service.py
+++ b/tests/test_soundcloud_service.py
@@ -149,24 +149,6 @@ async def test_transient_token_failure_is_not_auth_error() -> None:
     assert not isinstance(excinfo.value, sc.SoundCloudAuthError)
 
 
-class TestArtworkSsrf:
-    async def test_rejects_non_http_scheme(self) -> None:
-        with pytest.raises(sc.SoundCloudError):
-            await sc.fetch_artwork("ftp://example.com/cover.png")
-
-    async def test_rejects_loopback(self) -> None:
-        with pytest.raises(sc.SoundCloudError):
-            await sc.fetch_artwork("http://127.0.0.1/cover.png")
-
-    async def test_rejects_cloud_metadata_link_local(self) -> None:
-        with pytest.raises(sc.SoundCloudError):
-            await sc.fetch_artwork("http://169.254.169.254/latest/meta-data/")
-
-    async def test_allows_public_ip(self) -> None:
-        # Pure host check — no HTTP request is made, so this stays offline.
-        await sc._assert_public_url("https://8.8.8.8/cover.png")
-
-
 @respx.mock
 async def test_get_soundcloud_user_uses_oauth_header() -> None:
     route = respx.get(sc.SOUNDCLOUD_ME_URL).mock(return_value=httpx.Response(200, json={"id": 42, "username": "dj"}))

--- a/tests/test_soundcloud_service.py
+++ b/tests/test_soundcloud_service.py
@@ -132,11 +132,39 @@ async def test_refresh_access_token_uses_refresh_grant() -> None:
 
 
 @respx.mock
-async def test_token_request_error_is_wrapped() -> None:
+async def test_rejected_grant_raises_auth_error() -> None:
     settings = _settings()
-    respx.post(sc.SOUNDCLOUD_TOKEN_URL).mock(return_value=httpx.Response(401, json={"error": "invalid_grant"}))
-    with pytest.raises(sc.SoundCloudError):
-        await sc.refresh_access_token("bad", settings)
+    respx.post(sc.SOUNDCLOUD_TOKEN_URL).mock(return_value=httpx.Response(400, json={"error": "invalid_grant"}))
+    with pytest.raises(sc.SoundCloudAuthError):
+        await sc.refresh_access_token("revoked", settings)
+
+
+@respx.mock
+async def test_transient_token_failure_is_not_auth_error() -> None:
+    settings = _settings()
+    respx.post(sc.SOUNDCLOUD_TOKEN_URL).mock(return_value=httpx.Response(503))
+    with pytest.raises(sc.SoundCloudError) as excinfo:
+        await sc.refresh_access_token("good", settings)
+    # A 5xx is retryable: it must NOT be the auth subclass that deletes the link.
+    assert not isinstance(excinfo.value, sc.SoundCloudAuthError)
+
+
+class TestArtworkSsrf:
+    async def test_rejects_non_http_scheme(self) -> None:
+        with pytest.raises(sc.SoundCloudError):
+            await sc.fetch_artwork("ftp://example.com/cover.png")
+
+    async def test_rejects_loopback(self) -> None:
+        with pytest.raises(sc.SoundCloudError):
+            await sc.fetch_artwork("http://127.0.0.1/cover.png")
+
+    async def test_rejects_cloud_metadata_link_local(self) -> None:
+        with pytest.raises(sc.SoundCloudError):
+            await sc.fetch_artwork("http://169.254.169.254/latest/meta-data/")
+
+    async def test_allows_public_ip(self) -> None:
+        # Pure host check — no HTTP request is made, so this stays offline.
+        await sc._assert_public_url("https://8.8.8.8/cover.png")
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

Implements **US-13.2: SoundCloud OAuth and upload** (#133). Adds a new
`/api/v1/distribution` router that links a user's SoundCloud account via OAuth 2.1
+ PKCE (account-linking, distinct from login) and uploads owned clips as SoundCloud
tracks with metadata, cover art, and transparent token refresh.

Closes #133.

## What's included

- **`SoundCloudConnection`** Beanie model — one connection per user (unique `user_id`),
  storing the OAuth tokens and expiry. Registered in `ALL_MODELS`.
- **`services/soundcloud.py`** — one cohesive SoundCloud client: PKCE pair generation,
  signed-state CSRF (uid-bound, double-submit cookie pattern mirroring `auth/oauth.py`),
  token exchange/refresh, `get_valid_connection` (refresh-on-expiry), and multipart upload.
- **`routers/distribution.py`** — endpoints:
  - `POST /soundcloud/connect` → returns the authorize URL, sets per-flow HttpOnly cookies
  - `POST /soundcloud/callback` → validates state, exchanges the code, persists tokens
  - `GET /soundcloud/status` → reports link status + token validity
  - `POST /soundcloud/upload` → uploads an owned clip (metadata + the clip's cover art)
  - `DELETE /soundcloud/connect` → unlink (idempotent, 204)
- **Settings** — `ACEMUSIC_API_SOUNDCLOUD_CLIENT_ID/SECRET/REDIRECT_URI`.

## Deviations from the issue's CodeRabbit plan (live-codebase driven)

- **One service module**, not three (`soundcloud_oauth` + `soundcloud_client` +
  `soundcloud_service` collapsed) — YAGNI for a single platform.
- **No `artwork_url` override.** The plan accepted an optional external `artwork_url`;
  during review this proved to be an SSRF/unbounded-download surface for no real gain,
  since the clip's own validated cover art (US-13.1 `artwork_path`) already satisfies the
  cover-art criterion. The upload uses the clip's stored art instead.
- Verified the real SoundCloud OAuth 2.1 endpoints + `Authorization: OAuth <token>` header
  (not Bearer) rather than trusting the plan.

## Acceptance criteria → evidence

| Criterion | Evidence |
|---|---|
| OAuth completes & stores access/refresh tokens | `test_distribution_api.py::TestCallback::test_completes_flow_and_persists_connection` |
| Upload creates a track | `TestUpload::test_happy_path_uploads_with_merged_metadata` |
| Metadata (title, genre, BPM) set | same test + `test_soundcloud_service.py::test_upload_track_sends_multipart_metadata_and_audio` |
| Cover art uploaded alongside audio | `TestUpload::test_clip_artwork_uploaded_by_default` |
| Token refresh transparent on expiry | `TestUpload::test_token_refreshed_when_expired` |

## Review (codex, 3 rounds — all blocking items addressed)

- SSRF via arbitrary artwork URL → **removed the `artwork_url` path** entirely.
- Token-refresh deletes connection on transient failure → **only a rejected grant
  (400/401) unlinks**; network/5xx is retryable and preserves the connection.
- Untitled clip produced no `track[title]` → **falls back to the clip id**.
- Concurrent first-time link → duplicate-key 500 → **race-safe upsert** (DuplicateKeyError
  re-resolve, mirroring `users.get_or_create_user`).
- Concurrent refresh rotation could unlink a just-refreshed user → **re-read before delete**.
- Unbounded upload timeout → **finite connect/read/write/pool timeouts**.

## Known limitations

- **Audio is buffered fully in memory** before upload (`storage.download()`), matching the
  existing codebase-wide pattern (clip audio, artwork, mastering all do the same). True
  streaming would require extending the shared `StorageBackend` ABC and is out of scope for
  this PR; clips here are short generated audio well under the 500 MB ceiling.
- **No live SoundCloud credentials** in this environment, so verification is via unit +
  integration tests with the SoundCloud HTTP calls mocked (respx for wire format, service-seam
  monkeypatch for routes) — mirrors the Dolby/ElevenLabs precedent. The exact upstream
  multipart field names / token payload should be confirmed against a real SoundCloud app.

## Testing

- `tests/test_soundcloud_service.py` — 17 unit tests (PKCE, state round-trip, token
  exchange/refresh + auth-vs-transient mapping, `/me`, multipart upload).
- `tests/test_distribution_api.py` — 18 integration tests (connect/callback/status/upload/
  disconnect, ownership, size guard, refresh paths, race-safe upsert).
- `ruff` + `black --check` clean; full unit suite green.
