### PR TITLE
US-13.4: ISRC and UPC generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,3 +184,11 @@ ACEMUSIC_API_BAKUAGE_API_KEY=
 # Set ARTWORK_GENERATION_ENABLED=false as a kill-switch independent of the key.
 ACEMUSIC_API_OPENAI_API_KEY=
 ACEMUSIC_API_ARTWORK_GENERATION_ENABLED=true
+
+# Release identifiers (Stage 13, US-13.4). ISRC = country code (2 letters) +
+# registrant code (3 alphanumerics) issued to the platform operator; UPC = the
+# operator's 7-digit GS1 company prefix. Defaults are demo placeholders that mint
+# well-formed codes; a production deployment sets its own registered allocations.
+ACEMUSIC_API_ISRC_COUNTRY_CODE=US
+ACEMUSIC_API_ISRC_REGISTRANT_CODE=A1B
+ACEMUSIC_API_UPC_PREFIX=0000000

--- a/docs/demos/us-13.4-isrc-upc.md
+++ b/docs/demos/us-13.4-isrc-upc.md
@@ -1,0 +1,52 @@
+# US-13.4: ISRC & UPC generation
+
+*2026-06-21T23:37:23Z*
+
+US-13.4 auto-generates the identifiers a release needs across stores: an **ISRC** per recording (`CC-XXX-YY-NNNNN`) and an **EAN-13 UPC** per release. Codes are minted on `POST /releases` from atomic MongoDB counters and overridable via `PATCH /releases/{id}`. This demo drives the real production code paths (generators, the release service, and the PATCH schema validators) against a live MongoDB and prints the actual outcomes for every acceptance criterion.
+
+The driver script (`/tmp/demo_isrc.py`) calls `identifiers.generate_isrc/generate_upc`, `releases.create_release/update_release`, and constructs `ReleaseUpdate` exactly as the router does — no stubs.
+
+```bash
+uv run python /tmp/demo_isrc.py
+```
+
+```output
+=== AC1: auto-generated ISRC follows CC-XXX-YY-NNNNN and is unique ===
+  US-A1B-26-00001   valid_format=True
+  US-A1B-26-00002   valid_format=True
+  US-A1B-26-00003   valid_format=True
+  all distinct: True
+
+=== AC2: auto-generated UPC is a valid EAN-13 with correct check digit ===
+  0000000000017
+  13 digits: True
+  check digit 7 == computed 7: True
+
+=== AC5 + dual storage: codes persist on BOTH the release and the clip ===
+  release.isrc = US-A1B-26-00004
+  clip.isrc    = US-A1B-26-00004
+  release.upc  = 0000000000024
+  release.isrc == clip.isrc (synced): True
+
+=== AC3: manual PATCH overrides the auto-generated codes (and re-syncs the clip) ===
+  release.isrc -> US-OVR-26-12345   release.upc -> 5901234123457
+  clip.isrc re-synced -> US-OVR-26-12345
+
+=== AC4: duplicate ISRC codes are rejected ===
+  rejected -> HTTP 409, detail: 'isrc already in use'
+
+=== Invalid manual formats are rejected up front (HTTP 422) ===
+  isrc='USABC1234567' -> rejected (422)
+  upc='012345678905' -> rejected (422)
+```
+
+**Every acceptance criterion is demonstrated with outcome evidence above:**
+
+- **AC1** — three auto-generated ISRCs (`US-A1B-26-00001/2/3`) all match `CC-XXX-YY-NNNNN` and are distinct (sequential atomic counter → never reused).
+- **AC2** — the auto-generated UPC `0000000000017` is 13 digits and its check digit (`7`) equals the recomputed EAN-13 check digit.
+- **AC5 + dual storage** — on `create_release`, `release.isrc` and `clip.isrc` hold the *same* code: the ISRC persists on both the release package and the recording.
+- **AC3** — a `PATCH` with manual `isrc`/`upc` overrides the auto-generated values and re-syncs the clip.
+- **AC4** — reusing an ISRC already held by another recording is rejected with **HTTP 409**.
+- **Validation** — malformed manual codes (`USABC1234567` without dashes; a 12-digit UPC) are rejected with **HTTP 422** before they touch the database.
+
+Backed by 23 unit tests (`tests/test_identifiers.py`) and 8 integration tests (`tests/test_releases_api.py`), all green.

--- a/src/acemusic/api/exceptions.py
+++ b/src/acemusic/api/exceptions.py
@@ -16,3 +16,15 @@ class EmailAlreadyRegisteredError(Exception):
     The User model holds a single OAuth identity and email is unique-indexed, so a
     second provider reporting an already-registered address cannot be linked yet.
     """
+
+
+class DuplicateIdentifierError(Exception):
+    """A release/clip identifier (ISRC or UPC) is already in use (US-13.4).
+
+    Raised by the release service when a unique-index write collides; ``field``
+    names the offending identifier so the HTTP layer can return a clear 409.
+    """
+
+    def __init__(self, field: str) -> None:
+        self.field = field
+        super().__init__(f"{field} already in use")

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -20,7 +20,7 @@ from acemusic import __version__
 from acemusic.runpod_client import RunPodClient
 
 from . import database
-from .exceptions import HandleConflictError
+from .exceptions import DuplicateIdentifierError, HandleConflictError
 from .routers import (
     artwork,
     auth,
@@ -177,6 +177,12 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     @app.exception_handler(HandleConflictError)
     async def _handle_conflict(_request: Request, _exc: HandleConflictError) -> JSONResponse:
         return JSONResponse(status_code=409, content={"detail": "Handle already taken"})
+
+    # A release/clip identifier collision (US-13.4) surfaces from the service as a
+    # domain exception; map it to 409 with the offending field named.
+    @app.exception_handler(DuplicateIdentifierError)
+    async def _duplicate_identifier(_request: Request, exc: DuplicateIdentifierError) -> JSONResponse:
+        return JSONResponse(status_code=409, content={"detail": f"{exc.field} already in use"})
 
     return app
 

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -6,6 +6,7 @@
 from .artwork import ArtworkOption
 from .batch_job import BatchClipEntry, BatchJob
 from .clip import Clip
+from .counter import Counter
 from .credit_transaction import CreditTransaction
 from .job import Job, JobStatus
 from .preset import PRESET_PARAM_FIELDS, Preset
@@ -27,6 +28,7 @@ ALL_MODELS = [
     ArtworkOption,
     SoundCloudConnection,
     Release,
+    Counter,
 ]
 
 __all__ = [
@@ -45,5 +47,6 @@ __all__ = [
     "SoundCloudConnection",
     "Release",
     "ReleaseStatus",
+    "Counter",
     "ALL_MODELS",
 ]

--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -45,6 +45,11 @@ class Clip(Document):
     # owner selects a generated option or uploads custom artwork; the binary is
     # served via ``GET /clips/{id}/artwork`` (file_path stays internal, like audio).
     artwork_path: str | None = None
+    # International Standard Recording Code (US-13.4). Identifies this *recording*;
+    # minted (or reused) when the clip is first packaged into a release and shared
+    # with that release. Globally unique via the partial index below — a recording
+    # gets exactly one ISRC, never reused — while clips without one stay None.
+    isrc: str | None = None
     is_public: bool = False  # documents predating US-9.3 load as private
     created_at: datetime = Field(default_factory=utcnow)
 
@@ -60,4 +65,11 @@ class Clip(Document):
             # Multikey index over the parent list powers the children lookup
             # ("clips derived from this clip", US-10.6) without a collection scan.
             IndexModel([("parent_clip_ids", ASCENDING)]),
+            # One ISRC per recording (US-13.4). Partial filter excludes the many
+            # clips with no code so they don't collide on null.
+            IndexModel(
+                [("isrc", ASCENDING)],
+                unique=True,
+                partialFilterExpression={"isrc": {"$type": "string"}},
+            ),
         ]

--- a/src/acemusic/api/models/counter.py
+++ b/src/acemusic/api/models/counter.py
@@ -1,0 +1,31 @@
+"""Atomic named counters (US-13.4).
+
+A single tiny collection backing sequential identifier minting (ISRC/UPC). Each
+``get_next_sequence`` is one atomic ``find_one_and_update`` with ``$inc`` and an
+upsert, so concurrent release creations never hand out the same designation.
+"""
+
+from beanie import Document
+from pymongo import ASCENDING, IndexModel, ReturnDocument
+
+
+class Counter(Document):
+    """A monotonically increasing counter addressed by ``name`` (e.g. ``isrc_seq``)."""
+
+    name: str
+    value: int = 0
+
+    class Settings:
+        name = "counters"
+        indexes = [IndexModel([("name", ASCENDING)], unique=True)]
+
+
+async def get_next_sequence(name: str) -> int:
+    """Atomically increment ``name``'s counter and return the new value (starts at 1)."""
+    doc = await Counter.get_pymongo_collection().find_one_and_update(
+        {"name": name},
+        {"$inc": {"value": 1}},
+        upsert=True,
+        return_document=ReturnDocument.AFTER,
+    )
+    return doc["value"]

