### PR TITLE
feat(api): similar clips endpoint (US-14.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,15 @@ The queue is owner-scoped (one document per user, unique on `user_id`). Repeat i
 | `DELETE /api/v1/clips/{id}` | Delete the clip record and its stored audio |
 | `GET /api/v1/clips/{id}/audio` | Streams or downloads a clip's audio with the correct `Content-Type` |
 | `GET /api/v1/clips/{id}/stream` | Streams a clip for the web player — optional auth, full range support, rate-limited |
+| `GET /api/v1/clips/{id}/similar` | Clips similar to this one for radio-style discovery (US-14.4) |
 
 `GET /api/v1/clips` supports these query parameters: `workspace_id`, `search` (case-insensitive substring over title or style tags), `style`, `bpm_min`, `bpm_max`, `key`, `model`, `sort` (`newest` or `oldest`, default `newest`), `page` (default 1), `per_page` (default 20, max 100). An inverted BPM range (`bpm_min > bpm_max`) returns 422. The response includes `total`, `page`, `per_page`, and `total_pages`.
 
 All CRUD endpoints are owner-scoped. `GET /api/v1/clips/{id}/audio` additionally supports single HTTP byte ranges (`Range: bytes=…` → `206 Partial Content`, unsatisfiable ranges → `416`) for seeking, and on-the-fly conversion via `?format=wav|flac|mp3` (mp3/flac conversion requires ffmpeg on the host; byte ranges are ignored for converted output). For the audio endpoint an unknown or malformed id returns `404`, another user's private clip returns `403`, and clips marked `is_public` are retrievable by any authenticated user; the CRUD endpoints return `404` for any clip the caller does not own.
 
 `GET /api/v1/clips/{id}/stream` is the web player's playback endpoint. Unlike `/audio` it allows **unauthenticated** streaming of `is_public` clips (a private clip is an indistinguishable `404` for anonymous callers, `403` for an authenticated non-owner). It supports single **and** multi-range requests (`206`; multiple ranges return `multipart/byteranges`), `?format=mp3|wav` conversion (which disables ranges), sets `Accept-Ranges`/`Cache-Control`, and is rate-limited per client IP (`429` over the limit; configurable via `ACEMUSIC_API_STREAM_RATE_LIMIT_PER_MINUTE`, default 100).
+
+`GET /api/v1/clips/{id}/similar` finds clips related to a seed for a radio-style queue (pairs with the playback queue above). It scores candidates by shared style tags (each +1, case-insensitive), BPM within ±10% (+1), the same or relative key (+1), and matching model **and** generation mode (+1), returning them most-similar first. `?scope=mine|public|all` (default `all`) selects the candidate pool — the caller's own clips, public clips, or both — and `?limit=N` caps the result (default 20, max 50); `total` reports how many candidates matched before the limit. The seed is resolved like `/audio` (`404` unknown, `403` another user's private clip), so any clip the caller can see may seed a queue, and no matches returns `200` with an empty array.
 
 ### Audio Editing (US-10.1)
 

