### PR TITLE
feat(web): OAuth Login and Signup (US-15.4)

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,10 @@
+# Base URL of the FastAPI backend the BFF auth routes proxy to (server-side only,
+# so NOT exposed to the browser). Defaults to http://localhost:8000 if unset.
+API_BASE_URL=http://localhost:8000
+
+# --- Backend (FastAPI) OAuth config, for local reference ---
+# The provider redirect_uri MUST point at THIS app's callback page so the OAuth
+# round-trip returns here. Set these on the backend (ACEMUSIC_API_* env vars):
+#   ACEMUSIC_API_GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback/google
+#   ACEMUSIC_API_DISCORD_REDIRECT_URI=http://localhost:3000/auth/callback/discord
+# Local dev: backend on :8000, this app on :3000.

--- a/web/app/api/auth/callback/[provider]/route.ts
+++ b/web/app/api/auth/callback/[provider]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { REFRESH_COOKIE, isSupportedProvider } from "@/lib/auth"
+import {
+  BACKEND_URL,
+  REFRESH_MAX_AGE,
+  clearStateCookies,
+  collectStateCookies,
+  cookieOptions,
+} from "@/lib/auth-server"
+
+// Finish an OAuth flow: forward the state cookie + code to the backend, then
+// keep the refresh token in an httpOnly cookie and hand the access token back.
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ provider: string }> }
+) {
+  const { provider } = await ctx.params
+  if (!isSupportedProvider(provider)) {
+    return NextResponse.json({ detail: "Unknown provider." }, { status: 400 })
+  }
+  const { code, state } = (await request.json().catch(() => ({}))) as {
+    code?: string
+    state?: string
+  }
+  if (!code || !state) {
+    return NextResponse.json({ detail: "Missing code or state." }, { status: 400 })
+  }
+
+  const cookieHeader = collectStateCookies(request)
+  const res = await fetch(`${BACKEND_URL}/api/v1/auth/callback/${provider}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(cookieHeader ? { cookie: cookieHeader } : {}),
+    },
+    body: JSON.stringify({ code, state }),
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) return NextResponse.json(body, { status: res.status })
+  if (!body.access_token || !body.refresh_token) {
+    return NextResponse.json(
+      { detail: "Malformed token response from backend." },
+      { status: 502 }
+    )
+  }
+
+  const out = NextResponse.json({
+    access_token: body.access_token,
+    expires_in: body.expires_in,
+  })
+  out.cookies.set(REFRESH_COOKIE, body.refresh_token, cookieOptions(REFRESH_MAX_AGE))
+  clearStateCookies(request, out)
+  return out
+}

--- a/web/app/api/auth/login/[provider]/route.ts
+++ b/web/app/api/auth/login/[provider]/route.ts
@@ -18,6 +18,12 @@ export async function POST(
   })
   const body = await res.json().catch(() => ({}))
   if (!res.ok) return NextResponse.json(body, { status: res.status })
+  if (!body.authorization_url) {
+    return NextResponse.json(
+      { detail: "Malformed login response from backend." },
+      { status: 502 }
+    )
+  }
 
   const out = NextResponse.json({ authorization_url: body.authorization_url })
   for (const { name, value } of parseStateSetCookies(res.headers.getSetCookie())) {

--- a/web/app/api/auth/login/[provider]/route.ts
+++ b/web/app/api/auth/login/[provider]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server"
+
+import { isSupportedProvider, parseStateSetCookies } from "@/lib/auth"
+import { BACKEND_URL, STATE_MAX_AGE, cookieOptions } from "@/lib/auth-server"
+
+// Start an OAuth flow: ask the backend for the provider authorization URL and
+// re-emit its per-flow state cookie under a path the BFF callback can read back.
+export async function POST(
+  _request: Request,
+  ctx: { params: Promise<{ provider: string }> }
+) {
+  const { provider } = await ctx.params
+  if (!isSupportedProvider(provider)) {
+    return NextResponse.json({ detail: "Unknown provider." }, { status: 400 })
+  }
+  const res = await fetch(`${BACKEND_URL}/api/v1/auth/login/${provider}`, {
+    method: "POST",
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) return NextResponse.json(body, { status: res.status })
+
+  const out = NextResponse.json({ authorization_url: body.authorization_url })
+  for (const { name, value } of parseStateSetCookies(res.headers.getSetCookie())) {
+    out.cookies.set(name, value, cookieOptions(STATE_MAX_AGE))
+  }
+  return out
+}

--- a/web/app/api/auth/logout/route.ts
+++ b/web/app/api/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { REFRESH_COOKIE } from "@/lib/auth"
+import { BACKEND_URL, cookieOptions } from "@/lib/auth-server"
+
+// Revoke the refresh token on the backend (best-effort) and clear the cookie.
+export async function POST(request: NextRequest) {
+  const refreshToken = request.cookies.get(REFRESH_COOKIE)?.value
+  if (refreshToken) {
+    await fetch(`${BACKEND_URL}/api/v1/auth/logout`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    }).catch(() => {})
+  }
+  const out = new NextResponse(null, { status: 204 })
+  out.cookies.set(REFRESH_COOKIE, "", cookieOptions(0))
+  return out
+}

--- a/web/app/api/auth/refresh/route.test.ts
+++ b/web/app/api/auth/refresh/route.test.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { REFRESH_COOKIE } from "@/lib/auth"
+import { POST } from "./route"
+
+function request(cookie?: string): NextRequest {
+  const req = new NextRequest(
+    new URL("http://localhost:3000/api/auth/refresh"),
+    { method: "POST" }
+  )
+  if (cookie) req.cookies.set(REFRESH_COOKIE, cookie)
+  return req
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("refresh route", () => {
+  it("401s without a refresh cookie and never calls the backend", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    const res = await POST(request())
+    expect(res.status).toBe(401)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("does not clear the cookie when the backend 401s (refresh-race safety)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) }))
+    )
+    const res = await POST(request("stale-token"))
+    expect(res.status).toBe(401)
+    const setCookie = res.headers.get("set-cookie") ?? ""
+    expect(setCookie).not.toContain("Max-Age=0")
+  })
+
+  it("rotates the cookie on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "a",
+          refresh_token: "newR",
+          expires_in: 900,
+        }),
+      }))
+    )
+    const res = await POST(request("old-token"))
+    expect(res.status).toBe(200)
+    expect(res.headers.get("set-cookie")).toContain(`${REFRESH_COOKIE}=newR`)
+    expect(await res.json()).toEqual({ access_token: "a", expires_in: 900 })
+  })
+})

--- a/web/app/api/auth/refresh/route.ts
+++ b/web/app/api/auth/refresh/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { REFRESH_COOKIE } from "@/lib/auth"
+import {
+  BACKEND_URL,
+  REFRESH_MAX_AGE,
+  cookieOptions,
+} from "@/lib/auth-server"
+
+// Rotate tokens using the httpOnly refresh cookie. Used on app mount to restore
+// a session and (later) to renew an expired access token.
+export async function POST(request: NextRequest) {
+  const refreshToken = request.cookies.get(REFRESH_COOKIE)?.value
+  if (!refreshToken) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const res = await fetch(`${BACKEND_URL}/api/v1/auth/refresh`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    // Don't clear the cookie here: single-use rotation means a concurrent
+    // refresh (e.g. a second tab) legitimately 401s on the same token while
+    // another request already rotated it — clearing would wipe the valid
+    // session. The client treats 401 as signed-out; logout clears explicitly.
+    return NextResponse.json(body, { status: res.status })
+  }
+  if (!body.access_token || !body.refresh_token) {
+    return NextResponse.json(
+      { detail: "Malformed token response from backend." },
+      { status: 502 }
+    )
+  }
+
+  const out = NextResponse.json({
+    access_token: body.access_token,
+    expires_in: body.expires_in,
+  })
+  out.cookies.set(REFRESH_COOKIE, body.refresh_token, cookieOptions(REFRESH_MAX_AGE))
+  return out
+}

--- a/web/app/auth/callback/[provider]/page.tsx
+++ b/web/app/auth/callback/[provider]/page.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { Suspense, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { useParams, useRouter, useSearchParams } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Alert01Icon, Loading03Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { safeInternalPath } from "@/lib/auth"
+import { useAuth } from "@/hooks/use-auth"
+
+function CallbackHandler() {
+  const { completeLogin } = useAuth()
+  const router = useRouter()
+  const params = useParams<{ provider: string }>()
+  const searchParams = useSearchParams()
+  const [exchangeFailed, setExchangeFailed] = useState(false)
+  const started = useRef(false)
+
+  const code = searchParams.get("code")
+  const state = searchParams.get("state")
+  const from = safeInternalPath(searchParams.get("from"))
+  const failed = exchangeFailed || !code || !state
+
+  useEffect(() => {
+    if (started.current || !code || !state) return // exchange the code exactly once
+    started.current = true
+    completeLogin(params.provider, code, state)
+      .then(() => router.replace(from))
+      .catch(() => setExchangeFailed(true))
+  }, [completeLogin, params.provider, router, from, code, state])
+
+  if (failed) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
+        <HugeiconsIcon icon={Alert01Icon} size={32} className="text-destructive" />
+        <p role="alert" className="text-sm text-muted-foreground">
+          Sign-in could not be completed.
+        </p>
+        <Button asChild variant="outline">
+          <Link href="/login">Back to sign in</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <HugeiconsIcon icon={Loading03Icon} size={32} className="animate-spin" />
+      <p className="text-sm text-muted-foreground">Signing you in…</p>
+    </div>
+  )
+}
+
+export default function CallbackPage() {
+  return (
+    <Suspense fallback={null}>
+      <CallbackHandler />
+    </Suspense>
+  )
+}

--- a/web/app/auth/callback/[provider]/page.tsx
+++ b/web/app/auth/callback/[provider]/page.tsx
@@ -7,7 +7,7 @@ import { HugeiconsIcon } from "@hugeicons/react"
 import { Alert01Icon, Loading03Icon } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
-import { safeInternalPath } from "@/lib/auth"
+import { RETURN_TO_KEY, safeInternalPath } from "@/lib/auth"
 import { useAuth } from "@/hooks/use-auth"
 
 function CallbackHandler() {
@@ -20,16 +20,18 @@ function CallbackHandler() {
 
   const code = searchParams.get("code")
   const state = searchParams.get("state")
-  const from = safeInternalPath(searchParams.get("from"))
   const failed = exchangeFailed || !code || !state
 
   useEffect(() => {
     if (started.current || !code || !state) return // exchange the code exactly once
     started.current = true
+    // The return path was stashed by the login page (providers don't echo it back).
+    const from = safeInternalPath(sessionStorage.getItem(RETURN_TO_KEY))
+    sessionStorage.removeItem(RETURN_TO_KEY)
     completeLogin(params.provider, code, state)
       .then(() => router.replace(from))
       .catch(() => setExchangeFailed(true))
-  }, [completeLogin, params.provider, router, from, code, state])
+  }, [completeLogin, params.provider, router, code, state])
 
   if (failed) {
     return (

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,4 +1,14 @@
+"use client"
+
+import { useRequireAuth } from "@/hooks/use-require-auth"
+
 export default function CreatePage() {
+  const { isLoading, isAuthenticated } = useRequireAuth()
+
+  // ponytail: render nothing until authed — useRequireAuth redirects otherwise,
+  // and this avoids flashing protected content during the check.
+  if (isLoading || !isAuthenticated) return null
+
   return (
     <div className="p-8">
       <h1 className="text-2xl font-semibold">Create</h1>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -4,6 +4,7 @@ import { Nunito_Sans } from "next/font/google"
 import "./globals.css"
 import { AppShell, BottomPlaybar } from "@/components/layout"
 import { ThemeProvider } from "@/components/theme-provider"
+import { AuthProvider } from "@/contexts/auth-context"
 import { cn } from "@/lib/utils"
 
 export const metadata: Metadata = {
@@ -26,9 +27,11 @@ export default function RootLayout({
     >
       <body>
         <ThemeProvider>
-          <AppShell>{children}</AppShell>
-          {/* Sibling of AppShell so the fixed playbar stays viewport-anchored. */}
-          <BottomPlaybar />
+          <AuthProvider>
+            <AppShell>{children}</AppShell>
+            {/* Sibling of AppShell so the fixed playbar stays viewport-anchored. */}
+            <BottomPlaybar />
+          </AuthProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/web/app/login/page.test.tsx
+++ b/web/app/login/page.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+// This page uses useSearchParams, which the shared setup mock doesn't provide.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/login",
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+import LoginPage from "@/app/login/page"
+import { AuthContext } from "@/contexts/auth-context"
+
+const baseAuth = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function renderLogin(overrides: Partial<typeof baseAuth> = {}) {
+  const value = { ...baseAuth, ...overrides }
+  render(<AuthContext.Provider value={value}>
+    <LoginPage />
+  </AuthContext.Provider>)
+  return value
+}
+
+describe("LoginPage", () => {
+  it("renders both OAuth provider buttons", () => {
+    renderLogin()
+    expect(
+      screen.getByRole("button", { name: /Continue with Google/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /Continue with Discord/ })
+    ).toBeInTheDocument()
+  })
+
+  it("starts the OAuth flow for the chosen provider", async () => {
+    const user = userEvent.setup()
+    const login = vi.fn().mockResolvedValue(undefined)
+    renderLogin({ login })
+    await user.click(screen.getByRole("button", { name: /Continue with Google/ }))
+    expect(login).toHaveBeenCalledWith("google")
+  })
+})

--- a/web/app/login/page.test.tsx
+++ b/web/app/login/page.test.tsx
@@ -47,4 +47,12 @@ describe("LoginPage", () => {
     await user.click(screen.getByRole("button", { name: /Continue with Google/ }))
     expect(login).toHaveBeenCalledWith("google")
   })
+
+  it("stashes the return path for the callback to pick up after the round-trip", async () => {
+    const user = userEvent.setup()
+    renderLogin({ login: vi.fn().mockResolvedValue(undefined) })
+    await user.click(screen.getByRole("button", { name: /Continue with Discord/ }))
+    // searchParams is empty here, so it defaults to /create.
+    expect(sessionStorage.getItem("ams_return_to")).toBe("/create")
+  })
 })

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
-import { safeInternalPath } from "@/lib/auth"
+import { RETURN_TO_KEY, safeInternalPath } from "@/lib/auth"
 import { useAuth } from "@/hooks/use-auth"
 
 const PROVIDERS = [
@@ -36,6 +36,9 @@ function LoginForm() {
     setFailed(false)
     setPending(provider)
     try {
+      // Providers don't echo app params back on the callback URL, so stash the
+      // return path here for the callback page to pick up after the round-trip.
+      sessionStorage.setItem(RETURN_TO_KEY, from)
       await login(provider) // navigates away to the provider on success
     } catch {
       setFailed(true)

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { Suspense, useEffect, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  DiscordIcon,
+  GoogleIcon,
+  Loading03Icon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { safeInternalPath } from "@/lib/auth"
+import { useAuth } from "@/hooks/use-auth"
+
+const PROVIDERS = [
+  { id: "google", label: "Continue with Google", icon: GoogleIcon },
+  { id: "discord", label: "Continue with Discord", icon: DiscordIcon },
+] as const
+
+function LoginForm() {
+  const { isAuthenticated, isLoading, login } = useAuth()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const from = safeInternalPath(searchParams.get("from"))
+
+  const [pending, setPending] = useState<string | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  // Already signed in? Skip the login screen.
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) router.replace(from)
+  }, [isLoading, isAuthenticated, from, router])
+
+  async function handleLogin(provider: string) {
+    setFailed(false)
+    setPending(provider)
+    try {
+      await login(provider) // navigates away to the provider on success
+    } catch {
+      setFailed(true)
+      setPending(null)
+    }
+  }
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 p-8">
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h1 className="text-2xl font-semibold">Sign in to Auto Music Studio</h1>
+        <p className="text-sm text-muted-foreground">
+          Start creating music in seconds.
+        </p>
+      </div>
+      <div className="flex w-full max-w-xs flex-col gap-3">
+        {PROVIDERS.map((p) => (
+          <Button
+            key={p.id}
+            variant="outline"
+            size="lg"
+            className="w-full justify-center"
+            disabled={pending !== null}
+            onClick={() => handleLogin(p.id)}
+          >
+            <HugeiconsIcon
+              icon={pending === p.id ? Loading03Icon : p.icon}
+              size={18}
+              className={pending === p.id ? "animate-spin" : undefined}
+            />
+            {p.label}
+          </Button>
+        ))}
+        {failed && (
+          <p role="alert" className="text-center text-sm text-destructive">
+            Could not start sign-in. Please try again.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function LoginPage() {
+  // useSearchParams requires a Suspense boundary in the App Router.
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  )
+}

--- a/web/components/layout/Sidebar.test.tsx
+++ b/web/components/layout/Sidebar.test.tsx
@@ -1,19 +1,34 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Sidebar } from "@/components/layout"
+import { AuthProvider } from "@/contexts/auth-context"
 import { mainNav } from "@/config/navigation"
 import { LAYOUT } from "@/lib/constants/layout"
 import { routerMock } from "@/test/router-mock"
 
+// The Sidebar's account menu now reads auth state, so renders need a provider.
+function renderSidebar() {
+  return render(
+    <AuthProvider>
+      <Sidebar />
+    </AuthProvider>
+  )
+}
+
 beforeEach(() => {
   routerMock.pathname = "/"
+  // AuthProvider attempts a session refresh on mount; resolve it as signed-out.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) })
+  )
 })
 
 describe("Sidebar navigation (US-15.3)", () => {
   it("renders every main destination as a link to the correct route", () => {
-    render(<Sidebar />)
+    renderSidebar()
     for (const item of mainNav) {
       const link = screen.getByRole("link", { name: item.label })
       expect(link).toHaveAttribute("href", item.href)
@@ -30,7 +45,7 @@ describe("Sidebar navigation (US-15.3)", () => {
 
   it("marks the active route and only the active route", () => {
     routerMock.pathname = "/explore"
-    render(<Sidebar />)
+    renderSidebar()
     expect(screen.getByRole("link", { name: "Explore" })).toHaveAttribute(
       "aria-current",
       "page"
@@ -42,7 +57,7 @@ describe("Sidebar navigation (US-15.3)", () => {
 
   it("matches Home only on an exact root path (no false positives)", () => {
     routerMock.pathname = "/create"
-    render(<Sidebar />)
+    renderSidebar()
     expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute(
       "aria-current"
     )
@@ -54,7 +69,7 @@ describe("Sidebar navigation (US-15.3)", () => {
 
   it("highlights a parent route for nested paths", () => {
     routerMock.pathname = "/create/advanced"
-    render(<Sidebar />)
+    renderSidebar()
     expect(screen.getByRole("link", { name: "Create" })).toHaveAttribute(
       "aria-current",
       "page"
@@ -63,7 +78,7 @@ describe("Sidebar navigation (US-15.3)", () => {
 
   it("starts collapsed (icon-only) and toggles to icon+label mode", async () => {
     const user = userEvent.setup()
-    render(<Sidebar />)
+    renderSidebar()
 
     const sidebar = screen.getByTestId("app-sidebar")
     expect(sidebar).toHaveStyle({ width: `${LAYOUT.sidebarWidth}px` })
@@ -81,14 +96,18 @@ describe("Sidebar navigation (US-15.3)", () => {
 
   it("keeps the expanded state across a route change", async () => {
     const user = userEvent.setup()
-    const view = render(<Sidebar />)
+    const view = renderSidebar()
 
     await user.click(screen.getByRole("button", { name: "Expand sidebar" }))
     expect(screen.getByText("Explore")).toBeInTheDocument()
 
     // Simulate navigation: pathname changes, component re-renders in place.
     routerMock.pathname = "/explore"
-    view.rerender(<Sidebar />)
+    view.rerender(
+      <AuthProvider>
+        <Sidebar />
+      </AuthProvider>
+    )
 
     expect(screen.getByText("Explore")).toBeInTheDocument()
     expect(screen.getByTestId("app-sidebar")).toHaveStyle({
@@ -98,7 +117,7 @@ describe("Sidebar navigation (US-15.3)", () => {
 
   it("opens the profile dropdown with all account options", async () => {
     const user = userEvent.setup()
-    render(<Sidebar />)
+    renderSidebar()
 
     await user.click(screen.getByRole("button", { name: "Open account menu" }))
 
@@ -118,7 +137,7 @@ describe("Sidebar navigation (US-15.3)", () => {
 
   it("opens the account dialog from the bottom-pinned Account item", async () => {
     const user = userEvent.setup()
-    render(<Sidebar />)
+    renderSidebar()
 
     await user.click(screen.getByRole("button", { name: "Account" }))
 

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   type NavDialogItem,
   type NavLinkItem,
 } from "@/config/navigation"
+import { useAuth } from "@/hooks/use-auth"
 import { cn } from "@/lib/utils"
 import {
   DropdownMenu,
@@ -72,6 +73,32 @@ function NavLink({
   )
 }
 
+/**
+ * Account menu body. Kept separate from the trigger so it (and its `useAuth`
+ * call) only mounts when the dropdown opens — components rendering the Sidebar
+ * without an AuthProvider stay unaffected unless they open this menu.
+ */
+function AccountMenuItems() {
+  const { user, logout } = useAuth()
+  return (
+    <>
+      <DropdownMenuLabel className="truncate">
+        {user?.email ?? "Account"}
+      </DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem asChild>
+        <Link href="/me">Profile</Link>
+      </DropdownMenuItem>
+      <DropdownMenuItem>Account settings</DropdownMenuItem>
+      <DropdownMenuItem>Subscription</DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem variant="destructive" onSelect={() => logout()}>
+        Log out
+      </DropdownMenuItem>
+    </>
+  )
+}
+
 /** Profile avatar at the top; opens the account dropdown (spec section 1.4). */
 function ProfileMenu({ expanded }: { expanded: boolean }) {
   return (
@@ -86,15 +113,7 @@ function ProfileMenu({ expanded }: { expanded: boolean }) {
         {expanded && <span className="truncate text-sm">Your account</span>}
       </DropdownMenuTrigger>
       <DropdownMenuContent side="right" align="start" className="w-48">
-        <DropdownMenuLabel>Account</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <Link href="/me">Profile</Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem>Account settings</DropdownMenuItem>
-        <DropdownMenuItem>Subscription</DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem variant="destructive">Log out</DropdownMenuItem>
+        <AccountMenuItems />
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/web/contexts/auth-context.test.tsx
+++ b/web/contexts/auth-context.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { AuthProvider } from "@/contexts/auth-context"
+import { useAuth } from "@/hooks/use-auth"
+
+const accessToken = `h.${Buffer.from(
+  JSON.stringify({ sub: "u1", email: "musician@example.com" })
+).toString("base64url")}.s`
+
+function Probe() {
+  const { isLoading, isAuthenticated, user, logout } = useAuth()
+  if (isLoading) return <p>loading</p>
+  return (
+    <div>
+      <p data-testid="state">
+        {isAuthenticated ? `in:${user?.email}` : "out"}
+      </p>
+      <button onClick={() => logout()}>logout</button>
+    </div>
+  )
+}
+
+const ok = (body: object) => ({ ok: true, status: 200, json: async () => body })
+const unauthorized = { ok: false, status: 401, json: async () => ({}) }
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("AuthProvider", () => {
+  it("restores a session on mount via the refresh cookie", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) =>
+        url === "/api/auth/refresh" ? ok({ access_token: accessToken }) : unauthorized
+      )
+    )
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("state")).toHaveTextContent(
+        "in:musician@example.com"
+      )
+    )
+  })
+
+  it("stays signed out when the refresh fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => unauthorized))
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("state")).toHaveTextContent("out")
+    )
+  })
+
+  it("clears the session on logout", async () => {
+    const fetchMock = vi.fn(async (url: string) =>
+      url === "/api/auth/refresh" ? ok({ access_token: accessToken }) : ok({})
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("state")).toHaveTextContent("in:")
+    )
+
+    await user.click(screen.getByRole("button", { name: "logout" }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("state")).toHaveTextContent("out")
+    )
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/logout", {
+      method: "POST",
+    })
+  })
+})

--- a/web/contexts/auth-context.tsx
+++ b/web/contexts/auth-context.tsx
@@ -78,17 +78,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     router.push("/login")
   }, [router])
 
-  const value = useMemo<AuthContextValue>(
-    () => ({
-      user: accessToken ? decodeAccessToken(accessToken) : null,
-      isAuthenticated: accessToken !== null,
+  const value = useMemo<AuthContextValue>(() => {
+    // Derive isAuthenticated from the decoded user so the two can't disagree
+    // (a token missing sub/email decodes to null → treated as unauthenticated).
+    const user = accessToken ? decodeAccessToken(accessToken) : null
+    return {
+      user,
+      isAuthenticated: user !== null,
       isLoading,
       login,
       completeLogin,
       logout,
-    }),
-    [accessToken, isLoading, login, completeLogin, logout]
-  )
+    }
+  }, [accessToken, isLoading, login, completeLogin, logout])
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }

--- a/web/contexts/auth-context.tsx
+++ b/web/contexts/auth-context.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+import { useRouter } from "next/navigation"
+
+import { decodeAccessToken, type AuthUser } from "@/lib/auth"
+
+type AuthContextValue = {
+  user: AuthUser | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  /** Begin an OAuth flow; redirects the browser to the provider on success. */
+  login: (provider: string) => Promise<void>
+  /** Exchange an OAuth callback's code/state for a session. */
+  completeLogin: (provider: string, code: string, state: string) => Promise<void>
+  logout: () => Promise<void>
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const router = useRouter()
+  // Access token lives in memory only — never localStorage. The refresh token
+  // is held server-side in an httpOnly cookie by the BFF.
+  const [accessToken, setAccessToken] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  // On mount, try to restore a session via the refresh cookie.
+  useEffect(() => {
+    let active = true
+    fetch("/api/auth/refresh", { method: "POST" })
+      .then(async (res) => {
+        if (active && res.ok) {
+          const { access_token } = await res.json()
+          setAccessToken(access_token)
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setIsLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const login = useCallback(async (provider: string) => {
+    const res = await fetch(`/api/auth/login/${provider}`, { method: "POST" })
+    if (!res.ok) throw new Error("Failed to start login.")
+    const { authorization_url } = await res.json()
+    window.location.assign(authorization_url)
+  }, [])
+
+  const completeLogin = useCallback(
+    async (provider: string, code: string, state: string) => {
+      const res = await fetch(`/api/auth/callback/${provider}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ code, state }),
+      })
+      if (!res.ok) throw new Error("Authentication failed.")
+      const { access_token } = await res.json()
+      setAccessToken(access_token)
+    },
+    []
+  )
+
+  const logout = useCallback(async () => {
+    await fetch("/api/auth/logout", { method: "POST" }).catch(() => {})
+    setAccessToken(null)
+    router.push("/login")
+  }, [router])
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user: accessToken ? decodeAccessToken(accessToken) : null,
+      isAuthenticated: accessToken !== null,
+      isLoading,
+      login,
+      completeLogin,
+      logout,
+    }),
+    [accessToken, isLoading, login, completeLogin, logout]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/web/hooks/use-auth.ts
+++ b/web/hooks/use-auth.ts
@@ -1,0 +1,12 @@
+"use client"
+
+import { useContext } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+
+/** Access the auth context. Throws if used outside an AuthProvider. */
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error("useAuth must be used within an AuthProvider")
+  return ctx
+}

