### PR TITLE
US-13.6: Distribution status tracking (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,17 @@ Account-linking is distinct from login: it connects an already-authenticated use
 
 Because LANDR, DistroKid, and TuneCore have no public submission API, the platform prepares the package and the user submits manually. Validation reads the source clip (audio at `clip.file_path`, cover at `clip.artwork_path`) and checks audio presence/format (WAV or FLAC), cover-art presence and ≥3000×3000 resolution, required metadata, and ISRC/UPC. When everything passes, a target-formatted zip (`audio.* + cover.* + metadata.json + README.txt`) is uploaded to storage and its URL returned. An unknown target is rejected with `422`; releases are owner-scoped (`404`). `submit` is the user's attestation that they completed the upload on the target platform, and a release can be confirmed to more than one target.
 
+### Distribution status tracking (US-13.6)
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/v1/releases` | Each release in the listing now carries `channel_statuses` (per-channel status map) and `visibility` |
+| `GET /api/v1/releases/{id}/status` | Per-channel status breakdown: `channels` (`[{channel, status}]`), `visibility`, and `soundcloud_last_polled` |
+| `PATCH /api/v1/releases/{id}/channels/{channel}/status` | Manually set a **guided** channel's status (`landr`/`distrokid`/`tunecore`); `soundcloud` or an unknown channel → `400`, an out-of-sequence step → `409` |
+| `PATCH /api/v1/releases/{id}/visibility` | Set release visibility (`private`/`unlisted`/`public`); syncs the source clip's `is_public` and, if uploaded, the SoundCloud track's sharing |
+
+Each channel tracks its own status through the sequence `draft → ready → submitted → in_review → live | rejected` (no skipping — enforced by an atomic, guarded write). SoundCloud is driven automatically: `POST /distribution/soundcloud/upload` accepts an optional `release_id` to record the track id and start the channel at `submitted`, and a background `SoundCloudStatusPoller` advances it from the live track state (`processing`→`in_review`, `finished`+`public`→`live`, `failed`→`rejected`). Reaching `live`/`rejected` records a `NotificationEvent` (delivery is out of scope). The poller is gated by `ACEMUSIC_API_SOUNDCLOUD_POLLER_ENABLED` (default on) with `ACEMUSIC_API_SOUNDCLOUD_POLL_INTERVAL` (default 60s, floor 5s) and `ACEMUSIC_API_SOUNDCLOUD_POLL_BATCH_SIZE` (default 20); it orders by `soundcloud_last_polled` so no release starves. `unlisted` maps to SoundCloud `private` (SoundCloud has no unlisted state).
+
 ### Presets
 
 | Endpoint | Purpose |

--- a/docs/demos/us-13.6-distribution-status.md
+++ b/docs/demos/us-13.6-distribution-status.md
@@ -1,0 +1,61 @@
+# US-13.6: Distribution status tracking
+
+*2026-06-22T04:39:42Z*
+
+This demo drives the real API and SoundCloud poller against a local MongoDB (the same harness the integration tests use). Each of the five acceptance criteria is exercised end-to-end and the actual HTTP response / persisted state is printed as outcome evidence. The only stubbed seam is SoundCloud's account-gated HTTP API, replaced by a fake fetcher returning real SoundCloud-shaped payloads.
+
+- **AC5** transitions follow the valid sequence (draft→live rejected with 409; draft→ready accepted)
+- **AC3** manual guided-channel updates stored & visible (SoundCloud manual update rejected as automated)
+- **AC1** release listing shows per-channel status + visibility
+- **AC4** visibility=public flips the source clip's is_public so non-owners can access the audio
+- **AC2** the poller advances the SoundCloud channel submitted→in_review→live from real track state and records a notification
+
+```bash
+uv run python docs/demos/us-13.6-distribution-status.py
+```
+
+```output
+INFO:     acemusic.api.database - Connected to MongoDB database 'acemusic_demo_fd8bbe3d' at mongodb://localhost:27017
+INFO:     acemusic.api.database - Closed MongoDB connection
+Created release 6a38bc9874fa2320fc149d7a (clip 6a38bc9874fa2320fc149d79); clip.is_public = False
+
+======================================================================
+AC5: status transitions follow the valid sequence (no skipping)
+======================================================================
+draft → live (skip) ......... HTTP 409: Cannot move a channel from 'draft' to 'live'.
+draft → ready (valid step) .. HTTP 200: {'channel': 'landr', 'status': 'ready'}
+
+======================================================================
+AC3: manual status updates for guided channels are stored and visible
+======================================================================
+landr → submitted  HTTP 200: {'channel': 'landr', 'status': 'submitted'}
+landr → in_review  HTTP 200: {'channel': 'landr', 'status': 'in_review'}
+soundcloud (manual) ......... HTTP 400: SoundCloud status is updated automatically and cannot be set manually.
+GET /status channels ........ [{'channel': 'landr', 'status': 'in_review'}]
+
+======================================================================
+AC1: release listing shows per-channel distribution status
+======================================================================
+listed channel_statuses ..... {'landr': 'in_review'}
+listed visibility ........... private
+
+======================================================================
+AC4: visibility changes update the clip's sharing state
+======================================================================
+PATCH visibility=public ..... HTTP 200: visibility=public
+source clip.is_public now ... True  (was False)
+
+======================================================================
+AC2: SoundCloud status reflects actual track state (polled via API)
+======================================================================
+SoundCloud release 6a38bc9874fa2320fc149d7b starts at: submitted
+poll (SoundCloud {'state': 'processing'}) → changed=1, soundcloud status now: in_review
+poll (SoundCloud {'state': 'finished', 'sharing': 'public'}) → changed=1, soundcloud status now: live
+notifications recorded ...... [('status_live', 'soundcloud')]
+
+======================================================================
+All acceptance criteria demonstrated with real outcomes ✓
+======================================================================
+```
+
+Every acceptance criterion produced concrete, persisted evidence: the 409 on an out-of-sequence transition, stored channel statuses surfaced via both `GET /status` and the listing, the source clip flipped to `is_public=True` on publish, and the SoundCloud channel advancing through `submitted → in_review → live` purely from polled track state — with a `status_live` notification recorded. US-13.6 is complete.

--- a/docs/demos/us-13.6-distribution-status.py
+++ b/docs/demos/us-13.6-distribution-status.py
@@ -1,0 +1,163 @@
+"""US-13.6 demo harness — drives the real API + poller against local MongoDB.
+
+Each acceptance criterion is exercised end-to-end with real persistence and the
+actual response printed as outcome evidence. SoundCloud's gated HTTP API is the
+only stubbed seam (a fake status fetcher returns real SoundCloud-shaped payloads);
+everything else is the production code path.
+"""
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+
+import httpx
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.database import close_db, init_db
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, NotificationEvent, Release, Workspace
+from acemusic.api.models.distribution import SOUNDCLOUD_CHANNEL, DistributionStatus
+from acemusic.api.services import users as user_service
+from acemusic.api.services.mastering import APPROVED_GENERATION_MODE
+from acemusic.api.settings import ApiSettings
+from acemusic.api.tasks.soundcloud_poller import SoundCloudStatusPoller
+
+RELEASES = f"{API_V1_PREFIX}/releases"
+
+
+def hdr(title: str) -> None:
+    print(f"\n{'=' * 70}\n{title}\n{'=' * 70}")
+
+
+async def main() -> None:
+    settings = ApiSettings(
+        _env_file=None,
+        mongodb_url="mongodb://localhost:27017",
+        mongodb_db_name=f"acemusic_demo_{uuid.uuid4().hex[:8]}",
+        jwt_secret_key="demo-secret-key-at-least-32-bytes-long-xx",
+        job_processor_enabled=False,
+        soundcloud_poller_enabled=False,
+    )
+    client = await init_db(settings)
+    try:
+        app = create_app(settings)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://demo") as http:
+            user = await user_service.get_or_create_user(
+                email="demo@example.com", provider="google", oauth_id="g-demo", name="Demo"
+            )
+            token = create_access_token(
+                user_id=str(user.id), email=user.email, subscription_tier=user.subscription_tier, settings=settings
+            )
+            auth = {"Authorization": f"Bearer {token}"}
+
+            # A mastered clip + a release built from it.
+            ws = Workspace(name="Demo WS", user_id=user.id)
+            await ws.insert()
+            clip = Clip(
+                user_id=user.id,
+                workspace_id=ws.id,
+                file_path=f"{user.id}/{ws.id}/clips/demo.wav",
+                format="wav",
+                title="Demo Track",
+                generation_mode=APPROVED_GENERATION_MODE,
+                artwork_path=f"{user.id}/art/demo.png",
+            )
+            await clip.insert()
+            created = (
+                await http.post(
+                    RELEASES,
+                    json={
+                        "clip_id": str(clip.id),
+                        "title": "Demo Track",
+                        "artist": "Demo Artist",
+                        "genre": "house",
+                        "release_date": "2026-08-01T00:00:00Z",
+                    },
+                    headers=auth,
+                )
+            ).json()
+            rid = created["id"]
+            print(f"Created release {rid} (clip {clip.id}); clip.is_public = {clip.is_public}")
+
+            # ---- AC5: transitions follow the valid sequence ------------------
+            hdr("AC5: status transitions follow the valid sequence (no skipping)")
+            skip = await http.patch(
+                f"{RELEASES}/{rid}/channels/landr/status", json={"status": "live"}, headers=auth
+            )
+            print(f"draft → live (skip) ......... HTTP {skip.status_code}: {skip.json()['detail']}")
+            ok = await http.patch(
+                f"{RELEASES}/{rid}/channels/landr/status", json={"status": "ready"}, headers=auth
+            )
+            print(f"draft → ready (valid step) .. HTTP {ok.status_code}: {ok.json()}")
+
+            # ---- AC3: manual guided updates are stored and visible ------------
+            hdr("AC3: manual status updates for guided channels are stored and visible")
+            for step in ("submitted", "in_review"):
+                r = await http.patch(
+                    f"{RELEASES}/{rid}/channels/landr/status", json={"status": step}, headers=auth
+                )
+                print(f"landr → {step:10} HTTP {r.status_code}: {r.json()}")
+            # SoundCloud is automated → manual update rejected.
+            sc_manual = await http.patch(
+                f"{RELEASES}/{rid}/channels/soundcloud/status", json={"status": "ready"}, headers=auth
+            )
+            print(f"soundcloud (manual) ......... HTTP {sc_manual.status_code}: {sc_manual.json()['detail']}")
+            status = (await http.get(f"{RELEASES}/{rid}/status", headers=auth)).json()
+            print(f"GET /status channels ........ {status['channels']}")
+
+            # ---- AC1: listing shows per-channel status -----------------------
+            hdr("AC1: release listing shows per-channel distribution status")
+            listing = (await http.get(RELEASES, headers=auth)).json()["releases"][0]
+            print(f"listed channel_statuses ..... {listing['channel_statuses']}")
+            print(f"listed visibility ........... {listing['visibility']}")
+
+            # ---- AC4: visibility updates the clip's sharing state ------------
+            hdr("AC4: visibility changes update the clip's sharing state")
+            vis = await http.patch(f"{RELEASES}/{rid}/visibility", json={"state": "public"}, headers=auth)
+            refreshed_clip = await Clip.get(clip.id)
+            print(f"PATCH visibility=public ..... HTTP {vis.status_code}: visibility={vis.json()['visibility']}")
+            print(f"source clip.is_public now ... {refreshed_clip.is_public}  (was False)")
+
+            # ---- AC2: SoundCloud status reflects actual track state ----------
+            hdr("AC2: SoundCloud status reflects actual track state (polled via API)")
+            scr = Release(
+                clip_id=clip.id,
+                user_id=user.id,
+                title="SoundCloud Track",
+                artist="Demo Artist",
+                genre="house",
+                release_date=datetime.now(timezone.utc),
+                soundcloud_track_id="555",
+                channel_statuses={SOUNDCLOUD_CHANNEL: DistributionStatus.SUBMITTED},
+            )
+            await scr.insert()
+            print(f"SoundCloud release {scr.id} starts at: submitted")
+
+            class _Conn:
+                access_token = "tok"
+
+            async def _conn(uid, _s):
+                return _Conn()
+
+            # Two poll cycles with real SoundCloud-shaped payloads.
+            for state in ({"state": "processing"}, {"state": "finished", "sharing": "public"}):
+                async def _fetch(_t, _id, _state=state):
+                    return _state
+
+                poller = SoundCloudStatusPoller(settings, connection_getter=_conn, status_fetcher=_fetch)
+                changed = await poller.poll_once()
+                cur = (await Release.get(scr.id)).channel_statuses[SOUNDCLOUD_CHANNEL].value
+                print(f"poll (SoundCloud {state}) → changed={changed}, soundcloud status now: {cur}")
+
+            events = await NotificationEvent.find(NotificationEvent.release_id == scr.id).to_list()
+            print(f"notifications recorded ...... {[(e.event_type, e.channel) for e in events]}")
+
+            hdr("All acceptance criteria demonstrated with real outcomes ✓")
+    finally:
+        await client.drop_database(settings.mongodb_db_name)
+        await close_db(client)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/demos/us-13.6-distribution-status.py
+++ b/docs/demos/us-13.6-distribution-status.py
@@ -82,21 +82,15 @@ async def main() -> None:
 
             # ---- AC5: transitions follow the valid sequence ------------------
             hdr("AC5: status transitions follow the valid sequence (no skipping)")
-            skip = await http.patch(
-                f"{RELEASES}/{rid}/channels/landr/status", json={"status": "live"}, headers=auth
-            )
+            skip = await http.patch(f"{RELEASES}/{rid}/channels/landr/status", json={"status": "live"}, headers=auth)
             print(f"draft → live (skip) ......... HTTP {skip.status_code}: {skip.json()['detail']}")
-            ok = await http.patch(
-                f"{RELEASES}/{rid}/channels/landr/status", json={"status": "ready"}, headers=auth
-            )
+            ok = await http.patch(f"{RELEASES}/{rid}/channels/landr/status", json={"status": "ready"}, headers=auth)
             print(f"draft → ready (valid step) .. HTTP {ok.status_code}: {ok.json()}")
 
             # ---- AC3: manual guided updates are stored and visible ------------
             hdr("AC3: manual status updates for guided channels are stored and visible")
             for step in ("submitted", "in_review"):
-                r = await http.patch(
-                    f"{RELEASES}/{rid}/channels/landr/status", json={"status": step}, headers=auth
-                )
+                r = await http.patch(f"{RELEASES}/{rid}/channels/landr/status", json={"status": step}, headers=auth)
                 print(f"landr → {step:10} HTTP {r.status_code}: {r.json()}")
             # SoundCloud is automated → manual update rejected.
             sc_manual = await http.patch(
@@ -142,6 +136,7 @@ async def main() -> None:
 
             # Two poll cycles with real SoundCloud-shaped payloads.
             for state in ({"state": "processing"}, {"state": "finished", "sharing": "public"}):
+
                 async def _fetch(_t, _id, _state=state):
                     return _state
 

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -44,6 +44,7 @@ from .settings import ApiSettings
 from .tasks.artwork import get_image_client
 from .tasks.mastering import get_mastering_orchestrator
 from .tasks.processor import JobProcessor
+from .tasks.soundcloud_poller import SoundCloudStatusPoller
 
 API_V1_PREFIX = "/api/v1"
 
@@ -89,6 +90,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
         # try/finally wraps processor start too, so a start() failure still closes
         # the DB client rather than leaking it.
         processor: JobProcessor | None = None
+        poller: SoundCloudStatusPoller | None = None
         try:
             if settings.job_processor_enabled:
                 # Wire the RunPod backend (US-11.2) only when configured, so a
@@ -121,8 +123,22 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
                 )
                 await processor.start()
             app_.state.job_processor = processor
+
+            # SoundCloud distribution-status poller (US-13.6): keeps the SoundCloud
+            # channel status in sync with the real track state. Independent of the
+            # job processor and gated by its own flag.
+            if settings.soundcloud_poller_enabled:
+                poller = SoundCloudStatusPoller(
+                    settings,
+                    poll_interval=settings.soundcloud_poll_interval,
+                    batch_size=settings.soundcloud_poll_batch_size,
+                )
+                await poller.start()
+            app_.state.soundcloud_poller = poller
             yield
         finally:
+            if poller is not None:
+                await poller.stop()
             if processor is not None:
                 await processor.stop()
             await database.close_db(client)

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -8,7 +8,9 @@ from .batch_job import BatchClipEntry, BatchJob
 from .clip import Clip
 from .counter import Counter
 from .credit_transaction import CreditTransaction
+from .distribution import DistributionStatus, VisibilityState
 from .job import Job, JobStatus
+from .notification_event import NotificationEvent
 from .preset import PRESET_PARAM_FIELDS, Preset
 from .refresh_token import RefreshToken
 from .release import Release, ReleaseStatus
@@ -28,6 +30,7 @@ ALL_MODELS = [
     ArtworkOption,
     SoundCloudConnection,
     Release,
+    NotificationEvent,
     Counter,
 ]
 
@@ -47,6 +50,9 @@ __all__ = [
     "SoundCloudConnection",
     "Release",
     "ReleaseStatus",
+    "DistributionStatus",
+    "VisibilityState",
+    "NotificationEvent",
     "Counter",
     "ALL_MODELS",
 ]

--- a/src/acemusic/api/models/distribution.py
+++ b/src/acemusic/api/models/distribution.py
@@ -1,0 +1,55 @@
+"""Distribution status enums and the per-channel transition rules (US-13.6).
+
+A release goes out to several *channels* (SoundCloud directly, plus the guided
+LANDR/DistroKid/TuneCore targets from US-13.5). Each channel carries its own
+:class:`DistributionStatus`, tracked independently in ``Release.channel_statuses``
+— distinct from the release-level :class:`acemusic.api.models.release.ReleaseStatus`
+because a channel also has an ``in_review`` state (a platform is processing the
+upload) that the release lifecycle has no equivalent for.
+
+These live in the models layer because they are field *types* on the Release
+document; the business logic that uses them (validation, notifications) lives in
+:mod:`acemusic.api.services.distribution_status`.
+"""
+
+from enum import Enum
+
+
+class DistributionStatus(str, Enum):
+    """Per-channel distribution lifecycle: ``draft → ready → submitted → in_review → live | rejected``."""
+
+    DRAFT = "draft"
+    READY = "ready"
+    SUBMITTED = "submitted"
+    IN_REVIEW = "in_review"
+    LIVE = "live"
+    REJECTED = "rejected"
+
+
+class VisibilityState(str, Enum):
+    """How widely a release is shared. Maps onto SoundCloud's public/private sharing."""
+
+    PRIVATE = "private"
+    UNLISTED = "unlisted"
+    PUBLIC = "public"
+
+
+#: The one channel whose status is driven automatically (SoundCloud polling).
+SOUNDCLOUD_CHANNEL = "soundcloud"
+
+#: Channels whose status the owner updates by hand — they have no API integration,
+#: so the platform can only record what the user reports. Mirrors US-13.5's
+#: ``DistributionTarget`` (landr/distrokid/tunecore).
+GUIDED_CHANNELS: frozenset[str] = frozenset({"landr", "distrokid", "tunecore"})
+
+#: Allowed next statuses for each status. Terminal states (live, rejected) map to
+#: an empty set, so no transition out of them is permitted. Enforces the sequence
+#: in the AC: no skipping (e.g. draft → live is rejected).
+VALID_STATUS_TRANSITIONS: dict[DistributionStatus, frozenset[DistributionStatus]] = {
+    DistributionStatus.DRAFT: frozenset({DistributionStatus.READY}),
+    DistributionStatus.READY: frozenset({DistributionStatus.SUBMITTED}),
+    DistributionStatus.SUBMITTED: frozenset({DistributionStatus.IN_REVIEW}),
+    DistributionStatus.IN_REVIEW: frozenset({DistributionStatus.LIVE, DistributionStatus.REJECTED}),
+    DistributionStatus.LIVE: frozenset(),
+    DistributionStatus.REJECTED: frozenset(),
+}

--- a/src/acemusic/api/models/notification_event.py
+++ b/src/acemusic/api/models/notification_event.py
@@ -24,8 +24,7 @@ class NotificationEvent(Document):
     channel: str
     payload: dict = Field(default_factory=dict)
     created_at: datetime = Field(default_factory=utcnow)
-    # Null until a delivery mechanism (future work) processes it.
-    delivered_at: datetime | None = None
+    delivered_at: datetime | None = None  # set by a future delivery worker
 
     class Settings:
         name = "notification_events"

--- a/src/acemusic/api/models/notification_event.py
+++ b/src/acemusic/api/models/notification_event.py
@@ -1,0 +1,35 @@
+"""Notification event document model (US-13.6).
+
+Records a notification-worthy distribution event (a channel went ``live`` or was
+``rejected``) so it can be delivered later. This is deliberately just the
+*recorder*: actual delivery (email/push/in-app) is out of scope for US-13.6, so
+``delivered_at`` stays null and a future delivery worker fills it in.
+"""
+
+from datetime import datetime
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, DESCENDING, IndexModel
+
+from .common import utcnow
+
+
+class NotificationEvent(Document):
+    """A recorded status-change event awaiting (future) delivery."""
+
+    user_id: PydanticObjectId
+    release_id: PydanticObjectId
+    event_type: str  # e.g. "status_live", "status_rejected"
+    channel: str
+    payload: dict = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=utcnow)
+    # Null until a delivery mechanism (future work) processes it.
+    delivered_at: datetime | None = None
+
+    class Settings:
+        name = "notification_events"
+        indexes = [
+            # Serves "this user's notifications, newest first".
+            IndexModel([("user_id", ASCENDING), ("created_at", DESCENDING)]),
+        ]

--- a/src/acemusic/api/models/release.py
+++ b/src/acemusic/api/models/release.py
@@ -16,6 +16,7 @@ from pydantic import Field
 from pymongo import ASCENDING, DESCENDING, IndexModel
 
 from .common import utcnow
+from .distribution import DistributionStatus, VisibilityState
 
 
 class ReleaseStatus(str, Enum):
@@ -60,6 +61,17 @@ class Release(Document):
     # list of target names while ``status`` stays a single ``submitted`` flag.
     submitted_channels: list[str] = Field(default_factory=list)
 
+    # Per-channel distribution status (US-13.6): maps a channel name
+    # ("soundcloud", "landr", …) to its current DistributionStatus. Empty until a
+    # channel is engaged. Distinct from ``status`` above, which is the release's own
+    # lifecycle — a channel can be ``in_review`` while the release is ``submitted``.
+    channel_statuses: dict[str, DistributionStatus] = Field(default_factory=dict)
+    visibility: VisibilityState = VisibilityState.PRIVATE
+    # Set when the release is uploaded to SoundCloud (US-13.2 upload + US-13.6
+    # association); the poller uses it to fetch live track state.
+    soundcloud_track_id: str | None = None
+    soundcloud_last_polled: datetime | None = None
+
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime | None = None
 
@@ -75,4 +87,7 @@ class Release(Document):
                 unique=True,
                 partialFilterExpression={"upc": {"$type": "string"}},
             ),
+            # The SoundCloud poller scans releases that have a track id; sparse so
+            # the (common) un-uploaded releases stay out of the index.
+            IndexModel([("soundcloud_track_id", ASCENDING)], sparse=True),
         ]

--- a/src/acemusic/api/routers/distribution.py
+++ b/src/acemusic/api/routers/distribution.py
@@ -237,8 +237,7 @@ async def soundcloud_upload(
     """Upload an owned clip to the user's linked SoundCloud account."""
     clip = await clip_service.get_owned_clip(body.clip_id, current.user_id)
 
-    # Resolve the optional release association up front so a bad reference fails
-    # before the (potentially large) upload, not after.
+    # Validate the optional release association before the upload, not after.
     release = None
     if body.release_id is not None:
         release = await release_service.get_owned_release(body.release_id, current.user_id)
@@ -287,10 +286,12 @@ async def soundcloud_upload(
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="SoundCloud returned no track id.")
 
     if release is not None:
-        # Persist the track id and start the SoundCloud channel at ``submitted`` so
-        # the poller (US-13.6) can advance it as the upload is processed. validate
-        # is off: this is the channel's authoritative initial state.
+        # Persist the track id, then start the SoundCloud channel at ``submitted``
+        # so the poller (US-13.6) can advance it as the upload is processed. The
+        # save persists the track id (apply_channel_status only sets the channel
+        # field atomically); validate is off — this is the channel's initial state.
         release.soundcloud_track_id = str(track_id)
+        await release.save()
         await status_service.apply_channel_status(
             release, SOUNDCLOUD_CHANNEL, DistributionStatus.SUBMITTED, validate=False
         )

--- a/src/acemusic/api/routers/distribution.py
+++ b/src/acemusic/api/routers/distribution.py
@@ -26,7 +26,13 @@ from acemusic.storage import StorageBackend, get_storage_backend
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import Clip, SoundCloudConnection
 from ..models.common import utcnow
-from ..services import clips as clip_service, soundcloud as sc
+from ..models.distribution import SOUNDCLOUD_CHANNEL, DistributionStatus
+from ..services import (
+    clips as clip_service,
+    distribution_status as status_service,
+    releases as release_service,
+    soundcloud as sc,
+)
 from ..settings import ApiSettings
 
 logger = logging.getLogger(__name__)
@@ -69,6 +75,9 @@ class UploadRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     clip_id: str
+    # Optional: associate the upload with a release (US-13.6) so the SoundCloud
+    # track id is persisted and the release's soundcloud channel begins polling.
+    release_id: str | None = None
     metadata_overrides: MetadataOverrides = Field(default_factory=MetadataOverrides)
 
 
@@ -228,6 +237,17 @@ async def soundcloud_upload(
     """Upload an owned clip to the user's linked SoundCloud account."""
     clip = await clip_service.get_owned_clip(body.clip_id, current.user_id)
 
+    # Resolve the optional release association up front so a bad reference fails
+    # before the (potentially large) upload, not after.
+    release = None
+    if body.release_id is not None:
+        release = await release_service.get_owned_release(body.release_id, current.user_id)
+        if str(release.clip_id) != str(clip.id):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="release_id does not reference the uploaded clip.",
+            )
+
     # Validate the SoundCloud link first so the common "not connected" / revoked
     # case fast-fails before paying for a (potentially large) storage download.
     try:
@@ -265,6 +285,16 @@ async def soundcloud_upload(
     track_id = track.get("id")
     if track_id is None:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="SoundCloud returned no track id.")
+
+    if release is not None:
+        # Persist the track id and start the SoundCloud channel at ``submitted`` so
+        # the poller (US-13.6) can advance it as the upload is processed. validate
+        # is off: this is the channel's authoritative initial state.
+        release.soundcloud_track_id = str(track_id)
+        await status_service.apply_channel_status(
+            release, SOUNDCLOUD_CHANNEL, DistributionStatus.SUBMITTED, validate=False
+        )
+
     return UploadResponse(track_id=str(track_id), permalink_url=track.get("permalink_url"))
 
 

--- a/src/acemusic/api/routers/releases.py
+++ b/src/acemusic/api/routers/releases.py
@@ -14,17 +14,27 @@ piece (computed live from the clip). Persistence lives in
 :mod:`acemusic.api.services.releases`.
 """
 
+import logging
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from ..auth.dependencies import CurrentUser, get_current_user, get_settings, require_existing_user
-from ..models import Release, ReleaseStatus
-from ..services import clips as clip_service, distribution as distribution_service, releases as release_service
+from ..models import DistributionStatus, Release, ReleaseStatus, VisibilityState
+from ..models.distribution import GUIDED_CHANNELS, SOUNDCLOUD_CHANNEL
+from ..services import (
+    clips as clip_service,
+    distribution as distribution_service,
+    distribution_status as status_service,
+    releases as release_service,
+    soundcloud as sc,
+)
 from ..services.distribution import ChecklistItem, DistributionTarget
 from ..services.identifiers import validate_isrc_format, validate_upc_check_digit
 from ..settings import ApiSettings
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/releases", tags=["releases"], dependencies=[Depends(get_current_user)])
 
@@ -124,6 +134,10 @@ class ReleaseResponse(BaseModel):
     status: ReleaseStatus
     warnings: list[str]
     submitted_channels: list[str]
+    # Per-channel distribution status + visibility (US-13.6), so a listing shows
+    # where each release stands across all channels without a second call.
+    channel_statuses: dict[str, DistributionStatus]
+    visibility: VisibilityState
     created_at: datetime
     updated_at: datetime | None
 
@@ -148,10 +162,49 @@ class ReleaseResponse(BaseModel):
             status=release.status,
             warnings=warnings,
             submitted_channels=release.submitted_channels,
+            channel_statuses=release.channel_statuses,
+            visibility=release.visibility,
             created_at=release.created_at,
             updated_at=release.updated_at,
             **{field: getattr(release, field) for field in _METADATA_FIELDS},
         )
+
+
+class ChannelStatus(BaseModel):
+    channel: str
+    status: DistributionStatus
+
+
+class ReleaseStatusResponse(BaseModel):
+    release_id: str
+    title: str
+    channels: list[ChannelStatus]
+    visibility: VisibilityState
+    # Surfaced only when the release is on SoundCloud (the auto-polled channel).
+    soundcloud_last_polled: datetime | None = None
+
+    @classmethod
+    def from_release(cls, release: Release) -> "ReleaseStatusResponse":
+        return cls(
+            release_id=str(release.id),
+            title=release.title,
+            channels=[ChannelStatus(channel=ch, status=st) for ch, st in release.channel_statuses.items()],
+            visibility=release.visibility,
+            soundcloud_last_polled=release.soundcloud_last_polled,
+        )
+
+
+class StatusUpdateRequest(BaseModel):
+    # Pydantic rejects an unknown status value with 422 automatically.
+    model_config = ConfigDict(extra="forbid")
+
+    status: DistributionStatus
+
+
+class VisibilityUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: VisibilityState
 
 
 class PrepareResponse(BaseModel):
@@ -255,3 +308,75 @@ async def submit_release(
     """Confirm a manual submission to ``target`` — moves the release to ``submitted``."""
     release = await release_service.confirm_submission(release_id, current.user_id, target.value)
     return await _response_for(release)
+
+
+@router.get("/{release_id}/status", response_model=ReleaseStatusResponse)
+async def get_release_status(
+    release_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> ReleaseStatusResponse:
+    """Per-channel distribution status for a single release (US-13.6). 404 if not owned."""
+    release = await release_service.get_owned_release(release_id, current.user_id)
+    return ReleaseStatusResponse.from_release(release)
+
+
+@router.patch("/{release_id}/channels/{channel}/status", response_model=ChannelStatus)
+async def update_channel_status(
+    release_id: str,
+    channel: str,
+    body: StatusUpdateRequest,
+    current: CurrentUser = Depends(require_existing_user),
+) -> ChannelStatus:
+    """Manually update a *guided* channel's status (US-13.6).
+
+    SoundCloud is automated (rejected with 400); an unknown channel is also 400.
+    An out-of-sequence transition (e.g. draft → live) is 409.
+    """
+    if channel not in GUIDED_CHANNELS:
+        detail = (
+            "SoundCloud status is updated automatically and cannot be set manually."
+            if channel == SOUNDCLOUD_CHANNEL
+            else f"Unknown distribution channel: {channel}."
+        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+    release = await release_service.get_owned_release(release_id, current.user_id)
+    try:
+        old_status = await status_service.apply_channel_status(release, channel, body.status)
+    except status_service.InvalidStatusTransition as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    if status_service.should_notify(old_status, body.status):
+        await status_service.create_status_notification(release, channel, body.status)
+    return ChannelStatus(channel=channel, status=release.channel_statuses[channel])
+
+
+@router.patch("/{release_id}/visibility", response_model=ReleaseStatusResponse)
+async def update_visibility(
+    release_id: str,
+    body: VisibilityUpdateRequest,
+    current: CurrentUser = Depends(require_existing_user),
+    settings: ApiSettings = Depends(get_settings),
+) -> ReleaseStatusResponse:
+    """Change a release's visibility (US-13.6); sync SoundCloud sharing if it's uploaded there."""
+    release = await release_service.get_owned_release(release_id, current.user_id)
+    if release.soundcloud_track_id:
+        await _sync_soundcloud_sharing(release, body.state, settings)
+    release = await release_service.update_visibility(release_id, current.user_id, body.state)
+    return ReleaseStatusResponse.from_release(release)
+
+
+async def _sync_soundcloud_sharing(release: Release, state: VisibilityState, settings: ApiSettings) -> None:
+    """Best-effort mirror of a release's visibility onto its SoundCloud track.
+
+    SoundCloud only models public/private, so anything short of ``public`` maps to
+    private. A missing link or a transient SoundCloud failure is logged and
+    swallowed — the local visibility change still stands rather than failing the
+    whole request on an external dependency.
+    """
+    sharing = "public" if state == VisibilityState.PUBLIC else "private"
+    try:
+        connection = await sc.get_valid_connection(str(release.user_id), settings)
+        await sc.update_track_sharing(connection.access_token, release.soundcloud_track_id, sharing)
+    except sc.SoundCloudError as exc:
+        logger.warning("SoundCloud sharing sync for release %s failed: %s", release.id, exc)

--- a/src/acemusic/api/routers/releases.py
+++ b/src/acemusic/api/routers/releases.py
@@ -346,7 +346,10 @@ async def update_channel_status(
     except status_service.InvalidStatusTransition as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
-    if status_service.should_notify(old_status, body.status):
+    # Notify only on a transition this request actually applied — a lost concurrent
+    # race returns old == requested, so ``changed`` is False and we don't double-fire.
+    changed = old_status != body.status
+    if changed and status_service.should_notify(old_status, body.status):
         await status_service.create_status_notification(release, channel, body.status)
     return ChannelStatus(channel=channel, status=release.channel_statuses[channel])
 
@@ -362,7 +365,7 @@ async def update_visibility(
     release = await release_service.get_owned_release(release_id, current.user_id)
     if release.soundcloud_track_id:
         await _sync_soundcloud_sharing(release, body.state, settings)
-    release = await release_service.update_visibility(release_id, current.user_id, body.state)
+    release = await release_service.update_visibility(release, body.state)
     return ReleaseStatusResponse.from_release(release)
 
 

--- a/src/acemusic/api/services/distribution_status.py
+++ b/src/acemusic/api/services/distribution_status.py
@@ -13,7 +13,7 @@ Two callers, two contracts:
   truth and isn't forced through intermediate steps.
 """
 
-from beanie import PydanticObjectId
+from pymongo import ReturnDocument
 
 from ..models import NotificationEvent
 from ..models.common import utcnow
@@ -58,10 +58,31 @@ async def apply_channel_status(
     current = DistributionStatus(release.channel_statuses.get(channel, DistributionStatus.DRAFT))
     if validate and not validate_status_transition(current, new_status):
         raise InvalidStatusTransition(current, new_status)
-    # Reassign (not in-place mutate) so Beanie always sees the field as changed.
+
+    # Atomic per-channel $set guarded by the observed current state (mirrors the
+    # atomic claims in ``services.releases``): a concurrent update to a *different*
+    # channel isn't clobbered by a full-document save, and only one writer wins a
+    # given transition — so terminal notifications can't be duplicated.
+    field = f"channel_statuses.{channel}"
+    guard = {field: current.value} if channel in release.channel_statuses else {field: {"$exists": False}}
+    doc = await Release.get_pymongo_collection().find_one_and_update(
+        {"_id": release.id, **guard},
+        {"$set": {field: new_status.value, "updated_at": utcnow()}},
+        return_document=ReturnDocument.AFTER,
+    )
+    if doc is None:
+        # Lost the race: another writer already moved this channel. Reflect the
+        # winning state and report it as the "previous" status, so the caller's
+        # ``should_notify(old, new)`` sees old == new and does not double-notify.
+        refreshed = await Release.get(release.id)
+        if refreshed is not None:
+            release.channel_statuses = refreshed.channel_statuses
+            release.updated_at = refreshed.updated_at
+        return DistributionStatus(release.channel_statuses.get(channel, new_status))
+
+    # Reflect the win in the in-memory document for the caller's response.
     release.channel_statuses = {**release.channel_statuses, channel: new_status}
-    release.updated_at = utcnow()
-    await release.save()
+    release.updated_at = doc.get("updated_at")
     return current
 
 
@@ -75,8 +96,8 @@ async def create_status_notification(
 ) -> NotificationEvent:
     """Record a notification event for a channel reaching a terminal status."""
     event = NotificationEvent(
-        user_id=PydanticObjectId(release.user_id),
-        release_id=PydanticObjectId(release.id),
+        user_id=release.user_id,
+        release_id=release.id,
         event_type=f"status_{new_status.value}",
         channel=channel,
         payload={"title": release.title, "status": new_status.value},

--- a/src/acemusic/api/services/distribution_status.py
+++ b/src/acemusic/api/services/distribution_status.py
@@ -54,6 +54,9 @@ async def apply_channel_status(
     so the first manual update must begin the sequence. With ``validate=True`` an
     out-of-sequence step raises :class:`InvalidStatusTransition`; the SoundCloud
     poller passes ``validate=False`` to mirror real platform state verbatim.
+
+    The returned "previous" status lets the caller decide whether to notify; on a
+    lost concurrent race it returns ``new_status`` (a no-op signal) — see below.
     """
     current = DistributionStatus(release.channel_statuses.get(channel, DistributionStatus.DRAFT))
     if validate and not validate_status_transition(current, new_status):
@@ -71,14 +74,17 @@ async def apply_channel_status(
         return_document=ReturnDocument.AFTER,
     )
     if doc is None:
-        # Lost the race: another writer already moved this channel. Reflect the
-        # winning state and report it as the "previous" status, so the caller's
-        # ``should_notify(old, new)`` sees old == new and does not double-notify.
+        # Lost the race: another writer already moved this channel, so this call
+        # applied nothing. Reflect the winning state in memory for the response,
+        # but report ``new_status`` as the "previous" status — callers compute
+        # ``should_notify(old, new)``/``changed = old != new``, so returning the
+        # same value they passed makes both treat this as a no-op and never notify
+        # for a transition this call did not perform.
         refreshed = await Release.get(release.id)
         if refreshed is not None:
             release.channel_statuses = refreshed.channel_statuses
             release.updated_at = refreshed.updated_at
-        return DistributionStatus(release.channel_statuses.get(channel, new_status))
+        return new_status
 
     # Reflect the win in the in-memory document for the caller's response.
     release.channel_statuses = {**release.channel_statuses, channel: new_status}

--- a/src/acemusic/api/services/distribution_status.py
+++ b/src/acemusic/api/services/distribution_status.py
@@ -1,0 +1,103 @@
+"""Per-channel distribution status logic (US-13.6).
+
+The state machine and notification side of distribution tracking: validating a
+channel's status transition, applying it to a release, and recording a
+notification event when a channel reaches a terminal state (``live``/``rejected``).
+
+Two callers, two contracts:
+
+* **Manual guided updates** (router) go through :func:`apply_channel_status` with
+  validation on, so a user cannot skip the sequence (e.g. draft → live).
+* **SoundCloud polling** (the poller) reflects *authoritative external* state, so
+  it applies with ``validate=False`` — the platform's real track state is the
+  truth and isn't forced through intermediate steps.
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import NotificationEvent
+from ..models.common import utcnow
+from ..models.distribution import (
+    VALID_STATUS_TRANSITIONS,
+    DistributionStatus,
+)
+from ..models.release import Release
+
+#: Statuses no further transition leaves; reaching one is notification-worthy.
+TERMINAL_STATUSES: frozenset[DistributionStatus] = frozenset({DistributionStatus.LIVE, DistributionStatus.REJECTED})
+
+
+class InvalidStatusTransition(Exception):
+    """A requested status transition violates the valid sequence."""
+
+    def __init__(self, current: DistributionStatus, target: DistributionStatus) -> None:
+        self.current = current
+        self.target = target
+        super().__init__(f"Cannot move a channel from {current.value!r} to {target.value!r}.")
+
+
+def validate_status_transition(current: DistributionStatus, target: DistributionStatus) -> bool:
+    """True if ``current → target`` is an allowed step in the distribution sequence."""
+    return target in VALID_STATUS_TRANSITIONS.get(current, frozenset())
+
+
+async def apply_channel_status(
+    release: Release,
+    channel: str,
+    new_status: DistributionStatus,
+    *,
+    validate: bool = True,
+) -> DistributionStatus:
+    """Set ``channel``'s status on ``release`` and persist; return the *previous* status.
+
+    A channel with no recorded status is treated as ``draft`` (the implicit start),
+    so the first manual update must begin the sequence. With ``validate=True`` an
+    out-of-sequence step raises :class:`InvalidStatusTransition`; the SoundCloud
+    poller passes ``validate=False`` to mirror real platform state verbatim.
+    """
+    current = DistributionStatus(release.channel_statuses.get(channel, DistributionStatus.DRAFT))
+    if validate and not validate_status_transition(current, new_status):
+        raise InvalidStatusTransition(current, new_status)
+    # Reassign (not in-place mutate) so Beanie always sees the field as changed.
+    release.channel_statuses = {**release.channel_statuses, channel: new_status}
+    release.updated_at = utcnow()
+    await release.save()
+    return current
+
+
+def should_notify(old_status: DistributionStatus, new_status: DistributionStatus) -> bool:
+    """True when a channel newly reaches a terminal state (``live``/``rejected``)."""
+    return new_status in TERMINAL_STATUSES and new_status != old_status
+
+
+async def create_status_notification(
+    release: Release, channel: str, new_status: DistributionStatus
+) -> NotificationEvent:
+    """Record a notification event for a channel reaching a terminal status."""
+    event = NotificationEvent(
+        user_id=PydanticObjectId(release.user_id),
+        release_id=PydanticObjectId(release.id),
+        event_type=f"status_{new_status.value}",
+        channel=channel,
+        payload={"title": release.title, "status": new_status.value},
+    )
+    await event.insert()
+    return event
+
+
+def map_soundcloud_state(track: dict) -> DistributionStatus | None:
+    """Map a SoundCloud track's API state to a :class:`DistributionStatus`.
+
+    SoundCloud reports a ``state`` (``processing``/``finished``/``failed``) and a
+    ``sharing`` (``public``/``private``). ``None`` means "no opinion" — leave the
+    current status untouched (e.g. an unknown/empty state).
+    """
+    state = (track.get("state") or "").lower()
+    if state == "failed":
+        return DistributionStatus.REJECTED
+    if state == "processing":
+        return DistributionStatus.IN_REVIEW
+    if state == "finished":
+        # A finished-but-private track is processed yet not publicly live.
+        return DistributionStatus.LIVE if (track.get("sharing") == "public") else DistributionStatus.IN_REVIEW
+    return None

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -16,6 +16,7 @@ from pymongo.errors import DuplicateKeyError
 from ..exceptions import DuplicateIdentifierError
 from ..models import Clip, Release, ReleaseStatus
 from ..models.common import utcnow
+from ..models.distribution import VisibilityState
 from ..settings import ApiSettings
 from . import clips as clip_service, identifiers
 from .common import coerce_object_id
@@ -207,16 +208,26 @@ async def update_release(release_id: str, user_id: str, updates: dict) -> Releas
     return release
 
 
-async def update_visibility(release_id: str, user_id: str, visibility) -> Release:
-    """Set an owned release's visibility (US-13.6). Raises 404 if not owned.
+async def update_visibility(release_id: str, user_id: str, visibility: VisibilityState) -> Release:
+    """Set an owned release's visibility and mirror it onto the source clip (US-13.6).
 
-    Visibility is a sharing preference, not part of the submission lifecycle, so
-    it is editable in any state (unlike metadata, which locks after submission).
+    Visibility is a sharing preference, not part of the submission lifecycle, so it
+    is editable in any state (unlike metadata, which locks after submission). The
+    source clip's ``is_public`` flag — what actually gates non-owner audio access —
+    is synced too: only ``public`` exposes the clip; ``unlisted``/``private`` keep
+    it owner-only (there is no link-token sharing concept). A deleted source clip
+    is tolerated (the release keeps its own visibility).
     """
     release = await get_owned_release(release_id, user_id)
     release.visibility = visibility
     release.updated_at = utcnow()
     await release.save()
+
+    is_public = visibility == VisibilityState.PUBLIC
+    clip = await clip_service.find_owned_clip(str(release.clip_id), user_id)
+    if clip is not None and clip.is_public != is_public:
+        clip.is_public = is_public
+        await clip.save()
     return release
 
 

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -207,6 +207,19 @@ async def update_release(release_id: str, user_id: str, updates: dict) -> Releas
     return release
 
 
+async def update_visibility(release_id: str, user_id: str, visibility) -> Release:
+    """Set an owned release's visibility (US-13.6). Raises 404 if not owned.
+
+    Visibility is a sharing preference, not part of the submission lifecycle, so
+    it is editable in any state (unlike metadata, which locks after submission).
+    """
+    release = await get_owned_release(release_id, user_id)
+    release.visibility = visibility
+    release.updated_at = utcnow()
+    await release.save()
+    return release
+
+
 # A submission can only be confirmed once the package is assembled, and re-confirmed
 # for a further target after it has gone out — never from draft or a terminal state.
 _CONFIRMABLE_STATUSES = {ReleaseStatus.READY, ReleaseStatus.SUBMITTED}

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -208,23 +208,23 @@ async def update_release(release_id: str, user_id: str, updates: dict) -> Releas
     return release
 
 
-async def update_visibility(release_id: str, user_id: str, visibility: VisibilityState) -> Release:
-    """Set an owned release's visibility and mirror it onto the source clip (US-13.6).
+async def update_visibility(release: Release, visibility: VisibilityState) -> Release:
+    """Set ``release``'s visibility and mirror it onto the source clip (US-13.6).
 
-    Visibility is a sharing preference, not part of the submission lifecycle, so it
-    is editable in any state (unlike metadata, which locks after submission). The
-    source clip's ``is_public`` flag — what actually gates non-owner audio access —
-    is synced too: only ``public`` exposes the clip; ``unlisted``/``private`` keep
-    it owner-only (there is no link-token sharing concept). A deleted source clip
-    is tolerated (the release keeps its own visibility).
+    Takes an already-owned ``release`` (the router has validated ownership), so it
+    does not re-fetch. Visibility is a sharing preference, not part of the
+    submission lifecycle, so it is editable in any state (unlike metadata, which
+    locks after submission). The source clip's ``is_public`` flag — what actually
+    gates non-owner audio access — is synced too: only ``public`` exposes the clip;
+    ``unlisted``/``private`` keep it owner-only (there is no link-token sharing
+    concept). A deleted source clip is tolerated (the release keeps its visibility).
     """
-    release = await get_owned_release(release_id, user_id)
     release.visibility = visibility
     release.updated_at = utcnow()
     await release.save()
 
     is_public = visibility == VisibilityState.PUBLIC
-    clip = await clip_service.find_owned_clip(str(release.clip_id), user_id)
+    clip = await clip_service.find_owned_clip(str(release.clip_id), str(release.user_id))
     if clip is not None and clip.is_public != is_public:
         clip.is_public = is_public
         await clip.save()

--- a/src/acemusic/api/services/soundcloud.py
+++ b/src/acemusic/api/services/soundcloud.py
@@ -295,6 +295,43 @@ async def get_soundcloud_user(access_token: str) -> dict:
         raise SoundCloudError("Fetching the SoundCloud profile failed.") from exc
 
 
+def _track_url(track_id: str) -> str:
+    return f"{SOUNDCLOUD_UPLOAD_URL}/{track_id}"
+
+
+async def get_track_status(access_token: str, track_id: str) -> dict:
+    """Fetch a track's current state (``GET /tracks/{id}``) for status polling (US-13.6).
+
+    Returns the SoundCloud track JSON, which carries ``state``
+    (``processing``/``finished``/``failed``) and ``sharing`` — mapped to a
+    distribution status by :func:`acemusic.api.services.distribution_status.map_soundcloud_state`.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.get(_track_url(track_id), headers={"Authorization": f"OAuth {access_token}"})
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPError as exc:
+        raise SoundCloudError("Fetching the SoundCloud track status failed.") from exc
+
+
+async def update_track_sharing(access_token: str, track_id: str, sharing: str) -> dict:
+    """Set a track's sharing to ``public`` or ``private`` (``PUT /tracks/{id}``) (US-13.6)."""
+    if sharing not in ("public", "private"):
+        raise SoundCloudError("SoundCloud sharing must be 'public' or 'private'.")
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.put(
+                _track_url(track_id),
+                headers={"Authorization": f"OAuth {access_token}"},
+                data={"track[sharing]": sharing},
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPError as exc:
+        raise SoundCloudError("Updating the SoundCloud track sharing failed.") from exc
+
+
 def token_expiry(expires_in: object) -> datetime:
     """Translate SoundCloud's ``expires_in`` seconds into an absolute UTC instant.
 

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -90,6 +90,15 @@ class ApiSettings(BaseSettings):
     job_poll_timeout: float = Field(default=600.0, gt=0)
     job_processor_enabled: bool = Field(default=True)
 
+    # SoundCloud distribution-status poller (US-13.6). A background task that keeps
+    # the SoundCloud channel's status in sync with the real track state.
+    # ``soundcloud_poll_interval`` is the gap between cycles; ``soundcloud_poll_batch_size``
+    # caps how many pending releases each cycle checks. Disable it (or run a
+    # poller-less API) via ACEMUSIC_API_SOUNDCLOUD_POLLER_ENABLED=false.
+    soundcloud_poller_enabled: bool = Field(default=True)
+    soundcloud_poll_interval: float = Field(default=60.0, gt=0)
+    soundcloud_poll_batch_size: int = Field(default=20, ge=1)
+
     # Compute routing (US-11.1). ``compute_preference`` selects where a generation
     # runs when the request does not pin a ``compute_target``: ``*_first`` tries
     # the named target then falls back to the other; ``*_only`` never falls back

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -96,7 +96,8 @@ class ApiSettings(BaseSettings):
     # caps how many pending releases each cycle checks. Disable it (or run a
     # poller-less API) via ACEMUSIC_API_SOUNDCLOUD_POLLER_ENABLED=false.
     soundcloud_poller_enabled: bool = Field(default=True)
-    soundcloud_poll_interval: float = Field(default=60.0, gt=0)
+    # Floor at 5s so a misconfiguration can't hammer the SoundCloud API.
+    soundcloud_poll_interval: float = Field(default=60.0, ge=5)
     soundcloud_poll_batch_size: int = Field(default=20, ge=1)
 
     # Compute routing (US-11.1). ``compute_preference`` selects where a generation

--- a/src/acemusic/api/tasks/soundcloud_poller.py
+++ b/src/acemusic/api/tasks/soundcloud_poller.py
@@ -106,6 +106,9 @@ class SoundCloudStatusPoller:
         return changed
 
     async def _pending_batch(self) -> list[Release]:
+        # Oldest-polled first (nulls sort first in ascending order, so a
+        # never-polled release leads). Each poll stamps ``soundcloud_last_polled``,
+        # moving the release to the back — so a stuck track can't starve the rest.
         return (
             await Release.find(
                 {
@@ -113,6 +116,7 @@ class SoundCloudStatusPoller:
                     f"channel_statuses.{SOUNDCLOUD_CHANNEL}": {"$in": list(_NON_TERMINAL)},
                 }
             )
+            .sort(("soundcloud_last_polled", 1))
             .limit(self._batch_size)
             .to_list()
         )
@@ -123,14 +127,18 @@ class SoundCloudStatusPoller:
         new_status = status_service.map_soundcloud_state(track)
         current = DistributionStatus(release.channel_statuses.get(SOUNDCLOUD_CHANNEL, DistributionStatus.SUBMITTED))
 
-        release.soundcloud_last_polled = utcnow()
+        changed = False
         if new_status is not None and new_status != current:
-            # validate off: SoundCloud's real state is authoritative. apply saves
-            # the whole document, so the last_polled stamp above is persisted too.
-            await status_service.apply_channel_status(release, SOUNDCLOUD_CHANNEL, new_status, validate=False)
-            if status_service.should_notify(current, new_status):
+            # validate off: SoundCloud's real state is authoritative. apply is
+            # atomic and returns the pre-state; we only "won" if it actually moved.
+            old = await status_service.apply_channel_status(release, SOUNDCLOUD_CHANNEL, new_status, validate=False)
+            changed = old != new_status
+            if changed and status_service.should_notify(old, new_status):
                 await status_service.create_status_notification(release, SOUNDCLOUD_CHANNEL, new_status)
-            return True
 
-        await release.save()
-        return False
+        # Stamp the poll time regardless — atomic so it can't clobber a concurrent
+        # channel update the way a full-document save would.
+        await Release.get_pymongo_collection().update_one(
+            {"_id": release.id}, {"$set": {"soundcloud_last_polled": utcnow()}}
+        )
+        return changed

--- a/src/acemusic/api/tasks/soundcloud_poller.py
+++ b/src/acemusic/api/tasks/soundcloud_poller.py
@@ -1,0 +1,136 @@
+"""SoundCloud distribution-status poller (US-13.6).
+
+A lightweight background service that keeps the SoundCloud channel's status in
+sync with the real track state. It mirrors :class:`JobProcessor`'s lifecycle
+(``start``/``stop``, ``running`` flag, a single background task) but is
+purpose-built: each cycle finds releases whose SoundCloud upload is still in a
+non-terminal state, asks SoundCloud for the current track state, and advances the
+channel status (recording a notification when it reaches ``live``/``rejected``).
+
+The SoundCloud HTTP calls are injected (``connection_getter`` / ``status_fetcher``)
+so tests can drive the loop against a real MongoDB without hitting the gated
+SoundCloud API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+from ..models.common import utcnow
+from ..models.distribution import SOUNDCLOUD_CHANNEL, DistributionStatus
+from ..models.release import Release
+from ..services import distribution_status as status_service, soundcloud as sc
+from ..settings import ApiSettings
+
+logger = logging.getLogger(__name__)
+
+#: SoundCloud states the poller still acts on (terminal states are left alone).
+_NON_TERMINAL = (DistributionStatus.SUBMITTED.value, DistributionStatus.IN_REVIEW.value)
+
+ConnectionGetter = Callable[[str, ApiSettings], Awaitable[object]]
+StatusFetcher = Callable[[str, str], Awaitable[dict]]
+
+
+class SoundCloudStatusPoller:
+    """Background service that advances SoundCloud channel statuses from the API."""
+
+    def __init__(
+        self,
+        settings: ApiSettings,
+        *,
+        poll_interval: float = 60.0,
+        batch_size: int = 20,
+        connection_getter: ConnectionGetter | None = None,
+        status_fetcher: StatusFetcher | None = None,
+    ) -> None:
+        self._settings = settings
+        self._poll_interval = poll_interval
+        self._batch_size = batch_size
+        self._connection_getter = connection_getter or sc.get_valid_connection
+        self._status_fetcher = status_fetcher or sc.get_track_status
+        self._running = False
+        self._task: asyncio.Task[None] | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def start(self) -> None:
+        """Launch the polling loop. Idempotent."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._run_loop())
+        logger.info("SoundCloud status poller started (interval=%.0fs)", self._poll_interval)
+
+    async def stop(self) -> None:
+        """Stop the polling loop and await its unwind."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("SoundCloud status poller stopped")
+
+    async def _run_loop(self) -> None:
+        while self._running:
+            try:
+                await self.poll_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # a poll cycle must never kill the loop
+                logger.exception("SoundCloud status poll cycle failed")
+            await asyncio.sleep(self._poll_interval)
+
+    # -- work --------------------------------------------------------------
+
+    async def poll_once(self) -> int:
+        """Poll one batch of pending releases; return how many changed status.
+
+        A failure on one release (missing token, SoundCloud error) is logged and
+        skipped so the rest of the batch still makes progress.
+        """
+        releases = await self._pending_batch()
+        changed = 0
+        for release in releases:
+            try:
+                if await self._poll_release(release):
+                    changed += 1
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Polling SoundCloud status for release %s failed", release.id)
+        return changed
+
+    async def _pending_batch(self) -> list[Release]:
+        return (
+            await Release.find(
+                {
+                    "soundcloud_track_id": {"$ne": None},
+                    f"channel_statuses.{SOUNDCLOUD_CHANNEL}": {"$in": list(_NON_TERMINAL)},
+                }
+            )
+            .limit(self._batch_size)
+            .to_list()
+        )
+
+    async def _poll_release(self, release: Release) -> bool:
+        connection = await self._connection_getter(str(release.user_id), self._settings)
+        track = await self._status_fetcher(connection.access_token, release.soundcloud_track_id)
+        new_status = status_service.map_soundcloud_state(track)
+        current = DistributionStatus(release.channel_statuses.get(SOUNDCLOUD_CHANNEL, DistributionStatus.SUBMITTED))
+
+        release.soundcloud_last_polled = utcnow()
+        if new_status is not None and new_status != current:
+            # validate off: SoundCloud's real state is authoritative. apply saves
+            # the whole document, so the last_polled stamp above is persisted too.
+            await status_service.apply_channel_status(release, SOUNDCLOUD_CHANNEL, new_status, validate=False)
+            if status_service.should_notify(current, new_status):
+                await status_service.create_status_notification(release, SOUNDCLOUD_CHANNEL, new_status)
+            return True
+
+        await release.save()
+        return False

--- a/tests/test_distribution_api.py
+++ b/tests/test_distribution_api.py
@@ -16,7 +16,7 @@ from pymongo.errors import DuplicateKeyError
 
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
-from acemusic.api.models import Clip, SoundCloudConnection
+from acemusic.api.models import Clip, Release, SoundCloudConnection
 from acemusic.api.routers import distribution as dist
 from acemusic.api.services import soundcloud as sc, users as user_service
 from acemusic.api.settings import ApiSettings
@@ -475,3 +475,75 @@ class TestRelink:
         assert result.access_token == "mine-at"
         assert result.refresh_token == "mine-rt"
         assert await SoundCloudConnection.find(SoundCloudConnection.user_id == user.id).count() == 1
+
+
+# --- release association (US-13.6: persist track id + start SoundCloud channel) --
+async def _make_release(user, clip) -> Release:
+    release = Release(
+        clip_id=clip.id,
+        user_id=user.id,
+        title="Tune",
+        artist="DJ",
+        genre="house",
+        release_date=datetime.now(timezone.utc),
+    )
+    await release.insert()
+    return release
+
+
+class TestUploadReleaseAssociation:
+    async def test_upload_with_release_id_records_track_and_starts_channel(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        user = await _make_user("up-assoc@example.com")
+        clip = await _make_clip(user, b"RIFFaudio")
+        release = await _make_release(user, clip)
+        await _make_connection(user)
+
+        async def _upload(token, audio, filename, metadata, artwork=None):
+            return {"id": 555, "permalink_url": "https://snd.sc/y"}
+
+        monkeypatch.setattr(sc, "upload_track", _upload)
+
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(user, settings),
+            json={"clip_id": str(clip.id), "release_id": str(release.id)},
+        )
+        assert resp.status_code == 200
+        stored = await Release.get(release.id)
+        assert stored.soundcloud_track_id == "555"
+        assert stored.channel_statuses["soundcloud"].value == "submitted"
+
+    async def test_release_id_mismatched_clip_returns_400(self, client, settings, local_storage, monkeypatch) -> None:
+        user = await _make_user("up-assoc-mismatch@example.com")
+        clip = await _make_clip(user, b"RIFFaudio")
+        other_clip = await _make_clip(user, b"RIFFaudio2")
+        release = await _make_release(user, other_clip)  # release of a different clip
+        await _make_connection(user)
+
+        async def _upload(*a, **k):  # never reached
+            return {"id": 1}
+
+        monkeypatch.setattr(sc, "upload_track", _upload)
+
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(user, settings),
+            json={"clip_id": str(clip.id), "release_id": str(release.id)},
+        )
+        assert resp.status_code == 400
+
+    async def test_other_users_release_returns_404(self, client, settings, local_storage) -> None:
+        user = await _make_user("up-assoc-owner@example.com")
+        intruder = await _make_user("up-assoc-intruder@example.com")
+        clip = await _make_clip(user, b"RIFFaudio")
+        release = await _make_release(user, clip)
+        await _make_connection(intruder)
+        resp = await client.post(
+            _url("/soundcloud/upload"),
+            headers=_auth_headers(intruder, settings),
+            json={"clip_id": str(clip.id), "release_id": str(release.id)},
+        )
+        # intruder doesn't own the clip → 404 before the release check even matters
+        assert resp.status_code == 404

--- a/tests/test_distribution_status_api.py
+++ b/tests/test_distribution_status_api.py
@@ -228,6 +228,28 @@ class TestVisibility:
         assert resp.json()["visibility"] == "public"
         assert (await Release.get(PydanticObjectId(created["id"]))).visibility.value == "public"
 
+    async def test_public_visibility_publishes_source_clip(self, client, settings) -> None:
+        # The AC requires visibility to update the clip's sharing state — clip
+        # audio access is gated by Clip.is_public.
+        user = await _make_user("ds-vis-clip@example.com")
+        created = await _create_release(client, user, settings)
+        clip_id = PydanticObjectId(created["clip_id"])
+        assert (await Clip.get(clip_id)).is_public is False  # default
+
+        await client.patch(
+            f"{RELEASES_URL}/{created['id']}/visibility",
+            json={"state": "public"},
+            headers=_auth_headers(user, settings),
+        )
+        assert (await Clip.get(clip_id)).is_public is True
+
+        await client.patch(
+            f"{RELEASES_URL}/{created['id']}/visibility",
+            json={"state": "private"},
+            headers=_auth_headers(user, settings),
+        )
+        assert (await Clip.get(clip_id)).is_public is False
+
     async def test_visibility_syncs_soundcloud_sharing(self, client, settings, monkeypatch) -> None:
         user = await _make_user("ds-vis-sc@example.com")
         created = await _create_release(client, user, settings)

--- a/tests/test_distribution_status_api.py
+++ b/tests/test_distribution_status_api.py
@@ -1,0 +1,286 @@
+"""Tests for distribution status tracking endpoints (US-13.6, issue #137).
+
+Auth-gate tests run in CI; the status/visibility flows are ``integration`` and
+drive the real app over a local MongoDB, mirroring ``tests/test_releases_api.py``.
+"""
+
+import itertools
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, NotificationEvent, Release, SoundCloudConnection, Workspace
+from acemusic.api.services import soundcloud as sc, users as user_service
+from acemusic.api.services.mastering import APPROVED_GENERATION_MODE
+from acemusic.api.settings import ApiSettings
+
+RELEASES_URL = f"{API_V1_PREFIX}/releases"
+
+FULL_METADATA = {
+    "title": "Midnight Drive",
+    "artist": "The Algorithm",
+    "genre": "synthwave",
+    "release_date": "2026-07-01T00:00:00Z",
+}
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize(
+        ("method", "url"),
+        [
+            ("GET", f"{RELEASES_URL}/{PydanticObjectId()}/status"),
+            ("PATCH", f"{RELEASES_URL}/{PydanticObjectId()}/channels/landr/status"),
+            ("PATCH", f"{RELEASES_URL}/{PydanticObjectId()}/visibility"),
+        ],
+    )
+    def test_missing_auth_header_returns_401(self, method: str, url: str) -> None:
+        client = TestClient(create_app())
+        resp = client.request(method, url)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+            "soundcloud_poller_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+_SEQ = itertools.count(1)
+
+
+async def _insert_clip(user) -> Clip:
+    workspace = Workspace(name=f"WS-{next(_SEQ)}", user_id=user.id)
+    await workspace.insert()
+    clip_id = PydanticObjectId()
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.wav",
+        format="wav",
+        title="Source",
+        generation_mode=APPROVED_GENERATION_MODE,
+        artwork_path=f"{user.id}/art/{clip_id}.png",
+    )
+    await clip.insert()
+    return clip
+
+
+async def _create_release(client, user, settings, **overrides) -> dict:
+    clip = await _insert_clip(user)
+    payload = {"clip_id": str(clip.id), **FULL_METADATA, **overrides}
+    resp = await client.post(RELEASES_URL, json=payload, headers=_auth_headers(user, settings))
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _patch_channel(client, user, settings, release_id, channel, status) -> httpx.Response:
+    return await client.patch(
+        f"{RELEASES_URL}/{release_id}/channels/{channel}/status",
+        json={"status": status},
+        headers=_auth_headers(user, settings),
+    )
+
+
+@pytest.mark.integration
+class TestListingAndStatus:
+    async def test_listing_includes_channel_statuses_and_visibility(self, client, settings) -> None:
+        user = await _make_user("ds-list@example.com")
+        created = await _create_release(client, user, settings)
+        # Default state: no channels engaged, private.
+        assert created["channel_statuses"] == {}
+        assert created["visibility"] == "private"
+
+        listed = await client.get(RELEASES_URL, headers=_auth_headers(user, settings))
+        body = listed.json()["releases"][0]
+        assert body["channel_statuses"] == {}
+        assert body["visibility"] == "private"
+
+    async def test_status_endpoint_returns_channels(self, client, settings) -> None:
+        user = await _make_user("ds-status@example.com")
+        created = await _create_release(client, user, settings)
+        await _patch_channel(client, user, settings, created["id"], "landr", "ready")
+
+        resp = await client.get(f"{RELEASES_URL}/{created['id']}/status", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["release_id"] == created["id"]
+        assert body["title"] == FULL_METADATA["title"]
+        assert {"channel": "landr", "status": "ready"} in body["channels"]
+
+    async def test_status_other_users_release_returns_404(self, client, settings) -> None:
+        owner = await _make_user("ds-status-owner@example.com")
+        intruder = await _make_user("ds-status-intruder@example.com")
+        created = await _create_release(client, owner, settings)
+        resp = await client.get(f"{RELEASES_URL}/{created['id']}/status", headers=_auth_headers(intruder, settings))
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestManualChannelStatus:
+    async def test_valid_transition_is_stored(self, client, settings) -> None:
+        user = await _make_user("ds-manual-ok@example.com")
+        created = await _create_release(client, user, settings)
+        resp = await _patch_channel(client, user, settings, created["id"], "distrokid", "ready")
+        assert resp.status_code == 200
+        assert resp.json() == {"channel": "distrokid", "status": "ready"}
+
+        stored = await Release.get(PydanticObjectId(created["id"]))
+        assert stored.channel_statuses["distrokid"].value == "ready"
+
+    async def test_skip_transition_returns_409(self, client, settings) -> None:
+        user = await _make_user("ds-manual-skip@example.com")
+        created = await _create_release(client, user, settings)
+        # draft (implicit) → live is a skip.
+        resp = await _patch_channel(client, user, settings, created["id"], "landr", "live")
+        assert resp.status_code == 409
+
+    async def test_soundcloud_channel_rejected_with_400(self, client, settings) -> None:
+        user = await _make_user("ds-manual-sc@example.com")
+        created = await _create_release(client, user, settings)
+        resp = await _patch_channel(client, user, settings, created["id"], "soundcloud", "ready")
+        assert resp.status_code == 400
+        assert "automatically" in resp.json()["detail"].lower()
+
+    async def test_unknown_channel_returns_400(self, client, settings) -> None:
+        user = await _make_user("ds-manual-unknown@example.com")
+        created = await _create_release(client, user, settings)
+        resp = await _patch_channel(client, user, settings, created["id"], "bandcamp", "ready")
+        assert resp.status_code == 400
+
+    async def test_invalid_status_value_returns_422(self, client, settings) -> None:
+        user = await _make_user("ds-manual-422@example.com")
+        created = await _create_release(client, user, settings)
+        resp = await _patch_channel(client, user, settings, created["id"], "landr", "banana")
+        assert resp.status_code == 422
+
+    async def test_reaching_live_records_notification(self, client, settings) -> None:
+        user = await _make_user("ds-manual-notify@example.com")
+        created = await _create_release(client, user, settings)
+        # Walk the full sequence to a terminal state.
+        for step in ("ready", "submitted", "in_review", "live"):
+            resp = await _patch_channel(client, user, settings, created["id"], "tunecore", step)
+            assert resp.status_code == 200, (step, resp.text)
+
+        events = await NotificationEvent.find(NotificationEvent.release_id == PydanticObjectId(created["id"])).to_list()
+        assert len(events) == 1
+        assert events[0].event_type == "status_live"
+        assert events[0].channel == "tunecore"
+        assert events[0].delivered_at is None
+
+
+@pytest.mark.integration
+class TestVisibility:
+    async def test_update_visibility_persists(self, client, settings) -> None:
+        user = await _make_user("ds-vis@example.com")
+        created = await _create_release(client, user, settings)
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}/visibility",
+            json={"state": "public"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["visibility"] == "public"
+        assert (await Release.get(PydanticObjectId(created["id"]))).visibility.value == "public"
+
+    async def test_visibility_syncs_soundcloud_sharing(self, client, settings, monkeypatch) -> None:
+        user = await _make_user("ds-vis-sc@example.com")
+        created = await _create_release(client, user, settings)
+        # Put the release on SoundCloud and give the user a live connection.
+        release = await Release.get(PydanticObjectId(created["id"]))
+        release.soundcloud_track_id = "789"
+        await release.save()
+        await SoundCloudConnection(
+            user_id=user.id,
+            soundcloud_user_id="sc-1",
+            access_token="tok",
+            refresh_token="ref",
+            token_expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        ).insert()
+
+        calls: list[tuple[str, str, str]] = []
+
+        async def _fake_sharing(access_token: str, track_id: str, sharing: str) -> dict:
+            calls.append((access_token, track_id, sharing))
+            return {}
+
+        monkeypatch.setattr(sc, "update_track_sharing", _fake_sharing)
+
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}/visibility",
+            json={"state": "public"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert calls == [("tok", "789", "public")]
+
+    async def test_visibility_unaffected_by_soundcloud_failure(self, client, settings, monkeypatch) -> None:
+        user = await _make_user("ds-vis-scfail@example.com")
+        created = await _create_release(client, user, settings)
+        release = await Release.get(PydanticObjectId(created["id"]))
+        release.soundcloud_track_id = "789"
+        await release.save()
+        # No connection at all → get_valid_connection raises; the local change must stand.
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}/visibility",
+            json={"state": "unlisted"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["visibility"] == "unlisted"
+
+    async def test_visibility_other_users_release_returns_404(self, client, settings) -> None:
+        owner = await _make_user("ds-vis-owner@example.com")
+        intruder = await _make_user("ds-vis-intruder@example.com")
+        created = await _create_release(client, owner, settings)
+        resp = await client.patch(
+            f"{RELEASES_URL}/{created['id']}/visibility",
+            json={"state": "public"},
+            headers=_auth_headers(intruder, settings),
+        )
+        assert resp.status_code == 404

--- a/tests/test_distribution_status_service.py
+++ b/tests/test_distribution_status_service.py
@@ -1,0 +1,70 @@
+"""Unit tests for the distribution status state machine (US-13.6, issue #137).
+
+These cover the pure logic — transition validation, notification triggers, and
+SoundCloud state mapping — with no database, so they run in CI.
+"""
+
+import pytest
+
+from acemusic.api.models.distribution import DistributionStatus
+from acemusic.api.services import distribution_status as svc
+
+
+class TestValidateStatusTransition:
+    @pytest.mark.parametrize(
+        ("current", "target"),
+        [
+            (DistributionStatus.DRAFT, DistributionStatus.READY),
+            (DistributionStatus.READY, DistributionStatus.SUBMITTED),
+            (DistributionStatus.SUBMITTED, DistributionStatus.IN_REVIEW),
+            (DistributionStatus.IN_REVIEW, DistributionStatus.LIVE),
+            (DistributionStatus.IN_REVIEW, DistributionStatus.REJECTED),
+        ],
+    )
+    def test_allows_sequential_steps(self, current, target) -> None:
+        assert svc.validate_status_transition(current, target) is True
+
+    @pytest.mark.parametrize(
+        ("current", "target"),
+        [
+            (DistributionStatus.DRAFT, DistributionStatus.LIVE),  # the AC's headline case
+            (DistributionStatus.DRAFT, DistributionStatus.SUBMITTED),
+            (DistributionStatus.SUBMITTED, DistributionStatus.LIVE),
+            (DistributionStatus.READY, DistributionStatus.IN_REVIEW),
+            (DistributionStatus.LIVE, DistributionStatus.READY),  # terminal
+            (DistributionStatus.REJECTED, DistributionStatus.READY),  # terminal
+            (DistributionStatus.READY, DistributionStatus.READY),  # no self-loop
+        ],
+    )
+    def test_rejects_skips_and_terminals(self, current, target) -> None:
+        assert svc.validate_status_transition(current, target) is False
+
+
+class TestShouldNotify:
+    def test_terminal_transitions_notify(self) -> None:
+        assert svc.should_notify(DistributionStatus.IN_REVIEW, DistributionStatus.LIVE) is True
+        assert svc.should_notify(DistributionStatus.IN_REVIEW, DistributionStatus.REJECTED) is True
+
+    def test_non_terminal_does_not_notify(self) -> None:
+        assert svc.should_notify(DistributionStatus.SUBMITTED, DistributionStatus.IN_REVIEW) is False
+
+    def test_no_notify_when_unchanged(self) -> None:
+        assert svc.should_notify(DistributionStatus.LIVE, DistributionStatus.LIVE) is False
+
+
+class TestMapSoundCloudState:
+    @pytest.mark.parametrize(
+        ("track", "expected"),
+        [
+            ({"state": "processing"}, DistributionStatus.IN_REVIEW),
+            ({"state": "finished", "sharing": "public"}, DistributionStatus.LIVE),
+            ({"state": "finished", "sharing": "private"}, DistributionStatus.IN_REVIEW),
+            ({"state": "failed"}, DistributionStatus.REJECTED),
+        ],
+    )
+    def test_maps_known_states(self, track, expected) -> None:
+        assert svc.map_soundcloud_state(track) is expected
+
+    @pytest.mark.parametrize("track", [{}, {"state": ""}, {"state": "weird"}])
+    def test_unknown_state_is_none(self, track) -> None:
+        assert svc.map_soundcloud_state(track) is None

--- a/tests/test_soundcloud_poller.py
+++ b/tests/test_soundcloud_poller.py
@@ -62,7 +62,6 @@ def _poller(settings, *, track: dict, getter=None):
     )
 
 
-@pytest.mark.integration
 class TestPollOnce:
     async def test_advances_processing_to_in_review(self, mongo_db, mongo_settings) -> None:
         user = await _make_user("poll-proc@example.com")

--- a/tests/test_soundcloud_poller.py
+++ b/tests/test_soundcloud_poller.py
@@ -1,0 +1,138 @@
+"""Integration tests for the SoundCloud status poller (US-13.6, issue #137).
+
+These drive the real poller against a local MongoDB (``mongo_db``). The SoundCloud
+HTTP seam is injected (``connection_getter`` / ``status_fetcher``) so no network or
+real connection is needed — the poller's DB orchestration is what's under test.
+"""
+
+import itertools
+from datetime import datetime, timezone
+
+import pytest
+from beanie import PydanticObjectId
+
+from acemusic.api.models import NotificationEvent, Release, Workspace
+from acemusic.api.models.distribution import DistributionStatus
+from acemusic.api.services import users as user_service
+from acemusic.api.tasks.soundcloud_poller import SoundCloudStatusPoller
+
+pytestmark = pytest.mark.integration
+
+_SEQ = itertools.count(1)
+
+
+class _Conn:
+    def __init__(self, token: str = "tok") -> None:
+        self.access_token = token
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_release(user, sc_status: DistributionStatus | None, *, track_id: str | None = "t1") -> Release:
+    workspace = Workspace(name=f"WS-{next(_SEQ)}", user_id=user.id)
+    await workspace.insert()
+    statuses = {"soundcloud": sc_status} if sc_status is not None else {}
+    release = Release(
+        clip_id=PydanticObjectId(),
+        user_id=user.id,
+        title="Tune",
+        artist="DJ",
+        genre="house",
+        release_date=datetime.now(timezone.utc),
+        soundcloud_track_id=track_id,
+        channel_statuses=statuses,
+    )
+    await release.insert()
+    return release
+
+
+def _poller(settings, *, track: dict, getter=None):
+    async def _fetch(token: str, track_id: str) -> dict:
+        return track
+
+    async def _get(user_id: str, _settings) -> _Conn:
+        return _Conn()
+
+    return SoundCloudStatusPoller(
+        settings,
+        connection_getter=getter or _get,
+        status_fetcher=_fetch,
+    )
+
+
+@pytest.mark.integration
+class TestPollOnce:
+    async def test_advances_processing_to_in_review(self, mongo_db, mongo_settings) -> None:
+        user = await _make_user("poll-proc@example.com")
+        release = await _make_release(user, DistributionStatus.SUBMITTED)
+        poller = _poller(mongo_settings, track={"state": "processing"})
+
+        changed = await poller.poll_once()
+        assert changed == 1
+        stored = await Release.get(release.id)
+        assert stored.channel_statuses["soundcloud"] is DistributionStatus.IN_REVIEW
+        assert stored.soundcloud_last_polled is not None
+
+    async def test_finished_public_goes_live_and_notifies(self, mongo_db, mongo_settings) -> None:
+        user = await _make_user("poll-live@example.com")
+        release = await _make_release(user, DistributionStatus.IN_REVIEW)
+        poller = _poller(mongo_settings, track={"state": "finished", "sharing": "public"})
+
+        changed = await poller.poll_once()
+        assert changed == 1
+        stored = await Release.get(release.id)
+        assert stored.channel_statuses["soundcloud"] is DistributionStatus.LIVE
+
+        events = await NotificationEvent.find(NotificationEvent.release_id == release.id).to_list()
+        assert len(events) == 1
+        assert events[0].event_type == "status_live"
+        assert events[0].channel == "soundcloud"
+
+    async def test_terminal_release_is_not_polled(self, mongo_db, mongo_settings) -> None:
+        user = await _make_user("poll-terminal@example.com")
+        await _make_release(user, DistributionStatus.LIVE)
+        fetched: list[str] = []
+
+        async def _fetch(token: str, track_id: str) -> dict:
+            fetched.append(track_id)
+            return {"state": "finished", "sharing": "public"}
+
+        async def _get(user_id: str, _settings) -> _Conn:
+            return _Conn()
+
+        poller = SoundCloudStatusPoller(mongo_settings, connection_getter=_get, status_fetcher=_fetch)
+        changed = await poller.poll_once()
+        assert changed == 0
+        assert fetched == []  # terminal releases are excluded from the batch
+
+    async def test_no_change_still_stamps_last_polled(self, mongo_db, mongo_settings) -> None:
+        user = await _make_user("poll-nochange@example.com")
+        release = await _make_release(user, DistributionStatus.SUBMITTED)
+        poller = _poller(mongo_settings, track={})  # unknown state → no mapping
+
+        changed = await poller.poll_once()
+        assert changed == 0
+        stored = await Release.get(release.id)
+        assert stored.channel_statuses["soundcloud"] is DistributionStatus.SUBMITTED  # unchanged
+        assert stored.soundcloud_last_polled is not None
+
+    async def test_one_failure_does_not_stop_the_batch(self, mongo_db, mongo_settings) -> None:
+        good = await _make_user("poll-good@example.com")
+        bad = await _make_user("poll-bad@example.com")
+        good_release = await _make_release(good, DistributionStatus.SUBMITTED)
+        await _make_release(bad, DistributionStatus.SUBMITTED)
+
+        async def _fetch(token: str, track_id: str) -> dict:
+            return {"state": "processing"}
+
+        async def _get(user_id: str, _settings) -> _Conn:
+            if user_id == str(bad.id):
+                raise RuntimeError("no token")
+            return _Conn()
+
+        poller = SoundCloudStatusPoller(mongo_settings, connection_getter=_get, status_fetcher=_fetch)
+        changed = await poller.poll_once()
+        assert changed == 1  # the good one progressed; the bad one was skipped
+        assert (await Release.get(good_release.id)).channel_statuses["soundcloud"] is DistributionStatus.IN_REVIEW

--- a/tests/test_soundcloud_service.py
+++ b/tests/test_soundcloud_service.py
@@ -186,6 +186,39 @@ async def test_upload_track_omits_absent_optional_fields() -> None:
     assert b"track[artwork_data]" not in body
 
 
+@respx.mock
+async def test_get_track_status_uses_oauth_header() -> None:
+    track_url = f"{sc.SOUNDCLOUD_UPLOAD_URL}/555"
+    route = respx.get(track_url).mock(
+        return_value=httpx.Response(200, json={"id": 555, "state": "finished", "sharing": "public"})
+    )
+    track = await sc.get_track_status("tok", "555")
+    assert track["state"] == "finished"
+    assert route.calls.last.request.headers["Authorization"] == "OAuth tok"
+
+
+@respx.mock
+async def test_get_track_status_wraps_http_error() -> None:
+    respx.get(f"{sc.SOUNDCLOUD_UPLOAD_URL}/555").mock(return_value=httpx.Response(404))
+    with pytest.raises(sc.SoundCloudError):
+        await sc.get_track_status("tok", "555")
+
+
+@respx.mock
+async def test_update_track_sharing_puts_sharing_field() -> None:
+    track_url = f"{sc.SOUNDCLOUD_UPLOAD_URL}/555"
+    route = respx.put(track_url).mock(return_value=httpx.Response(200, json={"id": 555, "sharing": "private"}))
+    await sc.update_track_sharing("tok", "555", "private")
+    request = route.calls.last.request
+    assert request.headers["Authorization"] == "OAuth tok"
+    assert b"track%5Bsharing%5D=private" in request.content  # urlencoded track[sharing]=private
+
+
+async def test_update_track_sharing_rejects_invalid_value() -> None:
+    with pytest.raises(sc.SoundCloudError):
+        await sc.update_track_sharing("tok", "555", "secret")
+
+
 class TestTokenExpiry:
     def test_uses_expires_in_seconds(self) -> None:
         from datetime import datetime, timezone


### PR DESCRIPTION
## US-13.6: Distribution status tracking

Closes #137.

Per-channel distribution status for releases across **SoundCloud** (direct,
auto-polled) and the **guided** LANDR / DistroKid / TuneCore channels (manual
updates), plus release **visibility** with best-effort SoundCloud sharing sync.

### What changed
**Data layer**
- `models/distribution.py` — `DistributionStatus` (draft→ready→submitted→in_review→live/rejected),
  `VisibilityState` (private/unlisted/public), `GUIDED_CHANNELS`, `VALID_STATUS_TRANSITIONS`.
- `Release` gains `channel_statuses`, `visibility`, `soundcloud_track_id`, `soundcloud_last_polled`
  (+ sparse index on the track id).
- `models/notification_event.py` — a `NotificationEvent` recorder (delivery out of scope).

**Services**
- `services/distribution_status.py` — the state machine: `validate_status_transition`,
  `apply_channel_status` (atomic, guarded `$set`), `should_notify`, `create_status_notification`,
  `map_soundcloud_state`.
- `services/soundcloud.py` — `get_track_status`, `update_track_sharing`.
- `services/releases.py` — `update_visibility` (syncs the source clip's `is_public`).

**API**
- `GET /api/v1/releases/{id}/status` — per-channel status + visibility + last-polled.
- `PATCH /api/v1/releases/{id}/channels/{channel}/status` — manual guided update
  (SoundCloud → 400; unknown channel → 400; out-of-sequence → 409).
- `PATCH /api/v1/releases/{id}/visibility` — updates release + clip + SoundCloud sharing.
- `ReleaseResponse` (list/get) enriched with `channel_statuses` + `visibility`.
- `POST /api/v1/distribution/soundcloud/upload` accepts an optional `release_id`; on
  success it persists the track id and starts the SoundCloud channel at `submitted`.

**Background**
- `tasks/soundcloud_poller.py` — `SoundCloudStatusPoller` (JobProcessor-style lifecycle),
  wired into the app lifespan; new `ACEMUSIC_API_SOUNDCLOUD_POLLER_*` settings.

### Acceptance criteria
- [x] Release listing shows per-channel distribution status
- [x] SoundCloud status reflects actual track state (checked via API by the poller)
- [x] Manual status updates for guided channels are stored and visible
- [x] Visibility changes update the clip's sharing state (`Clip.is_public` + SoundCloud)
- [x] Status transitions follow the valid sequence (draft→live is rejected, 409)

### Tests
- Unit: transition validation, notification triggers, SoundCloud state mapping,
  `get_track_status`/`update_track_sharing` wire format (respx).
- Integration (local MongoDB): listing/status endpoints, manual update (valid/skip/
  soundcloud-reject/unknown/invalid-enum), terminal-state notification, visibility
  (persist, clip publish, SoundCloud sync, failure tolerance), poller (advance, notify,
  terminal-skip, no-change stamp, batch fault-tolerance), upload→release association.

### Deviations from the CodeRabbit plan (it predated US-13.2/.3)
- Reused the existing `Release`/`ReleaseStatus`/releases router (plan assumed greenfield).
- Dropped `cdbaby`, per-release `last_poll_error`, exponential backoff, rate-limit config,
  per-channel timestamps — YAGNI for this story.
- Out-of-sequence transition → **409** (matches the repo's `_state_error` house style).
- Wired the upload→release association (plan assumed US-13.2 already stored the track id).

### Known limitations
- **NotificationEvent is a recorder only** — no delivery mechanism (email/push/in-app) yet.
- **`unlisted` maps to SoundCloud `private`** — SoundCloud models only public/private, and
  the platform has no link-token sharing, so `unlisted`/`private` both keep the clip owner-only.
- **A `live` SoundCloud channel set back to private/unlisted** updates SoundCloud sharing but
  leaves the channel status at `live`; the poller doesn't revisit terminal states (codex P2,
  deferred — low-value edge case).
- **SoundCloud API calls are stubbed at the service seam in route/poller tests** (the API is
  account-gated); HTTP wire format is covered separately by `test_soundcloud_service.py`.