--- a/docs/demos/us-14.4-similar-clips.md
+++ b/docs/demos/us-14.4-similar-clips.md
@@ -1,0 +1,36 @@
+# US-14.4 — Similar clips endpoint
+
+*2026-06-24T02:33:20Z*
+
+`GET /api/v1/clips/{id}/similar` ranks clips by shared style tags, BPM proximity (±10%), related key, and matching model/generation-mode. `?scope=mine|public|all`, `?limit=N` (≤50). Seed resolved via the existing audio-access rule (404 unknown, 403 another user's private clip).
+
+The runner below seeds clips in an isolated local MongoDB, drives the real ASGI app, and prints outcome evidence for every acceptance criterion — including latency on a 1100+ clip library. The DB is dropped on teardown.
+
+```bash
+ulimit -n 64000 && uv run python .cache/demo_similar_clips.py 2>&1 | grep -v "^INFO:"
+```
+
+```output
+== AC1+AC3: matches share a tag or are within 10% BPM, ranked best-first ==
+HTTP 200  (scores: 4, 2, 1)
+    2 tags+bpm+key  6a3b41f3a2aaf48082fd8b02
+       1 tag + bpm  6a3b41f3a2aaf48082fd8b03
+          bpm only  6a3b41f3a2aaf48082fd8b04
+  -> ordered by score; 'unrelated' absent; seed excluded
+
+== AC2: scope=mine -> ['1 tag + bpm', '2 tags+bpm+key', 'bpm only']
+== AC2: scope=public -> ['OTHER-PUBLIC']
+== AC2: scope=all -> ['1 tag + bpm', '2 tags+bpm+key', 'OTHER-PUBLIC', 'bpm only']
+  -> mine: only owner's; public: only OTHER-PUBLIC; all: both
+
+== AC4: empty result set ==
+HTTP 200  body={"clips": [], "total": 0, "limit": 20}
+
+== AC5: query latency on a 1000+ clip library ==
+library size: 1107 clips
+HTTP 200  returned=20  total_candidates=576
+elapsed: 22 ms (budget 1000 ms)
+  -> within the 1-second budget
+
+All acceptance criteria demonstrated.
+```

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -217,6 +217,18 @@ class ClipChildrenResponse(BaseModel):
     children: list[ClipSummary]
 
 
+class SimilarClipsResponse(BaseModel):
+    """Clips similar to a seed clip (US-14.4), ranked most-similar first.
+
+    ``total`` is the number of candidates that matched before ``limit`` was
+    applied, so a client can tell a truncated radio queue from an exhausted one.
+    """
+
+    clips: list[ClipResponse]
+    total: int
+    limit: int
+
+
 @router.get("", response_model=ClipListResponse)
 async def list_clips(
     # Annotated[..., Query()] (not plain Depends) makes FastAPI validate the
@@ -265,6 +277,28 @@ async def get_clip_lineage(clip_id: str, current: CurrentUser = Depends(require_
         depth_limit=clip_service.MAX_LINEAGE_DEPTH,
         depth_truncated=truncated,
         nodes=[LineageNode.from_clip(clip, depth) for clip, depth in nodes],
+    )
+
+
+@router.get("/{clip_id}/similar", response_model=SimilarClipsResponse)
+async def get_similar_clips(
+    clip_id: str,
+    scope: Literal["mine", "public", "all"] = "all",
+    limit: int = Query(default=20, ge=1, le=50),
+    current: CurrentUser = Depends(require_existing_user),
+) -> SimilarClipsResponse:
+    """Return clips similar to this one for radio-style discovery (US-14.4).
+
+    Similarity blends shared style tags, BPM proximity, related key, and matching
+    model/generation-mode. ``scope`` selects the candidate pool: the caller's own
+    clips, public clips, or both (default). 404 if the seed is unknown, 403 if it
+    is another user's private clip, 200 with an empty list if nothing matches.
+    """
+    clips, total = await clip_service.find_similar_clips(clip_id, current.user_id, scope, limit)
+    return SimilarClipsResponse(
+        clips=[ClipResponse.from_clip(clip) for clip in clips],
+        total=total,
+        limit=limit,
     )
 
 

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -32,6 +32,126 @@ logger = logging.getLogger(__name__)
 # unboundedly. 50 levels is the documented maximum lineage depth.
 MAX_LINEAGE_DEPTH = 50
 
+# US-14.4: relative major/minor pairs ("C major" shares notes with "A minor"),
+# so a clip in one key is musically similar to a clip in its relative. Stored
+# both directions for an O(1) lookup; keys are compared lowercased.
+RELATIVE_KEYS: dict[str, str] = {
+    "c major": "a minor",
+    "g major": "e minor",
+    "d major": "b minor",
+    "a major": "f# minor",
+    "e major": "c# minor",
+    "b major": "g# minor",
+    "f# major": "d# minor",
+    "db major": "bb minor",
+    "ab major": "f minor",
+    "eb major": "c minor",
+    "bb major": "g minor",
+    "f major": "d minor",
+}
+RELATIVE_KEYS.update({v: k for k, v in list(RELATIVE_KEYS.items())})
+
+# US-14.4: a similar clip must share at least one style tag with the seed or sit
+# within this fraction of its BPM (acceptance criteria). The same window gates
+# the BPM scoring bonus.
+BPM_PROXIMITY = 0.10
+
+
+def keys_are_related(key1: str | None, key2: str | None) -> bool:
+    """True if two musical keys are identical or a relative major/minor pair.
+
+    None for either side means "unknown key" — not a match. Comparison is
+    case-insensitive ("C major" == "c MAJOR").
+    """
+    if key1 is None or key2 is None:
+        return False
+    k1, k2 = key1.strip().lower(), key2.strip().lower()
+    return k1 == k2 or RELATIVE_KEYS.get(k1) == k2
+
+
+def compute_similarity_score(seed: Clip, candidate: Clip) -> int:
+    """Score ``candidate`` against ``seed`` (US-14.4): higher = more similar.
+
+    +1 per shared style tag (case-insensitive), +1 if BPM is within
+    ``BPM_PROXIMITY``, +1 if the keys are related, +1 if model *and*
+    generation_mode both match. Criteria where the seed's field is unset
+    (None/empty) are skipped — they neither add nor subtract — so a sparsely
+    tagged seed still ranks candidates by what it does have.
+    """
+    score = 0
+    if seed.style_tags:
+        seed_tags = {t.lower() for t in seed.style_tags}
+        cand_tags = {t.lower() for t in candidate.style_tags}
+        score += len(seed_tags & cand_tags)
+    if seed.bpm and candidate.bpm is not None and abs(candidate.bpm - seed.bpm) <= seed.bpm * BPM_PROXIMITY:
+        score += 1
+    if keys_are_related(seed.key, candidate.key):
+        score += 1
+    if (
+        seed.model
+        and seed.generation_mode
+        and seed.model == candidate.model
+        and seed.generation_mode == candidate.generation_mode
+    ):
+        score += 1
+    return score
+
+
+async def find_similar_clips(
+    clip_id: str,
+    user_id: str,
+    scope: Literal["mine", "public", "all"] = "all",
+    limit: int = 20,
+) -> tuple[list[Clip], int]:
+    """Return clips similar to ``clip_id`` plus the total number of candidates.
+
+    The seed is resolved with :func:`get_clip_for_audio_access`, so any clip the
+    caller may see (their own, or a public one) can seed a radio queue (404
+    unknown, 403 another user's private clip). ``scope`` limits the candidate
+    pool to the caller's clips (``mine``), public clips (``public``), or both
+    (``all``).
+
+    Candidates must clear the base-similarity bar — share a style tag or fall
+    within ``BPM_PROXIMITY`` of the seed's BPM — then are scored and sorted in
+    Python (descending score, newest first as a tiebreak). A seed with neither
+    tags nor BPM has no bar to match, so the result is empty.
+    """
+    seed = await get_clip_for_audio_access(clip_id, user_id)
+
+    similarity_clauses: list[dict] = []
+    if seed.style_tags:
+        # Match tags case-insensitively so the DB filter agrees with the
+        # case-insensitive scorer (and with list_clips' style filter). An
+        # anchored IGNORECASE regex is an exact tag match ignoring case; $in
+        # keeps a candidate if any of its tags matches any of the seed's.
+        tag_patterns = [re.compile(f"^{re.escape(tag)}$", re.IGNORECASE) for tag in seed.style_tags]
+        similarity_clauses.append({"style_tags": {"$in": tag_patterns}})
+    if seed.bpm:
+        similarity_clauses.append(
+            {"bpm": {"$gte": seed.bpm * (1 - BPM_PROXIMITY), "$lte": seed.bpm * (1 + BPM_PROXIMITY)}}
+        )
+    if not similarity_clauses:
+        return [], 0
+
+    owner = PydanticObjectId(user_id)
+    if scope == "mine":
+        scope_clause: dict = {"user_id": owner}
+    elif scope == "public":
+        scope_clause = {"is_public": True}
+    else:
+        scope_clause = {"$or": [{"user_id": owner}, {"is_public": True}]}
+
+    query = {
+        "$and": [
+            scope_clause,
+            {"$or": similarity_clauses},
+            {"_id": {"$ne": seed.id}},
+        ]
+    }
+    candidates = await Clip.find(query).to_list()
+    candidates.sort(key=lambda c: (compute_similarity_score(seed, c), c.created_at), reverse=True)
+    return candidates[:limit], len(candidates)
+
 
 async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
     """Return ``clip_id``'s clip if ``current_user_id`` may retrieve its audio.

--- a/tests/test_similar_clips.py
+++ b/tests/test_similar_clips.py
@@ -1,0 +1,353 @@
+"""Tests for the similar-clips endpoint (US-14.4, issue #141).
+
+``GET /clips/{id}/similar`` returns up to 50 clips ranked by similarity to a
+seed clip — shared style tags, BPM proximity (±10%), related key, and matching
+model/generation-mode. Scope filters the candidate pool to the caller's own
+clips, public clips, or both.
+
+The 401 auth-gate and the pure scoring helpers run in CI (no DB); the endpoint
+behaviour is ``integration`` and drives the real app over a local MongoDB.
+"""
+
+import itertools
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.services.clips import (
+    compute_similarity_score,
+    keys_are_related,
+)
+from acemusic.api.settings import ApiSettings
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_missing_auth_header_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.get(f"{CLIPS_URL}/{PydanticObjectId()}/similar")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Pure scoring helpers — run in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestKeysAreRelated:
+    def test_exact_match_case_insensitive(self) -> None:
+        assert keys_are_related("C major", "c MAJOR") is True
+
+    def test_relative_pair(self) -> None:
+        assert keys_are_related("C major", "A minor") is True
+        assert keys_are_related("A minor", "C major") is True
+
+    def test_unrelated_keys(self) -> None:
+        assert keys_are_related("C major", "G major") is False
+
+    def test_none_inputs(self) -> None:
+        assert keys_are_related(None, "C major") is False
+        assert keys_are_related("C major", None) is False
+        assert keys_are_related(None, None) is False
+
+
+def _clip(**kwargs):
+    # The scoring helpers read plain attributes only; a namespace avoids the
+    # Beanie collection init that constructing a real Clip needs (no DB in CI).
+    base = dict(style_tags=[], bpm=None, key=None, model=None, generation_mode=None)
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+class TestComputeSimilarityScore:
+    def test_style_tag_overlap_counts_each_match(self) -> None:
+        seed = _clip(style_tags=["lofi", "chill", "jazzy"])
+        cand = _clip(style_tags=["LOFI", "CHILL", "trap"])
+        # two overlapping tags (case-insensitive), nothing else set on seed
+        assert compute_similarity_score(seed, cand) == 2
+
+    def test_bpm_within_ten_percent(self) -> None:
+        seed = _clip(bpm=100)
+        assert compute_similarity_score(seed, _clip(bpm=109)) == 1
+        assert compute_similarity_score(seed, _clip(bpm=91)) == 1
+
+    def test_bpm_outside_ten_percent(self) -> None:
+        seed = _clip(bpm=100)
+        assert compute_similarity_score(seed, _clip(bpm=120)) == 0
+        assert compute_similarity_score(seed, _clip(bpm=80)) == 0
+
+    def test_related_key_adds_point(self) -> None:
+        seed = _clip(key="C major")
+        assert compute_similarity_score(seed, _clip(key="A minor")) == 1
+        assert compute_similarity_score(seed, _clip(key="G major")) == 0
+
+    def test_model_and_generation_mode_must_both_match(self) -> None:
+        seed = _clip(model="ace-step-v1", generation_mode="text2music")
+        assert compute_similarity_score(seed, _clip(model="ace-step-v1", generation_mode="text2music")) == 1
+        # only model matches -> no point
+        assert compute_similarity_score(seed, _clip(model="ace-step-v1", generation_mode="cover")) == 0
+
+    def test_null_seed_fields_are_skipped(self) -> None:
+        # seed has no metadata at all -> every criterion skipped -> score 0
+        seed = _clip()
+        cand = _clip(style_tags=["lofi"], bpm=100, key="C major", model="m", generation_mode="g")
+        assert compute_similarity_score(seed, cand) == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+_SEQ = itertools.count(1)
+
+
+async def _insert_clip(
+    user,
+    workspace: Workspace,
+    *,
+    title: str | None = None,
+    style_tags: list[str] | None = None,
+    bpm: int | None = None,
+    key: str | None = None,
+    model: str | None = None,
+    generation_mode: str | None = None,
+    is_public: bool = False,
+    created_at: datetime | None = None,
+) -> Clip:
+    if created_at is None:
+        created_at = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=next(_SEQ))
+    clip_id = PydanticObjectId()
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.wav",
+        format="wav",
+        title=title,
+        style_tags=style_tags or [],
+        bpm=bpm,
+        key=key,
+        model=model,
+        generation_mode=generation_mode,
+        is_public=is_public,
+        created_at=created_at,
+    )
+    await clip.insert()
+    return clip
+
+
+def _ids(payload) -> list[str]:
+    return [c["id"] for c in payload["clips"]]
+
+
+@pytest.mark.integration
+class TestSimilarClips:
+    async def test_shared_style_tag_appears(self, client, settings) -> None:
+        user = await _make_user("sim-tag@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["lofi", "chill"], bpm=100)
+        match = await _insert_clip(user, ws, style_tags=["lofi"], bpm=200)
+        await _insert_clip(user, ws, style_tags=["metal"], bpm=200)  # no overlap, far bpm
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert _ids(resp.json()) == [str(match.id)]
+
+    async def test_style_tag_match_is_case_insensitive(self, client, settings) -> None:
+        # Candidate qualifies only by a differently-cased tag (BPM far apart),
+        # so the DB filter — not just the scorer — must match case-insensitively.
+        user = await _make_user("sim-tagcase@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["LoFi"], bpm=100)
+        match = await _insert_clip(user, ws, style_tags=["lofi"], bpm=300)
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(user, settings))
+        assert _ids(resp.json()) == [str(match.id)]
+
+    async def test_bpm_proximity_appears(self, client, settings) -> None:
+        user = await _make_user("sim-bpm@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["a"], bpm=100)
+        near = await _insert_clip(user, ws, style_tags=["z"], bpm=108)  # within 10%, no tag overlap
+        await _insert_clip(user, ws, style_tags=["z"], bpm=140)  # too far, no tag overlap
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(user, settings))
+        assert _ids(resp.json()) == [str(near.id)]
+
+    async def test_ordered_by_score_descending(self, client, settings) -> None:
+        user = await _make_user("sim-order@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["a", "b", "c"], bpm=100, key="C major")
+        low = await _insert_clip(user, ws, style_tags=["a"], bpm=300)  # 1 tag
+        high = await _insert_clip(user, ws, style_tags=["a", "b", "c"], bpm=100, key="A minor")  # 3 tags+bpm+key
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(user, settings))
+        assert _ids(resp.json()) == [str(high.id), str(low.id)]
+
+    async def test_seed_excluded(self, client, settings) -> None:
+        user = await _make_user("sim-seed@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["lofi"], bpm=100)
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(user, settings))
+        assert str(seed.id) not in _ids(resp.json())
+
+    async def test_scope_mine_excludes_others_public(self, client, settings) -> None:
+        owner = await _make_user("sim-owner@example.com")
+        other = await _make_user("sim-other@example.com")
+        ws = await _make_workspace(owner)
+        ws_other = await _make_workspace(other)
+        seed = await _insert_clip(owner, ws, style_tags=["lofi"], bpm=100)
+        mine = await _insert_clip(owner, ws, style_tags=["lofi"], bpm=100)
+        await _insert_clip(other, ws_other, style_tags=["lofi"], bpm=100, is_public=True)
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar?scope=mine", headers=_auth_headers(owner, settings))
+        assert _ids(resp.json()) == [str(mine.id)]
+
+    async def test_scope_public_includes_others_public_only(self, client, settings) -> None:
+        owner = await _make_user("sim-pub-owner@example.com")
+        other = await _make_user("sim-pub-other@example.com")
+        ws = await _make_workspace(owner)
+        ws_other = await _make_workspace(other)
+        seed = await _insert_clip(owner, ws, style_tags=["lofi"], bpm=100)
+        await _insert_clip(owner, ws, style_tags=["lofi"], bpm=100, is_public=False)  # own private, excluded
+        pub = await _insert_clip(other, ws_other, style_tags=["lofi"], bpm=100, is_public=True)
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar?scope=public", headers=_auth_headers(owner, settings))
+        assert _ids(resp.json()) == [str(pub.id)]
+
+    async def test_scope_all_includes_both(self, client, settings) -> None:
+        owner = await _make_user("sim-all-owner@example.com")
+        other = await _make_user("sim-all-other@example.com")
+        ws = await _make_workspace(owner)
+        ws_other = await _make_workspace(other)
+        seed = await _insert_clip(owner, ws, style_tags=["lofi"], bpm=100)
+        mine = await _insert_clip(owner, ws, style_tags=["lofi"], bpm=100, is_public=False)
+        pub = await _insert_clip(other, ws_other, style_tags=["lofi"], bpm=100, is_public=True)
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar?scope=all", headers=_auth_headers(owner, settings))
+        assert set(_ids(resp.json())) == {str(mine.id), str(pub.id)}
+
+    async def test_limit_respected(self, client, settings) -> None:
+        user = await _make_user("sim-limit@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["lofi"], bpm=100)
+        for _ in range(3):
+            await _insert_clip(user, ws, style_tags=["lofi"], bpm=100)
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar?limit=2", headers=_auth_headers(user, settings))
+        body = resp.json()
+        assert len(body["clips"]) == 2
+        assert body["total"] == 3
+        assert body["limit"] == 2
+
+    async def test_limit_over_max_returns_422(self, client, settings) -> None:
+        user = await _make_user("sim-422@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["lofi"], bpm=100)
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar?limit=51", headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+    async def test_unknown_clip_returns_404(self, client, settings) -> None:
+        user = await _make_user("sim-404@example.com")
+        resp = await client.get(f"{CLIPS_URL}/{PydanticObjectId()}/similar", headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_others_private_seed_returns_403(self, client, settings) -> None:
+        owner = await _make_user("sim-403-owner@example.com")
+        other = await _make_user("sim-403-other@example.com")
+        ws = await _make_workspace(owner)
+        seed = await _insert_clip(owner, ws, style_tags=["lofi"], bpm=100, is_public=False)
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(other, settings))
+        assert resp.status_code == 403
+
+    async def test_no_matches_returns_empty_200(self, client, settings) -> None:
+        user = await _make_user("sim-empty@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["unique-tag"], bpm=100)
+        await _insert_clip(user, ws, style_tags=["nothing"], bpm=300)
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["clips"] == []
+        assert body["total"] == 0
+
+    async def test_seed_without_tags_or_bpm_returns_empty(self, client, settings) -> None:
+        # A seed with no style tags and no BPM has no base-similarity criteria.
+        user = await _make_user("sim-nullseed@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, key="C major")
+        await _insert_clip(user, ws, key="A minor")
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["clips"] == []
+
+    async def test_null_metadata_candidate_handled(self, client, settings) -> None:
+        # A candidate that shares a tag but has null bpm/key/model must not error.
+        user = await _make_user("sim-nullcand@example.com")
+        ws = await _make_workspace(user)
+        seed = await _insert_clip(user, ws, style_tags=["lofi"], bpm=100, key="C major", model="m")
+        bare = await _insert_clip(user, ws, style_tags=["lofi"])
+
+        resp = await client.get(f"{CLIPS_URL}/{seed.id}/similar", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert _ids(resp.json()) == [str(bare.id)]


### PR DESCRIPTION
## US-14.4: Similar clips / radio queue

Closes #141.

Adds `GET /api/v1/clips/{id}/similar` so a clip can seed a radio-style queue of related music.

### What it does
- Ranks candidates by a simple, interpretable score: **+1 per shared style tag** (case-insensitive), **+1 BPM within ±10%**, **+1 related key** (same or relative major/minor), **+1 model *and* generation-mode both match**. Criteria the seed doesn't have are skipped (no penalty).
- `?scope=mine|public|all` (default `all`) selects the candidate pool — caller's own clips, public clips, or both.
- `?limit=N` (default 20, max 50) caps results; `total` reports the full candidate count so clients can tell a truncated queue from an exhausted one.
- Base-similarity bar (per acceptance criteria): a candidate must share a style tag **or** sit within 10% of the seed's BPM. A seed with neither tags nor BPM returns an empty list.

### Implementation notes
- Seed is resolved via the existing `get_clip_for_audio_access`, so any clip the caller can see (own or public) can seed a queue — 404 unknown, 403 another user's private clip.
- Mongo narrows candidates (case-insensitive tag `$in` + BPM window + scope); scoring/sorting happens in Python (descending score, newest-first tiebreak).

### Acceptance criteria
- [x] Similar clips share ≥1 style tag or are within 10% BPM of the seed
- [x] `scope` filters to own / public / all
- [x] Results ordered by relevance (most similar first)
- [x] Empty result set returns 200 with an empty array (not 404)
- [x] Query within budget for 1000+ clips (single indexed Mongo query + in-memory scoring)

### Tests
`tests/test_similar_clips.py` — scoring/key unit tests (CI, no DB) + endpoint integration (scope filtering, ordering, limits incl. `limit=51`→422, 404/403, empty, null and mixed-case metadata).

### Known limitations
- BPM proximity targets the AC's ±10%; clips with null BPM simply don't contribute that criterion.
- Scoring is a flat sum (style tags can dominate); a weighted formula can come later if ranking needs tuning.

### Review
Pre-PR cross-family review via `codex review` — flagged a case-insensitive tag-match gap in the Mongo filter (the scorer was case-insensitive but the query wasn't); fixed with an anchored IGNORECASE regex `$in` and a regression test.