--- a/web/hooks/use-require-auth.ts
+++ b/web/hooks/use-require-auth.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useRouter } from "next/navigation"
+
+import { useAuth } from "./use-auth"
+
+/**
+ * Redirect to /login (preserving the intended path) once we know the visitor is
+ * unauthenticated. Middleware already blocks the no-cookie case; this also
+ * covers a present-but-expired session that fails to refresh.
+ */
+export function useRequireAuth() {
+  const auth = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (!auth.isLoading && !auth.isAuthenticated) {
+      router.replace(`/login?from=${encodeURIComponent(pathname)}`)
+    }
+  }, [auth.isLoading, auth.isAuthenticated, pathname, router])
+
+  return auth
+}

--- a/web/lib/auth-server.ts
+++ b/web/lib/auth-server.ts
@@ -1,0 +1,42 @@
+// Server-only auth helpers for the BFF route handlers. Imports next/server, so
+// never pull this into a client component.
+import type { NextRequest, NextResponse } from "next/server"
+
+import { OAUTH_STATE_PREFIX } from "./auth"
+
+/** Backend base URL the BFF proxies to. Server-side only, so not NEXT_PUBLIC_. */
+export const BACKEND_URL = process.env.API_BASE_URL ?? "http://localhost:8000"
+
+/** Matches the backend's 10-minute OAuth state TTL. */
+export const STATE_MAX_AGE = 10 * 60
+/** Matches the backend's 7-day refresh-token TTL. */
+export const REFRESH_MAX_AGE = 7 * 24 * 60 * 60
+
+/** Standard cookie options. Path `/` so middleware can read the session cookie. */
+export function cookieOptions(maxAge: number) {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge,
+  }
+}
+
+/** Build a `Cookie` header of the `oauth_state_*` cookies to forward to the backend. */
+export function collectStateCookies(request: NextRequest): string {
+  return request.cookies
+    .getAll()
+    .filter((c) => c.name.startsWith(OAUTH_STATE_PREFIX))
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ")
+}
+
+/** Expire any `oauth_state_*` cookies on the response once the flow is consumed. */
+export function clearStateCookies(request: NextRequest, response: NextResponse) {
+  for (const c of request.cookies.getAll()) {
+    if (c.name.startsWith(OAUTH_STATE_PREFIX)) {
+      response.cookies.set(c.name, "", cookieOptions(0))
+    }
+  }
+}

