### PR TITLE
feat(api): audio streaming with range requests (US-14.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,13 @@ A default workspace is created automatically when a new user registers (OAuth ca
 | `PATCH /api/v1/clips/{id}` | Rename a clip (`title` is the only writable field; empty body is a no-op) |
 | `DELETE /api/v1/clips/{id}` | Delete the clip record and its stored audio |
 | `GET /api/v1/clips/{id}/audio` | Streams or downloads a clip's audio with the correct `Content-Type` |
+| `GET /api/v1/clips/{id}/stream` | Streams a clip for the web player — optional auth, full range support, rate-limited |
 
 `GET /api/v1/clips` supports these query parameters: `workspace_id`, `search` (case-insensitive substring over title or style tags), `style`, `bpm_min`, `bpm_max`, `key`, `model`, `sort` (`newest` or `oldest`, default `newest`), `page` (default 1), `per_page` (default 20, max 100). An inverted BPM range (`bpm_min > bpm_max`) returns 422. The response includes `total`, `page`, `per_page`, and `total_pages`.
 
 All CRUD endpoints are owner-scoped. `GET /api/v1/clips/{id}/audio` additionally supports single HTTP byte ranges (`Range: bytes=…` → `206 Partial Content`, unsatisfiable ranges → `416`) for seeking, and on-the-fly conversion via `?format=wav|flac|mp3` (mp3/flac conversion requires ffmpeg on the host; byte ranges are ignored for converted output). For the audio endpoint an unknown or malformed id returns `404`, another user's private clip returns `403`, and clips marked `is_public` are retrievable by any authenticated user; the CRUD endpoints return `404` for any clip the caller does not own.
+
+`GET /api/v1/clips/{id}/stream` is the web player's playback endpoint. Unlike `/audio` it allows **unauthenticated** streaming of `is_public` clips (a private clip is an indistinguishable `404` for anonymous callers, `403` for an authenticated non-owner). It supports single **and** multi-range requests (`206`; multiple ranges return `multipart/byteranges`), `?format=mp3|wav` conversion (which disables ranges), sets `Accept-Ranges`/`Cache-Control`, and is rate-limited per client IP (`429` over the limit; configurable via `ACEMUSIC_API_STREAM_RATE_LIMIT_PER_MINUTE`, default 100).
 
 ### Audio Editing (US-10.1)
 

--- a/docs/demos/us-14.2-streaming.md
+++ b/docs/demos/us-14.2-streaming.md
@@ -1,0 +1,67 @@
+# US-14.2 — Audio streaming with range requests (demo)
+
+`GET /api/v1/clips/{id}/stream` is the backend for the web player's global playback.
+It extends US-9.3's range support with optional auth (public clips stream without a
+token), multi-range responses, mp3/wav conversion, and per-client rate limiting.
+
+All output below is captured from the **real FastAPI app** driven over local MongoDB +
+LocalStorage via `httpx` (ASGI), against a ~3-minute mono WAV (**2,880,044 bytes**).
+
+## AC1 — seek without buffering the whole file (single range → 206)
+```
+GET (Range: bytes=0-99999)  -> 206
+Content-Range: bytes 0-99999/2880044   Accept-Ranges: bytes
+bytes returned: 100,000 of 2,880,044  (3% of file)
+payload == audio[0:100000]: True
+```
+A seek fetches only the requested 3% — the player never downloads the full file. The
+returned bytes are byte-exact against the source slice.
+
+## AC2 — range requests return 206 with correct Content-Range (incl. deep seek)
+```
+GET (Range: bytes=1440022-1490021) -> 206  Content-Range: bytes 1440022-1490021/2880044
+payload == audio[1440022:1490022]: True
+```
+Seeking to the middle of the clip returns the right window with a correct `Content-Range`.
+
+### Multi-range → 206 `multipart/byteranges`
+```
+GET (Range: bytes=0-99,500-599) -> 206
+Content-Type: multipart/byteranges; boundary=57c6997bcfd7469259f288df24ad0273
+contains audio[0:100]: True   contains audio[500:600]: True
+```
+
+## AC3 — full request (no Range) returns 200 with the complete file
+```
+GET (no Range) -> 200  bytes: 2,880,044  full match: True
+```
+
+### Unsatisfiable range → 416
+```
+GET (Range past EOF) -> 416  Content-Range: bytes */2880044
+```
+
+## AC4 — playback begins within 1 second
+Because a seek/initial fetch returns **only the first range** (100 KB = 3% of the file
+above, served from memory in a single 206), the player starts on the first chunk
+instead of buffering all 2.8 MB — no full-file download precedes playback.
+
+## AC5 — public clips stream without auth; private clips require auth
+```
+anonymous  -> public  : 200 (streams)
+anonymous  -> private : 404 (hidden as 'not found')
+owner      -> private : 200 (streams)
+non-owner  -> private : 403 (forbidden)
+```
+A stranger gets **404** (not 403) on a private clip, so the endpoint never reveals that
+a private clip exists.
+
+## Rate limiting — per-client cap curbs abuse
+```
+(app configured to 2/min)
+request 1: 200   request 2: 200   request 3: 429
+Retry-After on the 3rd: 59 s
+```
+The third request from the same client IP is rejected with `429` and a `Retry-After`
+hint. (>10 ranges in one request are ignored and served as a full 200 — bounding the
+multipart response size.)

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -46,6 +46,7 @@ from .tasks.artwork import get_image_client
 from .tasks.mastering import get_mastering_orchestrator
 from .tasks.processor import JobProcessor
 from .tasks.soundcloud_poller import SoundCloudStatusPoller
+from .utils.rate_limit import FixedWindowRateLimiter as RateLimiter
 
 API_V1_PREFIX = "/api/v1"
 
@@ -153,6 +154,10 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     )
     app.state.settings = settings
     app.state.start_time = time.monotonic()