--- a/src/acemusic/api/models/release.py
+++ b/src/acemusic/api/models/release.py
@@ -44,6 +44,10 @@ class Release(Document):
     # Optional metadata.
     album_name: str | None = None
     description: str | None = None
+    # Identifiers (US-13.4), auto-minted on create, overridable via PATCH. ``isrc``
+    # mirrors the source recording's code and is *not* unique here — re-releases of
+    # one recording legitimately share it (uniqueness is enforced on the clip).
+    # ``upc`` identifies this release and is globally unique (partial index below).
     isrc: str | None = None
     upc: str | None = None
     copyright: str | None = None
@@ -60,4 +64,10 @@ class Release(Document):
             # Serves "this user's releases, newest first" from the index.
             IndexModel([("user_id", ASCENDING), ("created_at", DESCENDING)]),
             IndexModel([("clip_id", ASCENDING)]),
+            # One UPC per release (US-13.4); partial filter skips releases without one.
+            IndexModel(
+                [("upc", ASCENDING)],
+                unique=True,
+                partialFilterExpression={"upc": {"$type": "string"}},
+            ),
         ]

--- a/src/acemusic/api/routers/releases.py
+++ b/src/acemusic/api/routers/releases.py
@@ -17,11 +17,13 @@ piece (computed live from the clip). Persistence lives in
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, status
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
-from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..auth.dependencies import CurrentUser, get_current_user, get_settings, require_existing_user
 from ..models import Release, ReleaseStatus
 from ..services import clips as clip_service, releases as release_service
+from ..services.identifiers import validate_isrc_format, validate_upc_check_digit, validate_upc_format
+from ..settings import ApiSettings
 
 router = APIRouter(prefix="/releases", tags=["releases"], dependencies=[Depends(get_current_user)])
 
@@ -52,11 +54,10 @@ class ReleaseCreate(BaseModel):
     artist: str
     genre: str
     release_date: datetime
-    # Optional metadata.
+    # Optional metadata. ISRC/UPC are not accepted here — they are auto-minted on
+    # create (US-13.4) and only overridable via PATCH.
     album_name: str | None = None
     description: str | None = None
-    isrc: str | None = None
-    upc: str | None = None
     copyright: str | None = None
     is_explicit: bool | None = None
     language: str | None = None
@@ -86,6 +87,22 @@ class ReleaseUpdate(BaseModel):
     is_explicit: bool | None = None
     language: str | None = None
     credits: str | None = None
+
+    @field_validator("isrc")
+    @classmethod
+    def _check_isrc(cls, value: str | None) -> str | None:
+        """Reject a malformed manual ISRC (422); None clears it."""
+        if value is not None and not validate_isrc_format(value):
+            raise ValueError("isrc must match the format CC-XXX-YY-NNNNN (e.g. US-A1B-26-00001)")
+        return value
+
+    @field_validator("upc")
+    @classmethod
+    def _check_upc(cls, value: str | None) -> str | None:
+        """Reject a non-EAN-13 manual UPC (422); None clears it."""
+        if value is not None and not (validate_upc_format(value) and validate_upc_check_digit(value)):
+            raise ValueError("upc must be a valid 13-digit EAN-13 with a correct check digit")
+        return value
 
     @model_validator(mode="after")
     def _reject_clearing_required(self) -> "ReleaseUpdate":
@@ -153,9 +170,10 @@ async def _response_for(release: Release) -> ReleaseResponse:
 async def create_release(
     body: ReleaseCreate,
     current: CurrentUser = Depends(require_existing_user),
+    settings: ApiSettings = Depends(get_settings),
 ) -> ReleaseResponse:
     metadata = body.model_dump(exclude={"clip_id"})
-    release = await release_service.create_release(current.user_id, body.clip_id, metadata)
+    release = await release_service.create_release(current.user_id, body.clip_id, metadata, settings)
     return await _response_for(release)
 
 

--- a/src/acemusic/api/routers/releases.py
+++ b/src/acemusic/api/routers/releases.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from ..auth.dependencies import CurrentUser, get_current_user, get_settings, require_existing_user
 from ..models import Release, ReleaseStatus
 from ..services import clips as clip_service, releases as release_service
-from ..services.identifiers import validate_isrc_format, validate_upc_check_digit, validate_upc_format
+from ..services.identifiers import validate_isrc_format, validate_upc_check_digit
 from ..settings import ApiSettings
 
 router = APIRouter(prefix="/releases", tags=["releases"], dependencies=[Depends(get_current_user)])
