### PR TITLE
feat(web): Profile Settings page (US-15.5)

### DIFF
--- a/docs/demos/us-15.5-profile-settings.md
+++ b/docs/demos/us-15.5-profile-settings.md
@@ -1,0 +1,82 @@
+# US-15.5 — Profile Settings Page (demo)
+
+A protected `/settings` page lets a musician edit their display name, handle, bio,
+style tags, and (preview-only) avatar, then save to `PATCH /api/v1/users/me`.
+The page is reachable from the sidebar account menu ("Account settings").
+
+The backend (`GET`/`PATCH /api/v1/users/me`) already exists; this story is the
+frontend. The client holds the access token in memory and calls a same-origin
+BFF proxy (`web/app/api/users/me/route.ts`) that forwards the Bearer header to
+the backend, so 409 (duplicate handle) and 422 (validation) surface unchanged.
+
+Because the page is auth-gated (OAuth), the outcome evidence below comes from
+integration tests that render the **real** page/components/hook and assert on the
+real DOM and the real request payloads sent to the BFF contract. Run them with:
+
+```
+cd web && npm test
+# Test Files  13 passed (13) · Tests  73 passed (73)
+```
+
+## AC1 — All fields save successfully and persist on reload
+`SettingsPage > saves changed fields and shows a success message` — edits the
+display name, clicks Save, and asserts:
+- the PATCH body is exactly the changed field: `{ "display_name": "Ada L" }`
+  (only-changed-fields / `exclude_unset` behavior), and
+- the success status "Saved." renders, with the form re-seeded from the server
+  response (the new value is the post-reload baseline).
+`useProfileSettings > save() returns the updated profile on success` covers the
+GET-on-mount → PATCH → updated-profile round-trip at the hook level.
+
+## AC2 — Username handle shows real-time availability feedback
+`SettingsPage > gives real-time format feedback on the handle as you type` —
+typing `ab` shows "Handle must be 3-30 characters" after the 400 ms debounce;
+extending to `abcde` switches to the "Looks good" affirmative state.
+Server-side uniqueness surfaces on save:
+`SettingsPage > shows an inline error when the handle is already taken (409)`
+renders "This handle is already taken." inline on the handle field.
+`validateHandle` unit tests pin every format rule (length, charset, no
+leading/trailing hyphen) to match the backend validator.
+
+> Known limitation: there is no handle-availability endpoint, so uniqueness is
+> only known at save time (409). Real-time feedback is format-only by design.
+
+## AC3 — Avatar upload previews the image before saving
+`AvatarUpload > previews the image after a valid file is chosen` — selecting a
+PNG renders an `<img alt="Avatar preview">` pointing at the local object URL.
+`AvatarUpload > rejects a non-image file dropped onto the zone` — a dropped
+`text/plain` file produces an inline "choose an image" error and no preview.
+
+> Known limitation: the backend avatar endpoint (US-8.5) doesn't exist yet, so
+> `avatar_url` is read-only and the chosen image is preview-only ("coming soon"
+> badge). Square crop is CSS `object-cover`, not a crop library.
+
+## AC4 — Style tags render as removable pill badges
+`StyleTagsInput > renders existing tags as removable pills` — clicking the X on
+"cello" calls `onChange(["lo-fi"])`.
+`StyleTagsInput > adds a tag on Enter` and `> shows typeahead suggestions
+filtered by input` cover add + typeahead; `> rejects a duplicate tag` shows the
+inline guard. Backend caps (≤20 tags, ≤30 chars, no empties/dupes) are enforced
+client-side via `validateNewStyleTag` (unit-tested).
+
+## AC5 — Validation errors display inline next to the offending field
+`SettingsPage > blocks save and shows a required error when display name is
+empty` — clearing the display name blocks submit and renders the inline
+"required" error next to the field (no PATCH sent). 409/422 responses map to the
+same inline `FieldError` slots (handle 409 test above; `useProfileSettings >
+maps a 422 to field errors` maps FastAPI `detail[].loc` to per-field messages).
+
+## Build
+`npm run build` registers the new routes:
+```
+├ ƒ /api/users/me        (BFF proxy: GET + PATCH)
+└ ○ /settings            (profile settings page)
+```
+
+## Reviewer notes (codex cross-family review)
+- Fixed: a slow in-flight save could clobber concurrent edits → fields are now
+  disabled (`<fieldset disabled={saving}>`) during save.
+- Known limitation: the in-memory access token is only refreshed on app mount
+  (inherited from US-15.4 auth foundation). After token expiry, an authenticated
+  call can 401 until reload — this affects all future authenticated client calls
+  and belongs in the shared auth layer, not this page.

--- a/docs/demos/us-15.5-profile-settings.md
+++ b/docs/demos/us-15.5-profile-settings.md
@@ -73,10 +73,19 @@ maps a 422 to field errors` maps FastAPI `detail[].loc` to per-field messages).
 └ ○ /settings            (profile settings page)
 ```
 
-## Reviewer notes (codex cross-family review)
-- Fixed: a slow in-flight save could clobber concurrent edits → fields are now
-  disabled (`<fieldset disabled={saving}>`) during save.
+## Reviewer notes
+codex (cross-family) + claude-review findings, triaged with verify-before-fix:
+- Fixed: in-flight save could clobber concurrent edits → `<fieldset disabled>`.
+- Fixed: trailing-space-only changes no longer fire a no-op PATCH; bio is
+  trimmed before send (no whitespace-only bios).
+- Fixed: avatar object-URL revocation is single-sourced in the effect cleanup.
+- Fixed: a 401 on load now shows "Your session expired. Please sign in again."
+- Hardened: proxy forwards `Accept: application/json`; custom style tags are
+  lowercased for a consistent list.
+- **Rejected (false positive):** a finding claimed the backend rejects
+  consecutive hyphens (`a--b`) and the client was too lenient. Verified the
+  backend `_HANDLE_PATTERN` *accepts* `a--b` — the client matches it exactly.
+  Tightening the client would have introduced a client/server divergence.
 - Known limitation: the in-memory access token is only refreshed on app mount
-  (inherited from US-15.4 auth foundation). After token expiry, an authenticated
-  call can 401 until reload — this affects all future authenticated client calls
-  and belongs in the shared auth layer, not this page.
+  (inherited from US-15.4). After token expiry an authenticated call can 401
+  until reload — belongs in the shared auth layer, not this page.

--- a/web/app/api/users/me/route.test.ts
+++ b/web/app/api/users/me/route.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { GET, PATCH } from "@/app/api/users/me/route"
+
+function req(init: RequestInit = {}): NextRequest {
+  return new Request("http://localhost/api/users/me", init) as unknown as NextRequest
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("GET /api/users/me", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await GET(req())
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the Bearer token and passes the profile through", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "u1", handle: "ada" }), { status: 200 })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await GET(req({ headers: { authorization: "Bearer tok" } }))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ id: "u1", handle: "ada" })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/users/me")
+    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+  })
+})
+
+describe("PATCH /api/users/me", () => {
+  it("forwards the body and surfaces a 409 verbatim", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ detail: "taken" }), { status: 409 })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await PATCH(
+      req({
+        method: "PATCH",
+        headers: { authorization: "Bearer tok", "content-type": "application/json" },
+        body: JSON.stringify({ handle: "taken" }),
+      })
+    )
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ detail: "taken" })
+
+    const [, opts] = fetchMock.mock.calls[0]
+    expect(opts.method).toBe("PATCH")
+    expect(opts.body).toBe(JSON.stringify({ handle: "taken" }))
+  })
+
+  it("401s without an Authorization header", async () => {
+    const res = await PATCH(req({ method: "PATCH" }))
+    expect(res.status).toBe(401)
+  })
+})

--- a/web/app/api/users/me/route.test.ts
+++ b/web/app/api/users/me/route.test.ts
@@ -4,7 +4,10 @@ import type { NextRequest } from "next/server"
 import { GET, PATCH } from "@/app/api/users/me/route"
 
 function req(init: RequestInit = {}): NextRequest {
-  return new Request("http://localhost/api/users/me", init) as unknown as NextRequest
+  return new Request(
+    "http://localhost/api/users/me",
+    init
+  ) as unknown as NextRequest
 }
 
 afterEach(() => vi.restoreAllMocks())
@@ -19,7 +22,9 @@ describe("GET /api/users/me", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(
-        new Response(JSON.stringify({ id: "u1", handle: "ada" }), { status: 200 })
+        new Response(JSON.stringify({ id: "u1", handle: "ada" }), {
+          status: 200,
+        })
       )
     vi.stubGlobal("fetch", fetchMock)
 
@@ -29,7 +34,9 @@ describe("GET /api/users/me", () => {
 
     const [url, opts] = fetchMock.mock.calls[0]
     expect(url).toContain("/api/v1/users/me")
-    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
   })
 })
 
@@ -45,7 +52,10 @@ describe("PATCH /api/users/me", () => {
     const res = await PATCH(
       req({
         method: "PATCH",
-        headers: { authorization: "Bearer tok", "content-type": "application/json" },
+        headers: {
+          authorization: "Bearer tok",
+          "content-type": "application/json",
+        },
         body: JSON.stringify({ handle: "taken" }),
       })
     )
@@ -60,5 +70,21 @@ describe("PATCH /api/users/me", () => {
   it("401s without an Authorization header", async () => {
     const res = await PATCH(req({ method: "PATCH" }))
     expect(res.status).toBe(401)
+  })
+
+  it("passes a 204 through without an empty {} body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    )
+    const res = await PATCH(
+      req({
+        method: "PATCH",
+        headers: { authorization: "Bearer tok" },
+        body: "{}",
+      })
+    )
+    expect(res.status).toBe(204)
+    expect(await res.text()).toBe("")
   })
 })

--- a/web/app/api/users/me/route.ts
+++ b/web/app/api/users/me/route.ts
@@ -33,6 +33,9 @@ async function proxy(
   }
 
   const res = await fetch(TARGET, init)
+  // Pass an empty (204) response through as-is rather than turning it into a
+  // {} JSON body — otherwise the client would treat it as an all-blank profile.
+  if (res.status === 204) return new NextResponse(null, { status: 204 })
   const body = await res.json().catch(() => ({}))
   return NextResponse.json(body, { status: res.status })
 }

--- a/web/app/api/users/me/route.ts
+++ b/web/app/api/users/me/route.ts
@@ -23,7 +23,10 @@ async function proxy(
     return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
   }
 
