### PR TITLE
feat(web): sidebar navigation icons (US-15.3)

### DIFF
--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,0 +1,7 @@
+export default function CreatePage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Create</h1>
+    </div>
+  )
+}

--- a/web/app/explore/page.tsx
+++ b/web/app/explore/page.tsx
@@ -1,0 +1,7 @@
+export default function ExplorePage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Explore</h1>
+    </div>
+  )
+}

--- a/web/app/feed/page.tsx
+++ b/web/app/feed/page.tsx
@@ -1,0 +1,7 @@
+export default function FeedPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Feed</h1>
+    </div>
+  )
+}

--- a/web/app/labs/page.tsx
+++ b/web/app/labs/page.tsx
@@ -1,0 +1,7 @@
+export default function LabsPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Labs</h1>
+    </div>
+  )
+}

--- a/web/app/me/page.tsx
+++ b/web/app/me/page.tsx
@@ -1,0 +1,7 @@
+export default function LibraryPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Library</h1>
+    </div>
+  )
+}

--- a/web/app/me/page.tsx
+++ b/web/app/me/page.tsx
@@ -1,4 +1,4 @@
-export default function LibraryPage() {
+export default function MePage() {
   return (
     <div className="p-8">
       <h1 className="text-2xl font-semibold">Library</h1>

--- a/web/app/notifications/page.tsx
+++ b/web/app/notifications/page.tsx
@@ -1,0 +1,7 @@
+export default function NotificationsPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Notifications</h1>
+    </div>
+  )
+}

--- a/web/app/release/page.tsx
+++ b/web/app/release/page.tsx
@@ -1,0 +1,7 @@
+export default function ReleasePage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Mastering &amp; Distribution</h1>
+    </div>
+  )
+}

--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -1,0 +1,7 @@
+export default function SearchPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Search</h1>
+    </div>
+  )
+}

--- a/web/app/studio/page.tsx
+++ b/web/app/studio/page.tsx
@@ -1,0 +1,7 @@
+export default function StudioPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold">Studio</h1>
+    </div>
+  )
+}

