### PR TITLE
US-13.5: Guided distribution prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ Generation is async: poll `GET /api/v1/jobs/{id}/status`, whose completed respon
 
 Account-linking is distinct from login: it connects an already-authenticated user's SoundCloud account so the platform can upload on their behalf, with PKCE (S256), a `uid`-bound signed `state`, and the PKCE verifier held in a per-flow HttpOnly cookie. Upload maps clip metadata (`title`, `bpm`, `key`→`key_signature`, first style tag→`genre`) onto the track, lets `metadata_overrides` (`title`, `genre`, `description`, `bpm`, `key_signature`, `isrc`, `sharing`) take precedence, and attaches the clip's own cover art (US-13.1) when present. Access tokens are refreshed transparently on expiry; a rejected refresh (revoked grant) unlinks the account, while a transient failure preserves it for retry. Uploads over 500 MB are rejected. Requires `ACEMUSIC_API_SOUNDCLOUD_CLIENT_ID/SECRET/REDIRECT_URI`.
 
+### Distribution — Guided prep for LANDR / DistroKid / TuneCore (US-13.5)
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/releases/{id}/prepare/{target}` | Validate a release against `target` (`landr`, `distrokid`, `tunecore`); returns a pass/fail `checklist`, `all_checks_passed`, a `bundle_url` (null until every check passes), and target-specific `instructions` |
+| `POST /api/v1/releases/{id}/submit/{target}` | Confirm a manual submission; moves the release to `submitted` and records the target in `submitted_channels` |
+
+Because LANDR, DistroKid, and TuneCore have no public submission API, the platform prepares the package and the user submits manually. Validation reads the source clip (audio at `clip.file_path`, cover at `clip.artwork_path`) and checks audio presence/format (WAV or FLAC), cover-art presence and ≥3000×3000 resolution, required metadata, and ISRC/UPC. When everything passes, a target-formatted zip (`audio.* + cover.* + metadata.json + README.txt`) is uploaded to storage and its URL returned. An unknown target is rejected with `422`; releases are owner-scoped (`404`). `submit` is the user's attestation that they completed the upload on the target platform, and a release can be confirmed to more than one target.
+
 ### Presets
 
 | Endpoint | Purpose |

--- a/docs/demos/us-13.5-distribution-prep.md
+++ b/docs/demos/us-13.5-distribution-prep.md
@@ -1,0 +1,64 @@
+# US-13.5: Guided distribution prep — demo
+
+Drives the real `POST /releases/{id}/prepare/{target}` and
+`POST /releases/{id}/submit/{target}` endpoints against a live MongoDB and local
+storage, seeding a clip + cover art so validation has real assets to inspect and
+bundle. Each section maps to an acceptance criterion with its captured output.
+
+## AC3 — the checklist identifies missing/non-compliant items
+
+Prepared an incomplete release (mp3 audio, no cover art) for LANDR:
+
+```
+    [PASS] Audio file present: Audio file is available.
+    [FAIL] Audio format: Format 'mp3' is not accepted; use one of: FLAC, WAV.
+    [FAIL] Cover art: Cover art has not been added.
+    [PASS] Required metadata: All required metadata is present.
+    [PASS] ISRC assigned: US-A1B-26-00001
+    [PASS] UPC assigned: 0000000000017
+  -> all_checks_passed=False  bundle_url=None
+```
+
+The two non-compliant items are flagged and no bundle is produced.
+
+## AC1 + AC2 — validates & formats the package; a downloadable bundle per target
+
+Prepared a compliant release (WAV, 3000×3000 cover, full metadata, ISRC/UPC) for
+each target:
+
+```
+  landr:     passed=True  bundle=['README.txt', 'audio.wav', 'cover.png', 'metadata.json']
+  distrokid: passed=True  bundle=['README.txt', 'audio.wav', 'cover.png', 'metadata.json']
+  tunecore:  passed=True  bundle=['README.txt', 'audio.wav', 'cover.png', 'metadata.json']
+```
+
+`bundle_url` resolves to a real, openable zip containing the formatted package.
+
+## AC4 — instructions are specific to each distribution target
+
+```
+  landr:     'Submitting to LANDR:'     (2. Sign in to landr.com/distribution ...)
+  distrokid: 'Submitting to DistroKid:' (2. Sign in to distrokid.com ...)
+  tunecore:  'Submitting to TuneCore:'  (2. Sign in to tunecore.com ...)
+```
+
+## AC5 — release status updates to `submitted` after user confirmation
+
+```
+  before:                 status=ready      submitted_channels=[]
+  after submit/landr:     status=submitted  channels=['landr']
+  after submit/distrokid: status=submitted  channels=['landr', 'distrokid']
+```
+
+Confirming a manual submission moves the release to `submitted` and records each
+target; a release can be submitted to more than one platform.
+
+## Security
+
+```
+  prepare/spotify (invalid target) -> 422
+  intruder submit (not owner)      -> 404
+```
+
+Reproduce: `uv run python` against a local mongod on :27017 (see
+`tests/test_distribution_prep_api.py` for the full automated coverage).

--- a/src/acemusic/api/models/release.py
+++ b/src/acemusic/api/models/release.py
@@ -55,6 +55,11 @@ class Release(Document):
     language: str | None = None
     credits: str | None = None
 
+    # Distribution targets the owner has confirmed a manual submission to (US-13.5).
+    # A release can go to more than one of LANDR/DistroKid/TuneCore, so this is a
+    # list of target names while ``status`` stays a single ``submitted`` flag.
+    submitted_channels: list[str] = Field(default_factory=list)
+
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime | None = None
 

--- a/src/acemusic/api/routers/releases.py
+++ b/src/acemusic/api/routers/releases.py
@@ -21,7 +21,8 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from ..auth.dependencies import CurrentUser, get_current_user, get_settings, require_existing_user
 from ..models import Release, ReleaseStatus
-from ..services import clips as clip_service, releases as release_service
+from ..services import clips as clip_service, distribution as distribution_service, releases as release_service
+from ..services.distribution import ChecklistItem, DistributionTarget
 from ..services.identifiers import validate_isrc_format, validate_upc_check_digit
 from ..settings import ApiSettings
 
@@ -122,6 +123,7 @@ class ReleaseResponse(BaseModel):
     clip_id: str
     status: ReleaseStatus
     warnings: list[str]
+    submitted_channels: list[str]
     created_at: datetime
     updated_at: datetime | None
 
@@ -145,10 +147,21 @@ class ReleaseResponse(BaseModel):
             clip_id=str(release.clip_id),
             status=release.status,
             warnings=warnings,
+            submitted_channels=release.submitted_channels,
             created_at=release.created_at,
             updated_at=release.updated_at,
             **{field: getattr(release, field) for field in _METADATA_FIELDS},
         )
+
+
+class PrepareResponse(BaseModel):
+    release_id: str
+    target: DistributionTarget
+    checklist: list[ChecklistItem]
+    all_checks_passed: bool
+    # Null until every checklist item passes; the package isn't bundled before then.
+    bundle_url: str | None
+    instructions: str
 
 
 class ReleaseListResponse(BaseModel):
@@ -207,4 +220,38 @@ async def update_release(
         release = await release_service.get_owned_release(release_id, current.user_id)
     else:
         release = await release_service.update_release(release_id, current.user_id, updates)
+    return await _response_for(release)
+
+
+@router.post("/{release_id}/prepare/{target}", response_model=PrepareResponse)
+async def prepare_release(
+    release_id: str,
+    target: DistributionTarget,
+    current: CurrentUser = Depends(require_existing_user),
+) -> PrepareResponse:
+    """Validate a release for a distribution target and, if it passes, build a bundle.
+
+    Always returns the checklist; ``bundle_url`` is null when any item fails. An
+    unknown target is rejected by FastAPI's enum path validation (422).
+    """
+    release = await release_service.get_owned_release(release_id, current.user_id)
+    checklist, bundle_url = await distribution_service.prepare_release(release, target)
+    return PrepareResponse(
+        release_id=str(release.id),
+        target=target,
+        checklist=checklist,
+        all_checks_passed=distribution_service.is_release_ready(checklist),
+        bundle_url=bundle_url,
+        instructions=distribution_service.instructions_for(target),
+    )
+
+
+@router.post("/{release_id}/submit/{target}", response_model=ReleaseResponse)
+async def submit_release(
+    release_id: str,
+    target: DistributionTarget,
+    current: CurrentUser = Depends(require_existing_user),
+) -> ReleaseResponse:
+    """Confirm a manual submission to ``target`` — moves the release to ``submitted``."""
+    release = await release_service.confirm_submission(release_id, current.user_id, target.value)
     return await _response_for(release)

--- a/src/acemusic/api/services/distribution.py
+++ b/src/acemusic/api/services/distribution.py
@@ -274,7 +274,8 @@ async def prepare_release(release: Release, target: DistributionTarget) -> tuple
     if not is_release_ready(validation.checklist):
         return validation.checklist, None
 
-    data = _build_zip(validation, release, target)
+    # _build_zip does synchronous tempfile/zip I/O — keep it off the event loop.
+    data = await asyncio.to_thread(_build_zip, validation, release, target)
     key = _bundle_key(release, target)
     storage = get_storage_backend()
     # upload() overwrites the key, so re-preparing a target replaces its bundle

--- a/src/acemusic/api/services/distribution.py
+++ b/src/acemusic/api/services/distribution.py
@@ -1,0 +1,284 @@
+"""Guided distribution prep service (US-13.5).
+
+LANDR, DistroKid, and TuneCore have no public submission API, so the platform
+prepares a release *package* to each target's requirements and hands the user a
+checklist plus a downloadable bundle to submit manually.
+
+A release is a metadata wrapper around a clip: the audio lives at
+``clip.file_path`` and the cover art at ``clip.artwork_path`` (US-13.1), so
+validation and bundling read the source clip rather than the release. Target
+rules are plain data in :data:`TARGET_CONFIGS` so adding a platform is a dict
+entry, not new code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from ...constants import ARTWORK_MIN_RESOLUTION, VALID_IMAGE_FORMATS
+from ...image_processing import ImageValidationError, validate_image
+from ...storage import get_storage_backend
+from ...utils import make_slug
+from ..models import Release
+from . import clips as clip_service
+
+# Lossless masters only — all three targets reject lossy uploads for the master.
+_ACCEPTED_AUDIO_FORMATS: frozenset[str] = frozenset({"wav", "flac"})
+
+# Release metadata required for a compliant submission (all enforced at create,
+# but isrc/upc are clearable via PATCH so they're re-checked here).
+_REQUIRED_METADATA: tuple[str, ...] = ("title", "artist", "genre", "release_date")
+
+
+class DistributionTarget(str, Enum):
+    """Supported manual-distribution platforms."""
+
+    LANDR = "landr"
+    DISTROKID = "distrokid"
+    TUNECORE = "tunecore"
+
+
+@dataclass(frozen=True)
+class TargetRequirements:
+    """A target platform's package requirements and submission instructions."""
+
+    label: str
+    instructions: str
+    accepted_audio_formats: frozenset[str] = _ACCEPTED_AUDIO_FORMATS
+    accepted_artwork_formats: frozenset[str] = VALID_IMAGE_FORMATS
+    min_artwork_resolution: int = ARTWORK_MIN_RESOLUTION
+    required_metadata: tuple[str, ...] = _REQUIRED_METADATA
+
+
+def _instructions(label: str, portal: str) -> str:
+    return (
+        f"Submitting to {label}:\n"
+        f"1. Download this bundle and unzip it.\n"
+        f"2. Sign in to {portal} and start a new release.\n"
+        f"3. Upload audio.* as the track and cover.* as the artwork.\n"
+        f"4. Copy the title, artist, genre, release date, ISRC, and UPC from "
+        f"metadata.json into the release form.\n"
+        f"5. Submit on {label}, then confirm here to mark the release submitted."
+    )
+
+
+TARGET_CONFIGS: dict[DistributionTarget, TargetRequirements] = {
+    DistributionTarget.LANDR: TargetRequirements(
+        label="LANDR",
+        instructions=_instructions("LANDR", "landr.com/distribution"),
+    ),
+    DistributionTarget.DISTROKID: TargetRequirements(
+        label="DistroKid",
+        instructions=_instructions("DistroKid", "distrokid.com"),
+    ),
+    DistributionTarget.TUNECORE: TargetRequirements(
+        label="TuneCore",
+        instructions=_instructions("TuneCore", "tunecore.com"),
+    ),
+}
+
+
+def instructions_for(target: DistributionTarget) -> str:
+    """Return the submission instructions for ``target``."""
+    return TARGET_CONFIGS[target].instructions
+
+
+class ChecklistItem(BaseModel):
+    """One pass/fail line in a preparation checklist."""
+
+    item: str
+    passed: bool
+    message: str
+
+
+@dataclass
+class _Validation:
+    """Validation result plus the bytes downloaded to produce it (reused by the
+    bundle so a passing prepare downloads each asset once)."""
+
+    checklist: list[ChecklistItem]
+    audio: bytes | None = None
+    audio_format: str | None = None
+    artwork: bytes | None = None
+    artwork_format: str | None = None
+
+
+def is_release_ready(checklist: list[ChecklistItem]) -> bool:
+    """True only if every checklist item passed."""
+    return all(c.passed for c in checklist)
+
+
+async def _validate(release: Release, target: DistributionTarget) -> _Validation:
+    reqs = TARGET_CONFIGS[target]
+    checklist: list[ChecklistItem] = []
+    result = _Validation(checklist=checklist)
+
+    clip = await clip_service.find_owned_clip(str(release.clip_id), str(release.user_id))
+    storage = get_storage_backend()
+
+    # Audio: the clip holds the master; download it both to confirm the object
+    # exists and to reuse for the bundle when everything passes.
+    if clip is None:
+        checklist.append(
+            ChecklistItem(item="Audio file present", passed=False, message="Source clip is no longer available.")
+        )
+    else:
+        try:
+            result.audio = await asyncio.to_thread(storage.download, clip.file_path)
+        except FileNotFoundError:
+            checklist.append(
+                ChecklistItem(item="Audio file present", passed=False, message="Audio file is missing from storage.")
+            )
+        else:
+            result.audio_format = (clip.format or "").lower()
+            checklist.append(ChecklistItem(item="Audio file present", passed=True, message="Audio file is available."))
+        fmt = (clip.format or "").lower()
+        if fmt in reqs.accepted_audio_formats:
+            checklist.append(ChecklistItem(item="Audio format", passed=True, message=f"{fmt.upper()} is accepted."))
+        else:
+            accepted = ", ".join(sorted(f.upper() for f in reqs.accepted_audio_formats))
+            checklist.append(
+                ChecklistItem(
+                    item="Audio format",
+                    passed=False,
+                    message=f"Format {fmt or 'unknown'!r} is not accepted; use one of: {accepted}.",
+                )
+            )
+
+    # Cover art: presence + resolution, reusing the artwork validator.
+    art_path = clip.artwork_path if clip is not None else None
+    if not art_path:
+        checklist.append(ChecklistItem(item="Cover art", passed=False, message="Cover art has not been added."))
+    else:
+        try:
+            result.artwork = await asyncio.to_thread(storage.download, art_path)
+            fmt, width, height = validate_image(result.artwork)
+        except (FileNotFoundError, ImageValidationError) as exc:
+            checklist.append(
+                ChecklistItem(item="Cover art", passed=False, message=f"Cover art could not be read: {exc}")
+            )
+        else:
+            result.artwork_format = fmt
+            ok = (
+                fmt in reqs.accepted_artwork_formats
+                and width >= reqs.min_artwork_resolution
+                and height >= reqs.min_artwork_resolution
+            )
+            min_res = reqs.min_artwork_resolution
+            checklist.append(
+                ChecklistItem(
+                    item="Cover art",
+                    passed=ok,
+                    message=(
+                        f"{width}x{height} {fmt.upper()} cover art."
+                        if ok
+                        else f"Cover art is {width}x{height} {fmt.upper()}; "
+                        f"need >= {min_res}x{min_res} in {', '.join(sorted(reqs.accepted_artwork_formats))}."
+                    ),
+                )
+            )
+
+    # Metadata completeness.
+    missing = [f for f in reqs.required_metadata if not getattr(release, f, None)]
+    checklist.append(
+        ChecklistItem(
+            item="Required metadata",
+            passed=not missing,
+            message="All required metadata is present." if not missing else f"Missing metadata: {', '.join(missing)}.",
+        )
+    )
+
+    # Identifiers (US-13.4) — clearable via PATCH, so re-check.
+    checklist.append(
+        ChecklistItem(item="ISRC assigned", passed=bool(release.isrc), message=release.isrc or "No ISRC assigned.")
+    )
+    checklist.append(
+        ChecklistItem(item="UPC assigned", passed=bool(release.upc), message=release.upc or "No UPC assigned.")
+    )
+    return result
+
+
+async def validate_release(release: Release, target: DistributionTarget) -> list[ChecklistItem]:
+    """Validate ``release`` against ``target``'s requirements, returning a checklist."""
+    return (await _validate(release, target)).checklist
+
+
+def _metadata_json(release: Release) -> str:
+    fields = (
+        "title",
+        "artist",
+        "genre",
+        "release_date",
+        "album_name",
+        "description",
+        "isrc",
+        "upc",
+        "copyright",
+        "is_explicit",
+        "language",
+        "credits",
+    )
+    payload: dict[str, object] = {"release_id": str(release.id)}
+    for f in fields:
+        value = getattr(release, f, None)
+        payload[f] = value.isoformat() if hasattr(value, "isoformat") else value
+    return json.dumps(payload, indent=2)
+
+
+def _bundle_key(release: Release, target: DistributionTarget) -> str:
+    return f"{release.user_id}/releases/{release.id}/bundles/{target.value}.zip"
+
+
+def _build_zip(validation: _Validation, release: Release, target: DistributionTarget) -> bytes:
+    """Assemble the target bundle as zip bytes (audio + cover + metadata + README)."""
+    slug = make_slug(release.title) or f"release-{release.id}"
+    root = f"{slug}_for_{target.value}"
+    audio_ext = validation.audio_format or "wav"
+    art_ext = "jpg" if validation.artwork_format == "jpeg" else (validation.artwork_format or "png")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tree = Path(tmp) / root
+        tree.mkdir(parents=True)
+        if validation.audio is not None:
+            (tree / f"audio.{audio_ext}").write_bytes(validation.audio)
+        if validation.artwork is not None:
+            (tree / f"cover.{art_ext}").write_bytes(validation.artwork)
+        (tree / "metadata.json").write_text(_metadata_json(release))
+        (tree / "README.txt").write_text(instructions_for(target))
+
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in sorted(tree.rglob("*")):
+                if path.is_file():
+                    zf.write(path, f"{root}/{path.relative_to(tree).as_posix()}")
+        return buffer.getvalue()
+
+
+async def prepare_release(release: Release, target: DistributionTarget) -> tuple[list[ChecklistItem], str | None]:
+    """Validate ``release`` for ``target`` and, if it passes, build and upload the bundle.
+
+    Returns ``(checklist, bundle_url)`` where ``bundle_url`` is ``None`` when any
+    check fails. The bundle reuses the assets downloaded during validation, so a
+    passing prepare downloads each source object exactly once.
+    """
+    validation = await _validate(release, target)
+    if not is_release_ready(validation.checklist):
+        return validation.checklist, None
+
+    data = _build_zip(validation, release, target)
+    key = _bundle_key(release, target)
+    storage = get_storage_backend()
+    # upload() overwrites the key, so re-preparing a target replaces its bundle
+    # in place — no separate delete (which would leave a window with no bundle if
+    # the upload then failed).
+    await asyncio.to_thread(storage.upload, key, data)
+    return validation.checklist, storage.get_url(key)

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -227,7 +227,9 @@ async def confirm_submission(release_id: str, user_id: str, target: str) -> Rele
     # claims take). The status filter re-checks the transition at write time.
     confirmable = [s.value for s in _CONFIRMABLE_STATUSES]
     doc = await Release.get_pymongo_collection().find_one_and_update(
-        {"_id": release.id, "status": {"$in": confirmable}},
+        # user_id in the filter too: closes the TOCTOU gap between the ownership
+        # read above and this write (the unique-claim helpers filter the same way).
+        {"_id": release.id, "user_id": release.user_id, "status": {"$in": confirmable}},
         {
             "$addToSet": {"submitted_channels": target},
             "$set": {"status": ReleaseStatus.SUBMITTED.value, "updated_at": utcnow()},

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -205,3 +205,34 @@ async def update_release(release_id: str, user_id: str, updates: dict) -> Releas
     except DuplicateKeyError as exc:  # manual UPC already used by another release
         raise DuplicateIdentifierError(_duplicate_field(exc)) from exc
     return release
+
+
+# A submission can only be confirmed once the package is assembled, and re-confirmed
+# for a further target after it has gone out — never from draft or a terminal state.
+_CONFIRMABLE_STATUSES = {ReleaseStatus.READY, ReleaseStatus.SUBMITTED}
+
+
+async def confirm_submission(release_id: str, user_id: str, target: str) -> Release:
+    """Mark an owned release submitted to ``target`` (US-13.5).
+
+    Transitions ``ready``/``submitted`` → ``submitted`` and records ``target`` in
+    ``submitted_channels`` (deduped, so re-confirming the same target is a no-op).
+    Raises 404 if not owned, 409 from ``draft`` or a terminal state.
+    """
+    release = await get_owned_release(release_id, user_id)
+    if release.status not in _CONFIRMABLE_STATUSES:
+        raise _state_error(f"Release cannot be submitted from status {release.status.value!r}")
+    # Atomic $addToSet + guarded $set so concurrent confirmations of different
+    # targets can't lose a channel via read-modify-write (same care the ISRC/UPC
+    # claims take). The status filter re-checks the transition at write time.
+    confirmable = [s.value for s in _CONFIRMABLE_STATUSES]
+    doc = await Release.get_pymongo_collection().find_one_and_update(
+        {"_id": release.id, "status": {"$in": confirmable}},
+        {
+            "$addToSet": {"submitted_channels": target},
+            "$set": {"status": ReleaseStatus.SUBMITTED.value, "updated_at": utcnow()},
+        },
+    )
+    if doc is None:  # a concurrent transition moved it out of a confirmable state
+        raise _state_error("Release is no longer in a submittable state")
+    return await get_owned_release(release_id, user_id)

--- a/tests/test_distribution_prep_api.py
+++ b/tests/test_distribution_prep_api.py
@@ -1,0 +1,271 @@
+"""Tests for guided distribution prep (US-13.5, issue #136).
+
+Distinct from ``tests/test_distribution_api.py`` (SoundCloud upload, US-13.2):
+these cover the LANDR/DistroKid/TuneCore *manual* prep endpoints on the releases
+router. Unit tests (target config + readiness helper) run in CI. The endpoint
+tests are ``integration``: they drive the real app over a local MongoDB and a
+throwaway local storage root, seeding real audio + a 3000x3000 cover so
+validation has something to download and bundle.
+"""
+
+import io
+import itertools
+import zipfile
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from PIL import Image
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Release, ReleaseStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.services.distribution import (
+    TARGET_CONFIGS,
+    ChecklistItem,
+    DistributionTarget,
+    instructions_for,
+    is_release_ready,
+)
+from acemusic.api.services.mastering import APPROVED_GENERATION_MODE
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+RELEASES_URL = f"{API_V1_PREFIX}/releases"
+
+FULL_METADATA = {
+    "title": "Midnight Drive",
+    "artist": "The Algorithm",
+    "genre": "synthwave",
+    "release_date": "2026-07-01T00:00:00Z",
+    "album_name": "Neon Highways",
+    "description": "A late-night cruise.",
+    "copyright": "© 2026 The Algorithm",
+    "is_explicit": False,
+    "language": "en",
+    "credits": "Produced by The Algorithm",
+}
+
+
+# ---------------------------------------------------------------------------
+# Unit — runs in CI (no DB, no storage)
+# ---------------------------------------------------------------------------
+
+
+class TestTargetConfig:
+    def test_all_targets_configured_with_distinct_instructions(self) -> None:
+        assert set(TARGET_CONFIGS) == set(DistributionTarget)
+        instructions = {instructions_for(t) for t in DistributionTarget}
+        assert len(instructions) == len(DistributionTarget)  # each target speaks for itself
+        assert "LANDR" in instructions_for(DistributionTarget.LANDR)
+
+    def test_is_release_ready(self) -> None:
+        ok = [ChecklistItem(item="a", passed=True, message=""), ChecklistItem(item="b", passed=True, message="")]
+        bad = [ChecklistItem(item="a", passed=True, message=""), ChecklistItem(item="b", passed=False, message="x")]
+        assert is_release_ready(ok) is True
+        assert is_release_ready(bad) is False
+        assert is_release_ready([]) is True
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB + local storage
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={"jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx", "job_processor_enabled": False}
+    )
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    """Point the storage backend at a throwaway local root."""
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), email=user.email, subscription_tier=user.subscription_tier, settings=settings
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+_SEQ = itertools.count(1)
+
+
+def _png_bytes(size: int) -> bytes:
+    out = io.BytesIO()
+    Image.new("RGB", (size, size), "navy").save(out, format="PNG")
+    return out.getvalue()
+
+
+async def _insert_clip(user, *, fmt: str = "wav", artwork: bool = True, art_size: int = 3000) -> Clip:
+    """Insert a clip and seed its audio (and optionally cover art) into storage."""
+    workspace = Workspace(name=f"WS-{next(_SEQ)}", user_id=user.id)
+    await workspace.insert()
+    clip_id = PydanticObjectId()
+    audio_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt}"
+    art_path = f"{user.id}/art/{clip_id}.png" if artwork else None
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=audio_path,
+        format=fmt,
+        title="Source",
+        generation_mode=APPROVED_GENERATION_MODE,
+        artwork_path=art_path,
+    )
+    await clip.insert()
+    storage = get_storage_backend()
+    storage.upload(audio_path, b"RIFF....fake-audio")
+    if art_path:
+        storage.upload(art_path, _png_bytes(art_size))
+    return clip
+
+
+async def _create_release(client, user, settings, clip, **overrides) -> httpx.Response:
+    payload = {"clip_id": str(clip.id), **FULL_METADATA, **overrides}
+    return await client.post(RELEASES_URL, json=payload, headers=_auth_headers(user, settings))
+
+
+async def _new_release(client, settings, *, email, **clip_kwargs):
+    user = await _make_user(email)
+    clip = await _insert_clip(user, **clip_kwargs)
+    resp = await _create_release(client, user=user, settings=settings, clip=clip)
+    assert resp.status_code == 201, resp.text
+    return user, resp.json()
+
+
+@pytest.mark.integration
+class TestPrepare:
+    async def test_compliant_release_passes_and_returns_bundle(self, client, settings, local_storage) -> None:
+        user, release = await _new_release(client, settings, email="prep-ok@example.com")
+        resp = await client.post(f"{RELEASES_URL}/{release['id']}/prepare/landr", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["target"] == "landr"
+        assert body["all_checks_passed"] is True
+        assert all(item["passed"] for item in body["checklist"])
+        assert "LANDR" in body["instructions"]
+        assert body["bundle_url"]
+
+        # The bundle is a real, downloadable zip with the target-formatted contents.
+        with zipfile.ZipFile(body["bundle_url"]) as zf:
+            names = {n.split("/", 1)[1] for n in zf.namelist()}
+        assert names == {"audio.wav", "cover.png", "metadata.json", "README.txt"}
+
+    async def test_mp3_audio_flagged_non_compliant_and_no_bundle(self, client, settings, local_storage) -> None:
+        user, release = await _new_release(client, settings, email="prep-mp3@example.com", fmt="mp3")
+        resp = await client.post(
+            f"{RELEASES_URL}/{release['id']}/prepare/distrokid", headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["all_checks_passed"] is False
+        assert body["bundle_url"] is None
+        audio_fmt = next(i for i in body["checklist"] if i["item"] == "Audio format")
+        assert audio_fmt["passed"] is False
+
+    async def test_missing_cover_art_flagged(self, client, settings, local_storage) -> None:
+        user, release = await _new_release(client, settings, email="prep-noart@example.com", artwork=False)
+        resp = await client.post(
+            f"{RELEASES_URL}/{release['id']}/prepare/tunecore", headers=_auth_headers(user, settings)
+        )
+        body = resp.json()
+        assert body["all_checks_passed"] is False
+        cover = next(i for i in body["checklist"] if i["item"] == "Cover art")
+        assert cover["passed"] is False
+
+    async def test_low_resolution_cover_art_flagged(self, client, settings, local_storage) -> None:
+        user, release = await _new_release(client, settings, email="prep-smallart@example.com", art_size=512)
+        resp = await client.post(f"{RELEASES_URL}/{release['id']}/prepare/landr", headers=_auth_headers(user, settings))
+        body = resp.json()
+        cover = next(i for i in body["checklist"] if i["item"] == "Cover art")
+        assert cover["passed"] is False
+        assert "512x512" in cover["message"]
+
+    async def test_missing_upc_flagged(self, client, settings, local_storage) -> None:
+        user, release = await _new_release(client, settings, email="prep-noupc@example.com")
+        # Clear the UPC via PATCH, then prepare should flag it.
+        await client.patch(f"{RELEASES_URL}/{release['id']}", json={"upc": None}, headers=_auth_headers(user, settings))
+        resp = await client.post(f"{RELEASES_URL}/{release['id']}/prepare/landr", headers=_auth_headers(user, settings))
+        body = resp.json()
+        upc = next(i for i in body["checklist"] if i["item"] == "UPC assigned")
+        assert upc["passed"] is False
+        assert body["all_checks_passed"] is False
+
+    async def test_invalid_target_returns_422(self, client, settings, local_storage) -> None:
+        user, release = await _new_release(client, settings, email="prep-bad@example.com")
+        resp = await client.post(
+            f"{RELEASES_URL}/{release['id']}/prepare/spotify", headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 422
+
+    async def test_other_users_release_is_404(self, client, settings, local_storage) -> None:
+        _owner, release = await _new_release(client, settings, email="prep-owner@example.com")
+        intruder = await _make_user("prep-intruder@example.com")
+        resp = await client.post(
+            f"{RELEASES_URL}/{release['id']}/prepare/landr", headers=_auth_headers(intruder, settings)
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestSubmit:
+    async def test_confirm_moves_release_to_submitted_and_records_channel(
+        self, client, settings, local_storage
+    ) -> None:
+        user, release = await _new_release(client, settings, email="submit-ok@example.com")
+        resp = await client.post(f"{RELEASES_URL}/{release['id']}/submit/landr", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "submitted"
+        assert body["submitted_channels"] == ["landr"]
+
+        stored = await Release.get(PydanticObjectId(release["id"]))
+        assert stored.status is ReleaseStatus.SUBMITTED
+
+    async def test_confirm_second_target_appends_channel(self, client, settings, local_storage) -> None:
+        user, release = await _new_release(client, settings, email="submit-two@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(f"{RELEASES_URL}/{release['id']}/submit/landr", headers=headers)
+        # Re-confirm the same target (dedup) then a second target.
+        await client.post(f"{RELEASES_URL}/{release['id']}/submit/landr", headers=headers)
+        resp = await client.post(f"{RELEASES_URL}/{release['id']}/submit/distrokid", headers=headers)
+        assert resp.json()["submitted_channels"] == ["landr", "distrokid"]
+
+    async def test_other_users_release_is_404(self, client, settings, local_storage) -> None:
+        _owner, release = await _new_release(client, settings, email="submit-owner@example.com")
+        intruder = await _make_user("submit-intruder@example.com")
+        resp = await client.post(
+            f"{RELEASES_URL}/{release['id']}/submit/landr", headers=_auth_headers(intruder, settings)
+        )
+        assert resp.status_code == 404
+
+    async def test_invalid_target_returns_422(self, client, settings, local_storage) -> None:
+        user, release = await _new_release(client, settings, email="submit-bad@example.com")
+        resp = await client.post(
+            f"{RELEASES_URL}/{release['id']}/submit/bandcamp", headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## US-13.5: Guided distribution prep

Closes #136.

Since LANDR, DistroKid, and TuneCore have no public submission API, the platform
prepares a release package to each target's requirements and hands the user a
checklist, a downloadable bundle, and submission instructions to complete the
upload manually.

### What's added
- **`services/distribution.py`** — `DistributionTarget` enum (landr/distrokid/tunecore),
  `TARGET_CONFIGS` (accepted audio formats, min artwork resolution, accepted artwork
  formats, required metadata, per-target instructions), package validation producing a
  pass/fail `ChecklistItem` list, and `prepare_release()` which builds a target-formatted
  zip (`audio.* + cover.* + metadata.json + README.txt`) and uploads it to storage.
- **`POST /api/v1/releases/{id}/prepare/{target}`** — returns the checklist, `all_checks_passed`,
  a `bundle_url` (null until every check passes), and target instructions.
- **`POST /api/v1/releases/{id}/submit/{target}`** — confirms a manual submission, atomically
  moving the release to `submitted` and recording the channel.
- **`Release.submitted_channels`** — tracks which of the three targets were confirmed
  (a release can go to more than one).

Validation and bundling read the **source clip** (audio at `clip.file_path`, cover at
`clip.artwork_path`), reusing `image_processing.validate_image`, the storage backend, and
the `daw_export` zip/arcname pattern.

### Acceptance criteria
- [x] Preparing for LANDR validates and formats the package to LANDR requirements
- [x] A downloadable bundle is available for each target
- [x] The preparation checklist identifies missing or non-compliant items
- [x] Instructions are specific to each distribution target
- [x] Release status updates to `submitted` after user confirmation

### Deviations from the issue's CodeRabbit plan (codebase reality)
- Audio/art live on the **clip**, not the release (no `audio_path`/`cover_art_path` on `Release`).
- Replaced the planned `PATCH /channels/{channel}/status` (no `channels` concept exists) with
  `POST /releases/{id}/submit/{target}`; the only valid status is `submitted`, so a request body
  was redundant. Added `submitted_channels` for multi-target tracking.
- Invalid target → **422** (FastAPI enum path validation), not 400.

### Tests
`tests/test_distribution_prep_api.py` — 2 unit (CI) + 11 integration (prepare pass → bundle
contents; mp3 / missing art / low-res art / missing UPC fail paths; submit transitions + channel
dedup/append; ownership 404; invalid-target 422). All 48 releases+prep integration tests pass.

### Known limitations
- **Format depth**: audio compliance is checked against `clip.format` (wav/flac accepted, mp3
  rejected). Bit depth / sample rate aren't tracked on the model, so deeper spec checks are out of scope.
- **In-memory bundling**: audio and the zip are held in memory, consistent with the existing
  bytes-based storage abstraction (the clip-audio endpoint buffers fully too). Streaming would
  require re-architecting the storage interface.
- **Submission is an attestation**: `submit` records the user's confirmation that they submitted
  on the target platform; it does not verify a bundle was first prepared (bundles are regenerable
  and prep state is not persisted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added distribution “prepare” and “submit” endpoints supporting LANDR, DistroKid, and TuneCore
  * Release validation now returns a checklist, readiness status, and a generated bundle link when all checks pass
  * Tracks which distribution channels have been manually submitted per release

* **Documentation**
  * Added a guided demo page for “US-13.5: Distribution prep”

* **Tests**
  * Added end-to-end and unit tests covering preparation outcomes, bundle contents, and submission status transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->