@@ -100,7 +100,8 @@ class ReleaseUpdate(BaseModel):
     @classmethod
     def _check_upc(cls, value: str | None) -> str | None:
         """Reject a non-EAN-13 manual UPC (422); None clears it."""
-        if value is not None and not (validate_upc_format(value) and validate_upc_check_digit(value)):
+        # validate_upc_check_digit already enforces the 13-digit shape.
+        if value is not None and not validate_upc_check_digit(value):
             raise ValueError("upc must be a valid 13-digit EAN-13 with a correct check digit")
         return value
 

--- a/src/acemusic/api/services/identifiers.py
+++ b/src/acemusic/api/services/identifiers.py
@@ -1,0 +1,63 @@
+"""ISRC and UPC generation/validation (US-13.4).
+
+ISRC (International Standard Recording Code) identifies a *recording*; UPC/EAN-13
+identifies a *release*. Codes are auto-minted on release creation from atomic
+per-name counters (so designations are sequential and never reused) and may be
+overridden manually via PATCH, in which case the format helpers here gate the
+input. The validators are pure (no DB) so they back both the schema-layer 422s
+and the unit tests; the generators read the configured prefixes and a counter.
+"""
+
+import re
+
+from ..models.common import utcnow
+from ..models.counter import get_next_sequence
+from ..settings import ApiSettings
+
+# CC-XXX-YY-NNNNN: 2-letter country, 3-char alphanumeric registrant, 2-digit
+# year, 5-digit designation. Uppercase only — manual entry must be canonical.
+_ISRC_RE = re.compile(r"^[A-Z]{2}-[A-Z0-9]{3}-\d{2}-\d{5}$")
+_UPC_RE = re.compile(r"^\d{13}$")
+
+
+def validate_isrc_format(isrc: str) -> bool:
+    """True if ``isrc`` matches the canonical dashed CC-XXX-YY-NNNNN form."""
+    return bool(_ISRC_RE.match(isrc))
+
+
+def validate_upc_format(upc: str) -> bool:
+    """True if ``upc`` is a 13-digit numeric string (EAN-13 shape)."""
+    return bool(_UPC_RE.match(upc))
+
+
+def calculate_ean13_check_digit(payload: str) -> int:
+    """Return the EAN-13 check digit for a 12-digit ``payload``.
+
+    Standard alternating weights (1 for the first data digit, 3 for the second,
+    …); the check digit makes the weighted sum a multiple of 10.
+    """
+    total = sum(int(d) * (1 if i % 2 == 0 else 3) for i, d in enumerate(payload))
+    return (10 - total % 10) % 10
+
+
+def validate_upc_check_digit(upc: str) -> bool:
+    """True if ``upc`` is a 13-digit code whose final digit is a valid check digit."""
+    if not validate_upc_format(upc):
+        return False
+    return calculate_ean13_check_digit(upc[:12]) == int(upc[12])
+
+
+async def generate_isrc(settings: ApiSettings) -> str:
+    """Mint the next sequential ISRC in CC-XXX-YY-NNNNN form."""
+    # ponytail: one global designation counter; real ISRC resets NNNNN per year.
+    # Revisit only if a single year ever exceeds 99999 recordings.
+    seq = await get_next_sequence("isrc_seq")
+    year = utcnow().year % 100
+    return f"{settings.isrc_country_code}-{settings.isrc_registrant_code}-{year:02d}-{seq:05d}"
+
+
+async def generate_upc(settings: ApiSettings) -> str:
+    """Mint the next sequential EAN-13 UPC for ``settings.upc_prefix``."""
+    seq = await get_next_sequence("upc_seq")
+    payload = f"{settings.upc_prefix}{seq:05d}"
+    return f"{payload}{calculate_ean13_check_digit(payload)}"

--- a/src/acemusic/api/services/identifiers.py
+++ b/src/acemusic/api/services/identifiers.py
@@ -19,6 +19,18 @@ from ..settings import ApiSettings
 _ISRC_RE = re.compile(r"^[A-Z]{2}-[A-Z0-9]{3}-\d{2}-\d{5}$")
 _UPC_RE = re.compile(r"^\d{13}$")
 
+# Both schemes carry a 5-digit sequential field, so the counter must stay below
+# 100000 or the formatted code overflows its width and becomes malformed.
+_MAX_SEQUENCE = 99999
+
+
+def _checked(seq: int, kind: str) -> int:
+    """Fail loudly if a counter has exhausted its 5-digit field, rather than
+    silently emitting an over-wide (invalid) code."""
+    if seq > _MAX_SEQUENCE:
+        raise RuntimeError(f"{kind} sequence space exhausted ({_MAX_SEQUENCE}); the counter scheme needs widening")
+    return seq
+
 
 def validate_isrc_format(isrc: str) -> bool:
     """True if ``isrc`` matches the canonical dashed CC-XXX-YY-NNNNN form."""
@@ -49,15 +61,15 @@ def validate_upc_check_digit(upc: str) -> bool:
 
 async def generate_isrc(settings: ApiSettings) -> str:
     """Mint the next sequential ISRC in CC-XXX-YY-NNNNN form."""
-    # ponytail: one global designation counter; real ISRC resets NNNNN per year.
-    # Revisit only if a single year ever exceeds 99999 recordings.
-    seq = await get_next_sequence("isrc_seq")
+    # ponytail: one global *lifetime* counter (real ISRC resets the designation
+    # per year), so the 5-digit field is a lifetime cap — guarded by _checked.
+    seq = _checked(await get_next_sequence("isrc_seq"), "ISRC")
     year = utcnow().year % 100
     return f"{settings.isrc_country_code}-{settings.isrc_registrant_code}-{year:02d}-{seq:05d}"
 
 
 async def generate_upc(settings: ApiSettings) -> str:
     """Mint the next sequential EAN-13 UPC for ``settings.upc_prefix``."""
-    seq = await get_next_sequence("upc_seq")
+    seq = _checked(await get_next_sequence("upc_seq"), "UPC")
     payload = f"{settings.upc_prefix}{seq:05d}"
     return f"{payload}{calculate_ean13_check_digit(payload)}"

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -10,15 +10,28 @@ post-submission edit lock (409).
 from beanie import PydanticObjectId
 from beanie.operators import Eq
 from fastapi import HTTPException, status
+from pymongo.errors import DuplicateKeyError
 
+from ..exceptions import DuplicateIdentifierError
 from ..models import Clip, Release, ReleaseStatus
 from ..models.common import utcnow
-from . import clips as clip_service
+from ..settings import ApiSettings
+from . import clips as clip_service, identifiers
 from .common import coerce_object_id
 from .mastering import APPROVED_GENERATION_MODE
 
 # Releases are editable only before they leave the user's hands.
 _EDITABLE_STATUSES = {ReleaseStatus.DRAFT, ReleaseStatus.READY}