--- a/web/lib/auth.test.ts
+++ b/web/lib/auth.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  decodeAccessToken,
+  isSupportedProvider,
+  parseStateSetCookies,
+  safeInternalPath,
+} from "@/lib/auth"
+
+const jwt = (payload: object) =>
+  `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.sig`
+
+describe("decodeAccessToken", () => {
+  it("extracts id and email from the JWT payload", () => {
+    const token = jwt({ sub: "user-123", email: "musician@example.com" })
+    expect(decodeAccessToken(token)).toEqual({
+      id: "user-123",
+      email: "musician@example.com",
+    })
+  })
+
+  it("returns null when required claims are missing", () => {
+    expect(decodeAccessToken(jwt({ sub: "only-id" }))).toBeNull()
+  })
+
+  it("returns null for a malformed token", () => {
+    expect(decodeAccessToken("not-a-jwt")).toBeNull()
+    expect(decodeAccessToken("")).toBeNull()
+  })
+})
+
+describe("parseStateSetCookies", () => {
+  it("keeps only oauth_state_* names with their values, dropping attributes", () => {
+    const result = parseStateSetCookies([
+      "oauth_state_abc123=nonce-value; Path=/api/v1/auth; HttpOnly; Secure; SameSite=Lax",
+      "other_cookie=ignored; Path=/",
+    ])
+    expect(result).toEqual([{ name: "oauth_state_abc123", value: "nonce-value" }])
+  })
+
+  it("skips empty-valued and malformed entries", () => {
+    expect(
+      parseStateSetCookies(["oauth_state_x=; Path=/", "garbage"])
+    ).toEqual([])
+  })
+})
+
+describe("safeInternalPath", () => {
+  it("keeps a same-site absolute path", () => {
+    expect(safeInternalPath("/create/advanced")).toBe("/create/advanced")
+  })
+
+  it("rejects external, protocol-relative, and relative targets", () => {
+    expect(safeInternalPath("https://evil.com")).toBe("/create")
+    expect(safeInternalPath("//evil.com")).toBe("/create")
+    expect(safeInternalPath("/\\evil.com")).toBe("/create")
+    expect(safeInternalPath("create")).toBe("/create")
+    expect(safeInternalPath(null)).toBe("/create")
+  })
+})
+
+describe("isSupportedProvider", () => {
+  it("accepts google and discord, rejects anything else", () => {
+    expect(isSupportedProvider("google")).toBe(true)
+    expect(isSupportedProvider("discord")).toBe(true)
+    expect(isSupportedProvider("../admin")).toBe(false)
+    expect(isSupportedProvider("facebook")).toBe(false)
+  })
+})

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -7,6 +7,9 @@ export const REFRESH_COOKIE = "ams_refresh_token"
 /** Prefix of the backend's per-flow OAuth state cookie (`oauth_state_<flow_id>`). */
 export const OAUTH_STATE_PREFIX = "oauth_state_"
 
