### PR TITLE
US-13.3: Release package assembly

### DIFF
--- a/docs/demos/us-13.3-releases.md
+++ b/docs/demos/us-13.3-releases.md
@@ -1,0 +1,175 @@
+# US-13.3: Release package assembly
+
+*2026-06-21T22:45:02Z*
+
+Release-package CRUD under `/api/v1/releases` bundles a clip's mastered audio, cover art, and distribution metadata into a validated package. This demo drives the real FastAPI app over a local MongoDB and exercises every acceptance criterion with live request/response evidence.
+
+```bash
+ulimit -n 64000 && uv run python .cache/demo_releases.py 2>/dev/null
+```
+
+```output
+======================================================================
+AC1: complete metadata + mastered clip with art -> 201 ready, no warnings
+======================================================================
+
+$ POST /releases (mastered clip, full metadata)
+  HTTP 201
+  {
+    "id": "6a3869755fe9c11e518d569f",
+    "clip_id": "6a3869755fe9c11e518d569e",
+    "status": "ready",
+    "warnings": [],
+    "created_at": "2026-06-21T22:45:09.755547Z",
+    "updated_at": null,
+    "title": "Midnight Drive",
+    "artist": "The Algorithm",
+    "genre": "synthwave",
+    "release_date": "2026-07-01T00:00:00Z",
+    "album_name": "Neon Highways",
+    "description": null,
+    "isrc": "USABC1234567",
+    "upc": null,
+    "copyright": null,
+    "is_explicit": null,
+    "language": null,
+    "credits": null
+  }
+
+  ✓ status=ready, warnings=[]
+
+======================================================================
+AC5: package contents = metadata JSON (inline) + clip_id + warnings
+======================================================================
+
+$ GET /releases/{id}
+  HTTP 200
+  {
+    "id": "6a3869755fe9c11e518d569f",
+    "clip_id": "6a3869755fe9c11e518d569e",
+    "status": "ready",
+    "warnings": [],
+    "created_at": "2026-06-21T22:45:09.755000",
+    "updated_at": null,
+    "title": "Midnight Drive",
+    "artist": "The Algorithm",
+    "genre": "synthwave",
+    "release_date": "2026-07-01T00:00:00",
+    "album_name": "Neon Highways",
+    "description": null,
+    "isrc": "USABC1234567",
+    "upc": null,
+    "copyright": null,
+    "is_explicit": null,
+    "language": null,
+    "credits": null
+  }
+
+  ✓ contents: metadata inline, clip_id resolves to audio+artwork, warnings present
+
+======================================================================
+AC2: missing required field -> 422 with field-specific error
+======================================================================
+
+$ POST /releases (no 'artist')
+  HTTP 422
+  {
+    "detail": [
+      {
+        "type": "missing",
+        "loc": [
+          "body",
+          "artist"
+        ],
+        "msg": "Field required",
+        "input": {
+          "clip_id": "6a3869755fe9c11e518d569e",
+          "title": "Midnight Drive",
+          "genre": "synthwave",
+          "release_date": "2026-07-01T00:00:00Z",
+          "album_name": "Neon Highways",
+          "isrc": "USABC1234567"
+        }
+      }
+    ]
+  }
+
+  ✓ 422, error names 'artist'
+
+======================================================================
+AC3: unmastered clip -> 201 with soft warning (not blocked)
+======================================================================
+
+$ POST /releases (unmastered, no art)
+  HTTP 201
+  {
+    "id": "6a3869755fe9c11e518d56a2",
+    "clip_id": "6a3869755fe9c11e518d56a1",
+    "status": "ready",
+    "warnings": [
+      "Audio has not been mastered",
+      "Cover art has not been added"
+    ],
+    "created_at": "2026-06-21T22:45:09.763692Z",
+    "updated_at": null,
+    "title": "Midnight Drive",
+    "artist": "The Algorithm",
+    "genre": "synthwave",
+    "release_date": "2026-07-01T00:00:00Z",
+    "album_name": "Neon Highways",
+    "description": null,
+    "isrc": "USABC1234567",
+    "upc": null,
+    "copyright": null,
+    "is_explicit": null,
+    "language": null,
+    "credits": null
+  }
+
+  ✓ 201 (soft block) with both warnings
+
+======================================================================
+AC4: editable while ready; 409 after submission
+======================================================================
+
+$ PATCH /releases/{id} (status=ready)
+  HTTP 200
+  {
+    "id": "6a3869755fe9c11e518d569f",
+    "clip_id": "6a3869755fe9c11e518d569e",
+    "status": "ready",
+    "warnings": [],
+    "created_at": "2026-06-21T22:45:09.755000",
+    "updated_at": "2026-06-21T22:45:09.766000",
+    "title": "Midnight Drive (Remastered)",
+    "artist": "The Algorithm",
+    "genre": "synthwave",
+    "release_date": "2026-07-01T00:00:00",
+    "album_name": "Neon Highways",
+    "description": null,
+    "isrc": "USABC1234567",
+    "upc": null,
+    "copyright": null,
+    "is_explicit": null,
+    "language": null,
+    "credits": null
+  }
+
+  ✓ edit accepted while ready
+
+  (release manually advanced to status=submitted)
+
+$ PATCH /releases/{id} (status=submitted)
+  HTTP 409
+  {
+    "detail": "Release metadata cannot be modified after submission"
+  }
+
+  ✓ 409 after submission
+
+======================================================================
+ALL ACCEPTANCE CRITERIA DEMONSTRATED ✓
+======================================================================
+```
+
+Every acceptance criterion is satisfied: **AC1** complete metadata + mastered clip → `201 ready` with no warnings; **AC2** missing required field → `422` naming the field; **AC3** unmastered/art-less clip → `201` with soft warnings (not blocked); **AC4** editable while `ready`, `409` after `submitted`; **AC5** the package response carries the metadata JSON inline, the `clip_id` (resolving to audio + artwork), and computed warnings.

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -36,6 +36,7 @@ from .routers import (
     jobs,
     mastering,
     presets,
+    releases,
     users,
     workspaces,
 )