--- a/web/components/layout/Sidebar.test.tsx
+++ b/web/components/layout/Sidebar.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { Sidebar } from "@/components/layout"
+import { mainNav } from "@/config/navigation"
+import { LAYOUT } from "@/lib/constants/layout"
+import { routerMock } from "@/test/router-mock"
+
+beforeEach(() => {
+  routerMock.pathname = "/"
+})
+
+describe("Sidebar navigation (US-15.3)", () => {
+  it("renders every main destination as a link to the correct route", () => {
+    render(<Sidebar />)
+    for (const item of mainNav) {
+      const link = screen.getByRole("link", { name: item.label })
+      expect(link).toHaveAttribute("href", item.href)
+    }
+    // Labs is a link, Account is a dialog trigger (button), pinned to the bottom.
+    expect(screen.getByRole("link", { name: "Labs" })).toHaveAttribute(
+      "href",
+      "/labs"
+    )
+    expect(
+      screen.getByRole("button", { name: "Account" })
+    ).toBeInTheDocument()
+  })
+
+  it("marks the active route and only the active route", () => {
+    routerMock.pathname = "/explore"
+    render(<Sidebar />)
+    expect(screen.getByRole("link", { name: "Explore" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    )
+    expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute(
+      "aria-current"
+    )
+  })
+
+  it("matches Home only on an exact root path (no false positives)", () => {
+    routerMock.pathname = "/create"
+    render(<Sidebar />)
+    expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute(
+      "aria-current"
+    )
+    expect(screen.getByRole("link", { name: "Create" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    )
+  })
+
+  it("highlights a parent route for nested paths", () => {
+    routerMock.pathname = "/create/advanced"
+    render(<Sidebar />)
+    expect(screen.getByRole("link", { name: "Create" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    )
+  })
+
+  it("starts collapsed (icon-only) and toggles to icon+label mode", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar />)
+
+    const sidebar = screen.getByTestId("app-sidebar")
+    expect(sidebar).toHaveStyle({ width: `${LAYOUT.sidebarWidth}px` })
+    // Collapsed: labels are not visible (links still have accessible names).
+    expect(screen.queryByText("Explore")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Expand sidebar" }))
+
+    expect(sidebar).toHaveStyle({ width: `${LAYOUT.sidebarExpandedWidth}px` })
+    expect(screen.getByText("Explore")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Collapse sidebar" })
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the expanded state across a route change", async () => {
+    const user = userEvent.setup()
+    const view = render(<Sidebar />)
+
+    await user.click(screen.getByRole("button", { name: "Expand sidebar" }))
+    expect(screen.getByText("Explore")).toBeInTheDocument()
+
+    // Simulate navigation: pathname changes, component re-renders in place.
+    routerMock.pathname = "/explore"
+    view.rerender(<Sidebar />)
+
+    expect(screen.getByText("Explore")).toBeInTheDocument()
+    expect(screen.getByTestId("app-sidebar")).toHaveStyle({
+      width: `${LAYOUT.sidebarExpandedWidth}px`,
+    })
+  })
+
+  it("opens the profile dropdown with all account options", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar />)
+
+    await user.click(screen.getByRole("button", { name: "Open account menu" }))
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Profile" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("menuitem", { name: "Account settings" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("menuitem", { name: "Subscription" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("menuitem", { name: "Log out" })
+    ).toBeInTheDocument()
+  })
+
+  it("opens the account dialog from the bottom-pinned Account item", async () => {
+    const user = userEvent.setup()
+    render(<Sidebar />)
+
+    await user.click(screen.getByRole("button", { name: "Account" }))
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+  })
+})

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -111,7 +111,7 @@ function NavDialog({
   return (
     <Dialog>
       <DialogTrigger
-        aria-label={item.label}
+        aria-label={expanded ? undefined : item.label}
         className={cn(sidebarItemBase, !expanded && "justify-center px-0")}
       >
         <HugeiconsIcon icon={item.icon} size={22} className="shrink-0" />

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -1,25 +1,187 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  SidebarLeftIcon,
+  UserCircleIcon,
+  UserIcon,
+} from "@hugeicons/core-free-icons"
+
 import { LAYOUT } from "@/lib/constants/layout"
+import { bottomNav, mainNav, type NavItem } from "@/config/navigation"
+import { cn } from "@/lib/utils"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+
+/** Active when the path equals the route, or sits under it (root matches exactly). */
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/") return pathname === "/"
+  return pathname === href || pathname.startsWith(`${href}/`)
+}
+
+function NavLink({
+  item,
+  expanded,
+  active,
+}: {
+  item: NavItem
+  expanded: boolean
+  active: boolean
+}) {
+  return (
+    <Link
+      href={item.href}
+      aria-label={item.label}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground",
+        active && "bg-sidebar-accent text-sidebar-foreground",
+        !expanded && "justify-center px-0"
+      )}
+    >
+      <HugeiconsIcon icon={item.icon} size={22} className="shrink-0" />
+      {expanded && <span className="truncate text-sm">{item.label}</span>}
+    </Link>
+  )
+}
+
+/** Profile avatar at the top; opens the account dropdown (spec section 1.4). */
+function ProfileMenu({ expanded }: { expanded: boolean }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Open account menu"
+        className={cn(
+          "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-3 focus-visible:ring-ring/50",
+          !expanded && "justify-center px-0"
+        )}
+      >
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-sidebar-foreground">
+          <HugeiconsIcon icon={UserIcon} size={18} />
+        </span>
+        {expanded && <span className="truncate text-sm">Your account</span>}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="right" align="start" className="w-48">
+        <DropdownMenuLabel>Account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/me">Profile</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem>Account settings</DropdownMenuItem>
+        <DropdownMenuItem>Subscription</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive">Log out</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/** Bottom-pinned Account item: opens a placeholder dialog (spec section 1.2). */
+function AccountDialogItem({ expanded }: { expanded: boolean }) {
+  return (
+    <Dialog>
+      <DialogTrigger
+        aria-label="Account"
+        className={cn(
+          "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-3 focus-visible:ring-ring/50",
+          !expanded && "justify-center px-0"
+        )}
+      >
+        <HugeiconsIcon icon={UserCircleIcon} size={22} className="shrink-0" />
+        {expanded && <span className="truncate text-sm">Account</span>}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Account</DialogTitle>
+          <DialogDescription>
+            Account, subscription, and billing details arrive in a later story.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 /**
- * Collapsed icon bar on the left edge of the shell. Placeholder icon slots —
- * real navigation arrives in US-15.3. Stays a fixed 64px at every breakpoint.
+ * Primary sidebar navigation (US-15.3). Collapsed 64px icon bar by default;
+ * the toggle expands it to an icon+label rail. Lives in the persistent App
+ * Router layout, so the expand state survives route changes.
  */
 export function Sidebar() {
+  const pathname = usePathname()
+  const [expanded, setExpanded] = useState(false)
+
   return (
     <aside
       data-testid="app-sidebar"
       aria-label="Primary navigation"
-      style={{ width: LAYOUT.sidebarWidth }}
-      className="z-40 flex h-full shrink-0 flex-col items-center gap-4 border-r border-border bg-sidebar py-4"
+      style={{
+        width: expanded ? LAYOUT.sidebarExpandedWidth : LAYOUT.sidebarWidth,
+      }}
+      className="z-40 flex h-full shrink-0 flex-col gap-2 overflow-hidden border-r border-border bg-sidebar px-2 py-4 transition-all duration-200"
     >
-      {/* placeholder icon slots — populated by US-15.3 */}
-      {Array.from({ length: 4 }).map((_, i) => (
-        <span
-          key={i}
-          className="size-8 rounded-md bg-sidebar-accent"
-          aria-hidden
+      <button
+        type="button"
+        aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+        className={cn(
+          "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-3 focus-visible:ring-ring/50",
+          !expanded && "justify-center px-0"
+        )}
+      >
+        <HugeiconsIcon
+          icon={SidebarLeftIcon}
+          size={22}
+          className={cn("shrink-0 transition-transform", !expanded && "rotate-180")}
         />
-      ))}
+        {expanded && <span className="truncate text-sm">Collapse</span>}
+      </button>
+
+      <ProfileMenu expanded={expanded} />
+
+      <nav aria-label="Main" className="flex flex-1 flex-col gap-1">
+        {mainNav.map((item) => (
+          <NavLink
+            key={item.id}
+            item={item}
+            expanded={expanded}
+            active={isActive(pathname, item.href)}
+          />
+        ))}
+      </nav>
+
+      <div className="flex flex-col gap-1">
+        {bottomNav.map((item) =>
+          item.isDialog ? (
+            <AccountDialogItem key={item.id} expanded={expanded} />
+          ) : (
+            <NavLink
+              key={item.id}
+              item={item}
+              expanded={expanded}
+              active={isActive(pathname, item.href)}
+            />
+          )
+        )}
+      </div>
     </aside>
   )
 }

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -6,12 +6,16 @@ import { usePathname } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
   SidebarLeftIcon,
-  UserCircleIcon,
   UserIcon,
 } from "@hugeicons/core-free-icons"
 
 import { LAYOUT } from "@/lib/constants/layout"
-import { bottomNav, mainNav, type NavItem } from "@/config/navigation"
+import {
+  bottomNav,
+  mainNav,
+  type NavDialogItem,
+  type NavLinkItem,
+} from "@/config/navigation"
 import { cn } from "@/lib/utils"
 import {
   DropdownMenu,
@@ -30,6 +34,10 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 
+/** Shared base styling for every interactive sidebar item (links, triggers). */
+const sidebarItemBase =
+  "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-3 focus-visible:ring-ring/50"
+
 /** Active when the path equals the route, or sits under it (root matches exactly). */
 function isActive(pathname: string, href: string): boolean {
   if (href === "/") return pathname === "/"
@@ -41,17 +49,19 @@ function NavLink({
   expanded,
   active,
 }: {
-  item: NavItem
+  item: NavLinkItem
   expanded: boolean
   active: boolean
 }) {
   return (
     <Link
       href={item.href}
-      aria-label={item.label}
+      // Collapsed items have no visible text, so the label must come from
+      // aria-label; expanded, the visible span is the accessible name already.
+      aria-label={expanded ? undefined : item.label}
       aria-current={active ? "page" : undefined}
       className={cn(
-        "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground",
+        sidebarItemBase,
         active && "bg-sidebar-accent text-sidebar-foreground",
         !expanded && "justify-center px-0"
       )}
@@ -68,10 +78,7 @@ function ProfileMenu({ expanded }: { expanded: boolean }) {
     <DropdownMenu>
       <DropdownMenuTrigger
         aria-label="Open account menu"
-        className={cn(
-          "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-3 focus-visible:ring-ring/50",
-          !expanded && "justify-center px-0"
-        )}
+        className={cn(sidebarItemBase, !expanded && "justify-center px-0")}
       >
         <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-sidebar-accent text-sidebar-foreground">
           <HugeiconsIcon icon={UserIcon} size={18} />
@@ -93,23 +100,26 @@ function ProfileMenu({ expanded }: { expanded: boolean }) {
   )
 }
 
-/** Bottom-pinned Account item: opens a placeholder dialog (spec section 1.2). */
-function AccountDialogItem({ expanded }: { expanded: boolean }) {
+/** Bottom-pinned dialog item (Account): opens a placeholder dialog (spec 1.2). */
+function NavDialog({
+  item,
+  expanded,
+}: {
+  item: NavDialogItem
+  expanded: boolean
+}) {
   return (
     <Dialog>
       <DialogTrigger
-        aria-label="Account"
-        className={cn(
-          "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-3 focus-visible:ring-ring/50",
-          !expanded && "justify-center px-0"
-        )}
+        aria-label={item.label}
+        className={cn(sidebarItemBase, !expanded && "justify-center px-0")}
       >
-        <HugeiconsIcon icon={UserCircleIcon} size={22} className="shrink-0" />
-        {expanded && <span className="truncate text-sm">Account</span>}
+        <HugeiconsIcon icon={item.icon} size={22} className="shrink-0" />
+        {expanded && <span className="truncate text-sm">{item.label}</span>}
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Account</DialogTitle>
+          <DialogTitle>{item.label}</DialogTitle>
           <DialogDescription>
             Account, subscription, and billing details arrive in a later story.
           </DialogDescription>
@@ -142,10 +152,7 @@ export function Sidebar() {
         aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
         aria-expanded={expanded}
         onClick={() => setExpanded((v) => !v)}
-        className={cn(
-          "flex h-10 items-center gap-3 rounded-md px-3 text-sidebar-foreground/70 outline-none transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-3 focus-visible:ring-ring/50",
-          !expanded && "justify-center px-0"
-        )}
+        className={cn(sidebarItemBase, !expanded && "justify-center px-0")}
       >
         <HugeiconsIcon
           icon={SidebarLeftIcon}
@@ -171,7 +178,7 @@ export function Sidebar() {
       <div className="flex flex-col gap-1">
         {bottomNav.map((item) =>
           item.isDialog ? (
-            <AccountDialogItem key={item.id} expanded={expanded} />
+            <NavDialog key={item.id} item={item} expanded={expanded} />
           ) : (
             <NavLink
               key={item.id}

--- a/web/components/ui/dialog.tsx
+++ b/web/components/ui/dialog.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Cancel01Icon } from "@hugeicons/core-free-icons"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-2 right-2"
+              size="icon-sm"
+            >
+              <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/web/components/ui/dropdown-menu.tsx
+++ b/web/components/ui/dropdown-menu.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import * as React from "react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Tick02Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/web/config/navigation.ts
+++ b/web/config/navigation.ts
@@ -14,19 +14,17 @@ import {
 } from "@hugeicons/core-free-icons"
 
 /**
- * A single sidebar destination. Most navigate via `href`; `Account` is special
- * (`isDialog`) and opens a dialog instead of routing. Single source of truth for
+ * A sidebar destination. Most route via `href` (`link`); `Account` opens a
+ * dialog (`dialog`) and so carries no route. The discriminated union keeps the
+ * two kinds from borrowing each other's fields. Single source of truth for
  * routes + icons (US-15.3, spec section 1.2).
  */
-export type NavItem = {
-  id: string
-  label: string
-  href: string
-  icon: IconSvgElement
-  isDialog?: boolean
-}
+type NavItemBase = { id: string; label: string; icon: IconSvgElement }
+export type NavLinkItem = NavItemBase & { href: string; isDialog?: false }
+export type NavDialogItem = NavItemBase & { isDialog: true }
+export type NavItem = NavLinkItem | NavDialogItem
 
-export const mainNav: NavItem[] = [
+export const mainNav: NavLinkItem[] = [
   { id: "home", label: "Home", href: "/", icon: HomeIcon },
   { id: "explore", label: "Explore", href: "/explore", icon: Compass01Icon },
   { id: "create", label: "Create", href: "/create", icon: MusicNote01Icon },
@@ -50,11 +48,5 @@ export const mainNav: NavItem[] = [
 
 export const bottomNav: NavItem[] = [
   { id: "labs", label: "Labs", href: "/labs", icon: TestTube01Icon },
-  {
-    id: "account",
-    label: "Account",
-    href: "#account",
-    icon: UserCircleIcon,
-    isDialog: true,
-  },
+  { id: "account", label: "Account", icon: UserCircleIcon, isDialog: true },
 ]

--- a/web/config/navigation.ts
+++ b/web/config/navigation.ts
@@ -1,0 +1,60 @@
+import type { IconSvgElement } from "@hugeicons/react"
+import {
+  Compass01Icon,
+  HomeIcon,
+  LibraryIcon,
+  MixerIcon,
+  MusicNote01Icon,
+  Notification01Icon,
+  Search01Icon,
+  TestTube01Icon,
+  TradeUpIcon,
+  Upload01Icon,
+  UserCircleIcon,
+} from "@hugeicons/core-free-icons"
+
+/**
+ * A single sidebar destination. Most navigate via `href`; `Account` is special
+ * (`isDialog`) and opens a dialog instead of routing. Single source of truth for
+ * routes + icons (US-15.3, spec section 1.2).
+ */
+export type NavItem = {
+  id: string
+  label: string
+  href: string
+  icon: IconSvgElement
+  isDialog?: boolean
+}
+
+export const mainNav: NavItem[] = [
+  { id: "home", label: "Home", href: "/", icon: HomeIcon },
+  { id: "explore", label: "Explore", href: "/explore", icon: Compass01Icon },
+  { id: "create", label: "Create", href: "/create", icon: MusicNote01Icon },
+  { id: "studio", label: "Studio", href: "/studio", icon: MixerIcon },
+  { id: "library", label: "Library", href: "/me", icon: LibraryIcon },
+  { id: "search", label: "Search", href: "/search", icon: Search01Icon },
+  { id: "feed", label: "Feed", href: "/feed", icon: TradeUpIcon },
+  {
+    id: "notifications",
+    label: "Notifications",
+    href: "/notifications",
+    icon: Notification01Icon,
+  },
+  {
+    id: "release",
+    label: "Mastering & Distribution",
+    href: "/release",
+    icon: Upload01Icon,
+  },
+]
+
+export const bottomNav: NavItem[] = [
+  { id: "labs", label: "Labs", href: "/labs", icon: TestTube01Icon },
+  {
+    id: "account",
+    label: "Account",
+    href: "#account",
+    icon: UserCircleIcon,
+    isDialog: true,
+  },
+]

--- a/web/lib/constants/layout.ts
+++ b/web/lib/constants/layout.ts
@@ -8,6 +8,7 @@
  */
 export const LAYOUT = {
   sidebarWidth: 64,
+  sidebarExpandedWidth: 240,
   playbarHeight: 72,
   rightPanelWidth: 320,
   z: {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -4269,6 +4270,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@ts-morph/common": {
@@ -8966,7 +8981,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -12842,6 +12856,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/web/test/router-mock.ts
+++ b/web/test/router-mock.ts
@@ -1,0 +1,6 @@
+/**
+ * Mutable Next.js App Router state for tests. `vitest.setup.ts` mocks
+ * `next/navigation` to read `pathname` from here; tests set it to drive
+ * active-route logic and reset it after each test.
+ */
+export const routerMock = { pathname: "/" }

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,7 +1,29 @@
 import "@testing-library/jest-dom/vitest"
-import { afterEach } from "vitest"
+import { afterEach, vi } from "vitest"
 import { cleanup } from "@testing-library/react"
+
+import { routerMock } from "./test/router-mock"
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => routerMock.pathname,
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}))
+
+// jsdom lacks the pointer-capture / scroll APIs Radix uses when opening menus.
+const proto = window.Element.prototype as unknown as Record<string, unknown>
+proto.hasPointerCapture ??= () => false
+proto.setPointerCapture ??= () => {}
+proto.releasePointerCapture ??= () => {}
+proto.scrollIntoView ??= () => {}
 
 afterEach(() => {
   cleanup()
+  routerMock.pathname = "/"
 })

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -4,16 +4,20 @@ import { cleanup } from "@testing-library/react"
 
 import { routerMock } from "./test/router-mock"
 
+// One shared router instance so a test capturing `const { push } = useRouter()`
+// holds the same spy the component calls.
+const mockRouter = {
+  push: vi.fn(),
+  replace: vi.fn(),
+  prefetch: vi.fn(),
+  back: vi.fn(),
+  forward: vi.fn(),
+  refresh: vi.fn(),
+}
+
 vi.mock("next/navigation", () => ({
   usePathname: () => routerMock.pathname,
-  useRouter: () => ({
-    push: vi.fn(),
-    replace: vi.fn(),
-    prefetch: vi.fn(),
-    back: vi.fn(),
-    forward: vi.fn(),
-    refresh: vi.fn(),
-  }),
+  useRouter: () => mockRouter,
 }))
 
 // jsdom lacks the pointer-capture / scroll APIs Radix uses when opening menus.

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -30,4 +30,5 @@ proto.scrollIntoView ??= () => {}
 afterEach(() => {
   cleanup()
   routerMock.pathname = "/"
+  vi.clearAllMocks()
 })


### PR DESCRIPTION
## US-15.3 — Sidebar Navigation Icons

Closes #183. Fills the US-15.2 sidebar shell with functional, icon-based navigation (spec sections 1.2–1.4).

### What's included
- **Centralized nav config** (`web/config/navigation.ts`) — single source of truth for routes + `@hugeicons/react` mappings; main destinations plus bottom-pinned Labs and Account.
- **Sidebar** rewritten as a client component:
  - Expand/collapse toggle: 64px icon-only ↔ 240px icon+label, animated (`transition-all`).
  - Active-route highlight via `usePathname` (`aria-current="page"`); root matches exactly, nested paths highlight their parent.
  - Profile dropdown (top): Profile / Account settings / Subscription / Log out.
  - Account item (bottom-pinned) opens a placeholder Dialog.
- **Primitives**: added shadcn `dropdown-menu` + `dialog`.
- **Routes**: minimal placeholder pages for the nine link destinations so navigation resolves.
- **Tests**: 8 RTL tests (render/links, active route, exact-root + nested matching, toggle, state-persistence, dropdown, dialog). Full suite 17/17 green; lint + `tsc` clean; production build passes (13 routes).

### Acceptance criteria
- [x] All navigation icons render and link to correct routes
- [x] Active route icon is visually distinct
- [x] Expand toggle switches sidebar between icon-only and icon+label modes
- [x] Sidebar state persists across navigation (does not reset on route change)
- [x] Profile dropdown shows profile, account settings, subscription, and logout options

### Deviations from the issue's coding plan
- **No React Context** for sidebar state — `Sidebar` renders inside the persistent App Router layout, so a local `useState` already survives route changes. Fewer moving parts; same behavior.
- **Paths** use the real `web/` root (alias `@/* → ./`), not `web/src/`.
- **No `avatar` primitive** — simple icon-button placeholder, since there's no user data yet.

### Known limitations
- Expand state persists across **navigation** but resets on a full page reload (no `localStorage`). Easy follow-up if reload-persistence is wanted.
- Profile menu (settings/subscription/logout) and the Account dialog are **placeholders** — wired up, no backend actions yet (future stories).
- Placeholder destination pages render a heading only.

https://claude.ai/code/session_01EnqmPMCgeazvLD9mWdmPev