-  const init: RequestInit = { method, headers: { authorization: auth } }
+  const init: RequestInit = {
+    method,
+    headers: { authorization: auth, accept: "application/json" },
+  }
   if (method === "PATCH") {
     init.headers = { ...init.headers, "content-type": "application/json" }
     init.body = await request.text()

--- a/web/app/api/users/me/route.ts
+++ b/web/app/api/users/me/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for the authenticated profile endpoints. The client holds
+// the access token in memory and sends it as a Bearer header; this route just
+// forwards it to the backend so the backend URL stays server-side and there's
+// no cross-origin call. Backend status/body are passed through verbatim, so 409
+// (duplicate handle) and 422 (validation) surface unchanged to the form.
+
+const TARGET = `${BACKEND_URL}/api/v1/users/me`
+
+function authHeader(request: NextRequest): string | null {
+  return request.headers.get("authorization")
+}
+
+async function proxy(
+  request: NextRequest,
+  method: "GET" | "PATCH"
+): Promise<NextResponse> {
+  const auth = authHeader(request)
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const init: RequestInit = { method, headers: { authorization: auth } }
+  if (method === "PATCH") {
+    init.headers = { ...init.headers, "content-type": "application/json" }
+    init.body = await request.text()
+  }
+
+  const res = await fetch(TARGET, init)
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}
+
+export function GET(request: NextRequest) {
+  return proxy(request, "GET")
+}
+
+export function PATCH(request: NextRequest) {
+  return proxy(request, "PATCH")
+}

--- a/web/app/login/page.test.tsx
+++ b/web/app/login/page.test.tsx
@@ -14,6 +14,7 @@ import { AuthContext } from "@/contexts/auth-context"
 
 const baseAuth = {
   user: null,
+  accessToken: null,
   isAuthenticated: false,
   isLoading: false,
   login: vi.fn(),

--- a/web/app/settings/page.test.tsx
+++ b/web/app/settings/page.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import SettingsPage from "@/app/settings/page"
+import { AuthContext } from "@/contexts/auth-context"
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function renderPage() {
+  function wrapper({ children }: { children: ReactNode }) {
+    return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+  }
+  return render(<SettingsPage />, { wrapper })
+}
+
+const PROFILE = {
+  id: "u1",
+  email: "a@b.co",
+  name: "Ada",
+  display_name: "Ada",
+  handle: "ada",
+  bio: "hello",
+  style_tags: ["cello"],
+  avatar_url: null,
+  subscription_tier: "free",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: null,
+}
+
+function jsonRes(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status })
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("SettingsPage", () => {
+  it("loads and populates the form from the profile", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(PROFILE)))
+    renderPage()
+
+    const nameInput = await screen.findByLabelText("Display name")
+    expect(nameInput).toHaveValue("Ada")
+    expect(screen.getByLabelText("Handle")).toHaveValue("ada")
+    expect(screen.getByText("cello")).toBeInTheDocument()
+  })
+
+  it("saves changed fields and shows a success message", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(PROFILE))
+      .mockResolvedValueOnce(jsonRes({ ...PROFILE, display_name: "Ada L" }))
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    renderPage()
+
+    const nameInput = await screen.findByLabelText("Display name")
+    await user.clear(nameInput)
+    await user.type(nameInput, "Ada L")
+    await user.click(screen.getByRole("button", { name: /Save changes/ }))
+
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Saved."))
+    const patch = fetchMock.mock.calls[1]
+    expect(patch[1].method).toBe("PATCH")
+    expect(JSON.parse(patch[1].body)).toEqual({ display_name: "Ada L" })
+  })
+
+  it("gives real-time format feedback on the handle as you type", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(PROFILE)))
+    const user = userEvent.setup()
+    renderPage()
+
+    const handleInput = await screen.findByLabelText("Handle")
+    await user.clear(handleInput)
+    await user.type(handleInput, "ab") // too short
+    await waitFor(() => expect(screen.getByText(/3-30 characters/)).toBeInTheDocument())
+
+    await user.type(handleInput, "cde") // now "abcde" — valid
+    await waitFor(() => expect(screen.getByText("Looks good")).toBeInTheDocument())
+  })
+
+  it("shows an inline error when the handle is already taken (409)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(PROFILE))
+      .mockResolvedValueOnce(jsonRes({ detail: "taken" }, 409))
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    renderPage()
+
+    const handleInput = await screen.findByLabelText("Handle")
+    await user.clear(handleInput)
+    await user.type(handleInput, "taken-one")
+    await user.click(screen.getByRole("button", { name: /Save changes/ }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/already taken/i)).toBeInTheDocument()
+    )
+  })
+
+  it("blocks save and shows a required error when display name is empty", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(PROFILE)))
+    const user = userEvent.setup()
+    renderPage()
+
+    const nameInput = await screen.findByLabelText("Display name")
+    await user.clear(nameInput)
+    // dirty the form so the save button enables
+    await user.type(screen.getByLabelText("Handle"), "x")
+    await user.click(screen.getByRole("button", { name: /Save changes/ }))
+
+    expect(screen.getByText(/required/i)).toBeInTheDocument()
+  })
+
+  it("shows an error state when the profile fails to load", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({}, 500)))
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByText(/Could not load your profile/i)).toBeInTheDocument()
+    )
+  })
+})

--- a/web/app/settings/page.test.tsx
+++ b/web/app/settings/page.test.tsx
@@ -128,4 +128,29 @@ describe("SettingsPage", () => {
       expect(screen.getByText(/Could not load your profile/i)).toBeInTheDocument()
     )
   })
+
+  it("surfaces a session-expired message on a 401 load", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({ detail: "x" }, 401)))
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByText(/session expired/i)).toBeInTheDocument()
+    )
+  })
+
+  it("skips the network round-trip when only trailing whitespace changed", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonRes(PROFILE))
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    renderPage()
+
+    const nameInput = await screen.findByLabelText("Display name")
+    await user.type(nameInput, "  ") // "Ada  " trims back to "Ada"
+    await user.click(screen.getByRole("button", { name: /Save changes/ }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Saved.")
+    )
+    // Only the mount GET fired — no PATCH.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/web/app/settings/page.test.tsx
+++ b/web/app/settings/page.test.tsx
@@ -18,7 +18,9 @@ const authValue = {
 
 function renderPage() {
   function wrapper({ children }: { children: ReactNode }) {
-    return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+    return (
+      <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+    )
   }
   return render(<SettingsPage />, { wrapper })
 }
@@ -68,7 +70,9 @@ describe("SettingsPage", () => {
     await user.type(nameInput, "Ada L")
     await user.click(screen.getByRole("button", { name: /Save changes/ }))
 
-    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Saved."))
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Saved.")
+    )
     const patch = fetchMock.mock.calls[1]
     expect(patch[1].method).toBe("PATCH")
     expect(JSON.parse(patch[1].body)).toEqual({ display_name: "Ada L" })
@@ -82,10 +86,14 @@ describe("SettingsPage", () => {
     const handleInput = await screen.findByLabelText("Handle")
     await user.clear(handleInput)
     await user.type(handleInput, "ab") // too short
-    await waitFor(() => expect(screen.getByText(/3-30 characters/)).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByText(/3-30 characters/)).toBeInTheDocument()
+    )
 
     await user.type(handleInput, "cde") // now "abcde" — valid
-    await waitFor(() => expect(screen.getByText("Looks good")).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByText("Looks good")).toBeInTheDocument()
+    )
   })
 
   it("shows an inline error when the handle is already taken (409)", async () => {
@@ -119,18 +127,30 @@ describe("SettingsPage", () => {
     await user.click(screen.getByRole("button", { name: /Save changes/ }))
 
     expect(screen.getByText(/required/i)).toBeInTheDocument()
+    // The error is associated with the field for assistive tech.
+    const nameField = screen.getByLabelText("Display name")
+    expect(nameField).toHaveAttribute("aria-describedby", "display_name-error")
+    expect(screen.getByText(/required/i)).toHaveAttribute(
+      "id",
+      "display_name-error"
+    )
   })
 
   it("shows an error state when the profile fails to load", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({}, 500)))
     renderPage()
     await waitFor(() =>
-      expect(screen.getByText(/Could not load your profile/i)).toBeInTheDocument()
+      expect(
+        screen.getByText(/Could not load your profile/i)
+      ).toBeInTheDocument()
     )
   })
 
   it("surfaces a session-expired message on a 401 load", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({ detail: "x" }, 401)))
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonRes({ detail: "x" }, 401))
+    )
     renderPage()
     await waitFor(() =>
       expect(screen.getByText(/session expired/i)).toBeInTheDocument()

--- a/web/app/settings/page.test.tsx
+++ b/web/app/settings/page.test.tsx
@@ -96,6 +96,45 @@ describe("SettingsPage", () => {
     )
   })
 