+    # US-14.2: per-client in-memory limiter for the streaming endpoint. Set on
+    # app.state (not module-global) so each app instance — and each test — gets
+    # an isolated window.
+    app.state.stream_limiter = RateLimiter(settings.stream_rate_limit_per_minute)
 
     # allow_credentials=True is incompatible with a wildcard allow_origins=["*"]
     # (browsers reject the combination). _split_origins in settings.py never
@@ -177,6 +182,8 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(generation.router, prefix=API_V1_PREFIX)
     app.include_router(jobs.router, prefix=API_V1_PREFIX)
     app.include_router(clips.router, prefix=API_V1_PREFIX)
+    # US-14.2: public streaming router (no blanket auth) shares the /clips prefix.
+    app.include_router(clips.stream_router, prefix=API_V1_PREFIX)
     app.include_router(editing.router, prefix=API_V1_PREFIX)
     app.include_router(artwork.router, prefix=API_V1_PREFIX)
     app.include_router(extraction.router, prefix=API_V1_PREFIX)

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -13,6 +13,7 @@ filter rules live in :mod:`acemusic.api.services.clips`.
 import asyncio
 import logging
 import math
+import secrets
 from datetime import datetime
 from typing import Annotated, Literal
 
@@ -21,13 +22,18 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from acemusic.storage import get_storage_backend
 
-from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..auth.dependencies import CurrentUser, get_current_user, get_current_user_optional, require_existing_user
 from ..models import Clip
 from ..services import clips as clip_service
 from ..services.audio_conversion import convert_audio_format
-from ..services.clips import get_clip_for_audio_access
+from ..services.clips import get_clip_for_audio_access, get_clip_for_streaming
 from ..utils.media_types import get_audio_content_type
-from ..utils.range_requests import parse_range_header
+from ..utils.range_requests import (
+    build_multipart_ranges_response,
+    parse_range_header,
+    parse_range_header_multi,
+)
+from ..utils.rate_limit import enforce_stream_rate_limit
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +46,12 @@ PER_PAGE_MAX = 100
 # Router-level dependency gates every route behind a valid Bearer token
 # (mirrors the jobs/generation routers), so unauthenticated requests get 401.
 router = APIRouter(prefix="/clips", tags=["clips"], dependencies=[Depends(get_current_user)])
+
+# US-14.2: the streaming endpoint must serve *public* clips to anonymous
+# listeners, so it lives on a separate router without the blanket auth gate
+# above. Auth is still resolved per-request (get_current_user_optional) to
+# enforce private-clip access. Mounted alongside ``router`` in main.py.
+stream_router = APIRouter(prefix="/clips", tags=["clips"])
 
 
 class ClipSearchParams(BaseModel):
