### PR TITLE
feat(web): Simple Creation Mode (US-16.1)

### DIFF
--- a/web/app/api/generate/route.test.ts
+++ b/web/app/api/generate/route.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { POST } from "@/app/api/generate/route"
+
+function req(init: RequestInit = {}): NextRequest {
+  return new Request("http://localhost/api/generate", {
+    method: "POST",
+    ...init,
+  }) as unknown as NextRequest
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("POST /api/generate", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await POST(req())
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the Bearer token and body, passing 202 through", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ job_id: "j1", status: "queued" }), {
+        status: 202,
+      })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await POST(
+      req({
+        headers: {
+          authorization: "Bearer tok",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ prompt: "hi", instrumental: false }),
+      })
+    )
+    expect(res.status).toBe(202)
+    expect(await res.json()).toMatchObject({ job_id: "j1" })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/generate")
+    expect(opts.method).toBe("POST")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+    expect(opts.body).toBe(JSON.stringify({ prompt: "hi", instrumental: false }))
+  })
+
+  it("surfaces a 422 verbatim", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "bad" }), { status: 422 })
+      )
+    )
+    const res = await POST(
+      req({ headers: { authorization: "Bearer tok" }, body: "{}" })
+    )
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({ detail: "bad" })
+  })
+})

--- a/web/app/api/generate/route.test.ts
+++ b/web/app/api/generate/route.test.ts
@@ -47,6 +47,15 @@ describe("POST /api/generate", () => {
     expect(opts.body).toBe(JSON.stringify({ prompt: "hi", instrumental: false }))
   })
 