+/** sessionStorage key holding the post-login return path across the OAuth round-trip. */
+export const RETURN_TO_KEY = "ams_return_to"
+
 export type AuthUser = { id: string; email: string }
 
 /** OAuth providers the UI and BFF support. */

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -1,0 +1,66 @@
+// Shared, client-safe auth constants and pure helpers. No server-only imports
+// here so this module is safe to pull into client components and middleware.
+
+/** httpOnly cookie the BFF uses to hold the backend refresh token. */
+export const REFRESH_COOKIE = "ams_refresh_token"
+
+/** Prefix of the backend's per-flow OAuth state cookie (`oauth_state_<flow_id>`). */
+export const OAUTH_STATE_PREFIX = "oauth_state_"
+
+export type AuthUser = { id: string; email: string }
+
+/** OAuth providers the UI and BFF support. */
+export const OAUTH_PROVIDERS = ["google", "discord"] as const
+
+export function isSupportedProvider(provider: string): boolean {
+  return (OAUTH_PROVIDERS as readonly string[]).includes(provider)
+}
+
+/**
+ * Clamp a post-login redirect target to a same-site absolute path. Rejects
+ * external (`//host`, `/\host`), absolute, and protocol URLs so a crafted
+ * `?from=` can't turn the login into an open redirect.
+ */
+export function safeInternalPath(raw: string | null, fallback = "/create"): string {
+  if (raw && raw[0] === "/" && raw[1] !== "/" && raw[1] !== "\\") return raw
+  return fallback
+}
+
+/**
+ * Decode the (unverified) JWT payload purely to show identity in the UI. The
+ * token's trust is established server-side; this is display-only. Returns null
+ * if the token is missing the expected claims or is malformed.
+ */
+export function decodeAccessToken(token: string): AuthUser | null {
+  try {
+    const payload = token.split(".")[1]
+    if (!payload) return null
+    let b64 = payload.replace(/-/g, "+").replace(/_/g, "/")
+    b64 += "=".repeat((4 - (b64.length % 4)) % 4)
+    const claims = JSON.parse(atob(b64)) as { sub?: string; email?: string }
+    if (!claims.sub || !claims.email) return null
+    return { id: claims.sub, email: claims.email }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Pull `oauth_state_*` cookies out of a backend `Set-Cookie` header list,
+ * returning just the `name`/`value` so the BFF can re-emit them under its own
+ * path. Cookie attributes (path/secure/etc.) are intentionally dropped.
+ */
+export function parseStateSetCookies(
+  setCookies: string[]
+): { name: string; value: string }[] {
+  const out: { name: string; value: string }[] = []
+  for (const raw of setCookies) {
+    const pair = raw.split(";", 1)[0]
+    const eq = pair.indexOf("=")
+    if (eq === -1) continue
+    const name = pair.slice(0, eq).trim()
+    const value = pair.slice(eq + 1).trim()
+    if (name.startsWith(OAUTH_STATE_PREFIX) && value) out.push({ name, value })
+  }
+  return out
+}

--- a/web/middleware.test.ts
+++ b/web/middleware.test.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server"
+import { describe, expect, it } from "vitest"
+
+import { middleware } from "@/middleware"
+import { REFRESH_COOKIE } from "@/lib/auth"
+
+function request(path: string, withSession: boolean): NextRequest {
+  const req = new NextRequest(new URL(`http://localhost:3000${path}`))
+  if (withSession) req.cookies.set(REFRESH_COOKIE, "some-refresh-token")
+  return req
+}
+
+describe("middleware route protection", () => {
+  it("redirects an unauthenticated visitor to /login, preserving the path", () => {
+    const res = middleware(request("/create", false))
+    const location = res.headers.get("location")!
+    const url = new URL(location)
+    expect(url.pathname).toBe("/login")
+    expect(url.searchParams.get("from")).toBe("/create")
+  })
+
+  it("lets an authenticated visitor through", () => {
+    const res = middleware(request("/create", true))
+    expect(res.headers.get("location")).toBeNull()
+  })
+})

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,0 +1,18 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { REFRESH_COOKIE } from "@/lib/auth"
+
+// Gate protected routes on the presence of the session (refresh) cookie. A
+// present-but-invalid token is handled client-side after the refresh attempt;
+// here we only need the cheap "never signed in" redirect, with no content flash.
+export function middleware(request: NextRequest) {
+  if (request.cookies.has(REFRESH_COOKIE)) return NextResponse.next()
+
+  const url = new URL("/login", request.url)
+  url.searchParams.set("from", request.nextUrl.pathname)
+  return NextResponse.redirect(url)
+}
+
+export const config = {
+  matcher: ["/create", "/create/:path*"],
+}

--- a/web/proxy.test.ts
+++ b/web/proxy.test.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server"
 import { describe, expect, it } from "vitest"
 
-import { middleware } from "@/middleware"
+import { proxy } from "@/proxy"
 import { REFRESH_COOKIE } from "@/lib/auth"
 
 function request(path: string, withSession: boolean): NextRequest {
@@ -10,9 +10,9 @@ function request(path: string, withSession: boolean): NextRequest {
   return req
 }
 
-describe("middleware route protection", () => {
+describe("proxy route protection", () => {
   it("redirects an unauthenticated visitor to /login, preserving the path", () => {
-    const res = middleware(request("/create", false))
+    const res = proxy(request("/create", false))
     const location = res.headers.get("location")!
     const url = new URL(location)
     expect(url.pathname).toBe("/login")
@@ -20,7 +20,7 @@ describe("middleware route protection", () => {
   })
 
   it("lets an authenticated visitor through", () => {
-    const res = middleware(request("/create", true))
+    const res = proxy(request("/create", true))
     expect(res.headers.get("location")).toBeNull()
   })
 })

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -5,7 +5,7 @@ import { REFRESH_COOKIE } from "@/lib/auth"
 // Gate protected routes on the presence of the session (refresh) cookie. A
 // present-but-invalid token is handled client-side after the refresh attempt;
 // here we only need the cheap "never signed in" redirect, with no content flash.
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   if (request.cookies.has(REFRESH_COOKIE)) return NextResponse.next()
 
   const url = new URL("/login", request.url)


### PR DESCRIPTION
## Summary

Implements **US-15.4: OAuth Login and Signup** (closes #184) for the Next.js frontend using a **BFF (Backend-for-Frontend)** pattern. The browser only talks to Next.js; Next.js API routes proxy server-side to the existing FastAPI auth API, keeping the **refresh token in an httpOnly cookie** and the **access token in memory** (React context).

### Flow
1. `/login` → click Google/Discord → `POST /api/auth/login/[provider]` (BFF) → backend returns `authorization_url`; BFF re-emits the backend's `oauth_state_<flow_id>` cookie under a path the callback can read → browser redirects to the provider.
2. Provider redirects back to `/auth/callback/[provider]?code&state` → page POSTs to the BFF callback → BFF forwards the state cookie to the backend, gets tokens, sets the `ams_refresh_token` httpOnly cookie, returns the access token → context stores it → redirect to `/create`.
3. On mount the context calls `/api/auth/refresh` to restore the session after a reload. Logout revokes the refresh token and clears the cookie.

## Acceptance criteria
| Criterion | How it's met | Evidence |
|---|---|---|
| Google OAuth → `/create` | login/callback BFF + context redirect | unit tests + manual (needs provider creds) |
| Discord OAuth → `/create` | same, provider-parametrized | unit tests + manual (needs provider creds) |
| Unauth `/create` → login | `middleware.ts` + `useRequireAuth` | `middleware.test.ts` + browser demo |
| Logout clears session → login | logout BFF clears cookie; sidebar menu | `auth-context.test.tsx` |
| Tokens stored securely (httpOnly) | refresh token in httpOnly cookie; access token in memory only | route code + `refresh/route.test.ts` |

## Notable decisions / deviations from the issue plan
- **Flat `web/` layout** (no `src/`), matching the existing scaffold.
- **Server-side `API_BASE_URL`** (not `NEXT_PUBLIC_`) — the BFF runs server-side, so the backend URL and the BFF↔backend hop stay private and dodge cross-origin cookie/CORS constraints documented in the backend auth router.
- **Email/password signup deferred** — no backend endpoint exists (matches CodeRabbit's plan).
- Security hardening from the pre-PR review: provider allowlist on the BFF routes, `safeInternalPath()` open-redirect guard on `?from=`, and the refresh route **does not clear the cookie on 401** so a single-use refresh race across tabs can't wipe a valid session.

## Setup for a live OAuth round-trip
See `web/.env.example`. The backend's provider `redirect_uri` must point at this app's callback page, e.g. `ACEMUSIC_API_GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback/google`.

## Known limitations (follow-ups)
- No **proactive pre-expiry access-token refresh** timer yet. This story has no authenticated API calls, so a silent mid-session 401 can't occur; add the refresh scheduler with the first story that makes authed calls.
- The login/callback pages render inside the existing AppShell (sidebar visible). A dedicated auth route-group layout is a cosmetic follow-up, out of scope here.

## Tests
`npm run test` → 35 passing (auth lib, context, middleware, login page, refresh route). `lint`, `typecheck`, `build` all green.

https://claude.ai/code/session_01EnqmPMCgeazvLD9mWdmPev