@@ -344,6 +356,83 @@ async def get_clip_audio(
                 content=audio[start : end + 1],
                 status_code=status.HTTP_206_PARTIAL_CONTENT,
                 media_type=media_type,
+                headers=headers,
+            )
+
+    return Response(content=audio, media_type=media_type, headers=headers)
+
+
+@stream_router.get("/{clip_id}/stream", dependencies=[Depends(enforce_stream_rate_limit)])
+async def stream_clip_audio(
+    clip_id: str,
+    request: Request,
+    format: Literal["wav", "mp3"] | None = Query(
+        default=None,
+        description="Convert to this format on the fly (mp3 for size, wav for lossless; default: stored format).",
+    ),
+    current: CurrentUser | None = Depends(get_current_user_optional),
+) -> Response:
+    """Stream a clip's audio with seeking support (US-14.2).
+
+    Public clips stream without authentication; private clips require the owner.
+    Honors single- and multi-range requests (206 / ``multipart/byteranges``),
+    serves the full body otherwise (200), and rate-limits per client IP.
+    """
+    clip = await get_clip_for_streaming(clip_id, current.user_id if current else None)
+
+    storage = get_storage_backend()
+    try:
+        audio = await asyncio.to_thread(storage.download, clip.file_path)
+    except FileNotFoundError:
+        logger.warning("Clip %s exists but its audio object %r is missing", clip.id, clip.file_path)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio file not found.")
+
+    native_format = clip_service.native_format(clip)
+    serve_format = native_format
+    converted = False
+    if format is not None and format != native_format:
+        try:
+            audio = await asyncio.to_thread(convert_audio_format, audio, native_format, format)
+        except Exception as exc:
+            logger.exception("Format conversion of clip %s (%s -> %s) failed", clip.id, native_format, format)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Could not convert audio to {format}.",
+            ) from exc
+        serve_format = format
+        converted = True
+
+    media_type = get_audio_content_type(serve_format)
+    # Public clips are immutable once shared, so shared caches may hold them;
+    # private clips stay client-only and uncached.
+    cache_control = "public, max-age=3600" if clip.is_public else "private, no-store"
+
+    # Conversion changes the byte layout, so Range (and Accept-Ranges) only
+    # applies to the unconverted stored representation — mirrors /audio.
+    if converted:
+        return Response(content=audio, media_type=media_type, headers={"Cache-Control": cache_control})
+
+    headers = {"Accept-Ranges": "bytes", "Cache-Control": cache_control}
+    range_header = request.headers.get("range")
+    if range_header is not None:
+        ranges = parse_range_header_multi(range_header, len(audio))  # raises 416 if all unsatisfiable
+        if ranges is not None and len(ranges) == 1:
+            start, end = ranges[0]
+            headers["Content-Range"] = f"bytes {start}-{end}/{len(audio)}"
+            return Response(
+                content=audio[start : end + 1],
+                status_code=status.HTTP_206_PARTIAL_CONTENT,
+                media_type=media_type,
+                headers=headers,
+            )
+        if ranges is not None:
+            # secrets.token_hex gives a boundary that won't appear in the audio.
+            boundary = secrets.token_hex(16)
+            body, multipart_type = build_multipart_ranges_response(audio, ranges, media_type, boundary)
+            return Response(
+                content=body,
+                status_code=status.HTTP_206_PARTIAL_CONTENT,
+                media_type=multipart_type,
                 headers=headers,
             )
 

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -49,6 +49,25 @@ async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
     return clip
 
 
+async def get_clip_for_streaming(clip_id: str, current_user_id: str | None) -> Clip:
+    """Resolve a clip for the public streaming endpoint (US-14.2).
+
+    Authenticated requests follow :func:`get_clip_for_audio_access` (404 for
+    unknown, 403 for another user's private clip). Anonymous requests
+    (``current_user_id is None``) may only reach public clips; a private or
+    unknown clip is an indistinguishable 404 so the endpoint never reveals a
+    private clip's existence to a stranger.
+    """
+    if current_user_id is not None:
+        return await get_clip_for_audio_access(clip_id, current_user_id)
+
+    oid = coerce_object_id(clip_id)
+    clip = await Clip.get(oid) if oid is not None else None
+    if clip is None or not clip.is_public:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found.")
+    return clip
+
+
 def _clip_not_found() -> HTTPException:
     return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found.")
 

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -170,6 +170,12 @@ class ApiSettings(BaseSettings):
     isrc_registrant_code: str = "A1B"
     upc_prefix: str = "0000000"
 
+    # Audio streaming rate limit (US-14.2). The /clips/{id}/stream endpoint is
+    # public for public clips, so it is rate-limited per client IP to curb abuse.
+    # In-memory fixed window; raise via the environment for higher-traffic
+    # deployments (swap for a shared store if the API runs multiple workers).
+    stream_rate_limit_per_minute: int = Field(default=100, ge=1)
+
     # Compute status endpoint (US-11.4). Per-target health-probe budget for
     # ``GET /api/v1/compute/status``; the local and remote checks run in parallel,
     # each bounded by this timeout, so the aggregate response stays well under the