+  it("returns a controlled 502 when the upstream fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")))
+    const res = await POST(
+      req({ headers: { authorization: "Bearer tok" }, body: "{}" })
+    )
+    expect(res.status).toBe(502)
+    expect(await res.json()).toMatchObject({ detail: expect.any(String) })
+  })
+
   it("surfaces a 422 verbatim", async () => {
     vi.stubGlobal(
       "fetch",

--- a/web/app/api/generate/route.ts
+++ b/web/app/api/generate/route.ts
@@ -16,15 +16,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
   }
 
-  const res = await fetch(TARGET, {
-    method: "POST",
-    headers: {
-      authorization: auth,
-      "content-type": "application/json",
-      accept: "application/json",
-    },
-    body: await request.text(),
-  })
+  let res: Response
+  try {
+    res = await fetch(TARGET, {
+      method: "POST",
+      headers: {
+        authorization: auth,
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: await request.text(),
+    })
+  } catch {
+    // Backend unreachable / network error — return a controlled 502 instead of
+    // letting the route throw an opaque 500.
+    return NextResponse.json(
+      { detail: "Generation service is unavailable." },
+      { status: 502 }
+    )
+  }
   const body = await res.json().catch(() => ({}))
   return NextResponse.json(body, { status: res.status })
 }

--- a/web/app/api/generate/route.ts
+++ b/web/app/api/generate/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for the generation endpoint (US-16.1). The client holds the
+// access token in memory and sends it as a Bearer header; this route forwards it
+// to the backend so the backend URL stays server-side. Backend status/body are
+// passed through verbatim, so 202 (queued), 401, and 422 (validation) surface
+// unchanged to the creation form.
+
+const TARGET = `${BACKEND_URL}/api/v1/generate`
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const res = await fetch(TARGET, {
+    method: "POST",
+    headers: {
+      authorization: auth,
+      "content-type": "application/json",
+      accept: "application/json",
+    },
+    body: await request.text(),
+  })
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useRequireAuth } from "@/hooks/use-require-auth"
+import { SimpleCreationForm } from "@/components/create/SimpleCreationForm"
 
 export default function CreatePage() {
   const { isLoading, isAuthenticated } = useRequireAuth()
@@ -11,7 +13,23 @@ export default function CreatePage() {
 
   return (
     <div className="p-8">
-      <h1 className="text-2xl font-semibold">Create</h1>
+      <h1 className="mb-6 text-2xl font-semibold">Create</h1>
+      <Tabs defaultValue="simple">
+        <TabsList>
+          <TabsTrigger value="simple">Simple</TabsTrigger>
+          <TabsTrigger value="advanced">Advanced</TabsTrigger>
+          <TabsTrigger value="sounds">Sounds</TabsTrigger>
+        </TabsList>
+        <TabsContent value="simple">
+          <SimpleCreationForm />
+        </TabsContent>
+        <TabsContent value="advanced">
+          <p className="text-sm text-muted-foreground">Coming soon.</p>
+        </TabsContent>
+        <TabsContent value="sounds">
+          <p className="text-sm text-muted-foreground">Coming soon.</p>
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/web/components/create/InspirationTags.test.tsx
+++ b/web/components/create/InspirationTags.test.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { InspirationTags } from "@/components/create/InspirationTags"
+
+// Controlled component — drive it through a stateful harness so clicks that call
+// onChange are reflected back, matching real usage in the form.
+function Harness() {
+  const [tags, setTags] = useState<string[]>([])
+  return <InspirationTags selectedTags={tags} onChange={setTags} />
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("InspirationTags", () => {
+  it("renders suggestion pills and shows one as selected on click", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const suggestionRow = screen
+      .getByRole("button", { name: "Shuffle suggestions" })
+      .closest("div") as HTMLElement
+    const firstTag = within(suggestionRow).getAllByRole("button")[0]
+    const label = firstTag.textContent ?? ""
+    await user.click(firstTag)
+
+    // The selected tag now appears in the "Selected tags" group as a chip.
+    const selected = screen.getByLabelText("Selected tags")
+    expect(within(selected).getByText(label)).toBeInTheDocument()
+  })
+
+  it("removes a selected tag when its chip is dismissed", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const suggestionRow = screen
+      .getByRole("button", { name: "Shuffle suggestions" })
+      .closest("div") as HTMLElement
+    const firstTag = within(suggestionRow).getAllByRole("button")[0]
+    const label = firstTag.textContent ?? ""
+    await user.click(firstTag)
+
+    await user.click(screen.getByRole("button", { name: `Remove ${label}` }))
+    expect(screen.queryByLabelText("Selected tags")).not.toBeInTheDocument()
+  })
+
+  it("replaces displayed suggestions on shuffle", async () => {
+    // Deterministic shuffle: first render uses the unstubbed order; after the
+    // stub, picks rotate predictably so the set changes.
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const before = screen
+      .getAllByRole("button")
+      .map((b) => b.textContent)
+      .filter((t) => t && t !== "")
+      .join("|")
+
+    vi.spyOn(Math, "random").mockReturnValue(0.99)
+    await user.click(screen.getByRole("button", { name: "Shuffle suggestions" }))
+
+    const after = screen
+      .getAllByRole("button")
+      .map((b) => b.textContent)
+      .filter((t) => t && t !== "")
+      .join("|")
+
+    expect(after).not.toBe(before)
+  })
+
+  it("keeps selected tags visible through a shuffle", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const suggestionRow = screen
+      .getByRole("button", { name: "Shuffle suggestions" })
+      .closest("div") as HTMLElement
+    const firstTag = within(suggestionRow).getAllByRole("button")[0]
+    const label = firstTag.textContent ?? ""
+    await user.click(firstTag)
+
+    await user.click(screen.getByRole("button", { name: "Shuffle suggestions" }))
+
+    const selected = screen.getByLabelText("Selected tags")
+    expect(within(selected).getByText(label)).toBeInTheDocument()
+  })
+})

--- a/web/components/create/InspirationTags.tsx
+++ b/web/components/create/InspirationTags.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Cancel01Icon, ShuffleIcon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { STYLE_SUGGESTIONS } from "@/lib/profile"
+
+// Curated pool the suggestions are drawn from. Reuses the profile style list
+// (genres, moods, instruments) so there's one source of style vocabulary; an
+// API-driven source can replace this later without touching the component API.
+const TAG_POOL = STYLE_SUGGESTIONS
+const SUGGESTION_COUNT = 8
+
+/** Pick `count` distinct tags at random from `pool`, excluding `exclude`. */
+function pickSuggestions(
+  pool: readonly string[],
+  count: number,
+  exclude: string[]
+): string[] {
+  const taken = new Set(exclude)
+  const candidates = pool.filter((t) => !taken.has(t))
+  // Fisher–Yates over a copy, then slice — unbiased and short.
+  for (let i = candidates.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[candidates[i], candidates[j]] = [candidates[j], candidates[i]]
+  }
+  return candidates.slice(0, count)
+}
+
+/**
+ * AI-suggested inspiration tags: a row of clickable style pills plus a shuffle
+ * button. Selected tags are owned by the parent (they feed the `style` field of
+ * the generation request); shuffling refreshes the unselected suggestions while
+ * keeping the current selection visible as removable chips.
+ */
+export function InspirationTags({
+  selectedTags,
+  onChange,
+}: {
+  selectedTags: string[]
+  onChange: (next: string[]) => void
+}) {
+  const [suggestions, setSuggestions] = useState<string[]>(() =>
+    pickSuggestions(TAG_POOL, SUGGESTION_COUNT, [])
+  )
+
+  // Show suggestions that aren't already selected, so a selected pill doesn't
+  // appear in both rows at once.
+  const visibleSuggestions = useMemo(
+    () => suggestions.filter((t) => !selectedTags.includes(t)),
+    [suggestions, selectedTags]
+  )
+
+  function toggle(tag: string) {
+    onChange(
+      selectedTags.includes(tag)
+        ? selectedTags.filter((t) => t !== tag)
+        : [...selectedTags, tag]
+    )
+  }
+
+  function shuffle() {
+    setSuggestions(pickSuggestions(TAG_POOL, SUGGESTION_COUNT, selectedTags))
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {selectedTags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5" aria-label="Selected tags">
+          {selectedTags.map((tag) => (
+            <Badge key={tag} variant="default" className="gap-1 pr-1">
+              {tag}
+              <button
+                type="button"
+                aria-label={`Remove ${tag}`}
+                onClick={() => toggle(tag)}
+                className="rounded-full p-0.5 hover:bg-primary-foreground/20"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        {visibleSuggestions.map((tag) => (
+          <Badge key={tag} variant="outline" asChild>
+            <button type="button" onClick={() => toggle(tag)}>
+              {tag}
+            </button>
+          </Badge>
+        ))}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Shuffle suggestions"
+          onClick={shuffle}
+        >
+          <HugeiconsIcon icon={ShuffleIcon} />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/components/create/SimpleCreationForm.test.tsx
+++ b/web/components/create/SimpleCreationForm.test.tsx
@@ -87,4 +87,12 @@ describe("SimpleCreationForm", () => {
     )
     expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
   })
+
+  it("shows the +Audio placeholder as a neutral notice, not an error", async () => {
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+    await user.click(screen.getByRole("button", { name: /audio/i }))
+    expect(screen.getByRole("status")).toHaveTextContent(/coming soon/i)
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
 })

--- a/web/components/create/SimpleCreationForm.test.tsx
+++ b/web/components/create/SimpleCreationForm.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SimpleCreationForm } from "@/components/create/SimpleCreationForm"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok" }),
+}))
+
+const submitGeneration = vi.fn()
+vi.mock("@/lib/generate", () => ({
+  submitGeneration: (...args: unknown[]) => submitGeneration(...args),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("SimpleCreationForm", () => {
+  function createButton() {
+    return screen.getByRole("button", { name: /create/i })
+  }
+
+  it("disables Create when description and lyrics are both empty", () => {
+    render(<SimpleCreationForm />)
+    expect(createButton()).toBeDisabled()
+  })
+
+  it("enables Create once the description has content", async () => {
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+    await user.type(
+      screen.getByLabelText("Song description"),
+      "a calm piano piece"
+    )
+    expect(createButton()).toBeEnabled()
+  })
+
+  it("reveals the lyrics textarea and enables Create from lyrics alone", async () => {
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+    expect(screen.queryByLabelText("Lyrics")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /lyrics/i }))
+    const lyrics = screen.getByLabelText("Lyrics")
+    expect(lyrics).toBeInTheDocument()
+
+    await user.type(lyrics, "la la la")
+    expect(createButton()).toBeEnabled()
+  })
+
+  it("toggles the instrumental switch", async () => {
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+    const toggle = screen.getByRole("switch", { name: "Instrumental" })
+    expect(toggle).toHaveAttribute("aria-checked", "false")
+    await user.click(toggle)
+    expect(toggle).toHaveAttribute("aria-checked", "true")
+  })
+
+  it("submits the form state and reports success", async () => {
+    submitGeneration.mockResolvedValue({ status: "accepted", jobId: "job-1" })
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+
+    await user.type(screen.getByLabelText("Song description"), "dreamy")
+    await user.click(screen.getByRole("switch", { name: "Instrumental" }))
+    await user.click(createButton())
+
+    expect(submitGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "dreamy", instrumental: true }),
+      "tok"
+    )
+    expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
+  })
+})

--- a/web/components/create/SimpleCreationForm.test.tsx
+++ b/web/components/create/SimpleCreationForm.test.tsx
@@ -50,6 +50,19 @@ describe("SimpleCreationForm", () => {
     expect(createButton()).toBeEnabled()
   })
 
+  it("disables Create again when lyrics are hidden after being the only input", async () => {
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+
+    await user.click(screen.getByRole("button", { name: /lyrics/i }))
+    await user.type(screen.getByLabelText("Lyrics"), "la la la")
+    expect(createButton()).toBeEnabled()
+
+    // Hiding the lyrics field must not leave Create enabled on hidden text.
+    await user.click(screen.getByRole("button", { name: /lyrics/i }))
+    expect(createButton()).toBeDisabled()
+  })
+
   it("toggles the instrumental switch", async () => {
     const user = userEvent.setup()
     render(<SimpleCreationForm />)

--- a/web/components/create/SimpleCreationForm.tsx
+++ b/web/components/create/SimpleCreationForm.tsx
@@ -13,9 +13,12 @@ import { useAuth } from "@/hooks/use-auth"
 import { submitGeneration } from "@/lib/generate"
 import { InspirationTags } from "@/components/create/InspirationTags"
 
+// A user-facing message only. Whether a request is in flight is tracked
+// separately (isSubmitting) so a non-error notice — e.g. the +Audio placeholder
+// — can't clobber the in-flight state and re-enable Create mid-request.
 type Status =
   | { kind: "idle" }
-  | { kind: "submitting" }
+  | { kind: "info"; message: string }
   | { kind: "success"; message: string }
   | { kind: "error"; message: string }
 
@@ -35,6 +38,7 @@ export function SimpleCreationForm() {
   const [showLyrics, setShowLyrics] = useState(false)
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [status, setStatus] = useState<Status>({ kind: "idle" })
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   // Lyrics only count when the field is open — hiding it shouldn't keep Create
   // enabled (and then submit an empty prompt). Use this one value everywhere.
@@ -46,32 +50,34 @@ export function SimpleCreationForm() {
     description.trim().length > 0 || effectiveLyrics.trim().length > 0
 
   async function handleCreate() {
-    if (!canSubmit || status.kind === "submitting") return
+    if (!canSubmit || isSubmitting) return
     if (!accessToken) {
       router.push("/login")
       return
     }
-    setStatus({ kind: "submitting" })
-    const result = await submitGeneration(
-      { description, lyrics: effectiveLyrics, instrumental, selectedTags },
-      accessToken
-    )
-    switch (result.status) {
-      case "accepted":
-        setStatus({
-          kind: "success",
-          message: "Generation started. We'll let you know when it's ready.",
-        })
-        break
-      case "unauthorized":
-        router.push("/login")
-        break
-      case "invalid":
-        setStatus({ kind: "error", message: result.detail })
-        break
-      case "error":
-        setStatus({ kind: "error", message: result.detail })
-        break
+    setIsSubmitting(true)
+    try {
+      const result = await submitGeneration(
+        { description, lyrics: effectiveLyrics, instrumental, selectedTags },
+        accessToken
+      )
+      switch (result.status) {
+        case "accepted":
+          setStatus({
+            kind: "success",
+            message: "Generation started. We'll let you know when it's ready.",
+          })
+          break
+        case "unauthorized":
+          router.push("/login")
+          break
+        case "invalid":
+        case "error":
+          setStatus({ kind: "error", message: result.detail })
+          break
+      }
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -106,7 +112,10 @@ export function SimpleCreationForm() {
           type="button"
           variant="outline"
           size="sm"
-          onClick={() => setStatus({ kind: "error", message: "Audio input is coming soon." })}
+          disabled={isSubmitting}
+          onClick={() =>
+            setStatus({ kind: "info", message: "Audio input is coming soon." })
+          }
         >
           <HugeiconsIcon icon={MusicNote01Icon} data-icon="inline-start" />
           Audio
@@ -133,7 +142,9 @@ export function SimpleCreationForm() {
 
       <InspirationTags selectedTags={selectedTags} onChange={setSelectedTags} />
 
-      {status.kind === "success" && (
+      {/* Neutral notices (info/success) are polite status; only real failures
+          use the assertive, destructive alert. */}
+      {(status.kind === "info" || status.kind === "success") && (
         <p role="status" className="text-sm text-muted-foreground">
           {status.message}
         </p>
@@ -147,10 +158,10 @@ export function SimpleCreationForm() {
       <Button
         type="button"
         className="w-fit"
-        disabled={!canSubmit || status.kind === "submitting"}
+        disabled={!canSubmit || isSubmitting}
         onClick={handleCreate}
       >
-        {status.kind === "submitting" ? "Creating..." : "Create"}
+        {isSubmitting ? "Creating..." : "Create"}
       </Button>
     </div>
   )

--- a/web/components/create/SimpleCreationForm.tsx
+++ b/web/components/create/SimpleCreationForm.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Add01Icon, MusicNote01Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { useAuth } from "@/hooks/use-auth"
+import { submitGeneration } from "@/lib/generate"
+import { InspirationTags } from "@/components/create/InspirationTags"
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success"; message: string }
+  | { kind: "error"; message: string }
+
+/**
+ * The Simple creation form (US-16.1): describe a song in plain language and go.
+ * A controlled form whose Create button enables as soon as there's a description
+ * or lyrics, then enqueues a generation request through the BFF proxy. Progress
+ * and result rendering are deferred to US-16.7 — success just reports the job id.
+ */
+export function SimpleCreationForm() {
+  const router = useRouter()
+  const { accessToken } = useAuth()
+
+  const [description, setDescription] = useState("")
+  const [instrumental, setInstrumental] = useState(false)
+  const [lyrics, setLyrics] = useState("")
+  const [showLyrics, setShowLyrics] = useState(false)
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [status, setStatus] = useState<Status>({ kind: "idle" })
+
+  // Enabled the moment either text field has content — tags and the instrumental
+  // toggle don't gate submission (per the acceptance criteria).
+  const canSubmit =
+    description.trim().length > 0 || lyrics.trim().length > 0
+
+  async function handleCreate() {
+    if (!canSubmit || status.kind === "submitting") return
+    if (!accessToken) {
+      router.push("/login")
+      return
+    }
+    setStatus({ kind: "submitting" })
+    const result = await submitGeneration(
+      { description, lyrics: showLyrics ? lyrics : "", instrumental, selectedTags },
+      accessToken
+    )
+    switch (result.status) {
+      case "accepted":
+        setStatus({
+          kind: "success",
+          message: "Generation started. We'll let you know when it's ready.",
+        })
+        break
+      case "unauthorized":
+        router.push("/login")
+        break
+      case "invalid":
+        setStatus({ kind: "error", message: result.detail })
+        break
+      case "error":
+        setStatus({ kind: "error", message: result.detail })
+        break
+    }
+  }
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="song-description">Song description</Label>
+        <Textarea
+          id="song-description"
+          rows={4}
+          placeholder="Describe the song you want to create..."
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+
+      {showLyrics && (
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="song-lyrics">Lyrics</Label>
+          <Textarea
+            id="song-lyrics"
+            rows={4}
+            placeholder="Write your lyrics here..."
+            value={lyrics}
+            onChange={(e) => setLyrics(e.target.value)}
+          />
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setStatus({ kind: "error", message: "Audio input is coming soon." })}
+        >
+          <HugeiconsIcon icon={MusicNote01Icon} data-icon="inline-start" />
+          Audio
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-pressed={showLyrics}
+          onClick={() => setShowLyrics((v) => !v)}
+        >
+          <HugeiconsIcon icon={Add01Icon} data-icon="inline-start" />
+          Lyrics
+        </Button>
+        <div className="ml-auto flex items-center gap-2">
+          <Switch
+            id="instrumental"
+            checked={instrumental}
+            onCheckedChange={setInstrumental}
+          />
+          <Label htmlFor="instrumental">Instrumental</Label>
+        </div>
+      </div>
+
+      <InspirationTags selectedTags={selectedTags} onChange={setSelectedTags} />
+
+      {status.kind === "success" && (
+        <p role="status" className="text-sm text-muted-foreground">
+          {status.message}
+        </p>
+      )}
+      {status.kind === "error" && (
+        <p role="alert" className="text-sm text-destructive">
+          {status.message}
+        </p>
+      )}
+
+      <Button
+        type="button"
+        className="w-fit"
+        disabled={!canSubmit || status.kind === "submitting"}
+        onClick={handleCreate}
+      >
+        {status.kind === "submitting" ? "Creating..." : "Create"}
+      </Button>
+    </div>
+  )
+}

--- a/web/components/create/SimpleCreationForm.tsx
+++ b/web/components/create/SimpleCreationForm.tsx
@@ -36,10 +36,14 @@ export function SimpleCreationForm() {
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [status, setStatus] = useState<Status>({ kind: "idle" })
 
+  // Lyrics only count when the field is open — hiding it shouldn't keep Create
+  // enabled (and then submit an empty prompt). Use this one value everywhere.
+  const effectiveLyrics = showLyrics ? lyrics : ""
+
   // Enabled the moment either text field has content — tags and the instrumental
   // toggle don't gate submission (per the acceptance criteria).
   const canSubmit =
-    description.trim().length > 0 || lyrics.trim().length > 0
+    description.trim().length > 0 || effectiveLyrics.trim().length > 0
 
   async function handleCreate() {
     if (!canSubmit || status.kind === "submitting") return
@@ -49,7 +53,7 @@ export function SimpleCreationForm() {
     }
     setStatus({ kind: "submitting" })
     const result = await submitGeneration(
-      { description, lyrics: showLyrics ? lyrics : "", instrumental, selectedTags },
+      { description, lyrics: effectiveLyrics, instrumental, selectedTags },
       accessToken
     )
     switch (result.status) {

--- a/web/components/ui/switch.tsx
+++ b/web/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block size-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/components/ui/tabs.tsx
+++ b/web/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-4", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "inline-flex h-7 items-center justify-center gap-1.5 rounded-md border border-transparent px-3 py-1 text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -70,6 +70,15 @@ describe("submitGeneration", () => {
     expect(JSON.parse(opts.body)).toEqual({ prompt: "song", instrumental: false })
   })
 
+  it("treats a 202 with no job id as an error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("not json", { status: 202 }))
+    )
+    const result = await submitGeneration(data, "tok")
+    expect(result.status).toBe("error")
+  })
+
   it("classifies a 401 as unauthorized", async () => {
     vi.stubGlobal(
       "fetch",

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -103,4 +103,10 @@ describe("submitGeneration", () => {
     const result = await submitGeneration(data, "tok")
     expect(result.status).toBe("error")
   })
+
+  it("returns an error result when the request rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")))
+    const result = await submitGeneration(data, "tok")
+    expect(result.status).toBe("error")
+  })
 })

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { buildGenerationPayload, submitGeneration } from "@/lib/generate"
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("buildGenerationPayload", () => {
+  it("maps description to prompt and joins tags into style", () => {
+    const payload = buildGenerationPayload({
+      description: "  a dreamy track  ",
+      lyrics: "",
+      instrumental: true,
+      selectedTags: ["lo-fi", "ambient"],
+    })
+    expect(payload).toEqual({
+      prompt: "a dreamy track",
+      style: "lo-fi, ambient",
+      instrumental: true,
+    })
+  })
+
+  it("omits style and lyrics when empty", () => {
+    const payload = buildGenerationPayload({
+      description: "just a beat",
+      lyrics: "   ",
+      instrumental: false,
+      selectedTags: [],
+    })
+    expect(payload).toEqual({ prompt: "just a beat", instrumental: false })
+    expect(payload).not.toHaveProperty("style")
+    expect(payload).not.toHaveProperty("lyrics")
+  })
+
+  it("falls back to lyrics for the prompt when description is empty", () => {
+    const payload = buildGenerationPayload({
+      description: "",
+      lyrics: "first line\nsecond line",
+      instrumental: false,
+      selectedTags: [],
+    })
+    expect(payload.prompt).toBe("first line\nsecond line")
+    expect(payload.lyrics).toBe("first line\nsecond line")
+  })
+})
+
+describe("submitGeneration", () => {
+  const data = {
+    description: "song",
+    lyrics: "",
+    instrumental: false,
+    selectedTags: [],
+  }
+
+  it("returns the job id on 202 and sends the Bearer token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ job_id: "job-123", status: "queued" }), {
+        status: 202,
+      })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await submitGeneration(data, "tok")
+    expect(result).toEqual({ status: "accepted", jobId: "job-123" })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/generate")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+    expect(JSON.parse(opts.body)).toEqual({ prompt: "song", instrumental: false })
+  })
+
+  it("classifies a 401 as unauthorized", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 401 }))
+    )
+    expect(await submitGeneration(data, "tok")).toEqual({
+      status: "unauthorized",
+    })
+  })
+
+  it("surfaces a 422 validation message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: [{ msg: "prompt too long" }] }), {
+          status: 422,
+        })
+      )
+    )
+    expect(await submitGeneration(data, "tok")).toEqual({
+      status: "invalid",
+      detail: "prompt too long",
+    })
+  })
+
+  it("returns a generic error on other failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 500 }))
+    )
+    const result = await submitGeneration(data, "tok")
+    expect(result.status).toBe("error")
+  })
+})

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -1,0 +1,95 @@
+// Client-side generation submission for the Simple creation form (US-16.1).
+// The form state is turned into the backend's GenerationRequest payload and
+// POSTed through the same-origin BFF proxy (app/api/generate/route.ts), which
+// forwards the Bearer token and keeps the backend URL server-side. Progress and
+// result handling are deferred to US-16.7 — here we just enqueue and report the
+// accepted job id (or the failure) back to the form.
+
+/** The slice of form state needed to build a generation request. */
+export type GenerationFormData = {
+  description: string
+  lyrics: string
+  instrumental: boolean
+  selectedTags: string[]
+}
+
+/** Subset of the backend GenerationRequest this form sends (extra keys forbidden). */
+export type GenerationPayload = {
+  prompt: string
+  style?: string
+  lyrics?: string
+  instrumental: boolean
+}
+
+export type SubmitResult =
+  | { status: "accepted"; jobId: string }
+  | { status: "unauthorized" }
+  | { status: "invalid"; detail: string }
+  | { status: "error"; detail: string }
+
+/**
+ * Build the backend payload from form state. The backend requires a non-empty
+ * `prompt` and forbids unknown keys, so empty optionals are omitted and the
+ * prompt falls back to the lyrics when no description is given — the Create
+ * button enables on either field, and this keeps that lyrics-only path valid.
+ */
+export function buildGenerationPayload(
+  data: GenerationFormData
+): GenerationPayload {
+  const description = data.description.trim()
+  const lyrics = data.lyrics.trim()
+  const style = data.selectedTags.join(", ").trim()
+
+  const payload: GenerationPayload = {
+    prompt: description || lyrics,
+    instrumental: data.instrumental,
+  }
+  if (style) payload.style = style
+  if (lyrics) payload.lyrics = lyrics
+  return payload
+}
+
+/** Pull a human-readable message out of a FastAPI error body (string or 422 list). */
+function extractDetail(body: unknown, fallback: string): string {
+  if (body && typeof body === "object" && "detail" in body) {
+    const detail = (body as { detail: unknown }).detail
+    if (typeof detail === "string") return detail
+    if (Array.isArray(detail) && detail.length > 0) {
+      const first = detail[0]
+      if (first && typeof first === "object" && "msg" in first) {
+        return String((first as { msg: unknown }).msg)
+      }
+    }
+  }
+  return fallback
+}
+
+/** Submit a generation request through the BFF proxy and classify the response. */
+export async function submitGeneration(
+  data: GenerationFormData,
+  accessToken: string
+): Promise<SubmitResult> {
+  const res = await fetch("/api/generate", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(buildGenerationPayload(data)),
+  })
+
+  if (res.status === 202) {
+    const body = await res.json().catch(() => ({}))
+    return { status: "accepted", jobId: (body as { job_id?: string }).job_id ?? "" }
+  }
+  if (res.status === 401) return { status: "unauthorized" }
+
+  const body = await res.json().catch(() => ({}))
+  if (res.status === 422) {
+    return { status: "invalid", detail: extractDetail(body, "Please check your input.") }
+  }
+  return {
+    status: "error",
+    detail: extractDetail(body, "Generation failed. Please try again."),
+  }
+}

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -69,14 +69,21 @@ export async function submitGeneration(
   data: GenerationFormData,
   accessToken: string
 ): Promise<SubmitResult> {
-  const res = await fetch("/api/generate", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${accessToken}`,
-    },
-    body: JSON.stringify(buildGenerationPayload(data)),
-  })
+  let res: Response
+  try {
+    res = await fetch("/api/generate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(buildGenerationPayload(data)),
+    })
+  } catch {
+    // Network failure / aborted request — never let it bubble out and leave the
+    // form stuck on "Creating..."; surface it as a generic error instead.
+    return { status: "error", detail: "Generation failed. Please try again." }
+  }
 
   if (res.status === 202) {
     const body = await res.json().catch(() => ({}))

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -38,7 +38,7 @@ export function buildGenerationPayload(
 ): GenerationPayload {
   const description = data.description.trim()
   const lyrics = data.lyrics.trim()
-  const style = data.selectedTags.join(", ").trim()
+  const style = data.selectedTags.join(", ")
 
   const payload: GenerationPayload = {
     prompt: description || lyrics,

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -87,7 +87,13 @@ export async function submitGeneration(
 
   if (res.status === 202) {
     const body = await res.json().catch(() => ({}))
-    return { status: "accepted", jobId: (body as { job_id?: string }).job_id ?? "" }
+    const jobId = (body as { job_id?: string }).job_id
+    // A 202 with no usable job id is unexpected (non-JSON body, schema drift) —
+    // treat it as an error rather than report a hollow success US-16.7 can't poll.
+    if (!jobId) {
+      return { status: "error", detail: "Server returned an unexpected response." }
+    }
+    return { status: "accepted", jobId }
   }
   if (res.status === 401) return { status: "unauthorized" }
 


### PR DESCRIPTION
## US-16.1: Simple Creation Mode

Closes #187.

Builds the **Simple** tab on `/create`: a minimal, low-barrier creation form where a musician describes a song in plain language and hits Create.

### What's included
- **`/create` tabs** — Simple (active), Advanced/Sounds ("Coming soon" placeholders).
- **Simple creation form** — song-description textarea, Instrumental toggle, **+Audio** button (placeholder for US-16.7), **+Lyrics** toggle revealing an inline lyrics textarea.
- **Inspiration tags** — 6–8 clickable style pills drawn from a curated pool, with a shuffle button; selected tags show as removable chips and feed the request's `style`.
- **Create button** — disabled until a description or (visible) lyrics is present; on submit it enqueues a generation request and reports the accepted job.
- **API wiring** — new BFF proxy `app/api/generate` forwards the Bearer token to `POST /api/v1/generate` (keeps the backend URL server-side, mirroring `app/api/users/me`). Handles 202 (success), 401 (→ login), 422 (validation message), and network errors.
- **UI primitives** — adds shadcn-style `Switch` and `Tabs` over `radix-ui`.

### Plan adaptations (vs. the CodeRabbit issue plan)
- Tests use the repo's **vitest + Testing Library** (co-located), not Jest; **Playwright isn't set up here**, so the E2E phase is covered by vitest component tests instead.
- API call routes through a **BFF proxy** rather than calling the backend directly.
- No toast library is installed → success/error surface via inline `role="status"`/`role="alert"` messages (no new dependency).
- Reuses the existing `STYLE_SUGGESTIONS` pool for tags instead of a new data file.

### Testing
`web/` isn't in CI, so verified locally — all green:
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (20 files, 139 tests)
- `npm run build` ✅

A local `codex` cross-family review flagged two P2 edge cases (hidden-lyrics enabling an empty-prompt submit; unhandled fetch rejection) — both fixed with added tests.

### Known limitations
- **+Audio** is a placeholder; the audio-input modal is US-16.7/16.8.
- Submission **enqueues only** — progress and result UI are deferred to US-16.7 (the accepted `job_id` isn't yet persisted/displayed).
- Inspiration tags use a **static curated pool**; AI/API-driven suggestions can replace it later without changing the component API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new create experience with tabs for Simple, Advanced, and Sounds.
  * Introduced a simple creation form with description, optional lyrics, inspiration tags, and an instrumental toggle.
  * Added inspiration tag suggestions with shuffle and selectable/removable chips.

* **Bug Fixes**
  * Improved create submission handling with clearer success, loading, and error states.
  * Ensured unauthorized users are redirected appropriately and API errors are shown more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->