@@ -169,6 +170,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(compute.router, prefix=API_V1_PREFIX)
     app.include_router(mastering.router, prefix=API_V1_PREFIX)
     app.include_router(distribution.router, prefix=API_V1_PREFIX)
+    app.include_router(releases.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -10,6 +10,7 @@ from .credit_transaction import CreditTransaction
 from .job import Job, JobStatus
 from .preset import PRESET_PARAM_FIELDS, Preset
 from .refresh_token import RefreshToken
+from .release import Release, ReleaseStatus
 from .soundcloud_connection import SoundCloudConnection
 from .user import User
 from .workspace import Workspace
@@ -25,6 +26,7 @@ ALL_MODELS = [
     BatchJob,
     ArtworkOption,
     SoundCloudConnection,
+    Release,
 ]
 
 __all__ = [
@@ -41,5 +43,7 @@ __all__ = [
     "Preset",
     "PRESET_PARAM_FIELDS",
     "SoundCloudConnection",
+    "Release",
+    "ReleaseStatus",
     "ALL_MODELS",
 ]

--- a/src/acemusic/api/models/release.py
+++ b/src/acemusic/api/models/release.py
@@ -1,0 +1,63 @@
+"""Release package document model (US-13.3).
+
+A release bundles a source clip's mastered audio and cover art with the metadata
+needed for distribution (title, artist, genre, ISRC, …). It is the input for the
+distribution channels (US-13.2 SoundCloud, future stores). Validation warnings
+(unmastered audio, missing artwork) are *computed* from the live clip at response
+time rather than stored, so they resolve automatically once the clip is fixed —
+see :func:`acemusic.api.services.releases.compute_warnings`.
+"""
+
+from datetime import datetime
+from enum import Enum
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, DESCENDING, IndexModel
+
+from .common import utcnow
+
+
+class ReleaseStatus(str, Enum):
+    """Lifecycle of a release package."""
+
+    DRAFT = "draft"
+    READY = "ready"
+    SUBMITTED = "submitted"
+    LIVE = "live"
+    REJECTED = "rejected"
+
+
+class Release(Document):
+    """A distribution-ready package assembled from a clip plus metadata."""
+
+    clip_id: PydanticObjectId
+    user_id: PydanticObjectId
+    status: ReleaseStatus = ReleaseStatus.DRAFT
+
+    # Required metadata (enforced at the schema layer, so 422 on create).
+    title: str
+    artist: str
+    genre: str
+    release_date: datetime
+
+    # Optional metadata.
+    album_name: str | None = None
+    description: str | None = None
+    isrc: str | None = None
+    upc: str | None = None
+    copyright: str | None = None
+    is_explicit: bool | None = None
+    language: str | None = None
+    credits: str | None = None
+
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime | None = None
+
+    class Settings:
+        name = "releases"
+        indexes = [
+            # Serves "this user's releases, newest first" from the index.
+            IndexModel([("user_id", ASCENDING), ("created_at", DESCENDING)]),
+            IndexModel([("clip_id", ASCENDING)]),
+        ]

--- a/src/acemusic/api/routers/releases.py
+++ b/src/acemusic/api/routers/releases.py
@@ -1,0 +1,191 @@
+"""Release package CRUD router (US-13.3), mounted under ``/api/v1/releases``.
+
+Endpoints (all require a valid Bearer access token and operate only on the
+authenticated user's releases):
+
+* ``POST  /releases``      → create from an owned clip (201; 404 if clip not owned)
+* ``GET   /releases``      → list the user's releases
+* ``GET   /releases/{id}`` → single release with computed warnings (404 if missing/not owned)
+* ``PATCH /releases/{id}`` → partial metadata update (409 once submitted)
+
+A release *is* the package: its metadata is inline in the response, ``clip_id``
+resolves to the mastered audio and cover art, and ``warnings`` flags any missing
+piece (computed live from the clip). Persistence lives in
+:mod:`acemusic.api.services.releases`.
+"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..models import Release, ReleaseStatus
+from ..services import clips as clip_service, releases as release_service
+
+router = APIRouter(prefix="/releases", tags=["releases"], dependencies=[Depends(get_current_user)])
+
+# Metadata fields carried on create/update/response (everything except identity,
+# status, clip_id, and timestamps).
+_METADATA_FIELDS: tuple[str, ...] = (
+    "title",
+    "artist",
+    "genre",
+    "release_date",
+    "album_name",
+    "description",
+    "isrc",
+    "upc",
+    "copyright",
+    "is_explicit",
+    "language",
+    "credits",
+)
+
+
+class ReleaseCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    clip_id: str
+    # Required metadata (missing → 422).
+    title: str
+    artist: str
+    genre: str
+    release_date: datetime
+    # Optional metadata.
+    album_name: str | None = None
+    description: str | None = None
+    isrc: str | None = None
+    upc: str | None = None
+    copyright: str | None = None
+    is_explicit: bool | None = None
+    language: str | None = None
+    credits: str | None = None
+
+
+# Required metadata cannot be cleared on update — clearing one would persist a
+# release that can no longer be serialized by ReleaseResponse.
+_REQUIRED_METADATA_FIELDS: tuple[str, ...] = ("title", "artist", "genre", "release_date")
+
+
+class ReleaseUpdate(BaseModel):
+    """Partial update — only explicitly-sent fields are applied. ``clip_id`` and
+    status are not editable here, and the required fields cannot be cleared."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = None
+    artist: str | None = None
+    genre: str | None = None
+    release_date: datetime | None = None
+    album_name: str | None = None
+    description: str | None = None
+    isrc: str | None = None
+    upc: str | None = None
+    copyright: str | None = None
+    is_explicit: bool | None = None
+    language: str | None = None
+    credits: str | None = None
+
+    @model_validator(mode="after")
+    def _reject_clearing_required(self) -> "ReleaseUpdate":
+        cleared = [
+            field
+            for field in _REQUIRED_METADATA_FIELDS
+            if field in self.model_fields_set and getattr(self, field) is None
+        ]
+        if cleared:
+            raise ValueError(f"Required fields cannot be cleared: {', '.join(cleared)}")
+        return self
+
+
+class ReleaseResponse(BaseModel):
+    id: str
+    clip_id: str
+    status: ReleaseStatus
+    warnings: list[str]
+    created_at: datetime
+    updated_at: datetime | None
+
+    title: str
+    artist: str
+    genre: str
+    release_date: datetime
+    album_name: str | None
+    description: str | None
+    isrc: str | None
+    upc: str | None
+    copyright: str | None
+    is_explicit: bool | None
+    language: str | None
+    credits: str | None
+
+    @classmethod
+    def from_release(cls, release: Release, warnings: list[str]) -> "ReleaseResponse":
+        return cls(
+            id=str(release.id),
+            clip_id=str(release.clip_id),
+            status=release.status,
+            warnings=warnings,
+            created_at=release.created_at,
+            updated_at=release.updated_at,
+            **{field: getattr(release, field) for field in _METADATA_FIELDS},
+        )
+
+
+class ReleaseListResponse(BaseModel):
+    releases: list[ReleaseResponse]
+    total: int
+
+
+async def _response_for(release: Release) -> ReleaseResponse:
+    """Build a response, computing warnings from the source clip.
+
+    The clip may have been deleted after the release was assembled; the release
+    keeps its own metadata, so a missing clip is tolerated (surfaced as a warning)
+    rather than making the package — or a whole list containing it — unreadable.
+    """
+    clip = await clip_service.find_owned_clip(str(release.clip_id), str(release.user_id))
+    return ReleaseResponse.from_release(release, release_service.compute_warnings(clip))
+
+
+@router.post("", response_model=ReleaseResponse, status_code=status.HTTP_201_CREATED)
+async def create_release(
+    body: ReleaseCreate,
+    current: CurrentUser = Depends(require_existing_user),
+) -> ReleaseResponse:
+    metadata = body.model_dump(exclude={"clip_id"})
+    release = await release_service.create_release(current.user_id, body.clip_id, metadata)
+    return await _response_for(release)
+
+
+@router.get("", response_model=ReleaseListResponse)
+async def list_releases(current: CurrentUser = Depends(require_existing_user)) -> ReleaseListResponse:
+    releases = await release_service.list_releases(current.user_id)
+    return ReleaseListResponse(
+        releases=[await _response_for(r) for r in releases],
+        total=len(releases),
+    )
+
+
+@router.get("/{release_id}", response_model=ReleaseResponse)
+async def get_release(
+    release_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> ReleaseResponse:
+    release = await release_service.get_owned_release(release_id, current.user_id)
+    return await _response_for(release)
+
+
+@router.patch("/{release_id}", response_model=ReleaseResponse)
+async def update_release(
+    release_id: str,
+    body: ReleaseUpdate,
+    current: CurrentUser = Depends(require_existing_user),
+) -> ReleaseResponse:
+    updates = body.model_dump(exclude_unset=True)
+    if not updates:
+        release = await release_service.get_owned_release(release_id, current.user_id)
+    else:
+        release = await release_service.update_release(release_id, current.user_id, updates)
+    return await _response_for(release)

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -1,0 +1,105 @@
+"""Release package service layer (US-13.3).
+
+Owns user-scoped release CRUD. Ownership failures and unknown/malformed ids
+surface as 404 so the API never reveals another user's releases (mirrors
+:mod:`acemusic.api.services.presets`). Required-metadata validation lives at the
+Pydantic schema layer (422); this layer enforces clip ownership and the
+post-submission edit lock (409).
+"""
+
+from beanie import PydanticObjectId
+from beanie.operators import Eq
+from fastapi import HTTPException, status
+
+from ..models import Clip, Release, ReleaseStatus
+from ..models.common import utcnow
+from . import clips as clip_service
+from .common import coerce_object_id
+from .mastering import APPROVED_GENERATION_MODE
+
+# Releases are editable only before they leave the user's hands.
+_EDITABLE_STATUSES = {ReleaseStatus.DRAFT, ReleaseStatus.READY}
+
+
+def _not_found() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Release not found.")
+
+
+def _state_error(detail: str) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+
+
+async def get_owned_release(release_id: str, user_id: str) -> Release:
+    """Return the release if ``user_id`` owns it; 404 for unknown/malformed/not-owned ids."""
+    oid = coerce_object_id(release_id)
+    release = await Release.get(oid) if oid is not None else None
+    if release is None or str(release.user_id) != user_id:
+        raise _not_found()
+    return release
+
+
+async def list_releases(user_id: str) -> list[Release]:
+    """Return all of ``user_id``'s releases, newest first.
+
+    The ``_id`` tiebreak keeps ordering stable when ``created_at`` values collide
+    (same reason the clips listing does it).
+    """
+    return (
+        await Release.find(Eq(Release.user_id, PydanticObjectId(user_id)))
+        .sort(("created_at", -1), ("_id", -1))
+        .to_list()
+    )
+
+
+async def create_release(user_id: str, clip_id: str, metadata: dict) -> Release:
+    """Create a release for an owned clip. Raises 404 if the clip is unknown/not-owned.
+
+    ``metadata`` holds only release metadata fields (the router validates and
+    dumps them), so identity/status fields cannot be injected through it. All
+    required fields are enforced upstream by the schema, so a created release is
+    immediately ``ready`` — the soft blocks (unmastered audio, missing art) are
+    surfaced as computed warnings, not status.
+    """
+    await clip_service.get_owned_clip(clip_id, user_id)
+    release = Release(
+        clip_id=PydanticObjectId(clip_id),
+        user_id=PydanticObjectId(user_id),
+        status=ReleaseStatus.READY,
+        **metadata,
+    )
+    await release.insert()
+    return release
+
+
+def compute_warnings(clip: Clip | None) -> list[str]:
+    """Soft-block warnings for a release's source clip (not stored; computed per response).
+
+    ``clip`` is ``None`` when the source clip has since been deleted: the release
+    still holds its own metadata and stays readable, so we surface the gap as a
+    warning rather than letting the package become unretrievable.
+    """
+    if clip is None:
+        return ["Source clip is no longer available"]
+    warnings: list[str] = []
+    if clip.generation_mode != APPROVED_GENERATION_MODE:
+        warnings.append("Audio has not been mastered")
+    if clip.artwork_path is None:
+        warnings.append("Cover art has not been added")
+    return warnings
+
+
+async def update_release(release_id: str, user_id: str, updates: dict) -> Release:
+    """Apply ``updates`` to an owned release. Raises 404 if not owned, 409 once submitted.
+
+    ``updates`` must come from a validated ``ReleaseUpdate`` dump — the setattr
+    loop trusts its keys, so a raw dict could reassign identity fields like
+    ``user_id`` (same contract as ``create_release``).
+    """
+    release = await get_owned_release(release_id, user_id)
+    if release.status not in _EDITABLE_STATUSES:
+        raise _state_error("Release metadata cannot be modified after submission")
+    for field, value in updates.items():
+        setattr(release, field, value)
+    release.updated_at = utcnow()
+    await release.save()
+    return release

--- a/tests/test_releases_api.py
+++ b/tests/test_releases_api.py
@@ -1,0 +1,346 @@
+"""Tests for the release package CRUD endpoints (US-13.3, issue #134).
+
+The 401 auth-gate tests run in CI (the router dependency rejects before any DB
+access; plain ``TestClient`` does not run the lifespan). The CRUD tests are
+``integration``: they drive the real app with ``httpx.AsyncClient`` over a local
+MongoDB (``mongo_db``), mirroring ``tests/test_presets_api.py``.
+"""
+
+import itertools
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Release, ReleaseStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.services.mastering import APPROVED_GENERATION_MODE
+from acemusic.api.settings import ApiSettings
+
+RELEASES_URL = f"{API_V1_PREFIX}/releases"
+
+# A representative complete create payload (clip_id is filled in per-test).
+FULL_METADATA = {
+    "title": "Midnight Drive",
+    "artist": "The Algorithm",
+    "genre": "synthwave",
+    "release_date": "2026-07-01T00:00:00Z",
+    "album_name": "Neon Highways",
+    "description": "A late-night cruise.",
+    "isrc": "USABC1234567",
+    "upc": "012345678905",
+    "copyright": "© 2026 The Algorithm",
+    "is_explicit": False,
+    "language": "en",
+    "credits": "Produced by The Algorithm",
+}
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize(
+        ("method", "url"),
+        [
+            ("GET", RELEASES_URL),
+            ("POST", RELEASES_URL),
+            ("GET", f"{RELEASES_URL}/{PydanticObjectId()}"),
+            ("PATCH", f"{RELEASES_URL}/{PydanticObjectId()}"),
+        ],
+    )
+    def test_missing_auth_header_returns_401(self, method: str, url: str) -> None:
+        client = TestClient(create_app())
+        resp = client.request(method, url)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+_SEQ = itertools.count(1)
+
+
+async def _make_workspace(user) -> Workspace:
+    # Unique per (user, name): the workspaces collection enforces it, and a test
+    # user may own several clips (hence several workspaces).
+    workspace = Workspace(name=f"WS-{next(_SEQ)}", user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(user, *, mastered: bool = False, artwork: bool = False) -> Clip:
+    workspace = await _make_workspace(user)
+    clip_id = PydanticObjectId()
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.wav",
+        format="wav",
+        title="Source",
+        generation_mode=APPROVED_GENERATION_MODE if mastered else "generate",
+        artwork_path=f"{user.id}/art/{clip_id}.png" if artwork else None,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _create_release(client, user, settings, clip, **overrides) -> httpx.Response:
+    payload = {"clip_id": str(clip.id), **FULL_METADATA, **overrides}
+    return await client.post(RELEASES_URL, json=payload, headers=_auth_headers(user, settings))
+
+
+@pytest.mark.integration
+class TestCreate:
+    async def test_create_complete_returns_201_ready(self, client, settings) -> None:
+        user = await _make_user("rel-create@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        resp = await _create_release(client, settings=settings, user=user, clip=clip)
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["id"]
+        assert body["status"] == "ready"
+        assert body["clip_id"] == str(clip.id)
+        assert body["warnings"] == []  # mastered + has artwork
+        for field, value in FULL_METADATA.items():
+            assert body[field] == value, f"field {field!r}: {body[field]!r} != {value!r}"
+
+        stored = await Release.get(PydanticObjectId(body["id"]))
+        assert stored is not None
+        assert stored.status is ReleaseStatus.READY
+        assert stored.title == FULL_METADATA["title"]
+
+    async def test_unmastered_clip_without_art_warns_but_creates(self, client, settings) -> None:
+        user = await _make_user("rel-warn@example.com")
+        clip = await _insert_clip(user, mastered=False, artwork=False)
+        resp = await _create_release(client, settings=settings, user=user, clip=clip)
+        assert resp.status_code == 201  # soft block, not hard block
+        warnings = resp.json()["warnings"]
+        assert "Audio has not been mastered" in warnings
+        assert "Cover art has not been added" in warnings
+
+    async def test_mastered_clip_has_no_mastering_warning(self, client, settings) -> None:
+        user = await _make_user("rel-mastered@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=False)
+        resp = await _create_release(client, settings=settings, user=user, clip=clip)
+        assert resp.status_code == 201
+        warnings = resp.json()["warnings"]
+        assert "Audio has not been mastered" not in warnings
+        assert "Cover art has not been added" in warnings
+
+    @pytest.mark.parametrize("missing", ["title", "artist", "genre", "release_date"])
+    async def test_missing_required_field_returns_422(self, client, settings, missing: str) -> None:
+        user = await _make_user(f"rel-422-{missing}@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        payload = {"clip_id": str(clip.id), **FULL_METADATA}
+        del payload[missing]
+        resp = await client.post(RELEASES_URL, json=payload, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        # The error names the offending field.
+        assert any(missing in str(err.get("loc", [])) for err in resp.json()["detail"])
+
+    async def test_unknown_field_returns_422(self, client, settings) -> None:
+        user = await _make_user("rel-extra@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        resp = await _create_release(client, settings=settings, user=user, clip=clip, nope=True)
+        assert resp.status_code == 422
+
+    async def test_unknown_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("rel-noclip@example.com")
+        payload = {"clip_id": str(PydanticObjectId()), **FULL_METADATA}
+        resp = await client.post(RELEASES_URL, json=payload, headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_clip_returns_404(self, client, settings) -> None:
+        owner = await _make_user("rel-owner@example.com")
+        intruder = await _make_user("rel-intruder@example.com")
+        clip = await _insert_clip(owner, mastered=True, artwork=True)
+        payload = {"clip_id": str(clip.id), **FULL_METADATA}
+        resp = await client.post(RELEASES_URL, json=payload, headers=_auth_headers(intruder, settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestList:
+    async def test_lists_only_own_releases_newest_first(self, client, settings) -> None:
+        user = await _make_user("rel-list@example.com")
+        other = await _make_user("rel-list-other@example.com")
+        clip_a = await _insert_clip(user, mastered=True, artwork=True)
+        clip_b = await _insert_clip(user, mastered=True, artwork=True)
+        other_clip = await _insert_clip(other, mastered=True, artwork=True)
+        first = (await _create_release(client, settings=settings, user=user, clip=clip_a, title="A")).json()
+        second = (await _create_release(client, settings=settings, user=user, clip=clip_b, title="B")).json()
+        await _create_release(client, settings=settings, user=other, clip=other_clip, title="Theirs")
+
+        resp = await client.get(RELEASES_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 2
+        ids = [r["id"] for r in body["releases"]]
+        assert ids == [second["id"], first["id"]]  # newest first
+
+    async def test_empty_list_for_new_user(self, client, settings) -> None:
+        user = await _make_user("rel-list-empty@example.com")
+        resp = await client.get(RELEASES_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json() == {"releases": [], "total": 0}
+
+
+@pytest.mark.integration
+class TestGet:
+    async def test_get_own_release_returns_200(self, client, settings) -> None:
+        user = await _make_user("rel-get@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        resp = await client.get(f"{RELEASES_URL}/{created['id']}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["id"] == created["id"]
+
+    async def test_unknown_release_returns_404(self, client, settings) -> None:
+        user = await _make_user("rel-get-unknown@example.com")
+        resp = await client.get(f"{RELEASES_URL}/{PydanticObjectId()}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_release_returns_404(self, client, settings) -> None:
+        owner = await _make_user("rel-get-owner@example.com")
+        intruder = await _make_user("rel-get-intruder@example.com")
+        clip = await _insert_clip(owner, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=owner, clip=clip)).json()
+        resp = await client.get(f"{RELEASES_URL}/{created['id']}", headers=_auth_headers(intruder, settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestUpdate:
+    async def test_update_persists_changes(self, client, settings) -> None:
+        user = await _make_user("rel-update@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}",
+            json={"title": "Renamed", "isrc": None},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"] == "Renamed"
+        assert body["isrc"] is None
+        assert body["updated_at"] is not None
+
+    async def test_empty_body_is_noop(self, client, settings) -> None:
+        user = await _make_user("rel-update-noop@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        resp = await client.patch(f"{RELEASES_URL}/{created['id']}", json={}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["title"] == FULL_METADATA["title"]
+        assert resp.json()["updated_at"] is None  # untouched
+
+    async def test_update_other_users_release_returns_404(self, client, settings) -> None:
+        owner = await _make_user("rel-update-owner@example.com")
+        intruder = await _make_user("rel-update-intruder@example.com")
+        clip = await _insert_clip(owner, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=owner, clip=clip)).json()
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}",
+            json={"title": "Hijacked"},
+            headers=_auth_headers(intruder, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_update_after_submission_returns_409(self, client, settings) -> None:
+        user = await _make_user("rel-update-locked@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        # Move it past the editable window directly.
+        release = await Release.get(PydanticObjectId(created["id"]))
+        release.status = ReleaseStatus.SUBMITTED
+        await release.save()
+
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}",
+            json={"title": "Too late"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 409
+
+    @pytest.mark.parametrize("field", ["title", "artist", "genre", "release_date"])
+    async def test_clearing_required_field_returns_422(self, client, settings, field: str) -> None:
+        # A null on a required field would persist an unserializable release (→ 500
+        # on later reads); the update schema must reject it up front.
+        user = await _make_user(f"rel-clear-{field}@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}",
+            json={field: None},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        # The release is left intact and still readable (the required field was
+        # not cleared to null).
+        again = await client.get(f"{RELEASES_URL}/{created['id']}", headers=_auth_headers(user, settings))
+        assert again.status_code == 200
+        assert again.json()[field] is not None
+
+
+@pytest.mark.integration
+class TestDanglingClip:
+    async def test_release_readable_after_source_clip_deleted(self, client, settings) -> None:
+        # The release is a self-contained package; deleting its source clip must
+        # not make it (or a list containing it) unreadable.
+        user = await _make_user("rel-dangling@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        await clip.delete()
+
+        got = await client.get(f"{RELEASES_URL}/{created['id']}", headers=_auth_headers(user, settings))
+        assert got.status_code == 200
+        assert "Source clip is no longer available" in got.json()["warnings"]
+
+        listed = await client.get(RELEASES_URL, headers=_auth_headers(user, settings))
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 1


### PR DESCRIPTION
## US-13.3: Release package assembly

Closes #134.

Adds release-package CRUD under `/api/v1/releases` — bundles a clip's mastered audio, cover art, and distribution metadata into a validated package that downstream channels (US-13.2 SoundCloud, future stores) consume. Mirrors the `presets` CRUD pattern.

### Endpoints
- `POST   /releases` — create from an owned clip (`201`; `404` if clip not owned; `422` on missing/invalid metadata)
- `GET    /releases` — list the user's releases, newest first
- `GET    /releases/{id}` — single release with computed warnings (`404` if missing/not owned)
- `PATCH  /releases/{id}` — partial metadata update (`409` once submitted; empty body is a no-op)

### Design notes
- **Status**: `draft / ready / submitted / live / rejected`. Create yields `ready` once required metadata validates; soft blocks are surfaced as *warnings*, not status.
- **Computed warnings** (not stored): "Audio has not been mastered" (`generation_mode != "mastered"`), "Cover art has not been added" (`clip.artwork_path is None`). Recomputed per response so they resolve automatically when the clip is fixed.
- **Self-contained package**: a release keeps its own metadata, so a *deleted source clip* is tolerated — the package stays readable and reports "Source clip is no longer available" rather than 404ing (which would also have broken the whole list).
- **Required fields** (`title, artist, genre, release_date`) are enforced at the schema layer and **cannot be cleared** on update (a null would persist an unserializable release).

### Acceptance criteria
- [x] Complete metadata + mastered clip → `ready`
- [x] Missing required fields → `422` with field-specific errors
- [x] Unmastered clip → soft warning, not blocked (still `201`)
- [x] Metadata editable in `draft`/`ready`; `409` after submission
- [x] Package = audio + artwork (via `clip_id`) + metadata JSON (inline) + warnings

### Tests
28 tests (`tests/test_releases_api.py`): 4 CI auth-gate + 24 integration (create/list/get/patch happy paths, ownership 404s, validation 422s, state-lock 409, soft-block warnings, dangling-clip robustness, required-field clear rejection).

### Known limitations / deliberate scope
- **Flat create payload** (`{clip_id, title, artist, …}`) rather than nested `{clip_id, metadata}`. The issue describes the input as `{clip_id, metadata}`; this implementation follows the `presets` convention (the issue's stated pattern reference) and CodeRabbit's own plan, giving field-level `422`s at the top level. No clients consume the endpoint yet, so the shape is easy to revisit if a nested contract is preferred.
- **Cover-art "resolution requirements"** are not pixel-validated — artwork presence is checked (warning if absent); dimension validation belongs with the artwork-generation pipeline (US-13.1) where image bytes are already in hand.
- **No pagination** on list (mirrors `presets`; per-user volume is low). Add if release counts grow.

🤖 Cross-family reviewed with `codex review`; P1 (null-clear corruption) and P2 (dangling clip) findings addressed.