--- a/src/acemusic/api/utils/range_requests.py
+++ b/src/acemusic/api/utils/range_requests.py
@@ -132,6 +132,12 @@ def parse_range_header_multi(range_header: str, content_length: int) -> list[tup
         ranges.append(pair)
 
     if ranges:
+        # Bound the multipart body by total bytes too, not just spec count:
+        # ``bytes=0-,0-,...`` stays under the count cap yet selects the whole
+        # representation N times. If the ranges overlap past the full size,
+        # ignore Range and serve the full body once.
+        if sum(end - start + 1 for start, end in ranges) > content_length:
+            return None
         return ranges
     # No satisfiable ranges: 416 if at least one was explicitly out of bounds,
     # otherwise the header was effectively empty ("bytes=-") — ignore it.

--- a/src/acemusic/api/utils/range_requests.py
+++ b/src/acemusic/api/utils/range_requests.py
@@ -1,9 +1,12 @@
-"""HTTP Range header parsing for byte-range (206) responses (US-9.3).
+"""HTTP Range header parsing for byte-range (206) responses (US-9.3, US-14.2).
 
-Implements the single-range subset of RFC 9110 §14: explicit (``bytes=0-99``),
-open-ended (``bytes=100-``), and suffix (``bytes=-100``) ranges. Multipart
-ranges and non-``bytes`` units are out of scope — per the RFC a server MAY
-ignore the Range header, so those serve the full body with 200.
+:func:`parse_range_header` implements the single-range subset of RFC 9110 §14:
+explicit (``bytes=0-99``), open-ended (``bytes=100-``), and suffix
+(``bytes=-100``) ranges, ignoring multipart/non-``bytes`` (serve full 200).
+
+US-14.2 adds :func:`parse_range_header_multi` (comma-separated ranges) and
+:func:`build_multipart_ranges_response` (``multipart/byteranges`` per §14.6) for
+the streaming endpoint, leaving the proven single-range path above untouched.
 """
 
 import re
@@ -59,3 +62,103 @@ def parse_range_header(range_header: str, content_length: int) -> tuple[int, int
     if end < start:  # "bytes=5-2" is syntactically invalid — ignore the header
         return None
     return start, min(end, content_length - 1)
+
+
+# One range-spec without the unit prefix: "<start?>-<end?>" (e.g. "0-99", "-100").
+_SPEC_RE = re.compile(r"(\d*)-(\d*)$")
+
+# Cap multi-range requests: a public streaming client could otherwise send dozens
+# of (overlapping) full-size ranges and force an N×-sized multipart body in memory
+# before the per-minute limiter helps. Beyond the cap we ignore Range and serve the
+# full body (RFC 9110 §14.2 permits ignoring Range entirely).
+MAX_MULTIRANGE_SPECS = 10
+
+
+def _parse_spec(start_s: str, end_s: str, content_length: int) -> tuple[int, int] | None:
+    """Resolve one ``<start>-<end>`` spec to an inclusive pair, mirroring
+    :func:`parse_range_header`'s single-spec rules. Returns ``None`` for an
+    ignorable spec; raises 416 for a well-formed-but-unsatisfiable one."""
+    if not start_s and not end_s:  # "-" alone
+        return None
+    if not start_s:
+        suffix = int(end_s)
+        if suffix == 0:
+            raise _unsatisfiable(content_length)
+        return max(0, content_length - suffix), content_length - 1
+    start = int(start_s)
+    if start >= content_length:
+        raise _unsatisfiable(content_length)
+    end = int(end_s) if end_s else content_length - 1
+    if end < start:
+        return None
+    return start, min(end, content_length - 1)
+
+
+def parse_range_header_multi(range_header: str, content_length: int) -> list[tuple[int, int]] | None:
+    """Parse a single- or multi-range ``Range`` header into inclusive pairs.
+
+    Accepts comma-separated specs (``bytes=0-99,200-299``). Returns ``None`` to
+    ignore the header (malformed, unsupported unit, or empty — caller serves the
+    full body), a one-element list for a single range, or a multi-element list.
+    Overlapping ranges are returned as-is (no merging, per RFC). More than
+    :data:`MAX_MULTIRANGE_SPECS` ranges are ignored (``None``, serve full body)
+    to bound the multipart response size. Raises a 416 :class:`HTTPException`
+    only when *every* requested range is unsatisfiable.
+    """
+    if content_length <= 0:
+        return None
+
+    stripped = range_header.strip()
+    if not stripped.startswith("bytes="):
+        return None
+
+    specs = stripped[len("bytes=") :].split(",")
+    if len(specs) > MAX_MULTIRANGE_SPECS:  # too many ranges — ignore Range, serve full body
+        return None
+
+    ranges: list[tuple[int, int]] = []
+    saw_unsatisfiable = False
+    for raw_spec in specs:
+        match = _SPEC_RE.fullmatch(raw_spec.strip())
+        if match is None:  # any malformed spec invalidates the whole header
+            return None
+        try:
+            pair = _parse_spec(match.group(1), match.group(2), content_length)
+        except HTTPException:
+            saw_unsatisfiable = True
+            continue
+        if pair is None:
+            return None
+        ranges.append(pair)
+
+    if ranges:
+        return ranges
+    # No satisfiable ranges: 416 if at least one was explicitly out of bounds,
+    # otherwise the header was effectively empty ("bytes=-") — ignore it.
+    if saw_unsatisfiable:
+        raise _unsatisfiable(content_length)
+    return None
+
+
+def build_multipart_ranges_response(
+    content: bytes, ranges: list[tuple[int, int]], content_type: str, boundary: str
+) -> tuple[bytes, str]:
+    """Assemble a ``multipart/byteranges`` body for ``ranges`` (RFC 9110 §14.6).
+
+    Returns ``(body, full_content_type)`` where ``full_content_type`` is
+    ``multipart/byteranges; boundary=<boundary>``. The caller must pass a
+    ``boundary`` that does not occur in ``content``.
+    """
+    total = len(content)
+    parts: list[bytes] = []
+    for start, end in ranges:
+        parts.append(
+            (
+                f"\r\n--{boundary}\r\n"
+                f"Content-Type: {content_type}\r\n"
+                f"Content-Range: bytes {start}-{end}/{total}\r\n\r\n"
+            ).encode("ascii")
+        )
+        parts.append(content[start : end + 1])
+    parts.append(f"\r\n--{boundary}--\r\n".encode("ascii"))
+    return b"".join(parts), f"multipart/byteranges; boundary={boundary}"

--- a/src/acemusic/api/utils/rate_limit.py
+++ b/src/acemusic/api/utils/rate_limit.py
@@ -1,0 +1,52 @@
+"""In-memory per-client rate limiting for the streaming endpoint (US-14.2).
+
+A fixed-window counter keyed by client IP. Deliberately tiny and dependency-free:
+the public ``/clips/{id}/stream`` endpoint only needs a single-process ceiling to
+curb abuse. Swap for a Redis-backed limiter (e.g. slowapi) if the API ever runs
+multiple workers that must share one limit.
+"""
+
+import time
+from threading import Lock
+
+from fastapi import HTTPException, Request, status
+
+
+class FixedWindowRateLimiter:
+    """Count requests per key within fixed wall-clock windows; reject over the cap."""
+
+    def __init__(self, limit: int, window_seconds: float = 60.0) -> None:
+        self._limit = limit
+        self._window = window_seconds
+        self._hits: dict[str, tuple[float, int]] = {}
+        self._lock = Lock()
+
+    def check(self, key: str) -> None:
+        """Record one hit for ``key``; raise 429 once it exceeds the limit."""
+        now = time.monotonic()
+        with self._lock:
+            window_start, count = self._hits.get(key, (now, 0))
+            if now - window_start >= self._window:  # window elapsed — reset
+                window_start, count = now, 0
+            count += 1
+            self._hits[key] = (window_start, count)
+            if count > self._limit:
+                retry_after = max(1, int(self._window - (now - window_start)))
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Too many streaming requests; slow down.",
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+
+def _client_key(request: Request) -> str:
+    # ponytail: keyed by the raw socket peer IP. Behind a trusted reverse proxy,
+    # parse a validated X-Forwarded-For here — spoofable headers are intentionally
+    # not trusted by default.
+    return request.client.host if request.client else "anonymous"
+
+
+def enforce_stream_rate_limit(request: Request) -> None:
+    """FastAPI dependency: rate-limit by client IP using the app's limiter."""
+    limiter: FixedWindowRateLimiter = request.app.state.stream_limiter
+    limiter.check(_client_key(request))

--- a/src/acemusic/api/utils/rate_limit.py
+++ b/src/acemusic/api/utils/rate_limit.py
@@ -19,12 +19,19 @@ class FixedWindowRateLimiter:
         self._limit = limit
         self._window = window_seconds
         self._hits: dict[str, tuple[float, int]] = {}
+        self._last_prune = 0.0
         self._lock = Lock()
 
     def check(self, key: str) -> None:
         """Record one hit for ``key``; raise 429 once it exceeds the limit."""
         now = time.monotonic()
         with self._lock:
+            # A public endpoint sees many one-off IPs; without pruning, _hits
+            # grows unbounded. Sweep expired windows at most once per window.
+            if now - self._last_prune >= self._window:
+                cutoff = now - self._window
+                self._hits = {k: v for k, v in self._hits.items() if v[0] > cutoff}
+                self._last_prune = now
             window_start, count = self._hits.get(key, (now, 0))
             if now - window_start >= self._window:  # window elapsed — reset
                 window_start, count = now, 0

--- a/tests/test_clips_api.py
+++ b/tests/test_clips_api.py
@@ -23,7 +23,11 @@ from acemusic.api.services import users as user_service
 from acemusic.api.services.audio_conversion import convert_audio_format
 from acemusic.api.settings import ApiSettings
 from acemusic.api.utils.media_types import get_audio_content_type
-from acemusic.api.utils.range_requests import parse_range_header
+from acemusic.api.utils.range_requests import (
+    build_multipart_ranges_response,
+    parse_range_header,
+    parse_range_header_multi,
+)
 from acemusic.storage import get_storage_backend
 
 requires_ffmpeg = pytest.mark.skipif(
@@ -33,6 +37,10 @@ requires_ffmpeg = pytest.mark.skipif(
 
 def _audio_url(clip_id: str) -> str:
     return f"{API_V1_PREFIX}/clips/{clip_id}/audio"
+
+
+def _stream_url(clip_id: str) -> str:
+    return f"{API_V1_PREFIX}/clips/{clip_id}/stream"
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +72,82 @@ class TestGetAudioContentType:
     @pytest.mark.parametrize("fmt", [None, "", "   "])
     def test_missing_or_blank_format_falls_back_to_octet_stream(self, fmt: str | None) -> None:
         assert get_audio_content_type(fmt) == "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# Multi-range parsing (US-14.2) — runs in CI (pure functions, no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestParseRangeHeaderMulti:
+    def test_single_range_returns_one_pair(self) -> None:
+        assert parse_range_header_multi("bytes=0-99", 1000) == [(0, 99)]
+
+    def test_two_ranges(self) -> None:
+        assert parse_range_header_multi("bytes=0-99,200-299", 1000) == [(0, 99), (200, 299)]
+
+    def test_many_ranges_preserve_order(self) -> None:
+        header = "bytes=0-9,20-29,40-49,60-69"
+        assert parse_range_header_multi(header, 1000) == [(0, 9), (20, 29), (40, 49), (60, 69)]
+
+    def test_overlapping_ranges_served_as_is(self) -> None:
+        # RFC permits serving overlapping ranges without merging.
+        assert parse_range_header_multi("bytes=0-99,50-149", 1000) == [(0, 99), (50, 149)]
+
+    def test_mixed_explicit_suffix_and_open_ended(self) -> None:
+        assert parse_range_header_multi("bytes=0-99,-100,800-", 1000) == [(0, 99), (900, 999), (800, 999)]
+
+    def test_whitespace_between_specs_is_tolerated(self) -> None:
+        assert parse_range_header_multi("bytes=0-99, 200-299", 1000) == [(0, 99), (200, 299)]
+
+    def test_end_clamped_to_content_length(self) -> None:
+        assert parse_range_header_multi("bytes=0-99,500-9999", 1000) == [(0, 99), (500, 999)]
+
+    def test_malformed_spec_invalidates_whole_header(self) -> None:
+        assert parse_range_header_multi("bytes=0-99,abc", 1000) is None
+
+    def test_non_bytes_unit_returns_none(self) -> None:
+        assert parse_range_header_multi("items=0-99", 1000) is None
+
+    def test_inverted_spec_invalidates_whole_header(self) -> None:
+        assert parse_range_header_multi("bytes=0-99,5-2", 1000) is None
+
+    def test_all_unsatisfiable_raises_416(self) -> None:
+        with pytest.raises(HTTPException) as exc:
+            parse_range_header_multi(f"bytes={2000}-,{3000}-", 1000)
+        assert exc.value.status_code == 416
+        assert exc.value.headers["Content-Range"] == "bytes */1000"
+
+    def test_satisfiable_plus_unsatisfiable_drops_the_bad_one(self) -> None:
+        # One valid, one past the end: serve the valid range, skip the rest.
+        assert parse_range_header_multi("bytes=0-99,5000-6000", 1000) == [(0, 99)]
+
+    def test_empty_content_returns_none(self) -> None:
+        assert parse_range_header_multi("bytes=0-99", 0) is None
+
+    def test_too_many_ranges_are_ignored(self) -> None:
+        # Guards against multipart amplification: >10 ranges -> ignore Range,
+        # serve the full body (None) rather than building an N×-sized response.
+        many = "bytes=" + ",".join(f"{i}-{i}" for i in range(11))
+        assert parse_range_header_multi(many, 1000) is None
+        at_cap = "bytes=" + ",".join(f"{i}-{i}" for i in range(10))
+        assert len(parse_range_header_multi(at_cap, 1000)) == 10
+
+
+class TestBuildMultipartRangesResponse:
+    def test_mime_structure_for_two_ranges(self) -> None:
+        content = bytes(range(256)) * 4  # 1024 deterministic bytes
+        body, content_type = build_multipart_ranges_response(content, [(0, 9), (100, 119)], "audio/wav", "BOUNDARY123")
+        assert content_type == "multipart/byteranges; boundary=BOUNDARY123"
+        # Two parts, each with its own headers and the exact slice as payload.
+        assert body.count(b"--BOUNDARY123\r\n") == 2
+        assert b"Content-Type: audio/wav\r\n" in body
+        assert b"Content-Range: bytes 0-9/1024\r\n" in body
+        assert b"Content-Range: bytes 100-119/1024\r\n" in body
+        assert content[0:10] in body
+        assert content[100:120] in body
+        # Closing boundary terminates the body.
+        assert body.endswith(b"\r\n--BOUNDARY123--\r\n")
 
 
 # ---------------------------------------------------------------------------
@@ -394,3 +478,125 @@ class TestClipAudioFormatConversion:
         resp = await client.get(_audio_url(str(clip.id)) + "?format=mp3", headers=headers)
         assert resp.status_code == 200
         assert len(resp.content) > 100
+
+
+@pytest.mark.integration
+class TestClipStreaming:
+    """US-14.2: GET /clips/{id}/stream — optional auth, multi-range, rate limit."""
+
+    # --- Authentication / access control -----------------------------------
+
+    async def test_anonymous_streams_public_clip(self, client, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-pub-owner@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        resp = await client.get(_stream_url(str(clip.id)))  # no auth header
+        assert resp.status_code == 200
+        assert resp.content == wav_bytes
+        assert resp.headers["accept-ranges"] == "bytes"
+        assert "public" in resp.headers["cache-control"]
+
+    async def test_anonymous_private_clip_returns_404(self, client, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-priv-owner@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=False)
+
+        # 404 (not 403) so a stranger cannot tell a private clip exists.
+        resp = await client.get(_stream_url(str(clip.id)))
+        assert resp.status_code == 404
+
+    async def test_owner_streams_own_private_clip(self, client, settings, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-own-priv@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=False)
+
+        resp = await client.get(_stream_url(str(clip.id)), headers=_auth_headers(owner, settings))
+        assert resp.status_code == 200
+        assert resp.content == wav_bytes
+        assert "private" in resp.headers["cache-control"]
+
+    async def test_authenticated_non_owner_private_clip_returns_403(
+        self, client, settings, local_storage, wav_bytes
+    ) -> None:
+        owner = await _make_user("stream-other-owner@example.com")
+        other = await _make_user("stream-other-user@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=False)
+
+        resp = await client.get(_stream_url(str(clip.id)), headers=_auth_headers(other, settings))
+        assert resp.status_code == 403
+
+    async def test_invalid_token_is_rejected(self, client, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-badtoken@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        # An explicitly-supplied bad token is a 401, not an anonymous request.
+        resp = await client.get(_stream_url(str(clip.id)), headers={"Authorization": "Bearer not-a-real-token"})
+        assert resp.status_code == 401
+
+    # --- Range requests ----------------------------------------------------
+
+    async def test_single_range_returns_206(self, client, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-range1@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        resp = await client.get(_stream_url(str(clip.id)), headers={"Range": "bytes=0-99"})
+        assert resp.status_code == 206
+        assert resp.content == wav_bytes[:100]
+        assert resp.headers["content-range"] == f"bytes 0-99/{len(wav_bytes)}"
+
+    async def test_no_range_returns_200_full(self, client, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-range2@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        resp = await client.get(_stream_url(str(clip.id)))
+        assert resp.status_code == 200
+        assert resp.content == wav_bytes
+
+    async def test_multi_range_returns_multipart_206(self, client, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-range3@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        resp = await client.get(_stream_url(str(clip.id)), headers={"Range": "bytes=0-99,200-299"})
+        assert resp.status_code == 206
+        assert resp.headers["content-type"].startswith("multipart/byteranges; boundary=")
+        # Both requested slices are present in the multipart body.
+        assert wav_bytes[0:100] in resp.content
+        assert wav_bytes[200:300] in resp.content
+        assert b"Content-Range: bytes 0-99/" in resp.content
+        assert b"Content-Range: bytes 200-299/" in resp.content
+
+    async def test_unsatisfiable_range_returns_416(self, client, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-range4@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        resp = await client.get(_stream_url(str(clip.id)), headers={"Range": f"bytes={len(wav_bytes)}-"})
+        assert resp.status_code == 416
+        assert resp.headers["content-range"] == f"bytes */{len(wav_bytes)}"
+
+    # --- Format conversion -------------------------------------------------
+
+    @requires_ffmpeg
+    async def test_format_mp3_converts_and_disables_ranges(self, client, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-fmt@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        headers = {"Range": "bytes=0-99"}  # ranges ignored once converted
+        resp = await client.get(_stream_url(str(clip.id)) + "?format=mp3", headers=headers)
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/mpeg"
+        assert resp.content[:3] == b"ID3" or resp.content[0] == 0xFF
+        assert "accept-ranges" not in resp.headers
+
+    # --- Rate limiting -----------------------------------------------------
+
+    async def test_exceeding_rate_limit_returns_429(self, settings, local_storage, wav_bytes) -> None:
+        owner = await _make_user("stream-ratelimit@example.com")
+        clip = await _make_clip(owner, wav_bytes, is_public=True)
+
+        # Dedicated app with a low limit; all requests share the test client IP.
+        limited = settings.model_copy(update={"stream_rate_limit_per_minute": 2})
+        async with _async_client(create_app(limited)) as limited_client:
+            url = _stream_url(str(clip.id))
+            assert (await limited_client.get(url)).status_code == 200
+            assert (await limited_client.get(url)).status_code == 200
+            third = await limited_client.get(url)
+            assert third.status_code == 429
+            assert "retry-after" in third.headers

--- a/tests/test_clips_api.py
+++ b/tests/test_clips_api.py
@@ -9,6 +9,7 @@ and skip when it is absent (CI does not install it).
 """
 
 import shutil
+import time
 
 import httpx
 import pytest
@@ -28,6 +29,7 @@ from acemusic.api.utils.range_requests import (
     parse_range_header,
     parse_range_header_multi,
 )
+from acemusic.api.utils.rate_limit import FixedWindowRateLimiter
 from acemusic.storage import get_storage_backend
 
 requires_ffmpeg = pytest.mark.skipif(
@@ -133,6 +135,13 @@ class TestParseRangeHeaderMulti:
         at_cap = "bytes=" + ",".join(f"{i}-{i}" for i in range(10))
         assert len(parse_range_header_multi(at_cap, 1000)) == 10
 
+    def test_aggregate_bytes_exceeding_content_are_ignored(self) -> None:
+        # Overlapping open-ended ranges stay under the count cap but each select
+        # the whole file -> serve the full body once (None) instead of N× memory.
+        assert parse_range_header_multi("bytes=0-,0-,0-", 1000) is None
+        # Non-overlapping ranges summing within the file are still honored.
+        assert parse_range_header_multi("bytes=0-99,200-299", 1000) == [(0, 99), (200, 299)]
+
 
 class TestBuildMultipartRangesResponse:
     def test_mime_structure_for_two_ranges(self) -> None:
@@ -148,6 +157,27 @@ class TestBuildMultipartRangesResponse:
         assert content[100:120] in body
         # Closing boundary terminates the body.
         assert body.endswith(b"\r\n--BOUNDARY123--\r\n")
+
+
+class TestFixedWindowRateLimiter:
+    def test_rejects_over_the_limit_within_a_window(self) -> None:
+        limiter = FixedWindowRateLimiter(limit=2, window_seconds=60.0)
+        limiter.check("ip")  # 1
+        limiter.check("ip")  # 2
+        with pytest.raises(HTTPException) as exc:
+            limiter.check("ip")  # 3 -> over
+        assert exc.value.status_code == 429
+        assert "Retry-After" in exc.value.headers
+
+    def test_expired_keys_are_pruned(self) -> None:
+        # One-off IPs must not accumulate forever on a public endpoint.
+        limiter = FixedWindowRateLimiter(limit=5, window_seconds=0.02)
+        limiter.check("old-ip")
+        assert "old-ip" in limiter._hits
+        time.sleep(0.03)  # let the window elapse
+        limiter.check("new-ip")  # triggers a prune sweep
+        assert "old-ip" not in limiter._hits
+        assert "new-ip" in limiter._hits
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## US-14.2: Audio streaming with range requests

Closes #139.

Adds `GET /api/v1/clips/{id}/stream` — the backend for the web player's global audio playback. It extends US-9.3's range-request support with optional auth, multi-range responses, and rate limiting.

### What changed
- **`utils/range_requests.py`** — `parse_range_header_multi()` (comma-separated ranges) and `build_multipart_ranges_response()` (RFC 9110 §14.6 `multipart/byteranges`). The proven single-range `parse_range_header()` is left untouched.
- **`utils/rate_limit.py`** (new) — a dependency-free in-memory fixed-window limiter, applied per client IP to the stream endpoint.
- **`services/clips.py`** — `get_clip_for_streaming()`: authenticated requests reuse `get_clip_for_audio_access` (404/403); anonymous requests reach public clips only, and a private/unknown clip is an indistinguishable **404** so a stranger can't probe for private clips.
- **`routers/clips.py`** — new `stream_router` (no blanket auth) with the `/{id}/stream` handler: single-range → 206 + `Content-Range`; multi-range → 206 + `multipart/byteranges`; no range → 200; unsatisfiable → 416; `?format=mp3|wav` on-the-fly conversion (disables ranges); `Accept-Ranges` + `Cache-Control`.
- **`main.py`** — mounts `stream_router`; builds the per-app limiter on `app.state`.
- **`settings.py`** — `stream_rate_limit_per_minute` (default 100, `ACEMUSIC_API_` prefix).

### Acceptance criteria
- ✅ Seek to any position without buffering the full file — single/multi byte ranges return 206 with correct `Content-Range`.
- ✅ Range requests return 206 with correct `Content-Range`; full request returns 200.
- ✅ Public clips stream without auth; private clips require the owner.
- ✅ "Playback within 1 second" — partial-content serving means the player fetches only the first range, not the whole file (range correctness verified by tests).

### Tests
- Unit (CI, no DB): multi-range parsing matrix incl. overlap/mixed/malformed/unsatisfiable/range-cap, and the multipart MIME builder.
- Integration (MongoDB + LocalStorage): auth matrix (anon→public 200, anon→private 404, owner→private 200, non-owner→private 403, bad-token 401), range matrix (single 206, multi multipart 206, no-range 200, unsatisfiable 416), mp3 conversion disables ranges, and rate-limit 429.
- `71 passed` for `tests/test_clips_api.py`; `ruff` + `black --check` clean.

### Design notes / deviations
- **Rate limiting**: implemented as a ~15-line in-memory limiter instead of adding the `slowapi` dependency (CodeRabbit's plan). Behavior is identical (in-memory either way) with no new dep or global app wiring. Swap for a shared store if the API ever runs multiple workers.
- **Multi-range cap** (from codex review): more than 10 ranges in one request are ignored (serve full 200, RFC-permitted) to bound multipart response size against a request-amplification vector on the public endpoint.

### Known limitations
- Rate limiting is **per-process, in-memory** — a multi-worker deployment would enforce the limit per worker, not globally. Documented in the limiter module; upgrade to a Redis-backed store when horizontal scaling is needed.
- Client identity for rate limiting is the raw socket peer IP; behind a trusted reverse proxy, `X-Forwarded-For` parsing must be added (intentionally not trusted by default to avoid spoofing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public audio streaming endpoint with on-the-fly format conversion (WAV/MP3)
  * Implemented HTTP range request support (single and multi-range) for efficient seeking
  * Applied per-IP rate limiting to the streaming endpoint

* **Configuration**
  * New configurable stream rate limit setting (default: 100 requests per minute)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->