### PR TITLE
US-14.1: DAW export endpoint (#138)

### DIFF
--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -27,6 +27,7 @@ from .routers import (
     batch,
     clips,
     compute,
+    daw_export,
     distribution,
     editing,
     extraction,
@@ -179,6 +180,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(editing.router, prefix=API_V1_PREFIX)
     app.include_router(artwork.router, prefix=API_V1_PREFIX)
     app.include_router(extraction.router, prefix=API_V1_PREFIX)
+    app.include_router(daw_export.router, prefix=API_V1_PREFIX)
     app.include_router(iterative.router, prefix=API_V1_PREFIX)
     app.include_router(batch.router, prefix=API_V1_PREFIX)
     app.include_router(workspaces.router, prefix=API_V1_PREFIX)

--- a/src/acemusic/api/routers/daw_export.py
+++ b/src/acemusic/api/routers/daw_export.py
@@ -1,0 +1,82 @@
+"""DAW-export endpoints (US-14.1), mounted under ``/api/v1/clips``.
+
+* ``POST /clips/{id}/export/daw`` → enqueue a DAW bundle build (202, job id)
+* ``GET  /clips/{id}/export/daw`` → download the assembled ZIP (404 until built)
+
+The POST mirrors the editing/extraction async pattern: verify ownership, persist
+a queued :class:`~acemusic.api.models.job.Job`, return 202. The build (stems +
+MIDI resolution and ZIP assembly) runs in the background worker, which uploads
+the bundle to a predictable per-clip key. The GET serves that object directly —
+no job id needed — using the same owner-or-public visibility rule as the audio
+download. Like editing/extraction, DAW export deducts no credits.
+"""
+
+import asyncio
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel
+
+from acemusic.daw_export import project_slug
+from acemusic.storage import get_storage_backend
+
+from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..models import Clip
+from ..services import clips as clip_service, daw_export as daw_export_service
+
+logger = logging.getLogger(__name__)
+
+# Router-level dependency gates every route behind a valid Bearer token
+# (mirrors the clips/editing routers), so unauthenticated requests get 401.
+router = APIRouter(prefix="/clips", tags=["daw-export"], dependencies=[Depends(get_current_user)])
+
+
+class DawExportJobResponse(BaseModel):
+    """The accepted-job acknowledgement returned with HTTP 202."""
+
+    job_id: str
+    status: Literal["queued"] = "queued"
+
+
+def _export_path(clip: Clip) -> str:
+    """Predictable per-clip storage key the worker writes and the GET serves."""
+    return f"{clip.user_id}/{clip.workspace_id}/exports/{clip.id}_daw.zip"
+
+
+@router.post("/{clip_id}/export/daw", response_model=DawExportJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def create_daw_export(
+    clip_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> DawExportJobResponse:
+    """Enqueue a DAW bundle build for ``clip_id``; poll the job, then GET the ZIP."""
+    clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    job = await daw_export_service.create_daw_export_job(
+        user_id=clip.user_id,
+        workspace_id=clip.workspace_id,
+        clip_id=clip.id,
+    )
+    return DawExportJobResponse(job_id=str(job.id))
+
+
+@router.get("/{clip_id}/export/daw")
+async def download_daw_export(
+    clip_id: str,
+    current: CurrentUser = Depends(get_current_user),
+) -> Response:
+    """Download the assembled DAW bundle ZIP; 404 until the export has been built."""
+    clip = await clip_service.get_clip_for_audio_access(clip_id, current.user_id)
+    storage = get_storage_backend()
+    try:
+        data = await asyncio.to_thread(storage.download, _export_path(clip))
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="DAW export not found. Trigger it with POST /clips/{id}/export/daw first.",
+        )
+    filename = f"{project_slug(clip)}_Export.zip"
+    return Response(
+        content=data,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/src/acemusic/api/routers/daw_export.py
+++ b/src/acemusic/api/routers/daw_export.py
@@ -51,6 +51,16 @@ async def create_daw_export(
 ) -> DawExportJobResponse:
     """Enqueue a DAW bundle build for ``clip_id``; poll the job, then GET the ZIP."""
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
+    # The bundle's full_mix (and any on-demand stem/MIDI extraction) round-trips
+    # through wav; the server has no ffmpeg to transcode a compressed source, so
+    # gate non-wav here with a clear 422 instead of a doomed queued job (mirrors
+    # the editing and stems endpoints).
+    fmt = clip_service.native_format(clip)
+    if fmt != "wav":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"unsupported format {fmt!r} for DAW export; currently only wav is supported.",
+        )
     job = await daw_export_service.create_daw_export_job(
         user_id=clip.user_id,
         workspace_id=clip.workspace_id,

--- a/src/acemusic/api/routers/daw_export.py
+++ b/src/acemusic/api/routers/daw_export.py
@@ -41,7 +41,7 @@ class DawExportJobResponse(BaseModel):
 
 def _export_path(clip: Clip) -> str:
     """Predictable per-clip storage key the worker writes and the GET serves."""
-    return f"{clip.user_id}/{clip.workspace_id}/exports/{clip.id}_daw.zip"
+    return daw_export_service.export_storage_path(clip.user_id, clip.workspace_id, clip.id)
 
 
 @router.post("/{clip_id}/export/daw", response_model=DawExportJobResponse, status_code=status.HTTP_202_ACCEPTED)

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -155,10 +155,11 @@ async def update_clip_title(clip_id: str, user_id: str, title: str) -> Clip:
 async def delete_clip(clip_id: str, user_id: str) -> None:
     """Delete the clip record and its stored audio (idempotent on the object).
 
-    Also removes any extracted MIDI objects (US-10.2 ``midi_paths``) and cover-art
+    Also removes any extracted MIDI objects (US-10.2 ``midi_paths``), cover-art
     artifacts (US-13.1: the selected ``artwork_path`` plus every generated
-    ``ArtworkOption`` and its image), which live under their own storage keys
-    rather than ``file_path`` and would otherwise be orphaned with the parent clip.
+    ``ArtworkOption`` and its image), and the DAW-export bundle (US-14.1), which
+    live under their own storage keys rather than ``file_path`` and would
+    otherwise be orphaned with the parent clip.
     """
     clip = await get_owned_clip(clip_id, user_id)
     storage = get_storage_backend()
@@ -175,6 +176,14 @@ async def delete_clip(clip_id: str, user_id: str) -> None:
         except Exception:  # pragma: no cover - cleanup is best-effort
             logger.warning("Failed to delete MIDI object %s while deleting clip %s", midi_key, clip.id)
     await _delete_artwork(storage, clip)
+    # DAW-export bundle (US-14.1): the predictable per-clip ZIP the export worker
+    # writes under its own key, orphaned otherwise. Best-effort and idempotent
+    # (a never-exported clip has no object to remove), like the MIDI cleanup.
+    export_key = f"{clip.user_id}/{clip.workspace_id}/exports/{clip.id}_daw.zip"
+    try:
+        await asyncio.to_thread(storage.delete, export_key)
+    except Exception:  # pragma: no cover - cleanup is best-effort
+        logger.warning("Failed to delete DAW export object %s while deleting clip %s", export_key, clip.id)
     await clip.delete()
 
 

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -23,7 +23,7 @@ from fastapi import HTTPException, status
 from acemusic.storage import get_storage_backend
 
 from ..models import ArtworkOption, Clip
-from . import workspaces as workspace_service
+from . import daw_export as daw_export_service, workspaces as workspace_service
 from .common import coerce_object_id
 
 logger = logging.getLogger(__name__)
@@ -179,7 +179,7 @@ async def delete_clip(clip_id: str, user_id: str) -> None:
     # DAW-export bundle (US-14.1): the predictable per-clip ZIP the export worker
     # writes under its own key, orphaned otherwise. Best-effort and idempotent
     # (a never-exported clip has no object to remove), like the MIDI cleanup.
-    export_key = f"{clip.user_id}/{clip.workspace_id}/exports/{clip.id}_daw.zip"
+    export_key = daw_export_service.export_storage_path(clip.user_id, clip.workspace_id, clip.id)
     try:
         await asyncio.to_thread(storage.delete, export_key)
     except Exception:  # pragma: no cover - cleanup is best-effort

--- a/src/acemusic/api/services/daw_export.py
+++ b/src/acemusic/api/services/daw_export.py
@@ -13,7 +13,7 @@ from .jobs import create_job
 DAW_EXPORT_JOB_TYPE = "daw_export"
 
 
-def export_storage_path(user_id, workspace_id, clip_id) -> str:
+def export_storage_path(user_id: PydanticObjectId, workspace_id: PydanticObjectId, clip_id: PydanticObjectId) -> str:
     """Canonical storage key for a clip's DAW-export ZIP.
 
     The single source of truth shared by the worker (which writes it), the GET

--- a/src/acemusic/api/services/daw_export.py
+++ b/src/acemusic/api/services/daw_export.py
@@ -13,6 +13,16 @@ from .jobs import create_job
 DAW_EXPORT_JOB_TYPE = "daw_export"
 
 
+def export_storage_path(user_id, workspace_id, clip_id) -> str:
+    """Canonical storage key for a clip's DAW-export ZIP.
+
+    The single source of truth shared by the worker (which writes it), the GET
+    endpoint (which serves it), and clip deletion (which removes it) — so the
+    three can never drift and silently orphan a bundle.
+    """
+    return f"{user_id}/{workspace_id}/exports/{clip_id}_daw.zip"
+
+
 async def create_daw_export_job(
     *,
     user_id: PydanticObjectId,

--- a/src/acemusic/api/services/daw_export.py
+++ b/src/acemusic/api/services/daw_export.py
@@ -1,0 +1,34 @@
+"""DAW-export service layer (US-14.1).
+
+Persists the queued ``daw_export`` job for the DAW-export endpoint, mirroring
+the other ``create_*_job`` wrappers (editing, extraction). Kept
+transport-agnostic (plain exceptions, never ``HTTPException``).
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import Job
+from .jobs import create_job
+
+DAW_EXPORT_JOB_TYPE = "daw_export"
+
+
+async def create_daw_export_job(
+    *,
+    user_id: PydanticObjectId,
+    workspace_id: PydanticObjectId,
+    clip_id: PydanticObjectId,
+) -> Job:
+    """Persist a queued DAW-export job for ``clip_id`` and dispatch it.
+
+    ``params`` carries only the source ``clip_id``; the worker resolves (or
+    extracts) stems and MIDI and assembles the bundle. Returns the saved
+    :class:`Job` (with its id).
+    """
+    return await create_job(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        job_type=DAW_EXPORT_JOB_TYPE,
+        params={"clip_id": str(clip_id)},
+        valid_types=(DAW_EXPORT_JOB_TYPE,),
+    )

--- a/src/acemusic/api/tasks/daw_export.py
+++ b/src/acemusic/api/tasks/daw_export.py
@@ -1,0 +1,114 @@
+"""DAW-export job handler (US-14.1): assemble a DAW-ready ZIP for a clip.
+
+Resolves the source clip's four stems and four MIDI files — reusing the cached
+extraction artifacts when a complete set is present, otherwise running the same
+stem/MIDI workers the extraction endpoints (US-10.2) use — downloads them
+alongside the full mix, and assembles the canonical bundle ZIP via
+:func:`acemusic.daw_export.assemble_daw_bundle`. The ZIP is uploaded to a
+predictable per-clip ``exports/{clip_id}_daw.zip`` key (the GET endpoint serves
+it directly) and the storage key is returned as ``export_path``.
+
+Reusing :func:`~acemusic.api.tasks.extraction.process_stems_job` /
+:func:`~acemusic.api.tasks.extraction.process_midi_job` means extraction is
+cached and rolled back exactly as a direct extraction call would be — there is
+no second copy of the stems/MIDI pipeline to keep in sync. A complete cached set
+short-circuits both, so a re-export of an already-extracted clip neither
+re-separates nor re-extracts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from beanie.operators import In
+
+from acemusic.daw_export import assemble_daw_bundle
+from acemusic.midi_client import MIDI_OUTPUT_LABELS
+from acemusic.stems_client import STEM_LABELS
+from acemusic.storage import StorageBackend
+
+from ..models import Clip, Job
+from ..services.clips import native_format
+from ..services.daw_export import DAW_EXPORT_JOB_TYPE
+from ..services.extraction import STEMS_JOB_TYPE
+from .common import download_clip, load_clip, load_source_clip
+from .extraction import process_midi_job, process_stems_job
+
+
+async def _stem_children(clip_id: object) -> dict[str, Clip]:
+    """The source's stem child clips, keyed by stem label (newest per label)."""
+    children = await Clip.find(
+        In(Clip.parent_clip_ids, [clip_id]),
+        Clip.generation_mode == STEMS_JOB_TYPE,
+    ).to_list()
+    by_label: dict[str, Clip] = {}
+    for child in children:
+        if child.title in STEM_LABELS and child.title not in by_label:
+            by_label[child.title] = child
+    return by_label
+
+
+def _midi_complete(clip: Clip) -> bool:
+    """True when ``clip.midi_paths`` holds all four MIDI labels (a usable cache)."""
+    paths = clip.midi_paths or {}
+    return all(label in paths for label in MIDI_OUTPUT_LABELS)
+
+
+async def process_daw_export_job(job: Job, storage: StorageBackend) -> dict[str, Any]:
+    """Resolve stems + MIDI (reusing the cache), assemble the bundle, store it."""
+    source = await load_source_clip(job)
+
+    # Stems: reuse a complete cached set, else run the stems worker (which
+    # deletes any partial set and stores a fresh, complete one), then re-read.
+    stems = await _stem_children(source.id)
+    if len(stems) < len(STEM_LABELS):
+        await process_stems_job(job, storage)
+        stems = await _stem_children(source.id)
+
+    # MIDI: reuse cached ``midi_paths``, else run the MIDI worker (which sets
+    # ``midi_paths`` on its own freshly-loaded copy — reload to pick it up).
+    if not _midi_complete(source):
+        await process_midi_job(job, storage)
+        source = await load_clip(str(source.id))
+
+    with tempfile.TemporaryDirectory(prefix="acemusic-daw-") as tmp_dir:
+        tmp = Path(tmp_dir)
+
+        full_mix = tmp / f"full_mix.{native_format(source)}"
+        await asyncio.to_thread(full_mix.write_bytes, await download_clip(storage, source))
+
+        stem_paths: dict[str, Path] = {}
+        for label, child in stems.items():
+            dest = tmp / f"stem-{label}.wav"
+            await asyncio.to_thread(dest.write_bytes, await download_clip(storage, child))
+            stem_paths[label] = dest
+
+        midi_paths: dict[str, Path] = {}
+        for label, key in (source.midi_paths or {}).items():
+            dest = tmp / f"midi-{label}.mid"
+            data = await asyncio.to_thread(storage.download, key)
+            await asyncio.to_thread(dest.write_bytes, data)
+            midi_paths[label] = dest
+
+        zip_local = tmp / "bundle.zip"
+        await asyncio.to_thread(
+            assemble_daw_bundle,
+            source,
+            full_mix_path=full_mix,
+            stem_paths=stem_paths,
+            midi_paths=midi_paths,
+            output_path=zip_local,
+        )
+        data = await asyncio.to_thread(zip_local.read_bytes)
+
+    export_path = f"{job.user_id}/{job.workspace_id}/exports/{source.id}_daw.zip"
+    await asyncio.to_thread(storage.upload, export_path, data)
+    return {"export_path": export_path}
+
+
+DAW_EXPORT_JOB_HANDLERS = {
+    DAW_EXPORT_JOB_TYPE: process_daw_export_job,
+}

--- a/src/acemusic/api/tasks/daw_export.py
+++ b/src/acemusic/api/tasks/daw_export.py
@@ -32,7 +32,7 @@ from acemusic.storage import StorageBackend
 
 from ..models import Clip, Job
 from ..services.clips import native_format
-from ..services.daw_export import DAW_EXPORT_JOB_TYPE
+from ..services.daw_export import DAW_EXPORT_JOB_TYPE, export_storage_path
 from ..services.extraction import STEMS_JOB_TYPE
 from .common import download_clip, load_clip, load_source_clip
 from .extraction import process_midi_job, process_stems_job
@@ -40,10 +40,15 @@ from .extraction import process_midi_job, process_stems_job
 
 async def _stem_children(clip_id: object) -> dict[str, Clip]:
     """The source's stem child clips, keyed by stem label (newest per label)."""
-    children = await Clip.find(
-        In(Clip.parent_clip_ids, [clip_id]),
-        Clip.generation_mode == STEMS_JOB_TYPE,
-    ).to_list()
+    children = (
+        await Clip.find(
+            In(Clip.parent_clip_ids, [clip_id]),
+            Clip.generation_mode == STEMS_JOB_TYPE,
+        )
+        # Newest-first so that after a partial re-extraction left duplicate
+        # children for a label, the freshest one wins deterministically.
+        .sort(("created_at", -1), ("_id", -1)).to_list()
+    )
     by_label: dict[str, Clip] = {}
     for child in children:
         if child.title in STEM_LABELS and child.title not in by_label:
@@ -104,7 +109,7 @@ async def process_daw_export_job(job: Job, storage: StorageBackend) -> dict[str,
         )
         data = await asyncio.to_thread(zip_local.read_bytes)
 
-    export_path = f"{job.user_id}/{job.workspace_id}/exports/{source.id}_daw.zip"
+    export_path = export_storage_path(job.user_id, job.workspace_id, source.id)
     await asyncio.to_thread(storage.upload, export_path, data)
     return {"export_path": export_path}
 

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -39,6 +39,7 @@ from ..models import Clip, Job, JobStatus
 from ..models.common import utcnow
 from .artwork import ARTWORK_JOB_HANDLERS
 from .common import JobProcessingError
+from .daw_export import DAW_EXPORT_JOB_HANDLERS
 from .editing import EDIT_JOB_HANDLERS
 from .export import EXPORT_JOB_HANDLERS
 from .extraction import EXTRACTION_JOB_HANDLERS
@@ -148,6 +149,7 @@ class JobProcessor:
             **EDIT_JOB_HANDLERS,
             **EXTRACTION_JOB_HANDLERS,
             **EXPORT_JOB_HANDLERS,
+            **DAW_EXPORT_JOB_HANDLERS,
         }.items():
             self._handlers[job_type] = partial(self._run_storage_handler, storage_handler)
         # Iterative generation handlers (US-10.3) are generative: they need the

--- a/src/acemusic/daw_export.py
+++ b/src/acemusic/daw_export.py
@@ -361,25 +361,27 @@ def export_midi(
     return written
 
 
-def build_daw_bundle(
+def assemble_daw_bundle(
     clip: Clip,
     *,
+    full_mix_path: Path | str,
+    stem_paths: dict[str, Path | str],
+    midi_paths: dict[str, Path | str],
     output_path: Path,
-    stems_client_factory: Callable[[], StemsClient] = StemsClient,
-    midi_client_factory: Callable[[], MidiClient] = MidiClient,
-    reuse_existing: bool = True,
 ) -> Path:
-    """Build a DAW-importable ZIP bundle for ``clip`` at ``output_path``.
+    """Assemble a DAW bundle ZIP from already-resolved local files.
 
-    Resolves (reusing existing child clips, else generating) the four stems and
-    four MIDI files, assembles the canonical directory tree, writes
-    ``project.json`` and a placeholder ``artwork.jpg``, then packages everything
-    into a ZIP rooted at ``<Slug>_Export/``.
+    The resolution-agnostic half of :func:`build_daw_bundle`: validate the four
+    stems and four MIDI files, lay out the ``<Slug>_Export/`` tree, write
+    ``project.json`` and a placeholder ``artwork.jpg``, then ZIP it. ``clip`` is
+    read only for metadata (``title``, ``id``, ``bpm``, ``key``, ``duration``,
+    ``lyrics``, ``style_tags``, ``model``, ``seed``), so both the CLI dataclass
+    and the API ``Clip`` document work as the source of metadata. ``stem_paths``
+    is keyed by ``CANONICAL_STEMS`` and ``midi_paths`` by ``MIDI_OUTPUT_LABELS``.
 
-    Raises ``ValueError`` if resolution yields an incomplete set of stems or MIDI
-    files, rather than shipping a partial bundle. ``time_signature`` is always
-    null because clip records do not persist meter (deferred to US-4.2); bundled
-    MIDI therefore uses ``save_midi``'s default 4/4 map.
+    Raises ``ValueError`` if either set is incomplete, rather than shipping a
+    partial bundle. ``time_signature`` is always null because clip records do not
+    persist meter (deferred to US-4.2); bundled MIDI uses ``save_midi``'s 4/4 map.
     """
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -395,9 +397,6 @@ def build_daw_bundle(
         audio_dir.mkdir(parents=True, exist_ok=True)
         midi_dir.mkdir(parents=True, exist_ok=True)
 
-        stem_paths = _resolve_stems(clip, stems_client_factory, reuse_existing)
-        midi_paths = _resolve_midi(clip, midi_client_factory, reuse_existing)
-
         missing_stems = [s for s in CANONICAL_STEMS if not (stem_paths.get(s) and Path(stem_paths[s]).exists())]
         missing_midi = [m for m in MIDI_OUTPUT_LABELS if not (midi_paths.get(m) and Path(midi_paths[m]).exists())]
         if missing_stems or missing_midi:
@@ -411,7 +410,7 @@ def build_daw_bundle(
                 "Re-run stem separation / MIDI extraction or check the source clip."
             )
 
-        _copy_as_wav(clip.file_path, audio_dir / "full_mix.wav")
+        _copy_as_wav(full_mix_path, audio_dir / "full_mix.wav")
 
         stem_refs: list[StemReference] = []
         for label in CANONICAL_STEMS:
@@ -448,3 +447,28 @@ def build_daw_bundle(
                     zf.write(path, arcname)
 
     return output_path
+
+
+def build_daw_bundle(
+    clip: Clip,
+    *,
+    output_path: Path,
+    stems_client_factory: Callable[[], StemsClient] = StemsClient,
+    midi_client_factory: Callable[[], MidiClient] = MidiClient,
+    reuse_existing: bool = True,
+) -> Path:
+    """Build a DAW-importable ZIP bundle for ``clip`` at ``output_path``.
+
+    Resolves (reusing existing child clips, else generating) the four stems and
+    four MIDI files, then assembles the bundle via :func:`assemble_daw_bundle`.
+    Raises ``ValueError`` if resolution yields an incomplete set.
+    """
+    stem_paths = _resolve_stems(clip, stems_client_factory, reuse_existing)
+    midi_paths = _resolve_midi(clip, midi_client_factory, reuse_existing)
+    return assemble_daw_bundle(
+        clip,
+        full_mix_path=clip.file_path,
+        stem_paths=stem_paths,
+        midi_paths=midi_paths,
+        output_path=output_path,
+    )

--- a/tests/test_daw_export_api.py
+++ b/tests/test_daw_export_api.py
@@ -316,6 +316,37 @@ class TestEnqueue:
         assert job.workspace_id == workspace.id
         assert job.input_params == {"clip_id": str(clip.id)}
 
+    @pytest.mark.parametrize("fmt", ["mp3", "flac"])
+    async def test_non_wav_clip_returns_422(self, client, settings, fmt: str) -> None:
+        # The server has no ffmpeg to transcode the full mix to wav, so a
+        # compressed source is rejected up front rather than failing the job.
+        user, _, clip = await _user_with_clip(f"daw-fmt-{fmt}@example.com", fmt=fmt)
+        resp = await client.post(_daw_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+        assert fmt in resp.json()["detail"]
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Clip deletion removes the orphan-able export bundle (US-14.1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestDeleteCleansExport:
+    async def test_deleting_clip_removes_its_daw_export(self, settings, local_storage) -> None:
+        from acemusic.api.services import clips as clip_service
+
+        user, workspace, clip = await _user_with_clip("daw-del@example.com")
+        storage = get_storage_backend()
+        export_key = f"{user.id}/{workspace.id}/exports/{clip.id}_daw.zip"
+        storage.upload(export_key, b"PK-bundle")
+
+        await clip_service.delete_clip(str(clip.id), str(user.id))
+
+        with pytest.raises(FileNotFoundError):
+            storage.download(export_key)
+
 
 # ---------------------------------------------------------------------------
 # GET — 404 until built; visibility rules

--- a/tests/test_daw_export_api.py
+++ b/tests/test_daw_export_api.py
@@ -31,6 +31,7 @@ from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
 from acemusic.api.models import Clip, Job, JobStatus, Workspace
 from acemusic.api.services import users as user_service
+from acemusic.api.services.daw_export import export_storage_path
 from acemusic.api.settings import ApiSettings
 from acemusic.daw_export import CANONICAL_STEMS, assemble_daw_bundle
 from acemusic.midi_client import CHANNEL_MAP, MIDI_OUTPUT_LABELS
@@ -95,10 +96,11 @@ class TestAssembleBundle:
             p.write_bytes(_midi_bytes(label, bpm=128))
             midi_paths[label] = p
 
+        full_mix = tmp_path / "full_mix.wav"
+        full_mix.write_bytes(_tone_bytes())
+
         out = tmp_path / "bundle.zip"
-        assemble_daw_bundle(
-            clip, full_mix_path=stem_paths["vocals"], stem_paths=stem_paths, midi_paths=midi_paths, output_path=out
-        )
+        assemble_daw_bundle(clip, full_mix_path=full_mix, stem_paths=stem_paths, midi_paths=midi_paths, output_path=out)
 
         with zipfile.ZipFile(out) as zf:
             names = set(zf.namelist())
@@ -339,7 +341,7 @@ class TestDeleteCleansExport:
 
         user, workspace, clip = await _user_with_clip("daw-del@example.com")
         storage = get_storage_backend()
-        export_key = f"{user.id}/{workspace.id}/exports/{clip.id}_daw.zip"
+        export_key = export_storage_path(user.id, workspace.id, clip.id)
         storage.upload(export_key, b"PK-bundle")
 
         await clip_service.delete_clip(str(clip.id), str(user.id))
@@ -362,7 +364,7 @@ class TestDownload:
 
     async def test_get_returns_zip_when_present(self, client, settings, local_storage) -> None:
         user, workspace, clip = await _user_with_clip("daw-get-ok@example.com", title="Cool Track")
-        export_path = f"{user.id}/{workspace.id}/exports/{clip.id}_daw.zip"
+        export_path = export_storage_path(user.id, workspace.id, clip.id)
         get_storage_backend().upload(export_path, b"PK\x03\x04 zip-bytes")
 
         resp = await client.get(_daw_url(clip.id), headers=_auth_headers(user, settings))
@@ -373,14 +375,14 @@ class TestDownload:
 
     async def test_other_users_private_clip_returns_403(self, client, settings, local_storage) -> None:
         user, workspace, clip = await _user_with_clip("daw-priv-owner@example.com")
-        get_storage_backend().upload(f"{user.id}/{workspace.id}/exports/{clip.id}_daw.zip", b"PK")
+        get_storage_backend().upload(export_storage_path(user.id, workspace.id, clip.id), b"PK")
         other = await _make_user("daw-priv-other@example.com")
         resp = await client.get(_daw_url(clip.id), headers=_auth_headers(other, settings))
         assert resp.status_code == 403
 
     async def test_public_clip_export_downloadable_by_other_user(self, client, settings, local_storage) -> None:
         user, workspace, clip = await _user_with_clip("daw-pub-owner@example.com", is_public=True)
-        get_storage_backend().upload(f"{user.id}/{workspace.id}/exports/{clip.id}_daw.zip", b"PK-public")
+        get_storage_backend().upload(export_storage_path(user.id, workspace.id, clip.id), b"PK-public")
         other = await _make_user("daw-pub-other@example.com")
         resp = await client.get(_daw_url(clip.id), headers=_auth_headers(other, settings))
         assert resp.status_code == 200

--- a/tests/test_daw_export_api.py
+++ b/tests/test_daw_export_api.py
@@ -1,0 +1,490 @@
+"""Tests for the DAW-export endpoints (US-14.1, issue #138).
+
+Covers ``POST /clips/{id}/export/daw`` (enqueue a bundle build) and
+``GET /clips/{id}/export/daw`` (download the assembled ZIP). The 401 auth-gate
+and the pure ``assemble_daw_bundle`` test run in CI (no DB); the rest are
+``integration`` and drive the real app with ``httpx.AsyncClient`` over a local
+MongoDB.
+
+The end-to-end tests substitute lightweight stem/MIDI client doubles so the real
+demucs / basic-pitch models never run — those algorithms are covered by US-5.3 /
+US-5.4 and the extraction wiring by US-10.2; here we verify the bundle assembly,
+the cache-reuse (no re-extraction), and the download.
+"""
+
+import asyncio
+import io
+import json
+import time
+import types
+import zipfile
+from pathlib import Path
+
+import mido
+import numpy as np
+import pytest
+import soundfile as sf
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Job, JobStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.daw_export import CANONICAL_STEMS, assemble_daw_bundle
+from acemusic.midi_client import CHANNEL_MAP, MIDI_OUTPUT_LABELS
+from acemusic.stems_client import STEM_LABELS
+from acemusic.storage import get_storage_backend
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+JOBS_URL = f"{API_V1_PREFIX}/jobs"
+
+
+def _daw_url(clip_id) -> str:
+    return f"{CLIPS_URL}/{clip_id}/export/daw"
+
+
+def _tone_bytes(duration_s: float = 0.5, sample_rate: int = 44100) -> bytes:
+    tone = (
+        0.2 * np.sin(2 * np.pi * 220 * np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False))
+    ).astype(np.float32)
+    buf = io.BytesIO()
+    sf.write(buf, np.column_stack([tone, tone]), sample_rate, format="WAV")
+    return buf.getvalue()
+
+
+def _midi_bytes(name: str, bpm: float = 120.0) -> bytes:
+    mid = mido.MidiFile(type=1)
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+    track.append(mido.MetaMessage("set_tempo", tempo=mido.bpm2tempo(bpm), time=0))
+    track.append(mido.MetaMessage("track_name", name=name, time=0))
+    track.append(mido.MetaMessage("end_of_track", time=0))
+    buf = io.BytesIO()
+    mid.save(file=buf)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Pure assembly — runs in CI (no DB, no ffmpeg: wav/midi are copied, not transcoded)
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleBundle:
+    def test_zip_structure_and_project_json(self, tmp_path) -> None:
+        clip = types.SimpleNamespace(
+            id="abc123",
+            title="My Song",
+            bpm=128,
+            key="C minor",
+            duration=12.5,
+            lyrics="la la la",
+            style_tags=["synthwave", "dreamy"],
+            model="ace-step-v1",
+            seed=42,
+        )
+        stem_paths = {}
+        for label in CANONICAL_STEMS:
+            p = tmp_path / f"{label}.wav"
+            p.write_bytes(_tone_bytes())
+            stem_paths[label] = p
+        midi_paths = {}
+        for label in MIDI_OUTPUT_LABELS:
+            p = tmp_path / f"{label}.mid"
+            p.write_bytes(_midi_bytes(label, bpm=128))
+            midi_paths[label] = p
+
+        out = tmp_path / "bundle.zip"
+        assemble_daw_bundle(
+            clip, full_mix_path=stem_paths["vocals"], stem_paths=stem_paths, midi_paths=midi_paths, output_path=out
+        )
+
+        with zipfile.ZipFile(out) as zf:
+            names = set(zf.namelist())
+            root = "my-song_Export"
+            expected = {f"{root}/audio/full_mix.wav", f"{root}/project.json", f"{root}/artwork.jpg"}
+            expected |= {f"{root}/audio/{s}.wav" for s in CANONICAL_STEMS}
+            expected |= {f"{root}/midi/{m}.mid" for m in MIDI_OUTPUT_LABELS}
+            assert expected <= names
+
+            meta = json.loads(zf.read(f"{root}/project.json"))
+
+        assert meta["bpm"] == 128
+        assert meta["key"] == "C minor"
+        assert meta["duration_seconds"] == 12.5
+        assert meta["lyrics"] == "la la la"
+        assert meta["style_tags"] == ["synthwave", "dreamy"]
+        assert meta["source_model"] == "ace-step-v1"
+        assert meta["generation_seed"] == 42
+        assert meta["time_signature"] is None
+        # MIDI channel assignments mirror CHANNEL_MAP (importable into a DAW).
+        assert {m["name"]: m["channel"] for m in meta["midi_files"]} == CHANNEL_MAP
+        assert {s["name"] for s in meta["stems"]} == set(CANONICAL_STEMS)
+
+    def test_incomplete_set_raises(self, tmp_path) -> None:
+        clip = types.SimpleNamespace(
+            id="x", title="t", bpm=None, key=None, duration=None, lyrics=None, style_tags=None, model=None, seed=None
+        )
+        full = tmp_path / "full.wav"
+        full.write_bytes(_tone_bytes())
+        with pytest.raises(ValueError, match="missing"):
+            assemble_daw_bundle(clip, full_mix_path=full, stem_paths={}, midi_paths={}, output_path=tmp_path / "b.zip")
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB; plain TestClient does not run the lifespan)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize("method", ["post", "get"])
+    def test_missing_auth_header_returns_401(self, method: str) -> None:
+        client = TestClient(create_app())
+        resp = getattr(client, method)(_daw_url(PydanticObjectId()))
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app):
+    import httpx
+
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path / "storage"))
+    return tmp_path
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(
+    user, workspace, *, title="Song", duration=10.0, bpm=120, key="C", fmt="wav", store_bytes=None, is_public=False
+) -> Clip:
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.{fmt or 'wav'}"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=file_path,
+        title=title,
+        format=fmt,
+        duration=duration,
+        bpm=bpm,
+        key=key,
+        is_public=is_public,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _user_with_clip(email: str, **clip_kwargs):
+    user = await _make_user(email)
+    workspace = await _make_workspace(user)
+    clip = await _insert_clip(user, workspace, **clip_kwargs)
+    return user, workspace, clip
+
+
+async def _seed_cached_stems(user, workspace, parent: Clip) -> list[Clip]:
+    """Pre-create the 4 stem child clips with real WAV bytes in storage."""
+    children = []
+    for label in STEM_LABELS:
+        cid = PydanticObjectId()
+        path = f"{user.id}/{workspace.id}/clips/{cid}.wav"
+        get_storage_backend().upload(path, _tone_bytes())
+        child = Clip(
+            id=cid,
+            user_id=parent.user_id,
+            workspace_id=parent.workspace_id,
+            file_path=path,
+            title=label,
+            format="wav",
+            duration=parent.duration,
+            parent_clip_ids=[parent.id],
+            generation_mode="stems",
+        )
+        await child.insert()
+        children.append(child)
+    return children
+
+
+async def _seed_cached_midi(user, workspace, clip: Clip) -> None:
+    """Attach the 4 MIDI files to the clip's midi_paths with real bytes in storage."""
+    storage = get_storage_backend()
+    midi_paths = {}
+    for label in MIDI_OUTPUT_LABELS:
+        key = f"{user.id}/{workspace.id}/clips/{clip.id}/midi/{label}.mid"
+        storage.upload(key, _midi_bytes(label, bpm=clip.bpm or 120))
+        midi_paths[label] = key
+    clip.midi_paths = midi_paths
+    await clip.save()
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown / malformed / other-user clip ids (POST creates no job)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestClipNotFound:
+    @pytest.mark.parametrize("method", ["post", "get"])
+    async def test_unknown_clip_returns_404(self, client, settings, method: str) -> None:
+        user = await _make_user(f"daw-404-{method}@example.com")
+        resp = await getattr(client, method)(_daw_url(PydanticObjectId()), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    @pytest.mark.parametrize("method", ["post", "get"])
+    async def test_malformed_id_returns_404(self, client, settings, method: str) -> None:
+        user = await _make_user(f"daw-malformed-{method}@example.com")
+        resp = await getattr(client, method)(_daw_url("not-an-object-id"), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_clip_returns_404_on_post(self, client, settings) -> None:
+        _, _, clip = await _user_with_clip("daw-owner@example.com")
+        other = await _make_user("daw-other@example.com")
+        resp = await client.post(_daw_url(clip.id), headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+        assert await Job.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 202 — job enqueue (always async, even when cached)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestEnqueue:
+    async def test_returns_202_and_persists_job(self, client, settings) -> None:
+        user, workspace, clip = await _user_with_clip("daw-202@example.com")
+        resp = await client.post(_daw_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+
+        jobs = await Job.find_all().to_list()
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert str(job.id) == body["job_id"]
+        assert job.job_type == "daw_export"
+        assert job.status == JobStatus.QUEUED
+        assert job.user_id == user.id
+        assert job.workspace_id == workspace.id
+        assert job.input_params == {"clip_id": str(clip.id)}
+
+
+# ---------------------------------------------------------------------------
+# GET — 404 until built; visibility rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestDownload:
+    async def test_get_returns_404_when_not_exported(self, client, settings, local_storage) -> None:
+        user, _, clip = await _user_with_clip("daw-get-404@example.com")
+        resp = await client.get(_daw_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_get_returns_zip_when_present(self, client, settings, local_storage) -> None:
+        user, workspace, clip = await _user_with_clip("daw-get-ok@example.com", title="Cool Track")
+        export_path = f"{user.id}/{workspace.id}/exports/{clip.id}_daw.zip"
+        get_storage_backend().upload(export_path, b"PK\x03\x04 zip-bytes")
+
+        resp = await client.get(_daw_url(clip.id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/zip"
+        assert resp.headers["content-disposition"] == 'attachment; filename="cool-track_Export.zip"'
+        assert resp.content == b"PK\x03\x04 zip-bytes"
+
+    async def test_other_users_private_clip_returns_403(self, client, settings, local_storage) -> None:
+        user, workspace, clip = await _user_with_clip("daw-priv-owner@example.com")
+        get_storage_backend().upload(f"{user.id}/{workspace.id}/exports/{clip.id}_daw.zip", b"PK")
+        other = await _make_user("daw-priv-other@example.com")
+        resp = await client.get(_daw_url(clip.id), headers=_auth_headers(other, settings))
+        assert resp.status_code == 403
+
+    async def test_public_clip_export_downloadable_by_other_user(self, client, settings, local_storage) -> None:
+        user, workspace, clip = await _user_with_clip("daw-pub-owner@example.com", is_public=True)
+        get_storage_backend().upload(f"{user.id}/{workspace.id}/exports/{clip.id}_daw.zip", b"PK-public")
+        other = await _make_user("daw-pub-other@example.com")
+        resp = await client.get(_daw_url(clip.id), headers=_auth_headers(other, settings))
+        assert resp.status_code == 200
+        assert resp.content == b"PK-public"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with stubbed clients
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingStemsClient:
+    def __init__(self, *a, **k):
+        raise AssertionError("StemsClient must not run when stems are cached")
+
+
+class _ExplodingMidiClient:
+    def __init__(self, *a, **k):
+        raise AssertionError("MidiClient must not run when MIDI is cached")
+
+
+class _FakeStemsClient:
+    model_samplerate = 44100
+
+    def separate(self, audio_path, progress_callback=None):
+        return {label: label for label in STEM_LABELS}
+
+    def save_stems(self, stems, output_dir, base_name, sample_rate=44100, output_format="wav"):
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        paths = {}
+        for label in STEM_LABELS:
+            path = output_dir / f"{base_name}-{label}.{output_format}"
+            path.write_bytes(_tone_bytes())
+            paths[label] = path
+        return paths
+
+
+class _FakeMidiClient:
+    def extract(self, audio_path, from_stems=False, stem_paths=None, progress_callback=None):
+        return {label: [] for label in MIDI_OUTPUT_LABELS}
+
+    def save_midi(self, midi_data, output_dir, base_name, bpm=120.0):
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        paths = {}
+        for label in MIDI_OUTPUT_LABELS:
+            path = output_dir / f"{base_name}-{label}.mid"
+            path.write_bytes(_midi_bytes(label, bpm=bpm))
+            paths[label] = path
+        return paths
+
+
+async def _run_to_completion(client, settings, job_id, headers) -> dict:
+    from acemusic.api.tasks.processor import JobProcessor
+
+    processor = JobProcessor(concurrency=1, poll_interval=0.05)
+    await processor.start()
+    try:
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            resp = await client.get(f"{JOBS_URL}/{job_id}/status", headers=headers)
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["status"] in {"queued", "processing", "completed"}, body.get("error")
+            if body["status"] == "completed":
+                return body
+            await asyncio.sleep(0.05)
+    finally:
+        await processor.stop()
+    raise AssertionError("daw_export job never completed")
+
+
+@pytest.mark.integration
+class TestLifecycleEndToEnd:
+    async def test_cached_stems_and_midi_reused_without_re_extraction(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        from acemusic.api.tasks import extraction as extraction_tasks
+
+        # Prove no re-extraction: instantiating either client fails the job.
+        monkeypatch.setattr(extraction_tasks, "StemsClient", _ExplodingStemsClient)
+        monkeypatch.setattr(extraction_tasks, "MidiClient", _ExplodingMidiClient)
+
+        user = await _make_user("daw-cached@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title="Reused Mix", bpm=120, store_bytes=_tone_bytes())
+        await _seed_cached_stems(user, workspace, clip)
+        await _seed_cached_midi(user, workspace, clip)
+        headers = _auth_headers(user, settings)
+
+        accepted = await client.post(_daw_url(clip.id), headers=headers)
+        assert accepted.status_code == 202
+        await _run_to_completion(client, settings, accepted.json()["job_id"], headers)
+
+        # No new stem children were created (cache was reused, not regenerated).
+        stem_children = await Clip.find(Clip.generation_mode == "stems").to_list()
+        assert len(stem_children) == len(STEM_LABELS)
+
+        resp = await client.get(_daw_url(clip.id), headers=headers)
+        assert resp.status_code == 200
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            names = set(zf.namelist())
+            root = "reused-mix_Export"
+            assert f"{root}/audio/full_mix.wav" in names
+            assert {f"{root}/audio/{s}.wav" for s in CANONICAL_STEMS} <= names
+            assert {f"{root}/midi/{m}.mid" for m in MIDI_OUTPUT_LABELS} <= names
+            meta = json.loads(zf.read(f"{root}/project.json"))
+            assert meta["bpm"] == 120
+            assert {m["name"]: m["channel"] for m in meta["midi_files"]} == CHANNEL_MAP
+
+    async def test_triggers_extraction_when_not_cached(self, client, settings, local_storage, monkeypatch) -> None:
+        from acemusic.api.tasks import extraction as extraction_tasks
+
+        monkeypatch.setattr(extraction_tasks, "StemsClient", _FakeStemsClient)
+        monkeypatch.setattr(extraction_tasks, "MidiClient", _FakeMidiClient)
+
+        user = await _make_user("daw-fresh@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title="Fresh Mix", bpm=90, store_bytes=_tone_bytes())
+        headers = _auth_headers(user, settings)
+
+        accepted = await client.post(_daw_url(clip.id), headers=headers)
+        assert accepted.status_code == 202
+        await _run_to_completion(client, settings, accepted.json()["job_id"], headers)
+
+        # Extraction ran: 4 stem children linked to the source, midi_paths populated.
+        stem_children = await Clip.find(Clip.generation_mode == "stems").to_list()
+        assert {c.title for c in stem_children} == set(STEM_LABELS)
+        assert all(c.parent_clip_ids == [clip.id] for c in stem_children)
+        reloaded = await Clip.get(clip.id)
+        assert set(reloaded.midi_paths or {}) == set(MIDI_OUTPUT_LABELS)
+
+        resp = await client.get(_daw_url(clip.id), headers=headers)
+        assert resp.status_code == 200
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            root = "fresh-mix_Export"
+            assert f"{root}/project.json" in zf.namelist()


### PR DESCRIPTION
## US-14.1: DAW export endpoint

Closes #138.

Wraps the CLI's DAW bundle export in an async API endpoint so musicians can download a DAW-ready ZIP (stems + MIDI + metadata) for import into Cubase or any DAW.

### Endpoints (mounted under `/api/v1/clips`)
- `POST /clips/{id}/export/daw` → enqueues a `daw_export` job, returns **202** `{job_id, status:"queued"}` (always async, matching the editing/extraction pattern).
- `GET /clips/{id}/export/daw` → streams the assembled ZIP (`application/zip`, `Content-Disposition: attachment; filename="{slug}_Export.zip"`), **404** until the export has been built. Owner-or-public visibility, like the audio download.

### How it works
The background worker (`process_daw_export_job`):
1. **Resolves stems** — reuses the 4 cached stem child clips (US-10.2) when complete, else runs the existing `process_stems_job` worker (no second copy of the pipeline).
2. **Resolves MIDI** — reuses `clip.midi_paths` when complete, else runs `process_midi_job`.
3. Downloads the full mix + stems + MIDI, calls `assemble_daw_bundle(...)`, uploads the ZIP to a predictable `exports/{clip_id}_daw.zip` key.

A complete cached set short-circuits both — re-exporting an already-extracted clip neither re-separates nor re-extracts.

### Bundle layout
```
{slug}_Export/
  audio/{full_mix,vocals,drums,bass,other}.wav
  midi/{melody,chords,drums,bass}.mid
  project.json      # bpm, key, duration, lyrics, style_tags, model, seed,
                    # time_signature(null), stem refs, MIDI channel map
  artwork.jpg
```

### Refactor
`acemusic.daw_export.build_daw_bundle` was split: the model-agnostic assembly half is now `assemble_daw_bundle(clip, *, full_mix_path, stem_paths, midi_paths, output_path)`, so both the CLI dataclass `Clip` and the API Beanie `Clip` reuse the same ZIP/project.json logic. `build_daw_bundle` calls it — behavior unchanged (existing CLI tests still pass).

### Tests
16 new tests (`tests/test_daw_export_api.py`): pure `assemble_daw_bundle` (zip structure + every `project.json` field, CI-safe), auth gate, 404/422 cases, 202 enqueue, download + visibility, delete-cleanup, and two end-to-end runs through `JobProcessor` — one proving **cached stems/MIDI are reused without re-extraction** (extraction clients raise if instantiated) and one proving extraction is triggered when not cached.

### Acceptance criteria
- [x] ZIP has the correct directory structure
- [x] `project.json` contains all metadata fields with correct values
- [x] MIDI files carry tempo + the `CHANNEL_MAP` channel assignments
- [x] Stems are equal length / time-aligned (inherit source duration, US-10.2)
- [x] Cached stems/MIDI reused without re-extraction or extra charge

### Known limitations / decisions
- **No credits charged.** The issue text suggests 1 credit per uncached stems/MIDI extraction, but the existing US-10.2 extraction endpoints are free, and DAW export grants nothing a user couldn't already get free via `POST /stems` + `/midi`. Per maintainer decision, DAW export matches that free model. (Flagged by codex review P1 — deliberate.)
- **Non-wav sources rejected (422).** The server has no ffmpeg to transcode the full mix to wav, so compressed clips are rejected up front (mirrors editing/stems). Server-side decoding would lift this.
- **Concurrent export of the same uncached clip** can race in the shared extraction worker (delete-then-store), the same race the extraction layer already has; the editing/export routers don't dedup either. Per-clip locking is out of scope for this story.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DAW bundle export functionality, enabling users to export clips with stems, MIDI files, and full mix audio for use in Digital Audio Workstations.
  * Users can now initiate exports and download assembled bundles when ready.

* **Bug Fixes**
  * Clip deletion now properly removes associated exported bundles to prevent orphaned files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->