+
+# Auto-minted UPCs come from an atomic counter and so never collide with each
+# other; the only way an insert can hit the unique index is a manually-assigned
+# code that already occupies this sequence slot. A few re-mints clear it.
+_MAX_MINT_ATTEMPTS = 5
+
+
+def _duplicate_field(exc: DuplicateKeyError) -> str:
+    """Name the identifier a unique-index violation collided on."""
+    return "isrc" if "isrc" in str(exc) else "upc"
 
 
 def _not_found() -> HTTPException:
@@ -51,24 +64,60 @@ async def list_releases(user_id: str) -> list[Release]:
     )
 
 
-async def create_release(user_id: str, clip_id: str, metadata: dict) -> Release:
-    """Create a release for an owned clip. Raises 404 if the clip is unknown/not-owned.
+async def create_release(user_id: str, clip_id: str, metadata: dict, settings: ApiSettings) -> Release:
+    """Create a release for an owned clip, auto-minting its ISRC and UPC (US-13.4).
 
     ``metadata`` holds only release metadata fields (the router validates and
-    dumps them), so identity/status fields cannot be injected through it. All
-    required fields are enforced upstream by the schema, so a created release is
-    immediately ``ready`` — the soft blocks (unmastered audio, missing art) are
-    surfaced as computed warnings, not status.
+    dumps them), so identity/status/identifier fields cannot be injected through
+    it. The ISRC identifies the *recording*: an already-coded clip keeps its code
+    (reused, not overwritten), otherwise a fresh ISRC is minted and written back
+    to the clip so the package and recording stay in sync. The UPC identifies the
+    release and is globally unique. All required fields are enforced upstream by
+    the schema, so a created release is immediately ``ready``.
     """
-    await clip_service.get_owned_clip(clip_id, user_id)
-    release = Release(
-        clip_id=PydanticObjectId(clip_id),
-        user_id=PydanticObjectId(user_id),
-        status=ReleaseStatus.READY,
-        **metadata,
-    )
-    await release.insert()
-    return release
+    clip = await clip_service.get_owned_clip(clip_id, user_id)
+
+    # Claim the recording's ISRC first, so a release is never inserted with a code
+    # the clip then fails to accept.
+    if clip.isrc is None:
+        clip.isrc = await identifiers.generate_isrc(settings)
+        try:
+            await clip.save()
+        except DuplicateKeyError as exc:  # minted ISRC already on another clip (rare)
+            raise DuplicateIdentifierError("isrc") from exc
+    isrc = clip.isrc
+
+    for _ in range(_MAX_MINT_ATTEMPTS):
+        release = Release(
+            clip_id=PydanticObjectId(clip_id),
+            user_id=PydanticObjectId(user_id),
+            status=ReleaseStatus.READY,
+            isrc=isrc,
+            upc=await identifiers.generate_upc(settings),
+            **metadata,
+        )
+        try:
+            await release.insert()
+        except DuplicateKeyError:
+            continue  # UPC slot taken by a manual code — mint the next
+        return release
+    raise DuplicateIdentifierError("upc")
+
+
+async def _sync_isrc_to_clip(clip_id: PydanticObjectId, user_id: str, isrc: str) -> None:
+    """Mirror a release's ISRC onto its source recording (clip).
+
+    A deleted source clip is tolerated (the release keeps its own code); a code
+    already held by a different recording surfaces as a duplicate (409).
+    """
+    clip = await clip_service.find_owned_clip(str(clip_id), user_id)
+    if clip is None or clip.isrc == isrc:
+        return
+    clip.isrc = isrc
+    try:
+        await clip.save()
+    except DuplicateKeyError as exc:
+        raise DuplicateIdentifierError("isrc") from exc
 
 
 def compute_warnings(clip: Clip | None) -> list[str]:
@@ -101,5 +150,14 @@ async def update_release(release_id: str, user_id: str, updates: dict) -> Releas
     for field, value in updates.items():
         setattr(release, field, value)
     release.updated_at = utcnow()
-    await release.save()
+    # A manual ISRC *override* re-identifies the recording, so mirror it onto the
+    # clip before persisting the release (so the two never diverge on a clash).
+    # Clearing it (isrc=None) only drops the release's copy: the recording keeps
+    # its permanent, never-reused code on the clip, so the mirror isn't synced.
+    if updates.get("isrc") is not None:
+        await _sync_isrc_to_clip(release.clip_id, user_id, updates["isrc"])
+    try:
+        await release.save()
+    except DuplicateKeyError as exc:  # manual UPC already used by another release
+        raise DuplicateIdentifierError(_duplicate_field(exc)) from exc
     return release

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -10,6 +10,7 @@ post-submission edit lock (409).
 from beanie import PydanticObjectId
 from beanie.operators import Eq
 from fastapi import HTTPException, status
+from pymongo import ReturnDocument
 from pymongo.errors import DuplicateKeyError
 
 from ..exceptions import DuplicateIdentifierError
@@ -76,16 +77,7 @@ async def create_release(user_id: str, clip_id: str, metadata: dict, settings: A
     the schema, so a created release is immediately ``ready``.
     """
     clip = await clip_service.get_owned_clip(clip_id, user_id)