+  it("does not flash 'Looks good' while typing an invalid handle", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(PROFILE)))
+    const user = userEvent.setup()
+    renderPage()
+
+    const handleInput = await screen.findByLabelText("Handle")
+    await user.clear(handleInput)
+    await user.type(handleInput, "ab") // too short → never valid
+    // Synchronous validity gate means the hint never appears, even pre-debounce.
+    expect(screen.queryByText("Looks good")).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByText(/3-30 characters/)).toBeInTheDocument()
+    )
+    expect(screen.queryByText("Looks good")).not.toBeInTheDocument()
+  })
+
+  it("hides 'Looks good' when a save fails with a form-level error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(PROFILE))
+      .mockResolvedValueOnce(jsonRes({}, 500))
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    renderPage()
+
+    const handleInput = await screen.findByLabelText("Handle")
+    await user.clear(handleInput)
+    await user.type(handleInput, "new-handle") // valid format
+    await waitFor(() =>
+      expect(screen.getByText("Looks good")).toBeInTheDocument()
+    )
+    await user.click(screen.getByRole("button", { name: /Save changes/ }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/Could not save changes/i)).toBeInTheDocument()
+    )
+    expect(screen.queryByText("Looks good")).not.toBeInTheDocument()
+  })
+
   it("shows an inline error when the handle is already taken (409)", async () => {
     const fetchMock = vi
       .fn()

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -232,12 +232,20 @@ function SettingsForm({
                 value={form.bio}
                 onChange={(e) => update("bio", e.target.value)}
                 aria-invalid={errors.bio || bioOver ? true : undefined}
-                aria-describedby={errors.bio ? "bio-error" : undefined}
+                aria-describedby={
+                  [
+                    errors.bio ? "bio-error" : null,
+                    bioOver ? "bio-counter" : null,
+                  ]
+                    .filter(Boolean)
+                    .join(" ") || undefined
+                }
                 rows={4}
               />
               <div className="flex items-center justify-between">
                 <FieldError id="bio-error" message={errors.bio} />
                 <span
+                  id="bio-counter"
                   className={
                     "ml-auto text-xs " +
                     (bioOver ? "text-destructive" : "text-muted-foreground")

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,0 +1,286 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  CheckmarkCircle01Icon,
+  Loading03Icon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { AvatarUpload } from "@/components/settings/AvatarUpload"
+import { FieldError } from "@/components/settings/FieldError"
+import { StyleTagsInput } from "@/components/settings/StyleTagsInput"
+import { useRequireAuth } from "@/hooks/use-require-auth"
+import {
+  useProfileSettings,
+  type FieldErrors,
+  type SaveResult,
+} from "@/hooks/use-profile-settings"
+import {
+  BIO_MAX_LENGTH,
+  validateBio,
+  validateDisplayName,
+  validateHandle,
+  type UserProfile,
+  type UserProfileUpdate,
+} from "@/lib/profile"
+
+type FormState = {
+  display_name: string
+  handle: string
+  bio: string
+  style_tags: string[]
+}
+
+function toForm(p: UserProfile): FormState {
+  return {
+    display_name: p.display_name ?? "",
+    handle: p.handle ?? "",
+    bio: p.bio ?? "",
+    style_tags: p.style_tags,
+  }
+}
+
+function SettingsForm({
+  profile,
+  save,
+}: {
+  profile: UserProfile
+  save: (update: UserProfileUpdate) => Promise<SaveResult>
+}) {
+  const initial = useMemo(() => toForm(profile), [profile])
+  const [form, setForm] = useState<FormState>(initial)
+  const [baseline, setBaseline] = useState<FormState>(initial)
+  const [errors, setErrors] = useState<FieldErrors>({})
+  const [handleHint, setHandleHint] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [savedOk, setSavedOk] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const isDirty = useMemo(
+    () => JSON.stringify(form) !== JSON.stringify(baseline),
+    [form, baseline]
+  )
+
+  // Real-time (debounced) handle format feedback. Server uniqueness is only
+  // known on save, surfaced as a 409 below.
+  const debounce = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (debounce.current) clearTimeout(debounce.current)
+    debounce.current = setTimeout(() => {
+      setHandleHint(
+        form.handle.length === 0 ? null : validateHandle(form.handle)
+      )
+    }, 400)
+    return () => {
+      if (debounce.current) clearTimeout(debounce.current)
+    }
+  }, [form.handle])
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }))
+    setErrors((e) => ({ ...e, [key]: undefined }))
+    setSavedOk(false)
+    setFormError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const clientErrors: FieldErrors = {}
+    const nameErr = validateDisplayName(form.display_name)
+    if (nameErr) clientErrors.display_name = nameErr
+    const handleErr = validateHandle(form.handle)
+    if (handleErr) clientErrors.handle = handleErr
+    const bioErr = validateBio(form.bio)
+    if (bioErr) clientErrors.bio = bioErr
+    if (Object.keys(clientErrors).length > 0) {
+      setErrors(clientErrors)
+      return
+    }
+
+    // Send only changed fields (exclude_unset). Empty handle clears it (null).
+    const payload: UserProfileUpdate = {}
+    if (form.display_name !== baseline.display_name)
+      payload.display_name = form.display_name.trim()
+    if (form.handle !== baseline.handle)
+      payload.handle = form.handle.length === 0 ? null : form.handle
+    if (form.bio !== baseline.bio) payload.bio = form.bio
+    if (JSON.stringify(form.style_tags) !== JSON.stringify(baseline.style_tags))
+      payload.style_tags = form.style_tags
+
+    setSaving(true)
+    setErrors({})
+    setFormError(null)
+    const result = await save(payload)
+    setSaving(false)
+    if (result.ok) {
+      const next = toForm(result.profile)
+      setForm(next)
+      setBaseline(next)
+      setSavedOk(true)
+    } else {
+      setErrors(result.fieldErrors)
+      setFormError(result.message)
+    }
+  }
+
+  const bioOver = form.bio.length > BIO_MAX_LENGTH
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Profile</CardTitle>
+          <CardDescription>
+            This information appears on your public profile.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {/* Disable edits while a save is in flight so a slow PATCH can't
+              clobber fields the user changed after clicking Save. */}
+          <fieldset
+            disabled={saving}
+            className="flex min-w-0 flex-col gap-5 border-0 p-0"
+          >
+            <div className="flex flex-col gap-2">
+              <Label>Avatar</Label>
+              <AvatarUpload currentUrl={profile.avatar_url} />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="display_name">Display name</Label>
+              <Input
+                id="display_name"
+                value={form.display_name}
+                onChange={(e) => update("display_name", e.target.value)}
+                aria-invalid={errors.display_name ? true : undefined}
+                maxLength={120}
+              />
+              <FieldError message={errors.display_name} />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="handle">Handle</Label>
+              <div className="relative">
+                <span className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-sm text-muted-foreground">
+                  @
+                </span>
+                <Input
+                  id="handle"
+                  value={form.handle}
+                  onChange={(e) => update("handle", e.target.value)}
+                  aria-invalid={errors.handle || handleHint ? true : undefined}
+                  className="pl-6"
+                  placeholder="your-handle"
+                />
+              </div>
+              <FieldError message={errors.handle ?? handleHint} />
+              {!errors.handle &&
+                !handleHint &&
+                form.handle.length > 0 &&
+                form.handle !== baseline.handle && (
+                  <p className="flex items-center gap-1 text-sm text-muted-foreground">
+                    <HugeiconsIcon icon={CheckmarkCircle01Icon} size={14} />
+                    Looks good
+                  </p>
+                )}
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="bio">Bio</Label>
+              <Textarea
+                id="bio"
+                value={form.bio}
+                onChange={(e) => update("bio", e.target.value)}
+                aria-invalid={errors.bio || bioOver ? true : undefined}
+                rows={4}
+              />
+              <div className="flex items-center justify-between">
+                <FieldError message={errors.bio} />
+                <span
+                  className={
+                    "ml-auto text-xs " +
+                    (bioOver ? "text-destructive" : "text-muted-foreground")
+                  }
+                >
+                  {form.bio.length}/{BIO_MAX_LENGTH}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label>Style tags</Label>
+              <StyleTagsInput
+                tags={form.style_tags}
+                onChange={(next) => update("style_tags", next)}
+              />
+              <FieldError message={errors.style_tags} />
+            </div>
+          </fieldset>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={!isDirty || saving}>
+          {saving && (
+            <HugeiconsIcon
+              icon={Loading03Icon}
+              size={16}
+              className="animate-spin"
+            />
+          )}
+          Save changes
+        </Button>
+        {savedOk && (
+          <p role="status" className="text-sm text-muted-foreground">
+            Saved.
+          </p>
+        )}
+        {formError && (
+          <p role="alert" className="text-sm text-destructive">
+            {formError}
+          </p>
+        )}
+      </div>
+    </form>
+  )
+}
+
+export default function SettingsPage() {
+  const { isLoading: authLoading, isAuthenticated } = useRequireAuth()
+  const { profile, isLoading, error, save } = useProfileSettings()
+
+  // useRequireAuth redirects unauthenticated users; render nothing meanwhile.
+  if (authLoading || !isAuthenticated) return null
+
+  return (
+    <div className="mx-auto w-full max-w-2xl p-8">
+      <h1 className="mb-6 text-2xl font-semibold">Settings</h1>
+      {isLoading && (
+        <div
+          data-testid="settings-skeleton"
+          className="h-64 animate-pulse rounded-xl bg-muted"
+        />
+      )}
+      {!isLoading && error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+      {!isLoading && !error && profile && (
+        <SettingsForm profile={profile} save={save} />
+      )}
+    </div>
+  )
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -109,15 +109,29 @@ function SettingsForm({
       return
     }
 
-    // Send only changed fields (exclude_unset). Empty handle clears it (null).
+    // Send only changed fields (exclude_unset). Compare the normalized
+    // (trimmed) values against the stored baseline so a trailing space alone
+    // doesn't trigger a no-op PATCH, and a whitespace-only bio isn't stored.
+    const trimmedName = form.display_name.trim()
+    const trimmedBio = form.bio.trim()
     const payload: UserProfileUpdate = {}
-    if (form.display_name !== baseline.display_name)
-      payload.display_name = form.display_name.trim()
+    if (trimmedName !== baseline.display_name)
+      payload.display_name = trimmedName
     if (form.handle !== baseline.handle)
       payload.handle = form.handle.length === 0 ? null : form.handle
-    if (form.bio !== baseline.bio) payload.bio = form.bio
+    if (trimmedBio !== baseline.bio) payload.bio = trimmedBio
     if (JSON.stringify(form.style_tags) !== JSON.stringify(baseline.style_tags))
       payload.style_tags = form.style_tags
+
+    // Nothing actually changed once normalized — just re-sync the form to the
+    // trimmed values and report success without a wasted round-trip.
+    if (Object.keys(payload).length === 0) {
+      const synced = { ...form, display_name: trimmedName, bio: trimmedBio }
+      setForm(synced)
+      setBaseline(synced)
+      setSavedOk(true)
+      return
+    }
 
     setSaving(true)
     setErrors({})

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -230,7 +230,7 @@ function SettingsForm({
                     (bioOver ? "text-destructive" : "text-muted-foreground")
                   }
                 >
-                  {form.bio.length}/{BIO_MAX_LENGTH}
+                  {form.bio.trim().length}/{BIO_MAX_LENGTH}
                 </span>
               </div>
             </div>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -239,12 +239,11 @@ function SettingsForm({
                 onChange={(e) => update("bio", e.target.value)}
                 aria-invalid={errors.bio || bioOver ? true : undefined}
                 aria-describedby={
-                  [
-                    errors.bio ? "bio-error" : null,
-                    bioOver ? "bio-counter" : null,
-                  ]
+                  // Counter is always rendered, so always announce it; add the
+                  // error id only when there's a submitted bio error.
+                  [errors.bio ? "bio-error" : null, "bio-counter"]
                     .filter(Boolean)
-                    .join(" ") || undefined
+                    .join(" ")
                 }
                 rows={4}
               />

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -153,6 +153,11 @@ function SettingsForm({
   // and aria-invalid never flag a bio that would actually save fine.
   const bioOver = form.bio.trim().length > BIO_MAX_LENGTH
 
+  // Synchronous validity gates the "Looks good" hint so it can't flash on a
+  // still-invalid handle during the 400 ms before the debounce settles.
+  const handleValid =
+    form.handle.length > 0 && validateHandle(form.handle) === null
+
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-6">
       <Card>
@@ -215,8 +220,9 @@ function SettingsForm({
                 message={errors.handle ?? handleHint}
               />
               {!errors.handle &&
+                !formError &&
                 !handleHint &&
-                form.handle.length > 0 &&
+                handleValid &&
                 form.handle !== baseline.handle && (
                   <p className="flex items-center gap-1 text-sm text-muted-foreground">
                     <HugeiconsIcon icon={CheckmarkCircle01Icon} size={14} />

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -149,7 +149,9 @@ function SettingsForm({
     }
   }
 
-  const bioOver = form.bio.length > BIO_MAX_LENGTH
+  // Trimmed, to match validateBio and the submitted payload — so the counter
+  // and aria-invalid never flag a bio that would actually save fine.
+  const bioOver = form.bio.trim().length > BIO_MAX_LENGTH
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-6">

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -181,9 +181,15 @@ function SettingsForm({
                 value={form.display_name}
                 onChange={(e) => update("display_name", e.target.value)}
                 aria-invalid={errors.display_name ? true : undefined}
+                aria-describedby={
+                  errors.display_name ? "display_name-error" : undefined
+                }
                 maxLength={120}
               />
-              <FieldError message={errors.display_name} />
+              <FieldError
+                id="display_name-error"
+                message={errors.display_name}
+              />
             </div>
 
             <div className="flex flex-col gap-1.5">
@@ -197,11 +203,17 @@ function SettingsForm({
                   value={form.handle}
                   onChange={(e) => update("handle", e.target.value)}
                   aria-invalid={errors.handle || handleHint ? true : undefined}
+                  aria-describedby={
+                    errors.handle || handleHint ? "handle-error" : undefined
+                  }
                   className="pl-6"
                   placeholder="your-handle"
                 />
               </div>
-              <FieldError message={errors.handle ?? handleHint} />
+              <FieldError
+                id="handle-error"
+                message={errors.handle ?? handleHint}
+              />
               {!errors.handle &&
                 !handleHint &&
                 form.handle.length > 0 &&
@@ -220,10 +232,11 @@ function SettingsForm({
                 value={form.bio}
                 onChange={(e) => update("bio", e.target.value)}
                 aria-invalid={errors.bio || bioOver ? true : undefined}
+                aria-describedby={errors.bio ? "bio-error" : undefined}
                 rows={4}
               />
               <div className="flex items-center justify-between">
-                <FieldError message={errors.bio} />
+                <FieldError id="bio-error" message={errors.bio} />
                 <span
                   className={
                     "ml-auto text-xs " +

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -89,7 +89,9 @@ function AccountMenuItems() {
       <DropdownMenuItem asChild>
         <Link href="/me">Profile</Link>
       </DropdownMenuItem>
-      <DropdownMenuItem>Account settings</DropdownMenuItem>
+      <DropdownMenuItem asChild>
+        <Link href="/settings">Account settings</Link>
+      </DropdownMenuItem>
       <DropdownMenuItem>Subscription</DropdownMenuItem>
       <DropdownMenuSeparator />
       <DropdownMenuItem variant="destructive" onSelect={() => logout()}>

--- a/web/components/settings/AvatarUpload.test.tsx
+++ b/web/components/settings/AvatarUpload.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AvatarUpload } from "@/components/settings/AvatarUpload"
+
+beforeEach(() => {
+  // jsdom has no object-URL support.
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:preview"),
+    revokeObjectURL: vi.fn(),
+  })
+})
+afterEach(() => vi.restoreAllMocks())
+
+describe("AvatarUpload", () => {
+  it("shows the 'coming soon' note (upload not yet persisted)", () => {
+    render(<AvatarUpload currentUrl={null} />)
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument()
+  })
+
+  it("previews the image after a valid file is chosen", async () => {
+    render(<AvatarUpload currentUrl={null} />)
+    const user = userEvent.setup()
+    const file = new File(["x"], "a.png", { type: "image/png" })
+    await user.upload(screen.getByLabelText("Avatar image"), file)
+
+    const img = screen.getByAltText("Avatar preview") as HTMLImageElement
+    expect(img.src).toContain("blob:preview")
+  })
+
+  it("rejects a non-image file dropped onto the zone", () => {
+    // Drag-and-drop bypasses the input's `accept` filter, so the component must
+    // validate the type itself — exercise that path directly.
+    render(<AvatarUpload currentUrl={null} />)
+    const file = new File(["x"], "a.txt", { type: "text/plain" })
+    const zone = screen.getByText(/Drag an image here/)
+    fireEvent.drop(zone, { dataTransfer: { files: [file] } })
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/image/i)
+    expect(screen.queryByAltText("Avatar preview")).not.toBeInTheDocument()
+  })
+})

--- a/web/components/settings/AvatarUpload.tsx
+++ b/web/components/settings/AvatarUpload.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { UserIcon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { FieldError } from "@/components/settings/FieldError"
+
+const ACCEPTED = ["image/jpeg", "image/png", "image/gif", "image/webp"]
+
+/**
+ * Avatar picker with drag-and-drop, file selection, and a square local preview.
+ * ponytail: preview only — the backend avatar endpoint (US-8.5) doesn't exist
+ * yet, so the chosen image is never persisted. The square crop is CSS
+ * (object-cover) rather than a crop library; revisit when upload lands.
+ */
+export function AvatarUpload({ currentUrl }: { currentUrl: string | null }) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [dragging, setDragging] = useState(false)
+
+  // Free the object URL when it's replaced or the component unmounts.
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+    }
+  }, [previewUrl])
+
+  function selectFile(file: File | undefined) {
+    if (!file) return
+    if (!ACCEPTED.includes(file.type)) {
+      setError("Please choose an image (JPG, PNG, GIF, or WebP).")
+      return
+    }
+    setError(null)
+    setPreviewUrl((old) => {
+      if (old) URL.revokeObjectURL(old)
+      return URL.createObjectURL(file)
+    })
+  }
+
+  const shown = previewUrl ?? currentUrl
+
+  return (
+    <div data-slot="avatar-upload" className="flex flex-col gap-2">
+      <div className="flex items-center gap-4">
+        <span className="flex size-20 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-muted text-muted-foreground">
+          {shown ? (
+            // eslint-disable-next-line @next/next/no-img-element -- local object URL / external avatar, no Next loader needed
+            <img
+              src={shown}
+              alt="Avatar preview"
+              className="size-full object-cover"
+            />
+          ) : (
+            <HugeiconsIcon icon={UserIcon} size={32} />
+          )}
+        </span>
+
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          onDragOver={(e) => {
+            e.preventDefault()
+            setDragging(true)
+          }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={(e) => {
+            e.preventDefault()
+            setDragging(false)
+            selectFile(e.dataTransfer.files?.[0])
+          }}
+          className={
+            "flex flex-1 flex-col items-center justify-center rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none" +
+            (dragging ? " border-ring bg-muted" : "")
+          }
+        >
+          Drag an image here, or click to choose
+        </button>
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED.join(",")}
+          className="hidden"
+          aria-label="Avatar image"
+          onChange={(e) => selectFile(e.target.files?.[0])}
+        />
+      </div>
+
+      <Badge variant="outline" className="w-fit">
+        Avatar upload coming soon
+      </Badge>
+      <FieldError message={error} />
+    </div>
+  )
+}

--- a/web/components/settings/AvatarUpload.tsx
+++ b/web/components/settings/AvatarUpload.tsx
@@ -35,10 +35,9 @@ export function AvatarUpload({ currentUrl }: { currentUrl: string | null }) {
       return
     }
     setError(null)
-    setPreviewUrl((old) => {
-      if (old) URL.revokeObjectURL(old)
-      return URL.createObjectURL(file)
-    })
+    // The effect below owns revocation: it revokes the prior URL when this
+    // value changes and on unmount, so we only create here.
+    setPreviewUrl(URL.createObjectURL(file))
   }
 
   const shown = previewUrl ?? currentUrl

--- a/web/components/settings/FieldError.tsx
+++ b/web/components/settings/FieldError.tsx
@@ -1,8 +1,18 @@
-/** Inline field-level validation error. Renders nothing when there's no message. */
-export function FieldError({ message }: { message?: string | null }) {
+/**
+ * Inline field-level validation error. Renders nothing when there's no message.
+ * Pass `id` and reference it from the field's `aria-describedby` so a screen
+ * reader associates the error with the input (not just the live-region announce).
+ */
+export function FieldError({
+  id,
+  message,
+}: {
+  id?: string
+  message?: string | null
+}) {
   if (!message) return null
   return (
-    <p role="alert" className="text-sm text-destructive">
+    <p id={id} role="alert" className="text-sm text-destructive">
       {message}
     </p>
   )

--- a/web/components/settings/FieldError.tsx
+++ b/web/components/settings/FieldError.tsx
@@ -1,0 +1,9 @@
+/** Inline field-level validation error. Renders nothing when there's no message. */
+export function FieldError({ message }: { message?: string | null }) {
+  if (!message) return null
+  return (
+    <p role="alert" className="text-sm text-destructive">
+      {message}
+    </p>
+  )
+}

--- a/web/components/settings/StyleTagsInput.test.tsx
+++ b/web/components/settings/StyleTagsInput.test.tsx
@@ -57,6 +57,32 @@ describe("StyleTagsInput", () => {
     ).toBeInTheDocument()
   })
 
+  it("navigates suggestions with arrow keys and selects with Enter", async () => {
+    const onChange = vi.fn()
+    render(<StyleTagsInput tags={[]} onChange={onChange} />)
+    const user = userEvent.setup()
+    const input = screen.getByRole("combobox", { name: "Add a style tag" })
+
+    await user.type(input, "o") // matches several suggestions
+    await user.keyboard("{ArrowDown}") // highlight first option
+    const first = screen.getAllByRole("option")[0]
+    expect(first).toHaveAttribute("aria-selected", "true")
+    expect(input).toHaveAttribute("aria-activedescendant", first.id)
+
+    await user.keyboard("{Enter}") // add the highlighted option
+    expect(onChange).toHaveBeenCalledWith([first.textContent])
+  })
+
+  it("closes the suggestion list on Escape", async () => {
+    render(<StyleTagsInput tags={[]} onChange={vi.fn()} />)
+    const user = userEvent.setup()
+    const input = screen.getByRole("combobox", { name: "Add a style tag" })
+    await user.type(input, "or")
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    await user.keyboard("{Escape}")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
   it("wires the combobox ARIA contract as the list opens", async () => {
     render(<StyleTagsInput tags={[]} onChange={vi.fn()} />)
     const user = userEvent.setup()

--- a/web/components/settings/StyleTagsInput.test.tsx
+++ b/web/components/settings/StyleTagsInput.test.tsx
@@ -56,4 +56,19 @@ describe("StyleTagsInput", () => {
       screen.getByRole("option", { name: "orchestral" })
     ).toBeInTheDocument()
   })
+
+  it("wires the combobox ARIA contract as the list opens", async () => {
+    render(<StyleTagsInput tags={[]} onChange={vi.fn()} />)
+    const user = userEvent.setup()
+    const input = screen.getByRole("combobox", { name: "Add a style tag" })
+    expect(input).toHaveAttribute("aria-expanded", "false")
+    expect(input).toHaveAttribute("aria-controls", "style-suggestions-list")
+
+    await user.type(input, "or")
+    expect(input).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByRole("listbox")).toHaveAttribute(
+      "id",
+      "style-suggestions-list"
+    )
+  })
 })

--- a/web/components/settings/StyleTagsInput.test.tsx
+++ b/web/components/settings/StyleTagsInput.test.tsx
@@ -83,6 +83,17 @@ describe("StyleTagsInput", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
   })
 
+  it("reopens a dismissed list when ArrowDown is pressed", async () => {
+    render(<StyleTagsInput tags={[]} onChange={vi.fn()} />)
+    const user = userEvent.setup()
+    const input = screen.getByRole("combobox", { name: "Add a style tag" })
+    await user.type(input, "or")
+    await user.keyboard("{Escape}")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    await user.keyboard("{ArrowDown}")
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+  })
+
   it("wires the combobox ARIA contract as the list opens", async () => {
     render(<StyleTagsInput tags={[]} onChange={vi.fn()} />)
     const user = userEvent.setup()

--- a/web/components/settings/StyleTagsInput.test.tsx
+++ b/web/components/settings/StyleTagsInput.test.tsx
@@ -24,6 +24,14 @@ describe("StyleTagsInput", () => {
     expect(onChange).toHaveBeenCalledWith(["ambient"])
   })
 
+  it("normalizes a custom tag to lowercase", async () => {
+    const onChange = vi.fn()
+    render(<StyleTagsInput tags={[]} onChange={onChange} />)
+    const user = userEvent.setup()
+    await user.type(screen.getByLabelText("Add a style tag"), "LoFi{Enter}")
+    expect(onChange).toHaveBeenCalledWith(["lofi"])
+  })
+
   it("rejects a duplicate tag with an inline error", async () => {
     const onChange = vi.fn()
     render(<StyleTagsInput tags={["jazz"]} onChange={onChange} />)

--- a/web/components/settings/StyleTagsInput.test.tsx
+++ b/web/components/settings/StyleTagsInput.test.tsx
@@ -73,6 +73,18 @@ describe("StyleTagsInput", () => {
     expect(onChange).toHaveBeenCalledWith([first.textContent])
   })
 
+  it("ignores a second Enter after adding (no spurious empty-tag error)", async () => {
+    const onChange = vi.fn()
+    render(<StyleTagsInput tags={[]} onChange={onChange} />)
+    const user = userEvent.setup()
+    const input = screen.getByRole("combobox", { name: "Add a style tag" })
+    await user.type(input, "o")
+    await user.keyboard("{ArrowDown}{Enter}") // add the highlighted suggestion
+    expect(onChange).toHaveBeenCalledTimes(1)
+    await user.keyboard("{Enter}") // draft is empty now — should be a no-op
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
   it("closes the suggestion list on Escape", async () => {
     render(<StyleTagsInput tags={[]} onChange={vi.fn()} />)
     const user = userEvent.setup()

--- a/web/components/settings/StyleTagsInput.test.tsx
+++ b/web/components/settings/StyleTagsInput.test.tsx
@@ -41,6 +41,13 @@ describe("StyleTagsInput", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(/already/i)
   })
 
+  it("does not offer an 'Add' option for a tag already in the list", async () => {
+    render(<StyleTagsInput tags={["cello"]} onChange={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.type(screen.getByLabelText("Add a style tag"), "cello")
+    expect(screen.queryByText(/Add /)).not.toBeInTheDocument()
+  })
+
   it("shows typeahead suggestions filtered by input", async () => {
     render(<StyleTagsInput tags={[]} onChange={vi.fn()} />)
     const user = userEvent.setup()

--- a/web/components/settings/StyleTagsInput.test.tsx
+++ b/web/components/settings/StyleTagsInput.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { StyleTagsInput } from "@/components/settings/StyleTagsInput"
+
+describe("StyleTagsInput", () => {
+  it("renders existing tags as removable pills", async () => {
+    const onChange = vi.fn()
+    render(<StyleTagsInput tags={["cello", "lo-fi"]} onChange={onChange} />)
+
+    expect(screen.getByText("cello")).toBeInTheDocument()
+    const user = userEvent.setup()
+    await user.click(screen.getByRole("button", { name: "Remove cello" }))
+    expect(onChange).toHaveBeenCalledWith(["lo-fi"])
+  })
+
+  it("adds a tag on Enter", async () => {
+    const onChange = vi.fn()
+    render(<StyleTagsInput tags={[]} onChange={onChange} />)
+    const user = userEvent.setup()
+    const input = screen.getByLabelText("Add a style tag")
+    await user.type(input, "ambient{Enter}")
+    expect(onChange).toHaveBeenCalledWith(["ambient"])
+  })
+
+  it("rejects a duplicate tag with an inline error", async () => {
+    const onChange = vi.fn()
+    render(<StyleTagsInput tags={["jazz"]} onChange={onChange} />)
+    const user = userEvent.setup()
+    await user.type(screen.getByLabelText("Add a style tag"), "Jazz{Enter}")
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByRole("alert")).toHaveTextContent(/already/i)
+  })
+
+  it("shows typeahead suggestions filtered by input", async () => {
+    render(<StyleTagsInput tags={[]} onChange={vi.fn()} />)
+    const user = userEvent.setup()
+    await user.type(screen.getByLabelText("Add a style tag"), "or")
+    expect(
+      screen.getByRole("option", { name: "orchestral" })
+    ).toBeInTheDocument()
+  })
+})

--- a/web/components/settings/StyleTagsInput.test.tsx
+++ b/web/components/settings/StyleTagsInput.test.tsx
@@ -99,10 +99,12 @@ describe("StyleTagsInput", () => {
     const user = userEvent.setup()
     const input = screen.getByRole("combobox", { name: "Add a style tag" })
     expect(input).toHaveAttribute("aria-expanded", "false")
-    expect(input).toHaveAttribute("aria-controls", "style-suggestions-list")
+    // Closed: aria-controls must not dangle (target isn't in the DOM yet).
+    expect(input).not.toHaveAttribute("aria-controls")
 
     await user.type(input, "or")
     expect(input).toHaveAttribute("aria-expanded", "true")
+    expect(input).toHaveAttribute("aria-controls", "style-suggestions-list")
     expect(screen.getByRole("listbox")).toHaveAttribute(
       "id",
       "style-suggestions-list"

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -27,6 +27,10 @@ export function StyleTagsInput({
 }) {
   const [draft, setDraft] = useState("")
   const [error, setError] = useState<string | null>(null)
+  // Highlighted option for keyboard navigation (-1 = none); `dismissed` closes
+  // the list on Escape until the next keystroke reopens it.
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const [dismissed, setDismissed] = useState(false)
 
   const suggestions = useMemo(() => {
     const q = draft.trim().toLowerCase()
@@ -61,7 +65,43 @@ export function StyleTagsInput({
     draftKey.length > 0 &&
     !suggestions.some((s) => s === draftKey) &&
     !tags.some((t) => t.toLowerCase() === draftKey)
-  const listOpen = suggestions.length > 0 || showAddCustom
+
+  // Unified, ordered options so keyboard navigation has a single index space.
+  const options = [
+    ...suggestions.map((s) => ({ id: `style-opt-${s}`, label: s, value: s })),
+    ...(showAddCustom
+      ? [{ id: "style-opt-add", label: `Add "${draft.trim()}"`, value: draft }]
+      : []),
+  ]
+  const listOpen = options.length > 0 && !dismissed
+  const activeId =
+    listOpen && activeIndex >= 0 ? options[activeIndex]?.id : undefined
+
+  function resetList() {
+    setActiveIndex(-1)
+    setDismissed(false)
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      add(activeIndex >= 0 ? (options[activeIndex]?.value ?? draft) : draft)
+      return
+    }
+    if (e.key === "Escape" && listOpen) {
+      setDismissed(true)
+      setActiveIndex(-1)
+      return
+    }
+    if (!listOpen) return
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setActiveIndex((i) => (i + 1) % options.length)
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setActiveIndex((i) => (i <= 0 ? options.length - 1 : i - 1))
+    }
+  }
 
   return (
     <div data-slot="style-tags" className="flex flex-col gap-2">
@@ -91,19 +131,16 @@ export function StyleTagsInput({
           onChange={(e) => {
             setDraft(e.target.value)
             setError(null)
+            resetList()
           }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault()
-              add(draft)
-            }
-          }}
+          onKeyDown={onKeyDown}
           placeholder="Add a style (e.g. cello, lo-fi)"
           aria-label="Add a style tag"
           role="combobox"
           aria-expanded={listOpen}
           aria-controls="style-suggestions-list"
           aria-autocomplete="list"
+          aria-activedescendant={activeId}
           disabled={tags.length >= STYLE_TAGS_MAX_ITEMS}
         />
         {listOpen && (
@@ -113,30 +150,24 @@ export function StyleTagsInput({
             aria-label="Style suggestions"
             className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-md"
           >
-            {suggestions.map((s) => (
-              <li key={s}>
+            {options.map((opt, i) => (
+              <li key={opt.id}>
                 <button
                   type="button"
+                  id={opt.id}
                   role="option"
-                  aria-selected={false}
-                  onClick={() => add(s)}
-                  className="flex w-full px-2.5 py-1.5 text-left text-sm hover:bg-muted"
+                  aria-selected={i === activeIndex}
+                  onClick={() => add(opt.value)}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  className={
+                    "flex w-full px-2.5 py-1.5 text-left text-sm hover:bg-muted" +
+                    (i === activeIndex ? " bg-muted" : "")
+                  }
                 >
-                  {s}
+                  {opt.label}
                 </button>
               </li>
             ))}
-            {showAddCustom && (
-              <li>
-                <button
-                  type="button"
-                  onClick={() => add(draft)}
-                  className="flex w-full px-2.5 py-1.5 text-left text-sm hover:bg-muted"
-                >
-                  Add &ldquo;{draft.trim()}&rdquo;
-                </button>
-              </li>
-            )}
           </ul>
         )}
       </div>

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -56,9 +56,11 @@ export function StyleTagsInput({
     setError(null)
   }
 
+  const draftKey = draft.trim().toLowerCase()
   const showAddCustom =
-    draft.trim().length > 0 &&
-    !suggestions.some((s) => s === draft.trim().toLowerCase())
+    draftKey.length > 0 &&
+    !suggestions.some((s) => s === draftKey) &&
+    !tags.some((t) => t.toLowerCase() === draftKey)
 
   return (
     <div data-slot="style-tags" className="flex flex-col gap-2">

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -38,7 +38,9 @@ export function StyleTagsInput({
   }, [draft, tags])
 
   function add(raw: string) {
-    const tag = raw.trim()
+    // Normalize to lowercase so custom tags match the (lowercase) suggestions
+    // and the case-insensitive duplicate guard, keeping the list consistent.
+    const tag = raw.trim().toLowerCase()
     const err = validateNewStyleTag(tag, tags)
     if (err) {
       setError(err)

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -147,6 +147,8 @@ export function StyleTagsInput({
           aria-controls={listOpen ? "style-suggestions-list" : undefined}
           aria-autocomplete="list"
           aria-activedescendant={activeId}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? "style-tag-error" : undefined}
           disabled={tags.length >= STYLE_TAGS_MAX_ITEMS}
         />
         {listOpen && (
@@ -179,7 +181,7 @@ export function StyleTagsInput({
         )}
       </div>
 
-      <FieldError message={error} />
+      <FieldError id="style-tag-error" message={error} />
     </div>
   )
 }

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -93,12 +93,18 @@ export function StyleTagsInput({
       setActiveIndex(-1)
       return
     }
-    if (!listOpen) return
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return
+    if (options.length === 0) return
+    e.preventDefault()
+    // ArrowDown/Up reopen the list if Escape dismissed it (APG pattern).
+    if (!listOpen) {
+      setDismissed(false)
+      setActiveIndex(e.key === "ArrowDown" ? 0 : options.length - 1)
+      return
+    }
     if (e.key === "ArrowDown") {
-      e.preventDefault()
       setActiveIndex((i) => (i + 1) % options.length)
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault()
+    } else {
       setActiveIndex((i) => (i <= 0 ? options.length - 1 : i - 1))
     }
   }
@@ -144,31 +150,32 @@ export function StyleTagsInput({
           disabled={tags.length >= STYLE_TAGS_MAX_ITEMS}
         />
         {listOpen && (
-          <ul
+          // role="option" elements are direct children of the listbox (no <li>
+          // intermediary) so the ARIA ownership chain stays intact. Focus stays
+          // on the input; selection is driven via aria-activedescendant.
+          <div
             id="style-suggestions-list"
             role="listbox"
             aria-label="Style suggestions"
             className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-md"
           >
             {options.map((opt, i) => (
-              <li key={opt.id}>
-                <button
-                  type="button"
-                  id={opt.id}
-                  role="option"
-                  aria-selected={i === activeIndex}
-                  onClick={() => add(opt.value)}
-                  onMouseEnter={() => setActiveIndex(i)}
-                  className={
-                    "flex w-full px-2.5 py-1.5 text-left text-sm hover:bg-muted" +
-                    (i === activeIndex ? " bg-muted" : "")
-                  }
-                >
-                  {opt.label}
-                </button>
-              </li>
+              <div
+                key={opt.id}
+                id={opt.id}
+                role="option"
+                aria-selected={i === activeIndex}
+                onClick={() => add(opt.value)}
+                onMouseEnter={() => setActiveIndex(i)}
+                className={
+                  "cursor-pointer px-2.5 py-1.5 text-sm hover:bg-muted" +
+                  (i === activeIndex ? " bg-muted" : "")
+                }
+              >
+                {opt.label}
+              </div>
             ))}
-          </ul>
+          </div>
         )}
       </div>
 

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -144,7 +144,7 @@ export function StyleTagsInput({
           aria-label="Add a style tag"
           role="combobox"
           aria-expanded={listOpen}
-          aria-controls="style-suggestions-list"
+          aria-controls={listOpen ? "style-suggestions-list" : undefined}
           aria-autocomplete="list"
           aria-activedescendant={activeId}
           disabled={tags.length >= STYLE_TAGS_MAX_ITEMS}

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Cancel01Icon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { FieldError } from "@/components/settings/FieldError"
+import {
+  STYLE_SUGGESTIONS,
+  STYLE_TAGS_MAX_ITEMS,
+  validateNewStyleTag,
+} from "@/lib/profile"
+
+/**
+ * Editable list of style tags shown as removable pill badges, with a typeahead
+ * over a static suggestion list. Validation mirrors the backend (max count,
+ * length, no duplicates/empties); the parent owns the tags array.
+ */
+export function StyleTagsInput({
+  tags,
+  onChange,
+}: {
+  tags: string[]
+  onChange: (next: string[]) => void
+}) {
+  const [draft, setDraft] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const suggestions = useMemo(() => {
+    const q = draft.trim().toLowerCase()
+    if (q.length === 0) return []
+    const taken = new Set(tags.map((t) => t.toLowerCase()))
+    return STYLE_SUGGESTIONS.filter(
+      (s) => s.includes(q) && !taken.has(s)
+    ).slice(0, 6)
+  }, [draft, tags])
+
+  function add(raw: string) {
+    const tag = raw.trim()
+    const err = validateNewStyleTag(tag, tags)
+    if (err) {
+      setError(err)
+      return
+    }
+    onChange([...tags, tag])
+    setDraft("")
+    setError(null)
+  }
+
+  function remove(tag: string) {
+    onChange(tags.filter((t) => t !== tag))
+    setError(null)
+  }
+
+  const showAddCustom =
+    draft.trim().length > 0 &&
+    !suggestions.some((s) => s === draft.trim().toLowerCase())
+
+  return (
+    <div data-slot="style-tags" className="flex flex-col gap-2">
+      {tags.length > 0 && (
+        <ul className="flex flex-wrap gap-1.5" aria-label="Style tags">
+          {tags.map((tag) => (
+            <li key={tag}>
+              <Badge variant="secondary" className="gap-1 pr-1">
+                {tag}
+                <button
+                  type="button"
+                  aria-label={`Remove ${tag}`}
+                  onClick={() => remove(tag)}
+                  className="rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none"
+                >
+                  <HugeiconsIcon icon={Cancel01Icon} size={12} />
+                </button>
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="relative">
+        <Input
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value)
+            setError(null)
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault()
+              add(draft)
+            }
+          }}
+          placeholder="Add a style (e.g. cello, lo-fi)"
+          aria-label="Add a style tag"
+          disabled={tags.length >= STYLE_TAGS_MAX_ITEMS}
+        />
+        {(suggestions.length > 0 || showAddCustom) && (
+          <ul
+            role="listbox"
+            aria-label="Style suggestions"
+            className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-md"
+          >
+            {suggestions.map((s) => (
+              <li key={s}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={false}
+                  onClick={() => add(s)}
+                  className="flex w-full px-2.5 py-1.5 text-left text-sm hover:bg-muted"
+                >
+                  {s}
+                </button>
+              </li>
+            ))}
+            {showAddCustom && (
+              <li>
+                <button
+                  type="button"
+                  onClick={() => add(draft)}
+                  className="flex w-full px-2.5 py-1.5 text-left text-sm hover:bg-muted"
+                >
+                  Add &ldquo;{draft.trim()}&rdquo;
+                </button>
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+
+      <FieldError message={error} />
+    </div>
+  )
+}

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -53,6 +53,7 @@ export function StyleTagsInput({
     onChange([...tags, tag])
     setDraft("")
     setError(null)
+    resetList()
   }
 
   function remove(tag: string) {
@@ -85,7 +86,11 @@ export function StyleTagsInput({
   function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Enter") {
       e.preventDefault()
-      add(activeIndex >= 0 ? (options[activeIndex]?.value ?? draft) : draft)
+      const active = activeIndex >= 0 ? options[activeIndex] : undefined
+      // No-op on Enter with an empty draft and nothing highlighted (e.g. right
+      // after adding a tag) instead of surfacing a spurious "empty" error.
+      if (active) add(active.value)
+      else if (draft.trim()) add(draft)
       return
     }
     if (e.key === "Escape" && listOpen) {

--- a/web/components/settings/StyleTagsInput.tsx
+++ b/web/components/settings/StyleTagsInput.tsx
@@ -61,6 +61,7 @@ export function StyleTagsInput({
     draftKey.length > 0 &&
     !suggestions.some((s) => s === draftKey) &&
     !tags.some((t) => t.toLowerCase() === draftKey)
+  const listOpen = suggestions.length > 0 || showAddCustom
 
   return (
     <div data-slot="style-tags" className="flex flex-col gap-2">
@@ -99,10 +100,15 @@ export function StyleTagsInput({
           }}
           placeholder="Add a style (e.g. cello, lo-fi)"
           aria-label="Add a style tag"
+          role="combobox"
+          aria-expanded={listOpen}
+          aria-controls="style-suggestions-list"
+          aria-autocomplete="list"
           disabled={tags.length >= STYLE_TAGS_MAX_ITEMS}
         />
-        {(suggestions.length > 0 || showAddCustom) && (
+        {listOpen && (
           <ul
+            id="style-suggestions-list"
             role="listbox"
             aria-label="Style suggestions"
             className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-md"

--- a/web/components/ui/badge.tsx
+++ b/web/components/ui/badge.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-colors [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "border-border text-foreground",
+        destructive: "border-transparent bg-destructive/10 text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/web/components/ui/card.tsx
+++ b/web/components/ui/card.tsx
@@ -1,0 +1,75 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border border-border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn("flex flex-col gap-1.5 px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("font-semibold leading-none", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+}

--- a/web/components/ui/input.tsx
+++ b/web/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "flex h-8 w-full min-w-0 rounded-lg border border-input bg-background px-2.5 py-1 text-sm shadow-xs transition-all outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/web/components/ui/label.tsx
+++ b/web/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm font-medium leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/web/components/ui/textarea.tsx
+++ b/web/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex min-h-20 w-full rounded-lg border border-input bg-background px-2.5 py-1.5 text-sm shadow-xs transition-all outline-none field-sizing-content placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/web/contexts/auth-context.tsx
+++ b/web/contexts/auth-context.tsx
@@ -14,6 +14,8 @@ import { decodeAccessToken, type AuthUser } from "@/lib/auth"
 
 type AuthContextValue = {
   user: AuthUser | null
+  /** In-memory access token for same-origin Bearer calls (e.g. /api/users/me). */
+  accessToken: string | null
   isAuthenticated: boolean
   isLoading: boolean
   /** Begin an OAuth flow; redirects the browser to the provider on success. */
@@ -84,6 +86,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const user = accessToken ? decodeAccessToken(accessToken) : null
     return {
       user,
+      accessToken,
       isAuthenticated: user !== null,
       isLoading,
       login,

--- a/web/hooks/use-profile-settings.test.tsx
+++ b/web/hooks/use-profile-settings.test.tsx
@@ -1,0 +1,114 @@
+import { renderHook, waitFor, act } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+import { useProfileSettings } from "@/hooks/use-profile-settings"
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+}
+
+const PROFILE = {
+  id: "u1",
+  email: "a@b.co",
+  name: "Ada",
+  display_name: "Ada",
+  handle: "ada",
+  bio: "",
+  style_tags: [],
+  avatar_url: null,
+  subscription_tier: "free",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: null,
+}
+
+function jsonRes(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status })
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("useProfileSettings", () => {
+  it("fetches the profile on mount with the Bearer token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonRes(PROFILE))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(() => useProfileSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.profile?.handle).toBe("ada")
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/users/me")
+    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+  })
+
+  it("save() returns the updated profile on success", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(PROFILE)) // mount fetch
+      .mockResolvedValueOnce(jsonRes({ ...PROFILE, display_name: "Ada L" })) // PATCH
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(() => useProfileSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    let res!: Awaited<ReturnType<typeof result.current.save>>
+    await act(async () => {
+      res = await result.current.save({ display_name: "Ada L" })
+    })
+    expect(res.ok).toBe(true)
+    if (res.ok) expect(res.profile.display_name).toBe("Ada L")
+  })
+
+  it("maps a 409 to a handle field error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(PROFILE))
+      .mockResolvedValueOnce(jsonRes({ detail: "taken" }, 409))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(() => useProfileSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    let res!: Awaited<ReturnType<typeof result.current.save>>
+    await act(async () => {
+      res = await result.current.save({ handle: "taken" })
+    })
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.fieldErrors.handle).toMatch(/already taken/)
+  })
+
+  it("maps a 422 to field errors", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(PROFILE))
+      .mockResolvedValueOnce(
+        jsonRes(
+          { detail: [{ loc: ["body", "bio"], msg: "too long" }] },
+          422
+        )
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(() => useProfileSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    let res!: Awaited<ReturnType<typeof result.current.save>>
+    await act(async () => {
+      res = await result.current.save({ bio: "x" })
+    })
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.fieldErrors.bio).toBe("too long")
+  })
+})

--- a/web/hooks/use-profile-settings.test.tsx
+++ b/web/hooks/use-profile-settings.test.tsx
@@ -16,7 +16,9 @@ const authValue = {
 }
 
 function wrapper({ children }: { children: ReactNode }) {
-  return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+  return (
+    <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+  )
 }
 
 const PROFILE = {
@@ -50,7 +52,9 @@ describe("useProfileSettings", () => {
     expect(result.current.profile?.handle).toBe("ada")
     const [url, opts] = fetchMock.mock.calls[0]
     expect(url).toBe("/api/users/me")
-    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
   })
 
   it("save() returns the updated profile on success", async () => {
@@ -94,10 +98,7 @@ describe("useProfileSettings", () => {
       .fn()
       .mockResolvedValueOnce(jsonRes(PROFILE))
       .mockResolvedValueOnce(
-        jsonRes(
-          { detail: [{ loc: ["body", "bio"], msg: "too long" }] },
-          422
-        )
+        jsonRes({ detail: [{ loc: ["body", "bio"], msg: "too long" }] }, 422)
       )
     vi.stubGlobal("fetch", fetchMock)
 
@@ -110,6 +111,24 @@ describe("useProfileSettings", () => {
     })
     expect(res.ok).toBe(false)
     if (!res.ok) expect(res.fieldErrors.bio).toBe("too long")
+  })
+
+  it("maps a 401 on save to a session-expired message", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(PROFILE))
+      .mockResolvedValueOnce(jsonRes({ detail: "x" }, 401))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(() => useProfileSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    let res!: Awaited<ReturnType<typeof result.current.save>>
+    await act(async () => {
+      res = await result.current.save({ display_name: "Ada L" })
+    })
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.message).toMatch(/session expired/i)
   })
 
   it("maps a nested style_tags item error to the style_tags field", async () => {

--- a/web/hooks/use-profile-settings.test.tsx
+++ b/web/hooks/use-profile-settings.test.tsx
@@ -111,4 +111,27 @@ describe("useProfileSettings", () => {
     expect(res.ok).toBe(false)
     if (!res.ok) expect(res.fieldErrors.bio).toBe("too long")
   })
+
+  it("maps a nested style_tags item error to the style_tags field", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(PROFILE))
+      .mockResolvedValueOnce(
+        jsonRes(
+          { detail: [{ loc: ["body", "style_tags", 0], msg: "too long" }] },
+          422
+        )
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(() => useProfileSettings(), { wrapper })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    let res!: Awaited<ReturnType<typeof result.current.save>>
+    await act(async () => {
+      res = await result.current.save({ style_tags: ["x".repeat(40)] })
+    })
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.fieldErrors.style_tags).toBe("too long")
+  })
 })

--- a/web/hooks/use-profile-settings.ts
+++ b/web/hooks/use-profile-settings.ts
@@ -1,0 +1,129 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import type { UserProfile, UserProfileUpdate } from "@/lib/profile"
+
+/** Field-keyed error messages mapped from a 409/422 response. */
+export type FieldErrors = Partial<
+  Record<"display_name" | "handle" | "bio" | "style_tags", string>
+>
+
+export type SaveResult =
+  | { ok: true; profile: UserProfile }
+  | { ok: false; fieldErrors: FieldErrors; message: string | null }
+
+// null = not loaded yet; failed reflects a load error. Loading/error are
+// derived from this + auth so the effect never calls setState synchronously.
+type Loaded = { profile: UserProfile | null; failed: boolean }
+
+// FastAPI validation error shape: { detail: [{ loc: ["body", field], msg }] }.
+type ValidationDetail = { loc: (string | number)[]; msg: string }
+
+const EDITABLE_FIELDS = new Set(["display_name", "handle", "bio", "style_tags"])
+
+function parseErrors(status: number, body: unknown): SaveResult {
+  if (status === 409) {
+    return {
+      ok: false,
+      fieldErrors: { handle: "This handle is already taken." },
+      message: null,
+    }
+  }
+  if (status === 422 && body && Array.isArray((body as { detail?: unknown }).detail)) {
+    const fieldErrors: FieldErrors = {}
+    for (const d of (body as { detail: ValidationDetail[] }).detail) {
+      const field = d.loc?.[d.loc.length - 1]
+      if (typeof field === "string" && EDITABLE_FIELDS.has(field)) {
+        fieldErrors[field as keyof FieldErrors] = d.msg
+      }
+    }
+    if (Object.keys(fieldErrors).length > 0) {
+      return { ok: false, fieldErrors, message: null }
+    }
+  }
+  const detail = (body as { detail?: unknown })?.detail
+  return {
+    ok: false,
+    fieldErrors: {},
+    message: typeof detail === "string" ? detail : "Could not save changes. Please try again.",
+  }
+}
+
+/**
+ * Load the current user's profile and expose a save action. Fetch waits for the
+ * in-memory access token (restored on app mount) before calling the same-origin
+ * BFF proxy at /api/users/me.
+ */
+export function useProfileSettings() {
+  const { accessToken, isLoading: authLoading } = useAuth()
+  const [loaded, setLoaded] = useState<Loaded | null>(null)
+
+  useEffect(() => {
+    // accessToken only flips null→token once on mount (logout redirects away),
+    // so there's no stale-load reset to do here.
+    if (authLoading || !accessToken) return
+    let active = true
+    fetch("/api/users/me", {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("fetch failed")
+        return (await res.json()) as UserProfile
+      })
+      .then((profile) => {
+        if (active) setLoaded({ profile, failed: false })
+      })
+      .catch(() => {
+        if (active) setLoaded({ profile: null, failed: true })
+      })
+    return () => {
+      active = false
+    }
+  }, [accessToken, authLoading])
+
+  const isLoading = authLoading || (!!accessToken && loaded === null)
+  const error =
+    !authLoading && !accessToken
+      ? "Not authenticated."
+      : loaded?.failed
+        ? "Could not load your profile. Please try again."
+        : null
+  const profile = loaded?.profile ?? null
+
+  const save = useCallback(
+    async (update: UserProfileUpdate): Promise<SaveResult> => {
+      if (!accessToken) {
+        return { ok: false, fieldErrors: {}, message: "Not authenticated." }
+      }
+      let res: Response
+      try {
+        res = await fetch("/api/users/me", {
+          method: "PATCH",
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(update),
+        })
+      } catch {
+        return {
+          ok: false,
+          fieldErrors: {},
+          message: "Network error. Please try again.",
+        }
+      }
+      const body = await res.json().catch(() => ({}))
+      if (res.ok) {
+        const updated = body as UserProfile
+        setLoaded({ profile: updated, failed: false })
+        return { ok: true, profile: updated }
+      }
+      return parseErrors(res.status, body)
+    },
+    [accessToken]
+  )
+
+  return { profile, isLoading, error, save }
+}

--- a/web/hooks/use-profile-settings.ts
+++ b/web/hooks/use-profile-settings.ts
@@ -14,9 +14,14 @@ export type SaveResult =
   | { ok: true; profile: UserProfile }
   | { ok: false; fieldErrors: FieldErrors; message: string | null }
 
-// null = not loaded yet; failed reflects a load error. Loading/error are
-// derived from this + auth so the effect never calls setState synchronously.
-type Loaded = { profile: UserProfile | null; failed: boolean }
+// null = not loaded yet; failed reflects a load error (expired = the access
+// token was rejected). Loading/error are derived from this + auth so the effect
+// never calls setState synchronously.
+type Loaded = {
+  profile: UserProfile | null
+  failed: boolean
+  expired?: boolean
+}
 
 // FastAPI validation error shape: { detail: [{ loc: ["body", field], msg }] }.
 type ValidationDetail = { loc: (string | number)[]; msg: string }
@@ -31,7 +36,11 @@ function parseErrors(status: number, body: unknown): SaveResult {
       message: null,
     }
   }
-  if (status === 422 && body && Array.isArray((body as { detail?: unknown }).detail)) {
+  if (
+    status === 422 &&
+    body &&
+    Array.isArray((body as { detail?: unknown }).detail)
+  ) {
     const fieldErrors: FieldErrors = {}
     for (const d of (body as { detail: ValidationDetail[] }).detail) {
       const field = d.loc?.[d.loc.length - 1]
@@ -47,7 +56,10 @@ function parseErrors(status: number, body: unknown): SaveResult {
   return {
     ok: false,
     fieldErrors: {},
-    message: typeof detail === "string" ? detail : "Could not save changes. Please try again.",
+    message:
+      typeof detail === "string"
+        ? detail
+        : "Could not save changes. Please try again.",
   }
 }
 
@@ -55,6 +67,10 @@ function parseErrors(status: number, body: unknown): SaveResult {
  * Load the current user's profile and expose a save action. Fetch waits for the
  * in-memory access token (restored on app mount) before calling the same-origin
  * BFF proxy at /api/users/me.
+ *
+ * Precondition: use behind an auth guard (e.g. useRequireAuth). When auth has
+ * settled with no token, this surfaces a "Not authenticated." error rather than
+ * loading — an unguarded consumer would flash that on first render.
  */
 export function useProfileSettings() {
   const { accessToken, isLoading: authLoading } = useAuth()
@@ -69,11 +85,13 @@ export function useProfileSettings() {
       headers: { authorization: `Bearer ${accessToken}` },
     })
       .then(async (res) => {
+        if (res.status === 401)
+          return { profile: null, failed: true, expired: true }
         if (!res.ok) throw new Error("fetch failed")
-        return (await res.json()) as UserProfile
+        return { profile: (await res.json()) as UserProfile, failed: false }
       })
-      .then((profile) => {
-        if (active) setLoaded({ profile, failed: false })
+      .then((next) => {
+        if (active) setLoaded(next)
       })
       .catch(() => {
         if (active) setLoaded({ profile: null, failed: true })
@@ -87,9 +105,11 @@ export function useProfileSettings() {
   const error =
     !authLoading && !accessToken
       ? "Not authenticated."
-      : loaded?.failed
-        ? "Could not load your profile. Please try again."
-        : null
+      : loaded?.expired
+        ? "Your session expired. Please sign in again."
+        : loaded?.failed
+          ? "Could not load your profile. Please try again."
+          : null
   const profile = loaded?.profile ?? null
 
   const save = useCallback(

--- a/web/hooks/use-profile-settings.ts
+++ b/web/hooks/use-profile-settings.ts
@@ -29,6 +29,15 @@ type ValidationDetail = { loc: (string | number)[]; msg: string }
 const EDITABLE_FIELDS = new Set(["display_name", "handle", "bio", "style_tags"])
 
 function parseErrors(status: number, body: unknown): SaveResult {
+  if (status === 401) {
+    // Token expired between load and save — match the load path's wording so a
+    // retry isn't implied to help.
+    return {
+      ok: false,
+      fieldErrors: {},
+      message: "Your session expired. Please sign in again.",
+    }
+  }
   if (status === 409) {
     return {
       ok: false,

--- a/web/hooks/use-profile-settings.ts
+++ b/web/hooks/use-profile-settings.ts
@@ -43,7 +43,12 @@ function parseErrors(status: number, body: unknown): SaveResult {
   ) {
     const fieldErrors: FieldErrors = {}
     for (const d of (body as { detail: ValidationDetail[] }).detail) {
-      const field = d.loc?.[d.loc.length - 1]
+      // The field name is the segment after "body"; for a per-item failure the
+      // loc is ["body", "style_tags", 0], so the *last* segment would be the
+      // index (a number) and miss the field. Fall back to last for safety.
+      const loc = d.loc ?? []
+      const bodyIdx = loc.indexOf("body")
+      const field = bodyIdx >= 0 ? loc[bodyIdx + 1] : loc[loc.length - 1]
       if (typeof field === "string" && EDITABLE_FIELDS.has(field)) {
         fieldErrors[field as keyof FieldErrors] = d.msg
       }

--- a/web/lib/profile.test.ts
+++ b/web/lib/profile.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  validateBio,
+  validateDisplayName,
+  validateHandle,
+  validateNewStyleTag,
+  STYLE_TAGS_MAX_ITEMS,
+} from "@/lib/profile"
+
+describe("validateDisplayName", () => {
+  it("accepts a normal name", () => {
+    expect(validateDisplayName("Ada Lovelace")).toBeNull()
+  })
+  it("requires a non-empty value", () => {
+    expect(validateDisplayName("   ")).toMatch(/required/)
+  })
+  it("rejects names over 100 chars", () => {
+    expect(validateDisplayName("a".repeat(101))).toMatch(/at most/)
+  })
+})
+
+describe("validateHandle", () => {
+  it("treats empty as valid (unclaimed)", () => {
+    expect(validateHandle("")).toBeNull()
+  })
+  it("accepts alphanumeric + internal hyphens", () => {
+    expect(validateHandle("ada-lovelace1")).toBeNull()
+  })
+  it("rejects too-short handles", () => {
+    expect(validateHandle("ab")).toMatch(/3-30/)
+  })
+  it("rejects too-long handles", () => {
+    expect(validateHandle("a".repeat(31))).toMatch(/3-30/)
+  })
+  it("rejects disallowed characters", () => {
+    expect(validateHandle("ada_lovelace")).toMatch(/letters, numbers/)
+  })
+  it("rejects leading/trailing hyphens", () => {
+    expect(validateHandle("-ada")).toMatch(/hyphen/)
+    expect(validateHandle("ada-")).toMatch(/hyphen/)
+  })
+})
+
+describe("validateBio", () => {
+  it("accepts within limit", () => {
+    expect(validateBio("hello")).toBeNull()
+  })
+  it("rejects over 500 chars", () => {
+    expect(validateBio("a".repeat(501))).toMatch(/at most/)
+  })
+})
+
+describe("validateNewStyleTag", () => {
+  it("accepts a fresh tag", () => {
+    expect(validateNewStyleTag("cello", [])).toBeNull()
+  })
+  it("trims and rejects empty", () => {
+    expect(validateNewStyleTag("   ", [])).toMatch(/empty/)
+  })
+  it("rejects duplicates case-insensitively", () => {
+    expect(validateNewStyleTag("Cello", ["cello"])).toMatch(/already/)
+  })
+  it("rejects tags over 30 chars", () => {
+    expect(validateNewStyleTag("a".repeat(31), [])).toMatch(/at most/)
+  })
+  it("rejects when the list is full", () => {
+    const full = Array.from({ length: STYLE_TAGS_MAX_ITEMS }, (_, i) => `t${i}`)
+    expect(validateNewStyleTag("more", full)).toMatch(/At most/)
+  })
+})

--- a/web/lib/profile.test.ts
+++ b/web/lib/profile.test.ts
@@ -49,6 +49,9 @@ describe("validateBio", () => {
   it("rejects over 500 chars", () => {
     expect(validateBio("a".repeat(501))).toMatch(/at most/)
   })
+  it("ignores surrounding whitespace when checking the limit", () => {
+    expect(validateBio("  " + "a".repeat(500) + "  ")).toBeNull()
+  })
 })
 
 describe("validateNewStyleTag", () => {

--- a/web/lib/profile.ts
+++ b/web/lib/profile.ts
@@ -81,8 +81,9 @@ export function validateHandle(value: string): string | null {
     return "Only letters, numbers, and hyphens allowed."
   if (value.startsWith("-") || value.endsWith("-"))
     return "Cannot start or end with a hyphen."
-  // Catch any residual mismatch (e.g. consecutive-hyphen edge cases the
-  // backend pattern rejects) so client and server never disagree.
+  // Backstop against the exact backend pattern so client and server never
+  // disagree. (The backend, like this, accepts internal consecutive hyphens —
+  // e.g. "a--b" — so we deliberately don't reject them here.)
   if (!HANDLE_PATTERN.test(value))
     return "Only letters, numbers, and hyphens allowed."
   return null

--- a/web/lib/profile.ts
+++ b/web/lib/profile.ts
@@ -1,0 +1,114 @@
+// Profile types and client-side validation for the settings page (US-15.5).
+// Rules mirror the backend (src/acemusic/api/routers/users.py and
+// services/users.py) so the form catches violations before the round-trip; the
+// server stays the source of truth (it re-validates and owns handle uniqueness).
+
+/** Full profile as returned by GET /api/v1/users/me. */
+export type UserProfile = {
+  id: string
+  email: string
+  name: string
+  display_name: string | null
+  handle: string | null
+  bio: string | null
+  style_tags: string[]
+  avatar_url: string | null
+  subscription_tier: string
+  created_at: string
+  updated_at: string | null
+}
+
+/** Editable fields sent to PATCH /api/v1/users/me (avatar_url is read-only). */
+export type UserProfileUpdate = {
+  display_name?: string
+  handle?: string | null
+  bio?: string
+  style_tags?: string[]
+}
+
+export const DISPLAY_NAME_MAX_LENGTH = 100
+export const BIO_MAX_LENGTH = 500
+export const HANDLE_MIN_LENGTH = 3
+export const HANDLE_MAX_LENGTH = 30
+export const STYLE_TAG_MAX_LENGTH = 30
+export const STYLE_TAGS_MAX_ITEMS = 20
+
+// Matches the backend _HANDLE_PATTERN: alphanumeric, internal hyphens allowed,
+// must start and end with an alphanumeric character.
+const HANDLE_PATTERN = /^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$/
+
+/** Curated typeahead suggestions; no backend endpoint exists yet (US-15.5). */
+export const STYLE_SUGGESTIONS = [
+  "cello",
+  "orchestral",
+  "lo-fi",
+  "ambient",
+  "electronic",
+  "acoustic",
+  "jazz",
+  "hip-hop",
+  "classical",
+  "indie",
+  "pop",
+  "rock",
+  "folk",
+  "synthwave",
+  "piano",
+  "drill",
+  "house",
+  "techno",
+  "soul",
+  "cinematic",
+] as const
+
+/** Return an error message, or null if valid. */
+export function validateDisplayName(value: string): string | null {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return "Display name is required."
+  if (trimmed.length > DISPLAY_NAME_MAX_LENGTH)
+    return `Display name must be at most ${DISPLAY_NAME_MAX_LENGTH} characters.`
+  return null
+}
+
+/** Validate handle format. Empty is allowed (handle stays unclaimed/null). */
+export function validateHandle(value: string): string | null {
+  if (value.length === 0) return null
+  if (value.length < HANDLE_MIN_LENGTH)
+    return `Handle must be ${HANDLE_MIN_LENGTH}-${HANDLE_MAX_LENGTH} characters.`
+  if (value.length > HANDLE_MAX_LENGTH)
+    return `Handle must be ${HANDLE_MIN_LENGTH}-${HANDLE_MAX_LENGTH} characters.`
+  if (/[^A-Za-z0-9-]/.test(value))
+    return "Only letters, numbers, and hyphens allowed."
+  if (value.startsWith("-") || value.endsWith("-"))
+    return "Cannot start or end with a hyphen."
+  // Catch any residual mismatch (e.g. consecutive-hyphen edge cases the
+  // backend pattern rejects) so client and server never disagree.
+  if (!HANDLE_PATTERN.test(value))
+    return "Only letters, numbers, and hyphens allowed."
+  return null
+}
+
+export function validateBio(value: string): string | null {
+  if (value.length > BIO_MAX_LENGTH)
+    return `Bio must be at most ${BIO_MAX_LENGTH} characters.`
+  return null
+}
+
+/**
+ * Validate a tag the user is trying to add against the current list.
+ * Returns an error message, or null if the (trimmed) tag is addable.
+ */
+export function validateNewStyleTag(
+  raw: string,
+  existing: string[]
+): string | null {
+  const tag = raw.trim()
+  if (tag.length === 0) return "Tag cannot be empty."
+  if (tag.length > STYLE_TAG_MAX_LENGTH)
+    return `Tag must be at most ${STYLE_TAG_MAX_LENGTH} characters.`
+  if (existing.some((t) => t.toLowerCase() === tag.toLowerCase()))
+    return "Tag already added."
+  if (existing.length >= STYLE_TAGS_MAX_ITEMS)
+    return `At most ${STYLE_TAGS_MAX_ITEMS} tags allowed.`
+  return null
+}

--- a/web/lib/profile.ts
+++ b/web/lib/profile.ts
@@ -90,7 +90,9 @@ export function validateHandle(value: string): string | null {
 }
 
 export function validateBio(value: string): string | null {
-  if (value.length > BIO_MAX_LENGTH)
+  // Validate the trimmed length, since that's what gets sent to the backend —
+  // trailing whitespace shouldn't trip the limit on an otherwise-valid bio.
+  if (value.trim().length > BIO_MAX_LENGTH)
     return `Bio must be at most ${BIO_MAX_LENGTH} characters.`
   return null
 }


### PR DESCRIPTION
Implements **US-15.5: Profile Settings Page** (#185).

A protected `/settings` page where a musician edits their display name, handle,
bio, style tags, and a preview avatar, saving to the existing
`PATCH /api/v1/users/me` backend. Reachable from the sidebar account menu
("Account settings", previously a dead item).

## How it works
- Client holds the access token in memory (existing auth model) and calls a new
  same-origin BFF proxy `web/app/api/users/me/route.ts` (GET + PATCH) that
  forwards the Bearer header to the backend, so the backend URL stays
  server-side and `409`/`422` responses pass through verbatim.
- Native React form state (mirrors the login page); client-side validation
  mirrors the backend rules in `web/lib/profile.ts`.

## What's included
- New Nova-style UI primitives: `input`, `label`, `textarea`, `badge`, `card`
- `StyleTagsInput` (removable pill badges + static typeahead), `AvatarUpload`
  (drag-drop + click, local square preview), `FieldError`, `useProfileSettings`
- Real-time (debounced) handle **format** validation with a "Looks good" state;
  inline 409 ("already taken") and 422 field-error mapping
- Expose `accessToken` from the auth context; disable fields during save

## Acceptance criteria → evidence
All five ACs are mapped to DOM-level integration tests (real page/components/hook,
asserting real DOM + PATCH payloads) in `docs/demos/us-15.5-profile-settings.md`.
`npm test`: **73 passed**. `npm run build`, `lint`, `typecheck`: clean.

## Known limitations (no backend support yet — out of this story's scope)
- **Avatar is preview-only.** The avatar storage endpoint (US-8.5) doesn't exist;
  `avatar_url` is read-only, so the chosen image isn't persisted ("coming soon"
  badge). Square crop is CSS `object-cover`, not a crop library.
- **Handle uniqueness is save-time only.** No availability endpoint exists, so
  real-time feedback is format-only; duplicates surface as an inline 409 on save.
- **Access token refreshes only on app mount** (inherited from US-15.4). After
  token expiry an authenticated call can 401 until reload — affects all future
  authenticated client calls and belongs in the shared auth layer, not this page.
  (Raised by codex review; the in-flight-save edit-clobber it also found is fixed.)

Closes #185

https://claude.ai/code/session_01EnqmPMCgeazvLD9mWdmPev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated Profile Settings page to edit display name, handle, bio, and style tags, with avatar upload preview.
  * Introduced style tag suggestions/typeahead with keyboard support, inline validation, and conflict/validation error display.
* **Bug Fixes**
  * Improved current-user profile API proxy behavior: consistent unauthenticated (401) handling and accurate pass-through of upstream conflict/validation responses.
* **Documentation**
  * Documented the Profile Settings demo flow and acceptance criteria.
* **Tests**
  * Added/expanded coverage for Settings page, profile settings hook, API proxy GET/PATCH, and avatar/style tag inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->