### PR TITLE
US-14.3: Playback queue API (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,23 @@ reported as unavailable, never a 5xx. `max_workers` is left `null` (RunPod's
 
 A default workspace is created automatically when a new user registers (OAuth callback). The get-or-create call is idempotent, so subsequent logins are a cheap lookup and accounts created before this feature are backfilled on their next login.
 
+### Playback Queue (US-14.3)
+
+A single server-side playback queue per user, so the web player can queue clips, support next/previous, and restore state across page navigations.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/queue` | Add clips at an optional `position` (appends by default) |
+| `GET /api/v1/queue` | Current queue, playback position, and modes |
+| `DELETE /api/v1/queue/{clip_id}` | Remove a clip (404 if not in the queue) |
+| `POST /api/v1/queue/next` | Advance to the next clip (repeat/shuffle aware) |
+| `POST /api/v1/queue/previous` | Go back to the previous clip (repeat/shuffle aware) |
+| `PUT /api/v1/queue/reorder` | Move a clip to a new position |
+| `DELETE /api/v1/queue` | Clear the entire queue (204) |
+| `PATCH /api/v1/queue` | Update `repeat_mode` (`none`/`one`/`all`) and/or `shuffle_enabled` |
+
+The queue is owner-scoped (one document per user, unique on `user_id`). Repeat is `none` (stops at the end, `current_index` → `null`), `one` (holds the current clip), or `all` (wraps). Shuffle is history-based: `next` picks a random unplayed clip and `previous` walks back through the play history. A single `GET` returns everything needed to rebuild player state after a reload.
+
 ### Clips
 
 | Endpoint | Purpose |

--- a/docs/demos/us-14.3-playback-queue.md
+++ b/docs/demos/us-14.3-playback-queue.md
@@ -1,0 +1,57 @@
+# US-14.3 — Playback queue API (demo)
+
+A single server-side `PlaybackQueue` per user (`/api/v1/queue`) lets the web player
+queue clips, navigate next/previous with repeat + shuffle modes, reorder, and
+restore state after a reload. Output below is from driving the **real app** over a
+local MongoDB (`scratchpad/queue_demo.py`) — the same code paths the API serves.
+
+Clip ids are shown by their last 4 chars. Two users (Alice, Bob) share the app.
+
+## AC1 — Adding clips persists across API requests
+```
+POST 4 clips, then GET (separate request) -> ['10e0', '10e1', '10e2', '10e3']
+persisted == added: True, current_clip=...10e0
+```
+A `POST /queue` then a *separate* `GET /queue` returns the same clips — state lives
+in MongoDB, not the request.
+
+## AC2 — Next/previous with repeat and shuffle modes
+```
+repeat=all, next x4 from idx0: [0, 1, 2, 3, 0]   (wraps 3->0)
+previous from idx0 (repeat=all wraps to end): 3
+shuffle ON, next x3: visit order [3, 0, 1, 2], all distinct & cover queue: True
+shuffle previous returns to last played: 1 == 1: True
+```
+- `repeat=all` wraps past the last clip back to 0, and `previous` at the start
+  wraps to the end.
+- `repeat=none` (default) stops at the end (`current_index → null`).
+- `repeat=one` holds the current clip (covered in tests).
+- Shuffle picks each remaining clip once (no repeats within a session) and
+  `previous` walks back through the actual play history.
+
+## AC3 — Reordering updates positions without losing clips
+```
+before: ['10e0', '10e1', '10e2', '10e3']
+move ...10e0 to pos 3 -> ['10e1', '10e2', '10e3', '10e0']
+no clips lost (same set): True, count 4
+```
+`PUT /queue/reorder` moves a clip; `current_index` follows the moved clip and the
+set of clips is unchanged.
+
+## AC4 — Queue scoped to the authenticated user
+```
+Alice has 4 clips; Bob's queue: []
+Bob DELETE Alice's clip id -> HTTP 404 (404, not in Bob's queue)
+Alice's queue untouched: 4 clips remain
+```
+Each queue is keyed by `user_id` (unique index). Bob never sees or mutates Alice's
+queue — operating on her clip id hits his own empty queue and 404s.
+
+## AC5 — State persists across page reloads (restore from GET)
+```
+a fresh GET (simulating reload) returns full restorable state:
+  clips=['10e1', '10e2', '10e3', '10e0'] current_index=0 repeat=none shuffle=False
+  current_clip_id=...10e1 updated_at=2026-06-23T23:33:51
+```
+One `GET /queue` returns everything the client needs to rebuild the player after a
+reload: ordered clips, current position, current clip id, and the modes.

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -37,6 +37,7 @@ from .routers import (
     jobs,
     mastering,
     presets,
+    queue,
     releases,
     users,
     workspaces,
@@ -196,6 +197,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(mastering.router, prefix=API_V1_PREFIX)
     app.include_router(distribution.router, prefix=API_V1_PREFIX)
     app.include_router(releases.router, prefix=API_V1_PREFIX)
+    app.include_router(queue.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -12,6 +12,7 @@ from .distribution import DistributionStatus, VisibilityState
 from .job import Job, JobStatus
 from .notification_event import NotificationEvent
 from .preset import PRESET_PARAM_FIELDS, Preset
+from .queue import PlaybackQueue, RepeatMode
 from .refresh_token import RefreshToken
 from .release import Release, ReleaseStatus
 from .soundcloud_connection import SoundCloudConnection
@@ -32,6 +33,7 @@ ALL_MODELS = [
     Release,
     NotificationEvent,
     Counter,
+    PlaybackQueue,
 ]
 
 __all__ = [
@@ -54,5 +56,7 @@ __all__ = [
     "VisibilityState",
     "NotificationEvent",
     "Counter",
+    "PlaybackQueue",
+    "RepeatMode",
     "ALL_MODELS",
 ]

--- a/src/acemusic/api/models/queue.py
+++ b/src/acemusic/api/models/queue.py
@@ -1,0 +1,45 @@
+"""Playback queue document model (US-14.3).
+
+One :class:`PlaybackQueue` document per user holds the server-side listening
+session: the ordered clip ids, the current position, and the repeat/shuffle
+modes. Shuffle uses ``shuffle_history`` (the indices visited, in order) so
+"previous" walks back through what was actually played.
+"""
+
+from datetime import datetime
+from enum import Enum
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+
+class RepeatMode(str, Enum):
+    NONE = "none"
+    ONE = "one"
+    ALL = "all"
+
+
+class PlaybackQueue(Document):
+    """A user's persisted playback queue (one per user)."""
+
+    user_id: PydanticObjectId
+    clips: list[PydanticObjectId] = Field(default_factory=list)
+    # None means "nothing playing" — distinct from index 0 on an empty queue.
+    current_index: int | None = None
+    repeat_mode: RepeatMode = RepeatMode.NONE
+    shuffle_enabled: bool = False
+    # Indices (into ``clips``) already played this shuffle session, in order.
+    shuffle_history: list[int] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime | None = None
+
+    class Settings:
+        name = "playback_queues"
+        indexes = [
+            # One queue per user; the unique index makes get-or-create race-safe
+            # (a concurrent double-insert fails rather than creating two queues).
+            IndexModel([("user_id", ASCENDING)], unique=True),
+        ]

--- a/src/acemusic/api/routers/queue.py
+++ b/src/acemusic/api/routers/queue.py
@@ -1,0 +1,141 @@
+"""Playback queue router (US-14.3), mounted under ``/api/v1/queue``.
+
+A single server-side queue per authenticated user, so the web player can queue
+songs, support next/previous, and restore state across page navigations.
+
+Endpoints (all require a valid Bearer access token; the queue is implicitly
+scoped to the authenticated user):
+
+* ``POST   /queue``            → add clips (optionally at a position)
+* ``GET    /queue``            → current queue + playback position
+* ``DELETE /queue/{clip_id}``  → remove a clip
+* ``POST   /queue/next``       → advance (repeat/shuffle aware)
+* ``POST   /queue/previous``   → go back (repeat/shuffle aware)
+* ``PUT    /queue/reorder``    → move a clip to a new position
+* ``DELETE /queue``            → clear the whole queue (204)
+* ``PATCH  /queue``            → update repeat_mode / shuffle_enabled
+
+Request/response schemas live here (same convention as the workspaces router);
+business rules live in :mod:`acemusic.api.services.queue`.
+"""
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Response, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..models import PlaybackQueue, RepeatMode
+from ..services import queue as queue_service
+
+router = APIRouter(prefix="/queue", tags=["queue"], dependencies=[Depends(get_current_user)])
+
+
+class QueueAddRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    clip_ids: Annotated[list[str], Field(min_length=1)]
+    # None appends; a value beyond the end appends; negatives clamp to the front.
+    position: int | None = None
+
+
+class QueueReorderRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    clip_id: str
+    new_position: int
+
+
+class QueueUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repeat_mode: RepeatMode | None = None
+    shuffle_enabled: bool | None = None
+
+
+class QueueResponse(BaseModel):
+    clips: list[str]
+    current_index: int | None
+    current_clip_id: str | None
+    repeat_mode: str
+    shuffle_enabled: bool
+    updated_at: datetime | None
+
+    @classmethod
+    def from_queue(cls, queue: PlaybackQueue) -> "QueueResponse":
+        current_clip_id = None
+        if queue.current_index is not None and 0 <= queue.current_index < len(queue.clips):
+            current_clip_id = str(queue.clips[queue.current_index])
+        return cls(
+            clips=[str(clip_id) for clip_id in queue.clips],
+            current_index=queue.current_index,
+            current_clip_id=current_clip_id,
+            repeat_mode=queue.repeat_mode.value,
+            shuffle_enabled=queue.shuffle_enabled,
+            updated_at=queue.updated_at,
+        )
+
+
+class NavigationResponse(QueueResponse):
+    """Same shape as :class:`QueueResponse`; signals that navigation occurred."""
+
+
+@router.post("", response_model=QueueResponse)
+async def add_clips(
+    body: QueueAddRequest,
+    current: CurrentUser = Depends(require_existing_user),
+) -> QueueResponse:
+    queue = await queue_service.add_clips(current.user_id, body.clip_ids, body.position)
+    return QueueResponse.from_queue(queue)
+
+
+@router.get("", response_model=QueueResponse)
+async def get_queue(current: CurrentUser = Depends(require_existing_user)) -> QueueResponse:
+    queue = await queue_service.get_or_create_queue(current.user_id)
+    return QueueResponse.from_queue(queue)
+
+
+@router.delete("/{clip_id}", response_model=QueueResponse)
+async def remove_clip(
+    clip_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> QueueResponse:
+    queue = await queue_service.remove_clip(current.user_id, clip_id)
+    return QueueResponse.from_queue(queue)
+
+
+@router.post("/next", response_model=NavigationResponse)
+async def next_clip(current: CurrentUser = Depends(require_existing_user)) -> NavigationResponse:
+    queue = await queue_service.go_next(current.user_id)
+    return NavigationResponse.from_queue(queue)
+
+
+@router.post("/previous", response_model=NavigationResponse)
+async def previous_clip(current: CurrentUser = Depends(require_existing_user)) -> NavigationResponse:
+    queue = await queue_service.go_previous(current.user_id)
+    return NavigationResponse.from_queue(queue)
+
+
+@router.put("/reorder", response_model=QueueResponse)
+async def reorder_clip(
+    body: QueueReorderRequest,
+    current: CurrentUser = Depends(require_existing_user),
+) -> QueueResponse:
+    queue = await queue_service.reorder_clip(current.user_id, body.clip_id, body.new_position)
+    return QueueResponse.from_queue(queue)
+
+
+@router.delete("", status_code=status.HTTP_204_NO_CONTENT)
+async def clear_queue(current: CurrentUser = Depends(require_existing_user)) -> Response:
+    await queue_service.clear_queue(current.user_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.patch("", response_model=QueueResponse)
+async def update_modes(
+    body: QueueUpdateRequest,
+    current: CurrentUser = Depends(require_existing_user),
+) -> QueueResponse:
+    queue = await queue_service.update_modes(current.user_id, body.repeat_mode, body.shuffle_enabled)
+    return QueueResponse.from_queue(queue)

--- a/src/acemusic/api/services/queue.py
+++ b/src/acemusic/api/services/queue.py
@@ -1,0 +1,229 @@
+"""Playback queue service layer (US-14.3).
+
+Business logic for the per-user playback queue. Every operation is scoped to a
+``user_id`` (one queue per user, enforced by the unique index on
+:class:`PlaybackQueue`), so cross-user access is impossible by construction.
+
+Shuffle is history-based: ``go_next`` records where it came from in
+``shuffle_history`` and picks a random unplayed clip; ``go_previous`` walks back
+through that trail. This matches common player behaviour and keeps state simple.
+
+Each mutation is a read-modify-write that ``save()``s the whole document
+(last-write-wins), the same pattern as ``workspaces``/``clips``. The queue is
+driven by a single user's player, so concurrent writes (e.g. two tabs) are rare
+and only ever cost a lost playback-state update, not data integrity — optimistic
+concurrency would be needless machinery here. Revisit with ``use_revision`` if
+multi-device simultaneous editing ever becomes a real workflow.
+"""
+
+import random
+
+from beanie import PydanticObjectId
+from beanie.operators import Eq
+from fastapi import HTTPException, status
+from pymongo.errors import DuplicateKeyError
+
+from ..models import PlaybackQueue, RepeatMode
+from ..models.common import utcnow
+from .common import coerce_object_id
+
+
+def _bad_clip_id(value: str) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid clip id: {value!r}.")
+
+
+def _not_in_queue() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not in queue.")
+
+
+async def get_or_create_queue(user_id: str) -> PlaybackQueue:
+    """Return the user's queue, creating an empty one on first use.
+
+    Race-safe: the unique index on ``user_id`` rejects a concurrent second
+    insert with ``DuplicateKeyError``, which we resolve by re-reading the winner
+    (mirroring ``workspaces.get_or_create_default_workspace``).
+    """
+    user_oid = PydanticObjectId(user_id)
+    queue = await PlaybackQueue.find_one(Eq(PlaybackQueue.user_id, user_oid))
+    if queue is not None:
+        return queue
+    queue = PlaybackQueue(user_id=user_oid)
+    try:
+        await queue.insert()
+    except DuplicateKeyError:
+        existing = await PlaybackQueue.find_one(Eq(PlaybackQueue.user_id, user_oid))
+        if existing is None:
+            raise
+        return existing
+    return queue
+
+
+def _shift_index(idx: int, old: int, new: int) -> int:
+    """Map ``idx`` after the element at ``old`` moves to ``new`` in a list."""
+    if idx == old:
+        return new
+    if old < idx <= new:
+        return idx - 1
+    if new <= idx < old:
+        return idx + 1
+    return idx
+
+
+async def add_clips(user_id: str, clip_ids: list[str], position: int | None) -> PlaybackQueue:
+    """Insert ``clip_ids`` at ``position`` (append if None/beyond end, clamp negatives)."""
+    new_clips: list[PydanticObjectId] = []
+    for raw in clip_ids:
+        oid = coerce_object_id(raw)
+        if oid is None:
+            raise _bad_clip_id(raw)
+        new_clips.append(oid)
+
+    queue = await get_or_create_queue(user_id)
+    if position is None or position > len(queue.clips):
+        position = len(queue.clips)
+    elif position < 0:
+        position = 0
+
+    was_empty = not queue.clips
+    queue.clips[position:position] = new_clips
+    if queue.current_index is None:
+        # Start "playing" the first clip only when the queue was empty, so a GET
+        # returns a sensible current clip. A queue that *stopped* (reached the
+        # end under repeat=none) keeps current_index None — adding clips must not
+        # silently restart playback.
+        if was_empty:
+            queue.current_index = 0
+    elif position <= queue.current_index:
+        queue.current_index += len(new_clips)
+    queue.shuffle_history = [h + len(new_clips) if h >= position else h for h in queue.shuffle_history]
+    queue.updated_at = utcnow()
+    await queue.save()
+    return queue
+
+
+async def remove_clip(user_id: str, clip_id: str) -> PlaybackQueue:
+    """Remove ``clip_id`` from the queue (404 if absent), adjusting current/history."""
+    oid = coerce_object_id(clip_id)
+    queue = await get_or_create_queue(user_id)
+    if oid is None or oid not in queue.clips:
+        raise _not_in_queue()
+
+    removed = queue.clips.index(oid)
+    queue.clips.pop(removed)
+
+    if not queue.clips:
+        queue.current_index = None
+    elif queue.current_index is not None:
+        if removed < queue.current_index:
+            queue.current_index -= 1
+        elif removed == queue.current_index and queue.current_index >= len(queue.clips):
+            # Removed the current (last) clip: clamp to the new last clip.
+            queue.current_index = len(queue.clips) - 1
+
+    queue.shuffle_history = [h - 1 if h > removed else h for h in queue.shuffle_history if h != removed]
+    queue.updated_at = utcnow()
+    await queue.save()
+    return queue
+
+
+async def go_next(user_id: str) -> PlaybackQueue:
+    """Advance to the next clip, honouring repeat and shuffle modes."""
+    queue = await get_or_create_queue(user_id)
+    if not queue.clips:
+        return queue
+    if queue.current_index is None:
+        queue.current_index = 0
+    elif queue.repeat_mode == RepeatMode.ONE:
+        pass  # repeat-one loops the current clip
+    elif queue.shuffle_enabled:
+        played = set(queue.shuffle_history) | {queue.current_index}
+        remaining = [i for i in range(len(queue.clips)) if i not in played]
+        queue.shuffle_history.append(queue.current_index)
+        if remaining:
+            queue.current_index = random.choice(remaining)
+        elif queue.repeat_mode == RepeatMode.ALL:
+            queue.shuffle_history = []
+            queue.current_index = random.choice(range(len(queue.clips)))
+        else:
+            queue.current_index = None
+    else:
+        if queue.current_index + 1 < len(queue.clips):
+            queue.current_index += 1
+        elif queue.repeat_mode == RepeatMode.ALL:
+            queue.current_index = 0
+        else:
+            queue.current_index = None
+
+    queue.updated_at = utcnow()
+    await queue.save()
+    return queue
+
+
+async def go_previous(user_id: str) -> PlaybackQueue:
+    """Go back to the previous clip, honouring repeat and shuffle modes."""
+    queue = await get_or_create_queue(user_id)
+    if not queue.clips:
+        return queue
+    if queue.repeat_mode == RepeatMode.ONE:
+        pass  # repeat-one loops the current clip
+    elif queue.shuffle_enabled:
+        if queue.shuffle_history:
+            queue.current_index = queue.shuffle_history.pop()
+    elif queue.current_index is None:
+        queue.current_index = len(queue.clips) - 1
+    elif queue.current_index - 1 >= 0:
+        queue.current_index -= 1
+    elif queue.repeat_mode == RepeatMode.ALL:
+        queue.current_index = len(queue.clips) - 1
+
+    queue.updated_at = utcnow()
+    await queue.save()
+    return queue
+
+
+async def reorder_clip(user_id: str, clip_id: str, new_position: int) -> PlaybackQueue:
+    """Move ``clip_id`` to ``new_position`` (clamped), 404 if not in the queue."""
+    oid = coerce_object_id(clip_id)
+    queue = await get_or_create_queue(user_id)
+    if oid is None or oid not in queue.clips:
+        raise _not_in_queue()
+
+    old = queue.clips.index(oid)
+    new = max(0, min(new_position, len(queue.clips) - 1))
+    if new != old:
+        queue.clips.insert(new, queue.clips.pop(old))
+        if queue.current_index is not None:
+            queue.current_index = _shift_index(queue.current_index, old, new)
+        queue.shuffle_history = [_shift_index(h, old, new) for h in queue.shuffle_history]
+
+    queue.updated_at = utcnow()
+    await queue.save()
+    return queue
+
+
+async def clear_queue(user_id: str) -> PlaybackQueue:
+    """Empty the queue, preserving repeat/shuffle mode settings."""
+    queue = await get_or_create_queue(user_id)
+    queue.clips = []
+    queue.current_index = None
+    queue.shuffle_history = []
+    queue.updated_at = utcnow()
+    await queue.save()
+    return queue
+
+
+async def update_modes(
+    user_id: str,
+    repeat_mode: RepeatMode | None,
+    shuffle_enabled: bool | None,
+) -> PlaybackQueue:
+    """Update repeat and/or shuffle mode; toggling shuffle resets its history."""
+    queue = await get_or_create_queue(user_id)
+    if repeat_mode is not None:
+        queue.repeat_mode = repeat_mode
+    if shuffle_enabled is not None:
+        queue.shuffle_enabled = shuffle_enabled
+        queue.shuffle_history = []
+    queue.updated_at = utcnow()
+    await queue.save()
+    return queue

--- a/tests/test_queue_api.py
+++ b/tests/test_queue_api.py
@@ -1,0 +1,328 @@
+"""Tests for the playback queue endpoints (US-14.3, issue #140).
+
+The 401 auth-gate tests run in CI (the router dependency rejects before any DB
+access). The behaviour tests are ``integration``: they drive the real app with
+``httpx.AsyncClient`` over a local MongoDB (``mongo_db``), mirroring
+``tests/test_workspaces_api.py``.
+
+Clip ids are opaque to the queue (it stores ids; ownership is enforced by the
+per-user queue), so the tests use synthetic ObjectIds rather than real clips.
+"""
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+
+QUEUE_URL = f"{API_V1_PREFIX}/queue"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    @pytest.mark.parametrize(
+        ("method", "url"),
+        [
+            ("GET", QUEUE_URL),
+            ("POST", QUEUE_URL),
+            ("DELETE", QUEUE_URL),
+            ("PATCH", QUEUE_URL),
+            ("PUT", f"{QUEUE_URL}/reorder"),
+            ("POST", f"{QUEUE_URL}/next"),
+            ("POST", f"{QUEUE_URL}/previous"),
+            ("DELETE", f"{QUEUE_URL}/{PydanticObjectId()}"),
+        ],
+    )
+    def test_missing_auth_header_returns_401(self, method: str, url: str) -> None:
+        client = TestClient(create_app())
+        resp = client.request(method, url)
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+def _ids(n: int) -> list[str]:
+    return [str(PydanticObjectId()) for _ in range(n)]
+
+
+# --- Basic operations ------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestBasicOperations:
+    async def test_add_clips_returns_queue(self, client, settings) -> None:
+        user = await _make_user("q-add@example.com")
+        clips = _ids(3)
+        resp = await client.post(QUEUE_URL, json={"clip_ids": clips}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["clips"] == clips
+        assert body["current_index"] == 0
+        assert body["current_clip_id"] == clips[0]
+
+    async def test_add_persists_across_requests(self, client, settings) -> None:
+        user = await _make_user("q-persist@example.com")
+        clips = _ids(2)
+        await client.post(QUEUE_URL, json={"clip_ids": clips}, headers=_auth_headers(user, settings))
+        resp = await client.get(QUEUE_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["clips"] == clips
+
+    async def test_add_at_position_inserts(self, client, settings) -> None:
+        user = await _make_user("q-pos@example.com")
+        headers = _auth_headers(user, settings)
+        a, b = _ids(2)
+        c = str(PydanticObjectId())
+        await client.post(QUEUE_URL, json={"clip_ids": [a, b]}, headers=headers)
+        resp = await client.post(QUEUE_URL, json={"clip_ids": [c], "position": 1}, headers=headers)
+        assert resp.json()["clips"] == [a, c, b]
+
+    async def test_get_empty_queue_for_new_user(self, client, settings) -> None:
+        user = await _make_user("q-empty@example.com")
+        resp = await client.get(QUEUE_URL, headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["clips"] == []
+        assert body["current_index"] is None
+        assert body["current_clip_id"] is None
+        assert body["repeat_mode"] == "none"
+        assert body["shuffle_enabled"] is False
+
+    async def test_remove_clip_adjusts_current_index(self, client, settings) -> None:
+        user = await _make_user("q-remove@example.com")
+        headers = _auth_headers(user, settings)
+        clips = _ids(3)
+        await client.post(QUEUE_URL, json={"clip_ids": clips}, headers=headers)
+        await client.post(f"{QUEUE_URL}/next", headers=headers)  # current_index -> 1
+        resp = await client.request("DELETE", f"{QUEUE_URL}/{clips[0]}", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["clips"] == [clips[1], clips[2]]
+        assert body["current_index"] == 0  # shifted down from 1
+
+    async def test_remove_clip_not_in_queue_returns_404(self, client, settings) -> None:
+        user = await _make_user("q-remove404@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(1)}, headers=headers)
+        resp = await client.request("DELETE", f"{QUEUE_URL}/{PydanticObjectId()}", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_clear_queue_returns_204(self, client, settings) -> None:
+        user = await _make_user("q-clear@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(2)}, headers=headers)
+        resp = await client.request("DELETE", QUEUE_URL, headers=headers)
+        assert resp.status_code == 204
+        after = await client.get(QUEUE_URL, headers=headers)
+        assert after.json()["clips"] == []
+        assert after.json()["current_index"] is None
+
+    async def test_add_to_stopped_queue_does_not_restart(self, client, settings) -> None:
+        # Play to the end under repeat=none (current_index -> None), then add a
+        # clip: playback stays stopped rather than silently jumping back to 0.
+        user = await _make_user("q-stopped@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(1)}, headers=headers)
+        resp = await client.post(f"{QUEUE_URL}/next", headers=headers)
+        assert resp.json()["current_index"] is None
+        added = await client.post(QUEUE_URL, json={"clip_ids": _ids(1)}, headers=headers)
+        assert added.json()["current_index"] is None
+
+    async def test_add_empty_clip_ids_returns_422(self, client, settings) -> None:
+        user = await _make_user("q-emptyadd@example.com")
+        resp = await client.post(QUEUE_URL, json={"clip_ids": []}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+    async def test_invalid_clip_id_returns_400(self, client, settings) -> None:
+        user = await _make_user("q-badid@example.com")
+        resp = await client.post(QUEUE_URL, json={"clip_ids": ["not-an-id"]}, headers=_auth_headers(user, settings))
+        assert resp.status_code == 400
+
+
+# --- Navigation ------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestNavigation:
+    async def test_next_advances(self, client, settings) -> None:
+        user = await _make_user("q-next@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(3)}, headers=headers)
+        resp = await client.post(f"{QUEUE_URL}/next", headers=headers)
+        assert resp.json()["current_index"] == 1
+
+    async def test_previous_decrements(self, client, settings) -> None:
+        user = await _make_user("q-prev@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(3)}, headers=headers)
+        await client.post(f"{QUEUE_URL}/next", headers=headers)
+        resp = await client.post(f"{QUEUE_URL}/previous", headers=headers)
+        assert resp.json()["current_index"] == 0
+
+    async def test_repeat_one_keeps_position(self, client, settings) -> None:
+        user = await _make_user("q-repeatone@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(3)}, headers=headers)
+        await client.post(f"{QUEUE_URL}/next", headers=headers)  # -> 1
+        await client.patch(QUEUE_URL, json={"repeat_mode": "one"}, headers=headers)
+        resp = await client.post(f"{QUEUE_URL}/next", headers=headers)
+        assert resp.json()["current_index"] == 1
+
+    async def test_repeat_all_wraps_at_end(self, client, settings) -> None:
+        user = await _make_user("q-repeatall@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(2)}, headers=headers)
+        await client.patch(QUEUE_URL, json={"repeat_mode": "all"}, headers=headers)
+        await client.post(f"{QUEUE_URL}/next", headers=headers)  # -> 1
+        resp = await client.post(f"{QUEUE_URL}/next", headers=headers)  # wraps -> 0
+        assert resp.json()["current_index"] == 0
+
+    async def test_repeat_none_stops_at_end(self, client, settings) -> None:
+        user = await _make_user("q-repeatnone@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(2)}, headers=headers)
+        await client.post(f"{QUEUE_URL}/next", headers=headers)  # -> 1
+        resp = await client.post(f"{QUEUE_URL}/next", headers=headers)  # end -> None
+        body = resp.json()
+        assert body["current_index"] is None
+        assert body["current_clip_id"] is None
+
+    async def test_shuffle_picks_from_remaining(self, client, settings) -> None:
+        user = await _make_user("q-shuffle@example.com")
+        headers = _auth_headers(user, settings)
+        clips = _ids(5)
+        await client.post(QUEUE_URL, json={"clip_ids": clips}, headers=headers)
+        await client.patch(QUEUE_URL, json={"shuffle_enabled": True}, headers=headers)
+        seen = {0}
+        for _ in range(4):
+            resp = await client.post(f"{QUEUE_URL}/next", headers=headers)
+            idx = resp.json()["current_index"]
+            assert idx not in seen  # never replays within the session
+            seen.add(idx)
+        assert seen == set(range(5))
+
+    async def test_shuffle_previous_returns_to_last_played(self, client, settings) -> None:
+        user = await _make_user("q-shuffleprev@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(4)}, headers=headers)
+        await client.patch(QUEUE_URL, json={"shuffle_enabled": True}, headers=headers)
+        await client.post(f"{QUEUE_URL}/next", headers=headers)  # history=[0]
+        resp = await client.post(f"{QUEUE_URL}/previous", headers=headers)
+        assert resp.json()["current_index"] == 0
+
+    async def test_navigation_on_empty_queue_is_noop(self, client, settings) -> None:
+        user = await _make_user("q-navempty@example.com")
+        headers = _auth_headers(user, settings)
+        resp = await client.post(f"{QUEUE_URL}/next", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["current_index"] is None
+
+
+# --- Reorder ---------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestReorder:
+    async def test_reorder_moves_clip(self, client, settings) -> None:
+        user = await _make_user("q-reorder@example.com")
+        headers = _auth_headers(user, settings)
+        a, b, c = _ids(3)
+        await client.post(QUEUE_URL, json={"clip_ids": [a, b, c]}, headers=headers)
+        resp = await client.put(QUEUE_URL + "/reorder", json={"clip_id": c, "new_position": 0}, headers=headers)
+        assert resp.json()["clips"] == [c, a, b]
+
+    async def test_reorder_adjusts_current_index(self, client, settings) -> None:
+        user = await _make_user("q-reorderidx@example.com")
+        headers = _auth_headers(user, settings)
+        a, b, c = _ids(3)
+        await client.post(QUEUE_URL, json={"clip_ids": [a, b, c]}, headers=headers)
+        # current_index is 0 (a). Move a to the end -> current should follow to 2.
+        resp = await client.put(QUEUE_URL + "/reorder", json={"clip_id": a, "new_position": 2}, headers=headers)
+        body = resp.json()
+        assert body["clips"] == [b, c, a]
+        assert body["current_index"] == 2
+        assert body["current_clip_id"] == a
+
+    async def test_reorder_missing_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("q-reorder404@example.com")
+        headers = _auth_headers(user, settings)
+        await client.post(QUEUE_URL, json={"clip_ids": _ids(2)}, headers=headers)
+        resp = await client.put(
+            QUEUE_URL + "/reorder",
+            json={"clip_id": str(PydanticObjectId()), "new_position": 0},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+
+# --- User isolation --------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestUserIsolation:
+    async def test_queue_is_per_user(self, client, settings) -> None:
+        alice = await _make_user("q-alice@example.com")
+        bob = await _make_user("q-bob@example.com")
+        alice_clips = _ids(2)
+        await client.post(QUEUE_URL, json={"clip_ids": alice_clips}, headers=_auth_headers(alice, settings))
+        # Bob sees his own (empty) queue, not Alice's.
+        resp = await client.get(QUEUE_URL, headers=_auth_headers(bob, settings))
+        assert resp.json()["clips"] == []
+
+    async def test_user_cannot_remove_from_another_queue(self, client, settings) -> None:
+        alice = await _make_user("q-alice2@example.com")
+        bob = await _make_user("q-bob2@example.com")
+        alice_clips = _ids(2)
+        await client.post(QUEUE_URL, json={"clip_ids": alice_clips}, headers=_auth_headers(alice, settings))
+        # Bob removing one of Alice's clip ids hits his own empty queue -> 404.
+        resp = await client.request("DELETE", f"{QUEUE_URL}/{alice_clips[0]}", headers=_auth_headers(bob, settings))
+        assert resp.status_code == 404
+        # Alice's queue is untouched.
+        after = await client.get(QUEUE_URL, headers=_auth_headers(alice, settings))
+        assert after.json()["clips"] == alice_clips


### PR DESCRIPTION
## Summary

Server-side playback queue (US-14.3, closes #140) so the web player can queue
clips, navigate next/previous, and restore state across page navigations.

One `PlaybackQueue` document per user (unique index on `user_id`), mounted at
`/api/v1/queue`. Follows the existing `workspaces` model/service/router pattern.

### Endpoints
| Method | Path | Purpose |
|---|---|---|
| `POST` | `/queue` | add clips (optional `position`) |
| `GET` | `/queue` | current queue + playback position |
| `DELETE` | `/queue/{clip_id}` | remove a clip |
| `POST` | `/queue/next` | advance (repeat/shuffle aware) |
| `POST` | `/queue/previous` | go back (repeat/shuffle aware) |
| `PUT` | `/queue/reorder` | move a clip to a new position |
| `DELETE` | `/queue` | clear the queue (204) |
| `PATCH` | `/queue` | update `repeat_mode` / `shuffle_enabled` |

- **Repeat**: `none` (stops at end), `one` (holds current), `all` (wraps).
- **Shuffle**: history-based — `next` picks a random unplayed clip, `previous`
  walks back through the play history.
- **Ownership**: every operation is scoped by `user_id`; cross-user access is
  impossible by construction (unique index + implicit filter).

## Acceptance criteria — demoed against the live app
All five criteria verified with outcome evidence in
`docs/demos/us-14.3-playback-queue.md` (driven over a real MongoDB):
1. ✅ Adds persist across separate API requests
2. ✅ Next/previous correct under repeat (none/one/all) and shuffle
3. ✅ Reorder preserves the clip set and tracks `current_index`
4. ✅ Queue scoped to the authenticated user (Bob 404s on Alice's clip; her queue untouched)
5. ✅ Full state restorable from a single `GET` (clips, index, current clip, modes)

## Tests
`tests/test_queue_api.py` — 8 auth-gate (CI, no DB) + 24 integration (real Mongo):
basic ops, navigation across all repeat/shuffle modes, reorder + index tracking,
edge cases (empty queue, stopped queue, bad ids), and user isolation. All green.

## Review
- Internal review found one real bug — adding clips to a *stopped* queue
  (`current_index=None` after `repeat=none` reached the end) silently restarted
  playback. Fixed, with a regression test.
- `codex` cross-family review: one P2 noted (below).

## Known limitations
- **Last-write-wins on concurrent mutations.** Each operation is a
  read-modify-write `save()` of the whole document, matching the codebase
  convention (`workspaces`, `clips`). The queue is driven by one user's player,
  so a concurrent write (e.g. two tabs) only risks a lost playback-state update,
  not data integrity. Documented in the service module; revisit with
  `use_revision` if simultaneous multi-device editing becomes a real workflow.
- Clip ids are stored opaquely — the queue does not verify each id exists or
  belongs to the user (ownership is enforced at the queue level). Matches the
  approved plan; a stale id simply sits in the queue until removed.