-
-    # Claim the recording's ISRC first, so a release is never inserted with a code
-    # the clip then fails to accept.
-    if clip.isrc is None:
-        clip.isrc = await identifiers.generate_isrc(settings)
-        try:
-            await clip.save()
-        except DuplicateKeyError as exc:  # minted ISRC already on another clip (rare)
-            raise DuplicateIdentifierError("isrc") from exc
-    isrc = clip.isrc
+    isrc = await _claim_clip_isrc(clip, settings)
 
     for _ in range(_MAX_MINT_ATTEMPTS):
         release = Release(
@@ -102,6 +94,42 @@ async def create_release(user_id: str, clip_id: str, metadata: dict, settings: A
             continue  # UPC slot taken by a manual code — mint the next
         return release
     raise DuplicateIdentifierError("upc")
+
+
+async def _claim_clip_isrc(clip: Clip, settings: ApiSettings) -> str:
+    """Return the recording's ISRC, atomically minting and claiming one if absent.
+
+    Concurrent creations for the same uncoded clip race on the claim: exactly one
+    ``$set``-on-null wins and the losers read back its code, so every release
+    mirrors a single recording ISRC instead of diverging.
+    """
+    if clip.isrc is not None:
+        return clip.isrc
+    minted = await identifiers.generate_isrc(settings)
+    try:
+        doc = await Clip.get_pymongo_collection().find_one_and_update(
+            {"_id": clip.id, "isrc": None},
+            {"$set": {"isrc": minted}},
+            return_document=ReturnDocument.AFTER,
+        )
+    except DuplicateKeyError as exc:  # minted ISRC already on another recording (rare)
+        raise DuplicateIdentifierError("isrc") from exc
+    if doc is not None:
+        return doc["isrc"]  # we won the claim
+    # A concurrent creation already coded the clip — read back the canonical value.
+    refreshed = await Clip.get(clip.id)
+    return refreshed.isrc if refreshed and refreshed.isrc else minted
+
+
+async def _ensure_upc_unused(upc: str, release_id: PydanticObjectId) -> None:
+    """Raise 409 if a *different* release already holds ``upc``.
+
+    Checked before any write so a clashing UPC override can never leave the clip
+    re-coded while the release update itself rolls back on the unique index.
+    """
+    existing = await Release.find_one(Eq(Release.upc, upc))
+    if existing is not None and existing.id != release_id:
+        raise DuplicateIdentifierError("upc")
 
 
 async def _sync_isrc_to_clip(clip_id: PydanticObjectId, user_id: str, isrc: str) -> None:
@@ -147,6 +175,10 @@ async def update_release(release_id: str, user_id: str, updates: dict) -> Releas
     release = await get_owned_release(release_id, user_id)
     if release.status not in _EDITABLE_STATUSES:
         raise _state_error("Release metadata cannot be modified after submission")
+    # Reject a duplicate UPC up front, so a clashing override can't re-code the
+    # clip (below) and then have the release write roll back on the unique index.
+    if updates.get("upc") is not None:
+        await _ensure_upc_unused(updates["upc"], release.id)
     for field, value in updates.items():
         setattr(release, field, value)
     release.updated_at = utcnow()

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -31,8 +31,13 @@ _MAX_MINT_ATTEMPTS = 5
 
 
 def _duplicate_field(exc: DuplicateKeyError) -> str:
-    """Name the identifier a unique-index violation collided on."""
-    return "isrc" if "isrc" in str(exc) else "upc"
+    """Name the identifier a unique-index violation collided on.
+
+    Reads the driver's structured ``keyPattern`` (stable across versions) rather
+    than string-matching the message.
+    """
+    key_pattern = (exc.details or {}).get("keyPattern", {})
+    return "isrc" if "isrc" in key_pattern else "upc"
 
 
 def _not_found() -> HTTPException:
@@ -177,6 +182,11 @@ async def update_release(release_id: str, user_id: str, updates: dict) -> Releas
         raise _state_error("Release metadata cannot be modified after submission")
     # Reject a duplicate UPC up front, so a clashing override can't re-code the
     # clip (below) and then have the release write roll back on the unique index.
+    # With this pre-check both sequential failure directions stay clean: a UPC
+    # clash 409s here before any write; an ISRC clash 409s in the clip sync below,
+    # before release.save(). The residual is a true-concurrency TOCTOU that only a
+    # multi-doc transaction could close (unavailable on standalone MongoDB); the
+    # unique indexes still guarantee no duplicate is ever persisted.
     if updates.get("upc") is not None:
         await _ensure_upc_unused(updates["upc"], release.id)
     for field, value in updates.items():

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -110,20 +110,22 @@ async def _claim_clip_isrc(clip: Clip, settings: ApiSettings) -> str:
     """
     if clip.isrc is not None:
         return clip.isrc
-    minted = await identifiers.generate_isrc(settings)
-    try:
-        doc = await Clip.get_pymongo_collection().find_one_and_update(
-            {"_id": clip.id, "isrc": None},
-            {"$set": {"isrc": minted}},
-            return_document=ReturnDocument.AFTER,
-        )
-    except DuplicateKeyError as exc:  # minted ISRC already on another recording (rare)
-        raise DuplicateIdentifierError("isrc") from exc
-    if doc is not None:
-        return doc["isrc"]  # we won the claim
-    # A concurrent creation already coded the clip — read back the canonical value.
-    refreshed = await Clip.get(clip.id)
-    return refreshed.isrc if refreshed and refreshed.isrc else minted
+    for _ in range(_MAX_MINT_ATTEMPTS):
+        minted = await identifiers.generate_isrc(settings)
+        try:
+            doc = await Clip.get_pymongo_collection().find_one_and_update(
+                {"_id": clip.id, "isrc": None},
+                {"$set": {"isrc": minted}},
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError:
+            continue  # a manual override took this slot — mint the next (as for UPC)
+        if doc is not None:
+            return doc["isrc"]  # we won the claim
+        # A concurrent creation already coded the clip — read back the canonical value.
+        refreshed = await Clip.get(clip.id)
+        return refreshed.isrc if refreshed and refreshed.isrc else minted
+    raise DuplicateIdentifierError("isrc")
 
 
 async def _ensure_upc_unused(upc: str, release_id: PydanticObjectId) -> None:

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -5,6 +5,7 @@ All API settings are namespaced under the ``ACEMUSIC_API_`` env prefix so they d
 not collide with CLI or ACE-Step server variables.
 """
 
+import re
 from typing import Annotated, Literal
 from urllib.parse import urlsplit
 
@@ -237,6 +238,35 @@ class ApiSettings(BaseSettings):
                 "oauth_cookie_samesite='none' requires oauth_cookie_secure=True (browsers ignore it otherwise)."
             )
         return self
+
+    @field_validator("isrc_country_code")
+    @classmethod
+    def _check_isrc_country_code(cls, value: str) -> str:
+        """ISRC country code is exactly two uppercase letters (US-13.4).
+
+        Validated here so a misconfiguration fails at startup, not silently at
+        mint time as a malformed ISRC the generator can't reject.
+        """
+        if not re.fullmatch(r"[A-Z]{2}", value):
+            raise ValueError(f"isrc_country_code {value!r} must be exactly two uppercase letters")
+        return value
+
+    @field_validator("isrc_registrant_code")
+    @classmethod
+    def _check_isrc_registrant_code(cls, value: str) -> str:
+        """ISRC registrant code is exactly three uppercase alphanumerics (US-13.4)."""
+        if not re.fullmatch(r"[A-Z0-9]{3}", value):
+            raise ValueError(f"isrc_registrant_code {value!r} must be exactly three uppercase alphanumerics")
+        return value
+
+    @field_validator("upc_prefix")
+    @classmethod
+    def _check_upc_prefix(cls, value: str) -> str:
+        """GS1 company prefix is exactly seven digits, so prefix + 5-digit item +
+        check digit form a valid 13-digit EAN-13 (US-13.4)."""
+        if not re.fullmatch(r"\d{7}", value):
+            raise ValueError(f"upc_prefix {value!r} must be exactly seven digits")
+        return value
 
     @field_validator("jwt_algorithm")
     @classmethod

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -150,6 +150,15 @@ class ApiSettings(BaseSettings):
     openai_api_key: str | None = None
     artwork_generation_enabled: bool = True
 
+    # Release identifiers (US-13.4). ISRC = country code + registrant code issued
+    # by the platform operator's national agency; UPC = the operator's 7-digit GS1
+    # company prefix. The defaults are demo placeholders ("US"/"A1B"/"0000000") so
+    # codes are well-formed out of the box; a production deployment overrides them
+    # with its own registered allocations via the environment.
+    isrc_country_code: str = "US"
+    isrc_registrant_code: str = "A1B"
+    upc_prefix: str = "0000000"
+
     # Compute status endpoint (US-11.4). Per-target health-probe budget for
     # ``GET /api/v1/compute/status``; the local and remote checks run in parallel,
     # each bounded by this timeout, so the aggregate response stays well under the

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -6,6 +6,7 @@ are exercised through the release integration tests in ``test_releases_api.py``.
 """
 
 import pytest
+from pydantic import ValidationError
 
 from acemusic.api.services.identifiers import (
     calculate_ean13_check_digit,
@@ -13,6 +14,31 @@ from acemusic.api.services.identifiers import (
     validate_upc_check_digit,
     validate_upc_format,
 )
+from acemusic.api.settings import ApiSettings
+
+
+class TestIdentifierSettings:
+    """Identifier prefixes are width-validated at startup, not at mint time."""
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"isrc_country_code": "USA"},  # 3 letters
+            {"isrc_country_code": "u1"},  # lowercase / digit
+            {"isrc_registrant_code": "AB"},  # 2 chars
+            {"isrc_registrant_code": "ab1"},  # lowercase
+            {"upc_prefix": "000000"},  # 6 digits
+            {"upc_prefix": "00000000"},  # 8 digits
+            {"upc_prefix": "123456X"},  # non-digit
+        ],
+    )
+    def test_malformed_prefix_rejected_at_startup(self, overrides: dict) -> None:
+        with pytest.raises(ValidationError):
+            ApiSettings(jwt_secret_key="x" * 40, **overrides)
+
+    def test_defaults_are_valid(self) -> None:
+        s = ApiSettings(jwt_secret_key="x" * 40)
+        assert (s.isrc_country_code, s.isrc_registrant_code, s.upc_prefix) == ("US", "A1B", "0000000")
 
 
 class TestIsrcFormat:

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,77 @@
+"""Unit tests for ISRC/UPC validation and the EAN-13 check digit (US-13.4).
+
+These cover the pure logic only (no DB), so they run in CI. The async
+generators (`generate_isrc`/`generate_upc`) hit the atomic counter collection and
+are exercised through the release integration tests in ``test_releases_api.py``.
+"""
+
+import pytest
+
+from acemusic.api.services.identifiers import (
+    calculate_ean13_check_digit,
+    validate_isrc_format,
+    validate_upc_check_digit,
+    validate_upc_format,
+)
+
+
+class TestIsrcFormat:
+    @pytest.mark.parametrize("isrc", ["US-A1B-26-00001", "GB-XYZ-99-12345", "DE-AB1-00-00000"])
+    def test_valid(self, isrc: str) -> None:
+        assert validate_isrc_format(isrc) is True
+
+    @pytest.mark.parametrize(
+        "isrc",
+        [
+            "USA1B2600001",  # compact (no dashes) not accepted — issue mandates dashes
+            "US-A1B-26-0001",  # designation too short (4 digits)
+            "US-A1B-26-000011",  # designation too long
+            "U1-A1B-26-00001",  # country code not alpha
+            "us-a1b-26-00001",  # lowercase
+            "US-A1B-2X-00001",  # year not numeric
+            "US-A1B-26-0000A",  # designation not numeric
+            "",
+        ],
+    )
+    def test_invalid(self, isrc: str) -> None:
+        assert validate_isrc_format(isrc) is False
+
+
+class TestUpcFormat:
+    @pytest.mark.parametrize("upc", ["4006381333931", "0000000000017"])
+    def test_valid_shape(self, upc: str) -> None:
+        assert validate_upc_format(upc) is True
+
+    @pytest.mark.parametrize(
+        "upc",
+        [
+            "012345678905",  # 12 digits (UPC-A, not EAN-13)
+            "40063813339311",  # 14 digits
+            "400638133393X",  # non-numeric
+            "",
+        ],
+    )
+    def test_invalid_shape(self, upc: str) -> None:
+        assert validate_upc_format(upc) is False
+
+
+class TestEan13CheckDigit:
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            ("400638133393", 1),  # published EAN-13 4006381333931
+            ("000000000001", 7),
+            ("978014300723", 4),  # ISBN-13 978-0-14-300723-4
+        ],
+    )
+    def test_known_examples(self, payload: str, expected: int) -> None:
+        assert calculate_ean13_check_digit(payload) == expected
+
+    def test_validate_check_digit_round_trips_generation(self) -> None:
+        payload = "590123412345"
+        check = calculate_ean13_check_digit(payload)
+        assert validate_upc_check_digit(f"{payload}{check}") is True
+
+    @pytest.mark.parametrize("upc", ["4006381333930", "0000000000010"])
+    def test_wrong_check_digit_rejected(self, upc: str) -> None:
+        assert validate_upc_check_digit(upc) is False

--- a/tests/test_releases_api.py
+++ b/tests/test_releases_api.py
@@ -7,6 +7,7 @@ MongoDB (``mongo_db``), mirroring ``tests/test_presets_api.py``.
 """
 
 import itertools
+import re
 
 import httpx
 import pytest
@@ -17,12 +18,23 @@ from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Clip, Release, ReleaseStatus, Workspace
 from acemusic.api.services import users as user_service
+from acemusic.api.services.identifiers import calculate_ean13_check_digit
 from acemusic.api.services.mastering import APPROVED_GENERATION_MODE
 from acemusic.api.settings import ApiSettings
 
 RELEASES_URL = f"{API_V1_PREFIX}/releases"
 
-# A representative complete create payload (clip_id is filled in per-test).
+_ISRC_RE = re.compile(r"^[A-Z]{2}-[A-Z0-9]{3}-\d{2}-\d{5}$")
+
+
+def _valid_ean13(payload12: str) -> str:
+    """Build a valid 13-digit EAN-13 from a 12-digit payload (for override tests)."""
+    return f"{payload12}{calculate_ean13_check_digit(payload12)}"
+
+
+# A representative complete create payload (clip_id is filled in per-test). ISRC
+# and UPC are intentionally absent: they are auto-minted on create (US-13.4) and
+# only set manually via PATCH.
 FULL_METADATA = {
     "title": "Midnight Drive",
     "artist": "The Algorithm",
@@ -30,8 +42,6 @@ FULL_METADATA = {
     "release_date": "2026-07-01T00:00:00Z",
     "album_name": "Neon Highways",
     "description": "A late-night cruise.",
-    "isrc": "USABC1234567",
-    "upc": "012345678905",
     "copyright": "© 2026 The Algorithm",
     "is_explicit": False,
     "language": "en",
@@ -325,6 +335,97 @@ class TestUpdate:
         again = await client.get(f"{RELEASES_URL}/{created['id']}", headers=_auth_headers(user, settings))
         assert again.status_code == 200
         assert again.json()[field] is not None
+
+
+@pytest.mark.integration
+class TestIdentifiers:
+    """ISRC/UPC auto-generation, dual storage, manual override, uniqueness (US-13.4)."""
+
+    async def test_create_auto_generates_valid_isrc_and_upc(self, client, settings) -> None:
+        user = await _make_user("rel-ids-auto@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        body = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        assert _ISRC_RE.match(body["isrc"]), body["isrc"]
+        upc = body["upc"]
+        assert len(upc) == 13 and upc.isdigit()
+        assert calculate_ean13_check_digit(upc[:12]) == int(upc[12])  # valid EAN-13
+
+    async def test_auto_isrc_is_written_to_the_linked_clip(self, client, settings) -> None:
+        user = await _make_user("rel-ids-sync@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        body = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        refreshed = await Clip.get(clip.id)
+        assert refreshed.isrc == body["isrc"]  # dual storage: release + clip
+
+    async def test_existing_clip_isrc_is_preserved(self, client, settings) -> None:
+        user = await _make_user("rel-ids-preserve@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        clip.isrc = "US-ZZZ-20-00042"
+        await clip.save()
+        body = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        assert body["isrc"] == "US-ZZZ-20-00042"  # reused, not regenerated
+
+    async def test_patch_overrides_isrc_and_syncs_clip(self, client, settings) -> None:
+        user = await _make_user("rel-ids-patch-isrc@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}",
+            json={"isrc": "US-OVR-26-12345"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["isrc"] == "US-OVR-26-12345"
+        assert (await Clip.get(clip.id)).isrc == "US-OVR-26-12345"
+
+    async def test_patch_overrides_upc(self, client, settings) -> None:
+        user = await _make_user("rel-ids-patch-upc@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        manual_upc = _valid_ean13("123456789012")
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}",
+            json={"upc": manual_upc},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["upc"] == manual_upc
+
+    async def test_duplicate_isrc_returns_409(self, client, settings) -> None:
+        user = await _make_user("rel-ids-dup@example.com")
+        clip_a = await _insert_clip(user, mastered=True, artwork=True)
+        clip_b = await _insert_clip(user, mastered=True, artwork=True)
+        rel_a = (await _create_release(client, settings=settings, user=user, clip=clip_a)).json()
+        rel_b = (await _create_release(client, settings=settings, user=user, clip=clip_b)).json()
+        # Claim a code on A's recording, then try to reuse it on B's.
+        await client.patch(
+            f"{RELEASES_URL}/{rel_a['id']}",
+            json={"isrc": "US-DUP-26-00001"},
+            headers=_auth_headers(user, settings),
+        )
+        resp = await client.patch(
+            f"{RELEASES_URL}/{rel_b['id']}",
+            json={"isrc": "US-DUP-26-00001"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 409
+        assert "isrc" in resp.json()["detail"].lower()
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("isrc", "not-an-isrc"), ("isrc", "USABC1234567"), ("upc", "012345678905"), ("upc", "abc")],
+    )
+    async def test_invalid_identifier_returns_422(self, client, settings, field: str, value: str) -> None:
+        user = await _make_user(f"rel-ids-422-{field}-{value[:4]}@example.com")
+        clip = await _insert_clip(user, mastered=True, artwork=True)
+        created = (await _create_release(client, settings=settings, user=user, clip=clip)).json()
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}",
+            json={field: value},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert any(field in str(err.get("loc", [])) for err in resp.json()["detail"])
 
 
 @pytest.mark.integration

--- a/tests/test_releases_api.py
+++ b/tests/test_releases_api.py
@@ -449,6 +449,24 @@ class TestIdentifiers:
         assert "upc" in resp.json()["detail"].lower()
         assert (await Clip.get(clip_b.id)).isrc == clip_b_isrc_before  # not re-coded
 
+    async def test_auto_isrc_retries_past_a_manually_claimed_slot(self, client, settings) -> None:
+        # A manual override can occupy a future counter slot; auto-create must mint
+        # the next code rather than 409, mirroring the UPC retry.
+        from acemusic.api.models.counter import Counter
+
+        await Counter.get_pymongo_collection().find_one_and_update(
+            {"name": "isrc_seq"}, {"$set": {"value": 100}}, upsert=True
+        )
+        # Park the code the counter will produce next (seq 101) on another recording.
+        squatter = await _insert_clip(user := await _make_user("rel-ids-retry@example.com"))
+        squatter.isrc = "US-A1B-26-00101"
+        await squatter.save()
+
+        fresh = await _insert_clip(user, mastered=True, artwork=True)
+        body = (await _create_release(client, settings=settings, user=user, clip=fresh)).json()
+        assert body["isrc"] == "US-A1B-26-00102"  # retried to the next slot
+        assert (await Clip.get(fresh.id)).isrc == "US-A1B-26-00102"
+
     async def test_sequence_exhaustion_is_rejected(self, client, settings) -> None:
         # Seed the UPC counter at its 5-digit ceiling: the next mint overflows the
         # field, so generation must fail loudly rather than emit a malformed code.

--- a/tests/test_releases_api.py
+++ b/tests/test_releases_api.py
@@ -455,7 +455,11 @@ class TestIdentifiers:
         from acemusic.api.models.counter import Counter
         from acemusic.api.services.identifiers import generate_upc
 
-        await Counter(name="upc_seq", value=99999).insert()
+        # Force-set via the same upsert the production counter uses, so the seed
+        # works whether or not the counter document already exists.
+        await Counter.get_pymongo_collection().find_one_and_update(
+            {"name": "upc_seq"}, {"$set": {"value": 99999}}, upsert=True
+        )
         with pytest.raises(RuntimeError):
             await generate_upc(settings)
 

--- a/tests/test_releases_api.py
+++ b/tests/test_releases_api.py
@@ -70,6 +70,22 @@ class TestAuthGate:
         assert resp.status_code == 401
 
 
+class TestDuplicateFieldDetection:
+    """`_duplicate_field` reads the driver's structured keyPattern (no DB)."""
+
+    @pytest.mark.parametrize(
+        ("key_pattern", "expected"),
+        [({"isrc": 1}, "isrc"), ({"upc": 1}, "upc"), ({"user_id": 1, "upc": 1}, "upc")],
+    )
+    def test_maps_key_pattern_to_field(self, key_pattern: dict, expected: str) -> None:
+        from pymongo.errors import DuplicateKeyError
+
+        from acemusic.api.services.releases import _duplicate_field
+
+        exc = DuplicateKeyError("E11000 duplicate key", 11000, {"keyPattern": key_pattern})
+        assert _duplicate_field(exc) == expected
+
+
 # ---------------------------------------------------------------------------
 # Integration — real MongoDB
 # ---------------------------------------------------------------------------

--- a/tests/test_releases_api.py
+++ b/tests/test_releases_api.py
@@ -411,6 +411,38 @@ class TestIdentifiers:
         assert resp.status_code == 409
         assert "isrc" in resp.json()["detail"].lower()
 
+    async def test_duplicate_upc_override_returns_409_without_recoding_clip(self, client, settings) -> None:
+        user = await _make_user("rel-ids-dup-upc@example.com")
+        clip_a = await _insert_clip(user, mastered=True, artwork=True)
+        clip_b = await _insert_clip(user, mastered=True, artwork=True)
+        rel_a = (await _create_release(client, settings=settings, user=user, clip=clip_a)).json()
+        rel_b = (await _create_release(client, settings=settings, user=user, clip=clip_b)).json()
+        manual_upc = _valid_ean13("111222333444")
+        await client.patch(
+            f"{RELEASES_URL}/{rel_a['id']}", json={"upc": manual_upc}, headers=_auth_headers(user, settings)
+        )
+        # Reusing it on B with a simultaneous ISRC override must 409 *before* B's
+        # clip is re-coded (the clip stays on its auto-generated ISRC).
+        clip_b_isrc_before = (await Clip.get(clip_b.id)).isrc
+        resp = await client.patch(
+            f"{RELEASES_URL}/{rel_b['id']}",
+            json={"isrc": "US-XXX-26-54321", "upc": manual_upc},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 409
+        assert "upc" in resp.json()["detail"].lower()
+        assert (await Clip.get(clip_b.id)).isrc == clip_b_isrc_before  # not re-coded
+
+    async def test_sequence_exhaustion_is_rejected(self, client, settings) -> None:
+        # Seed the UPC counter at its 5-digit ceiling: the next mint overflows the
+        # field, so generation must fail loudly rather than emit a malformed code.
+        from acemusic.api.models.counter import Counter
+        from acemusic.api.services.identifiers import generate_upc
+
+        await Counter(name="upc_seq", value=99999).insert()
+        with pytest.raises(RuntimeError):
+            await generate_upc(settings)
+
     @pytest.mark.parametrize(
         ("field", "value"),
         [("isrc", "not-an-isrc"), ("isrc", "USABC1234567"), ("upc", "012345678905"), ("upc", "abc")],


### PR DESCRIPTION
## US-13.4: ISRC and UPC generation

Closes #135.

Auto-generates the identifiers a release needs to be recognised across stores: an
**ISRC** per recording (`CC-XXX-YY-NNNNN`) and an **EAN-13 UPC** per release.
Both are minted on `POST /releases` from atomic MongoDB counters and can be
overridden manually via `PATCH /releases/{id}`.

### Note on the plan
The CodeRabbit plan on the issue (2026-06-13) predates **US-13.3 (#177)**, which
already shipped the `Release` model, service, router, and tests. This PR layers
the identifier feature onto that existing infrastructure instead of building a
Release model from scratch.

### Design decisions (confirmed with the maintainer)
- **POST auto-generates; PATCH overrides.** `isrc`/`upc` were removed from
  `ReleaseCreate` (they are now always minted). This is a **breaking change** vs
  US-13.3, which accepted unvalidated codes on create — but the issue specifies
  create auto-generates and only PATCH does manual entry.
- **ISRC identifies a recording; UPC identifies a release.** So `Clip.isrc` is
  globally unique (one code per recording, never reused) and the ISRC is mirrored
  onto the clip (dual storage). `Release.upc` is globally unique. `Release.isrc`
  is **not** unique — re-releases of one recording legitimately share its ISRC.
  (The plan's unique index on `Release.isrc` would have broken re-releases.)

### Changes
- `services/identifiers.py` — pure validators (`validate_isrc_format`,
  `validate_upc_format`, `validate_upc_check_digit`, `calculate_ean13_check_digit`)
  and async generators (`generate_isrc`, `generate_upc`).
- `models/counter.py` — `Counter` doc + atomic `get_next_sequence`.
- `models/clip.py` — `isrc` field + partial unique index.
- `models/release.py` — partial unique index on `upc`.
- `services/releases.py` — auto-generate on create (reuse the clip's ISRC if it
  has one), sync ISRC override to the clip, map duplicate-key violations to 409.
- `routers/releases.py` — drop `isrc`/`upc` from create; validate them on PATCH.
- `exceptions.py` / `main.py` — `DuplicateIdentifierError` → HTTP 409.
- `settings.py` — `isrc_country_code` / `isrc_registrant_code` / `upc_prefix`
  (demo defaults; production overrides with its own registered allocations).

### Acceptance criteria
- [x] Auto-generated ISRC follows `CC-XXX-YY-NNNNN` and is unique
- [x] Auto-generated UPC is a valid EAN-13 with correct check digit
- [x] Manually entered codes override auto-generated ones
- [x] Duplicate ISRC codes are rejected (409)
- [x] Codes persist in both the release package and the clip record

### Tests
- `tests/test_identifiers.py` — 23 unit tests (validators + check digit, no DB).
- `tests/test_releases_api.py` — 8 new integration tests (auto-gen, clip sync,
  preserve existing clip ISRC, PATCH override, duplicate→409, invalid→422).
- Full release + clip-CRUD integration suites and the 1548-test non-integration
  suite all pass.

### Known limitations
- ISRC designation and UPC item number use one global counter each (no per-year
  reset); fine until a single year exceeds 99,999 releases.
- Identifier defaults are demo placeholders; a production deployment must set its
  own registered ISRC country/registrant codes and GS1 prefix.


### Review triage (codex cross-family review)
Five findings were triaged; three fixed in code (atomic ISRC claim on create,
UPC pre-check on PATCH, sequence-exhaustion guard). Two are documented rather
than fixed:

- **Pre-existing duplicate UPCs vs. the new unique index.** A deployment that had
  already stored duplicate non-null UPCs would fail Beanie's startup index build.
  The partial index excludes nulls (the common case), and there is no production
  release data yet (US-13.3 just merged), so no migration script is included; a
  deployment with such data must dedupe `releases.upc` before upgrading.
- **ISRC override across multiple releases of one clip.** Overriding one
  release's ISRC re-codes that release and the clip but not sibling releases of
  the same recording. The "correct" propagation is underspecified by the issue,
  so this is left as a known edge rather than building speculative fan-out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic ISRC generation for recordings and EAN-13 UPC generation for releases with proper check-digit validation.
  * Implemented ISRC/UPC format validation rejecting invalid formats with HTTP 422 responses.
  * Added ability to override ISRCs and UPCs via PATCH requests.
  * Added HTTP 409 Conflict responses for duplicate identifier attempts.
  * Ensured ISRC synchronization between releases and their source clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->