### PR TITLE
feat(web): Advanced Creation Mode (US-16.2)

### DIFF
--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -3,6 +3,7 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useRequireAuth } from "@/hooks/use-require-auth"
 import { SimpleCreationForm } from "@/components/create/SimpleCreationForm"
+import { AdvancedCreationForm } from "@/components/create/AdvancedCreationForm"
 
 export default function CreatePage() {
   const { isLoading, isAuthenticated } = useRequireAuth()
@@ -24,7 +25,7 @@ export default function CreatePage() {
           <SimpleCreationForm />
         </TabsContent>
         <TabsContent value="advanced">
-          <p className="text-sm text-muted-foreground">Coming soon.</p>
+          <AdvancedCreationForm />
         </TabsContent>
         <TabsContent value="sounds">
           <p className="text-sm text-muted-foreground">Coming soon.</p>

--- a/web/components/create/AdvancedCreationForm.test.tsx
+++ b/web/components/create/AdvancedCreationForm.test.tsx
@@ -58,12 +58,14 @@ describe("AdvancedCreationForm", () => {
     const user = userEvent.setup()
     render(<AdvancedCreationForm />)
     const toggle = screen.getByRole("button", { name: /more options/i })
-    expect(screen.queryByLabelText("BPM")).not.toBeInTheDocument()
+    // The panel is always in the DOM (so aria-controls resolves) but hidden when
+    // collapsed; assert visibility rather than presence.
+    expect(screen.getByLabelText("BPM")).not.toBeVisible()
     await user.click(toggle)
-    expect(screen.getByLabelText("BPM")).toBeInTheDocument()
-    expect(screen.getByLabelText("Weirdness")).toBeInTheDocument()
+    expect(screen.getByLabelText("BPM")).toBeVisible()
+    expect(screen.getByLabelText(/weirdness/i)).toBeVisible()
     await user.click(toggle)
-    expect(screen.queryByLabelText("BPM")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("BPM")).not.toBeVisible()
   })
 
   it("restores the styles field after Clear via Undo", async () => {

--- a/web/components/create/AdvancedCreationForm.test.tsx
+++ b/web/components/create/AdvancedCreationForm.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { AdvancedCreationForm } from "@/components/create/AdvancedCreationForm"
+import { STYLE_SUGGESTIONS } from "@/lib/profile"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok" }),
+}))
+
+const submitAdvancedGeneration = vi.fn()
+vi.mock("@/lib/generate", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/generate")>()
+  return {
+    ...actual,
+    submitAdvancedGeneration: (...args: unknown[]) => submitAdvancedGeneration(...args),
+  }
+})
+
+afterEach(() => vi.clearAllMocks())
+
+function createButton() {
+  return screen.getByRole("button", { name: /^create$/i })
+}
+
+describe("AdvancedCreationForm", () => {
+  it("renders the lyrics panel with structure-tag placeholder and a vocal language selector", () => {
+    render(<AdvancedCreationForm />)
+    expect(screen.getByPlaceholderText(/\[Verse 1\]/)).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { name: /vocal language/i })).toBeInTheDocument()
+  })
+
+  it("keeps Create disabled until there is a style or lyrics", async () => {
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    expect(createButton()).toBeDisabled()
+    await user.type(screen.getByLabelText("Styles"), "rock")
+    expect(createButton()).toBeEnabled()
+  })
+
+  it("lets style pills and the styles textarea both contribute", async () => {
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    await user.type(screen.getByLabelText("Styles"), "cinematic")
+
+    const pill = screen
+      .getAllByRole("button")
+      .find((b) =>
+        (STYLE_SUGGESTIONS as readonly string[]).includes(b.textContent?.trim() ?? "")
+      )
+    expect(pill).toBeDefined()
+    await user.click(pill!)
+    expect(screen.getByLabelText("Selected tags")).toBeInTheDocument()
+  })
+
+  it("expands and collapses the More Options section", async () => {
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    const toggle = screen.getByRole("button", { name: /more options/i })
+    expect(screen.queryByLabelText("BPM")).not.toBeInTheDocument()
+    await user.click(toggle)
+    expect(screen.getByLabelText("BPM")).toBeInTheDocument()
+    expect(screen.getByLabelText("Weirdness")).toBeInTheDocument()
+    await user.click(toggle)
+    expect(screen.queryByLabelText("BPM")).not.toBeInTheDocument()
+  })
+
+  it("restores the styles field after Clear via Undo", async () => {
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    const styles = screen.getByLabelText("Styles")
+    await user.type(styles, "rock")
+
+    const stylesSection = screen.getByRole("region", { name: "Styles panel" })
+    await user.click(within(stylesSection).getByRole("button", { name: /clear/i }))
+    expect(styles).toHaveValue("")
+
+    // Undo pops the empty entry pushed by Clear, restoring the prior text.
+    await user.click(within(stylesSection).getByRole("button", { name: /undo/i }))
+    expect(screen.getByLabelText("Styles")).toHaveValue("rock")
+  })
+
+  it("validates BPM range before submitting", async () => {
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    await user.type(screen.getByLabelText("Styles"), "rock")
+    await user.click(screen.getByRole("button", { name: /more options/i }))
+    await user.click(screen.getByRole("switch", { name: "Auto" })) // turn Auto off
+    await user.type(screen.getByLabelText("BPM"), "300")
+    await user.click(createButton())
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/bpm/i)
+    expect(submitAdvancedGeneration).not.toHaveBeenCalled()
+  })
+
+  it("submits a valid form and reports success", async () => {
+    submitAdvancedGeneration.mockResolvedValue({ status: "accepted", jobId: "job-1" })
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    await user.type(screen.getByLabelText("Styles"), "orchestral")
+    await user.click(createButton())
+
+    expect(submitAdvancedGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ styles: "orchestral" }),
+      "tok"
+    )
+    expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
+  })
+
+  it("shows the enhance input and a coming-soon notice on apply", async () => {
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    await user.click(screen.getByRole("button", { name: /enhance/i }))
+    await user.type(screen.getByLabelText(/enhancement prompt/i), "make it darker")
+    await user.click(screen.getByRole("button", { name: /apply/i }))
+    expect(screen.getByRole("status")).toHaveTextContent(/coming soon/i)
+  })
+})

--- a/web/components/create/AdvancedCreationForm.tsx
+++ b/web/components/create/AdvancedCreationForm.tsx
@@ -1,0 +1,295 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowTurnBackwardIcon, MagicWand01Icon, SparklesIcon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { useAuth } from "@/hooks/use-auth"
+import { InspirationTags } from "@/components/create/InspirationTags"
+import { MoreOptionsSection, type MoreOptions } from "@/components/create/MoreOptionsSection"
+import { useUndoableField } from "@/components/create/useUndoableField"
+import {
+  combineStyles,
+  submitAdvancedGeneration,
+  validateAdvanced,
+  type AdvancedFormData,
+} from "@/lib/generate"
+import {
+  STYLE_INFLUENCE_DEFAULT,
+  VOCAL_LANGUAGES,
+  WEIRDNESS_DEFAULT,
+} from "@/lib/constants/generation"
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "info"; message: string }
+  | { kind: "success"; message: string }
+  | { kind: "error"; message: string }
+
+const STUB_NOTICE = "This feature is coming soon."
+
+const selectClass =
+  "h-8 w-full rounded-lg border border-input bg-background px-2.5 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+
+const initialOptions: MoreOptions = {
+  bpmAuto: true,
+  bpm: "",
+  duration: "",
+  weirdness: WEIRDNESS_DEFAULT,
+  styleInfluence: STYLE_INFLUENCE_DEFAULT,
+  seedRandom: true,
+  seed: "",
+  key: "",
+  timeSignature: "",
+  vocalGender: "female",
+  excludeStyles: "",
+  songTitle: "",
+}
+
+/**
+ * The Advanced creation form (US-16.2): separate Lyrics and Styles panels plus a
+ * collapsible More Options section, giving precise control over every generation
+ * parameter the backend accepts. Mirrors SimpleCreationForm's controlled-state,
+ * BFF-submit pattern; lyrics and styles each get single-step undo.
+ */
+export function AdvancedCreationForm() {
+  const router = useRouter()
+  const { accessToken } = useAuth()
+
+  const lyricsField = useUndoableField("")
+  const stylesField = useUndoableField("")
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [lyricsMode, setLyricsMode] = useState<"manual" | "auto">("manual")
+  const [vocalLanguage, setVocalLanguage] = useState("")
+  const [instrumental, setInstrumental] = useState(false)
+  const [options, setOptions] = useState<MoreOptions>(initialOptions)
+  const [status, setStatus] = useState<Status>({ kind: "idle" })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showEnhance, setShowEnhance] = useState(false)
+  const [enhancePrompt, setEnhancePrompt] = useState("")
+
+  const updateOptions = (patch: Partial<MoreOptions>) =>
+    setOptions((o) => ({ ...o, ...patch }))
+
+  const effectiveStyle = combineStyles(stylesField.value, selectedTags)
+  const effectiveLyrics = lyricsMode === "manual" ? lyricsField.value : ""
+  // Enabled the moment there's a style or lyrics to build a prompt from; range
+  // validation runs on submit so out-of-range values surface a message.
+  const canSubmit = effectiveStyle.trim().length > 0 || effectiveLyrics.trim().length > 0
+
+  function formData(): AdvancedFormData {
+    return {
+      lyrics: lyricsField.value,
+      lyricsMode,
+      vocalLanguage,
+      styles: stylesField.value,
+      selectedTags,
+      instrumental,
+      bpmAuto: options.bpmAuto,
+      bpm: options.bpm,
+      key: options.key,
+      timeSignature: options.timeSignature,
+      duration: options.duration,
+      weirdness: options.weirdness,
+      styleInfluence: options.styleInfluence,
+      seedRandom: options.seedRandom,
+      seed: options.seed,
+    }
+  }
+
+  async function handleCreate() {
+    if (!canSubmit || isSubmitting) return
+    if (!accessToken) {
+      router.push("/login")
+      return
+    }
+    const data = formData()
+    const error = validateAdvanced(data)
+    if (error) {
+      setStatus({ kind: "error", message: error })
+      return
+    }
+    setIsSubmitting(true)
+    try {
+      const result = await submitAdvancedGeneration(data, accessToken)
+      switch (result.status) {
+        case "accepted":
+          setStatus({
+            kind: "success",
+            message: "Generation started. We'll let you know when it's ready.",
+          })
+          break
+        case "unauthorized":
+          router.push("/login")
+          break
+        case "invalid":
+        case "error":
+          setStatus({ kind: "error", message: result.detail })
+          break
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-6">
+      {/* Lyrics panel */}
+      <section className="flex flex-col gap-3" aria-label="Lyrics panel">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="adv-lyrics">Lyrics</Label>
+          <div className="flex gap-1.5">
+            {(["manual", "auto"] as const).map((mode) => (
+              <Button
+                key={mode}
+                type="button"
+                size="xs"
+                variant={lyricsMode === mode ? "default" : "outline"}
+                aria-pressed={lyricsMode === mode}
+                className="capitalize"
+                onClick={() => setLyricsMode(mode)}
+              >
+                {mode}
+              </Button>
+            ))}
+          </div>
+        </div>
+        <Textarea
+          id="adv-lyrics"
+          rows={6}
+          placeholder={"[Verse 1]\nYour lyrics here...\n\n[Chorus]\n..."}
+          disabled={lyricsMode === "auto"}
+          value={lyricsField.value}
+          onChange={(e) => lyricsField.setValue(e.target.value)}
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            aria-label="Vocal language"
+            className={`${selectClass} w-auto`}
+            value={vocalLanguage}
+            onChange={(e) => setVocalLanguage(e.target.value)}
+          >
+            <option value="">Auto language</option>
+            {VOCAL_LANGUAGES.map((lang) => (
+              <option key={lang} value={lang}>
+                {lang}
+              </option>
+            ))}
+          </select>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-pressed={showEnhance}
+            onClick={() => setShowEnhance((v) => !v)}
+          >
+            <HugeiconsIcon icon={SparklesIcon} data-icon="inline-start" />
+            Enhance
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!lyricsField.canUndo}
+            onClick={lyricsField.undo}
+          >
+            <HugeiconsIcon icon={ArrowTurnBackwardIcon} data-icon="inline-start" />
+            Undo
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => lyricsField.setValue("")}>
+            Clear
+          </Button>
+        </div>
+        {showEnhance && (
+          <div className="flex items-center gap-2">
+            <Input
+              aria-label="Enhancement prompt"
+              placeholder="Describe how to enhance the lyrics..."
+              value={enhancePrompt}
+              onChange={(e) => setEnhancePrompt(e.target.value)}
+            />
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => setStatus({ kind: "info", message: STUB_NOTICE })}
+            >
+              Apply
+            </Button>
+          </div>
+        )}
+      </section>
+
+      {/* Styles panel */}
+      <section className="flex flex-col gap-3" aria-label="Styles panel">
+        <Label htmlFor="adv-styles">Styles</Label>
+        <Textarea
+          id="adv-styles"
+          rows={2}
+          placeholder="Enter styles separated by commas (e.g., cinematic, epic, orchestral)"
+          value={stylesField.value}
+          onChange={(e) => stylesField.setValue(e.target.value)}
+        />
+        <InspirationTags
+          selectedTags={selectedTags}
+          onChange={(next) => setSelectedTags(next)}
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setStatus({ kind: "info", message: STUB_NOTICE })}
+          >
+            <HugeiconsIcon icon={MagicWand01Icon} data-icon="inline-start" />
+            Magic wand
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!stylesField.canUndo}
+            onClick={stylesField.undo}
+          >
+            <HugeiconsIcon icon={ArrowTurnBackwardIcon} data-icon="inline-start" />
+            Undo
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => stylesField.setValue("")}>
+            Clear
+          </Button>
+          <div className="ml-auto flex items-center gap-2">
+            <Switch id="adv-instrumental" checked={instrumental} onCheckedChange={setInstrumental} />
+            <Label htmlFor="adv-instrumental">Instrumental</Label>
+          </div>
+        </div>
+      </section>
+
+      <MoreOptionsSection value={options} onChange={updateOptions} />
+
+      {(status.kind === "info" || status.kind === "success") && (
+        <p role="status" className="text-sm text-muted-foreground">
+          {status.message}
+        </p>
+      )}
+      {status.kind === "error" && (
+        <p role="alert" className="text-sm text-destructive">
+          {status.message}
+        </p>
+      )}
+
+      <Button
+        type="button"
+        className="w-fit"
+        disabled={!canSubmit || isSubmitting}
+        onClick={handleCreate}
+      >
+        {isSubmitting ? "Creating..." : "Create"}
+      </Button>
+    </div>
+  )
+}

--- a/web/components/create/AdvancedCreationForm.tsx
+++ b/web/components/create/AdvancedCreationForm.tsx
@@ -25,6 +25,7 @@ import {
   VOCAL_LANGUAGES,
   WEIRDNESS_DEFAULT,
 } from "@/lib/constants/generation"
+import { SELECT_CLASS } from "@/lib/constants/ui"
 
 type Status =
   | { kind: "idle" }
@@ -33,9 +34,6 @@ type Status =
   | { kind: "error"; message: string }
 
 const STUB_NOTICE = "This feature is coming soon."
-
-const selectClass =
-  "h-8 w-full rounded-lg border border-input bg-background px-2.5 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
 
 const initialOptions: MoreOptions = {
   bpmAuto: true,
@@ -171,7 +169,7 @@ export function AdvancedCreationForm() {
         <div className="flex flex-wrap items-center gap-2">
           <select
             aria-label="Vocal language"
-            className={`${selectClass} w-auto`}
+            className={`${SELECT_CLASS} w-auto`}
             value={vocalLanguage}
             onChange={(e) => setVocalLanguage(e.target.value)}
           >

--- a/web/components/create/MoreOptionsSection.tsx
+++ b/web/components/create/MoreOptionsSection.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
+import { SELECT_CLASS } from "@/lib/constants/ui"
 import {
   BPM_MAX,
   BPM_MIN,
@@ -42,13 +43,30 @@ export type MoreOptions = {
   songTitle: string
 }
 
-const selectClass =
-  "h-8 w-full rounded-lg border border-input bg-background px-2.5 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+/**
+ * A labelled control row. When `htmlFor` is given the visible label is a real
+ * `<label>` so clicking it (and voice-control "click X") focuses the input;
+ * fields with multiple/zero focusable controls (sliders, the gender toggle) omit
+ * it and rely on each control's own `aria-label`.
+ */
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string
+  htmlFor?: string
+  children: React.ReactNode
+}) {
   return (
     <div className="flex flex-col gap-1.5">
-      <span className="text-sm font-medium">{label}</span>
+      {htmlFor ? (
+        <label htmlFor={htmlFor} className="text-sm font-medium">
+          {label}
+        </label>
+      ) : (
+        <span className="text-sm font-medium">{label}</span>
+      )}
       {children}
     </div>
   )
@@ -68,7 +86,9 @@ export function MoreOptionsSection({
   onChange: (patch: Partial<MoreOptions>) => void
 }) {
   const [open, setOpen] = useState(false)
-  const panelId = useId()
+  const base = useId()
+  const id = (name: string) => `${base}-${name}`
+  const panelId = id("panel")
 
   return (
     <div className="flex flex-col gap-3 border-t pt-4">
@@ -83,178 +103,177 @@ export function MoreOptionsSection({
         More Options
       </button>
 
-      {open && (
-        <div id={panelId} className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <Field label="BPM">
-            <div className="flex items-center gap-2">
-              <Input
-                type="number"
-                min={BPM_MIN}
-                max={BPM_MAX}
-                aria-label="BPM"
-                disabled={value.bpmAuto}
-                value={value.bpm}
-                onChange={(e) => onChange({ bpm: e.target.value })}
-              />
-              <div className="flex shrink-0 items-center gap-1.5">
-                <Switch
-                  id="bpm-auto"
-                  checked={value.bpmAuto}
-                  onCheckedChange={(c) => onChange({ bpmAuto: c })}
-                />
-                <Label htmlFor="bpm-auto">Auto</Label>
-              </div>
-            </div>
-          </Field>
-
-          <Field label="Duration (seconds)">
-            <div className="flex flex-col gap-1.5">
-              <Input
-                type="number"
-                min={DURATION_MIN}
-                max={DURATION_MAX}
-                aria-label="Duration"
-                placeholder="Auto"
-                value={value.duration}
-                onChange={(e) => onChange({ duration: e.target.value })}
-              />
-              <div className="flex flex-wrap gap-1.5">
-                {DURATION_PRESETS.map((preset) => (
-                  <Button
-                    key={preset}
-                    type="button"
-                    variant="outline"
-                    size="xs"
-                    onClick={() => onChange({ duration: String(preset) })}
-                  >
-                    {preset}s
-                  </Button>
-                ))}
-              </div>
-            </div>
-          </Field>
-
-          <Field label={`Weirdness: ${value.weirdness}`}>
-            <input
-              type="range"
-              min={WEIRDNESS_MIN}
-              max={WEIRDNESS_MAX}
-              aria-label="Weirdness"
-              value={value.weirdness}
-              onChange={(e) => onChange({ weirdness: Number(e.target.value) })}
-              className="w-full"
+      {/* Always rendered (hidden when collapsed) so aria-controls always resolves. */}
+      <div id={panelId} hidden={!open} className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="BPM" htmlFor={id("bpm")}>
+          <div className="flex items-center gap-2">
+            <Input
+              id={id("bpm")}
+              type="number"
+              min={BPM_MIN}
+              max={BPM_MAX}
+              disabled={value.bpmAuto}
+              value={value.bpm}
+              onChange={(e) => onChange({ bpm: e.target.value })}
             />
-          </Field>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <Switch
+                id={id("bpm-auto")}
+                checked={value.bpmAuto}
+                onCheckedChange={(c) => onChange({ bpmAuto: c })}
+              />
+              <Label htmlFor={id("bpm-auto")}>Auto</Label>
+            </div>
+          </div>
+        </Field>
 
-          <Field label={`Style influence: ${value.styleInfluence}`}>
-            <input
-              type="range"
-              min={STYLE_INFLUENCE_MIN}
-              max={STYLE_INFLUENCE_MAX}
-              aria-label="Style influence"
-              value={value.styleInfluence}
-              onChange={(e) => onChange({ styleInfluence: Number(e.target.value) })}
-              className="w-full"
+        <Field label="Duration (seconds)" htmlFor={id("duration")}>
+          <div className="flex flex-col gap-1.5">
+            <Input
+              id={id("duration")}
+              type="number"
+              min={DURATION_MIN}
+              max={DURATION_MAX}
+              placeholder="Auto"
+              value={value.duration}
+              onChange={(e) => onChange({ duration: e.target.value })}
             />
-          </Field>
-
-          <Field label="Key">
-            <select
-              aria-label="Key"
-              className={selectClass}
-              value={value.key}
-              onChange={(e) => onChange({ key: e.target.value })}
-            >
-              <option value="">Any</option>
-              {KEY_OPTIONS.map((k) => (
-                <option key={k} value={k}>
-                  {k}
-                </option>
-              ))}
-            </select>
-          </Field>
-
-          <Field label="Time signature">
-            <select
-              aria-label="Time signature"
-              className={selectClass}
-              value={value.timeSignature}
-              onChange={(e) => onChange({ timeSignature: e.target.value })}
-            >
-              <option value="">Any</option>
-              {VALID_TIME_SIGNATURES.map((ts) => (
-                <option key={ts} value={ts}>
-                  {ts}
-                </option>
-              ))}
-            </select>
-          </Field>
-
-          <Field label="Vocal gender">
-            <div className="flex gap-1.5">
-              {(["female", "male"] as const).map((gender) => (
+            <div className="flex flex-wrap gap-1.5">
+              {DURATION_PRESETS.map((preset) => (
                 <Button
-                  key={gender}
+                  key={preset}
                   type="button"
-                  size="sm"
-                  variant={value.vocalGender === gender ? "default" : "outline"}
-                  aria-pressed={value.vocalGender === gender}
-                  className="capitalize"
-                  onClick={() => onChange({ vocalGender: gender })}
+                  variant="outline"
+                  size="xs"
+                  onClick={() => onChange({ duration: String(preset) })}
                 >
-                  {gender}
+                  {preset}s
                 </Button>
               ))}
             </div>
-          </Field>
+          </div>
+        </Field>
 
-          <Field label="Seed">
-            <div className="flex items-center gap-2">
-              <Input
-                type="number"
-                aria-label="Seed"
-                placeholder="Random"
-                disabled={value.seedRandom}
-                value={value.seed}
-                onChange={(e) => onChange({ seed: e.target.value })}
+        <Field label={`Weirdness: ${value.weirdness}`}>
+          <input
+            type="range"
+            min={WEIRDNESS_MIN}
+            max={WEIRDNESS_MAX}
+            aria-label={`Weirdness: ${value.weirdness}`}
+            value={value.weirdness}
+            onChange={(e) => onChange({ weirdness: Number(e.target.value) })}
+            className="w-full"
+          />
+        </Field>
+
+        <Field label={`Style influence: ${value.styleInfluence}`}>
+          <input
+            type="range"
+            min={STYLE_INFLUENCE_MIN}
+            max={STYLE_INFLUENCE_MAX}
+            aria-label={`Style influence: ${value.styleInfluence}`}
+            value={value.styleInfluence}
+            onChange={(e) => onChange({ styleInfluence: Number(e.target.value) })}
+            className="w-full"
+          />
+        </Field>
+
+        <Field label="Key" htmlFor={id("key")}>
+          <select
+            id={id("key")}
+            className={SELECT_CLASS}
+            value={value.key}
+            onChange={(e) => onChange({ key: e.target.value })}
+          >
+            <option value="">Any</option>
+            {KEY_OPTIONS.map((k) => (
+              <option key={k} value={k}>
+                {k}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="Time signature" htmlFor={id("time-signature")}>
+          <select
+            id={id("time-signature")}
+            className={SELECT_CLASS}
+            value={value.timeSignature}
+            onChange={(e) => onChange({ timeSignature: e.target.value })}
+          >
+            <option value="">Any</option>
+            {VALID_TIME_SIGNATURES.map((ts) => (
+              <option key={ts} value={ts}>
+                {ts}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="Vocal gender">
+          <div className="flex gap-1.5">
+            {(["female", "male"] as const).map((gender) => (
+              <Button
+                key={gender}
+                type="button"
+                size="sm"
+                variant={value.vocalGender === gender ? "default" : "outline"}
+                aria-pressed={value.vocalGender === gender}
+                className="capitalize"
+                onClick={() => onChange({ vocalGender: gender })}
+              >
+                {gender}
+              </Button>
+            ))}
+          </div>
+        </Field>
+
+        <Field label="Seed" htmlFor={id("seed")}>
+          <div className="flex items-center gap-2">
+            <Input
+              id={id("seed")}
+              type="number"
+              placeholder="Random"
+              disabled={value.seedRandom}
+              value={value.seed}
+              onChange={(e) => onChange({ seed: e.target.value })}
+            />
+            <div className="flex shrink-0 items-center gap-1.5">
+              <Switch
+                id={id("seed-random")}
+                checked={value.seedRandom}
+                onCheckedChange={(c) => onChange({ seedRandom: c })}
               />
-              <div className="flex shrink-0 items-center gap-1.5">
-                <Switch
-                  id="seed-random"
-                  checked={value.seedRandom}
-                  onCheckedChange={(c) => onChange({ seedRandom: c })}
-                />
-                <Label htmlFor="seed-random">Random</Label>
-              </div>
+              <Label htmlFor={id("seed-random")}>Random</Label>
             </div>
-          </Field>
+          </div>
+        </Field>
 
-          <Field label="Exclude styles">
-            <Input
-              aria-label="Exclude styles"
-              placeholder="Styles to avoid"
-              value={value.excludeStyles}
-              onChange={(e) => onChange({ excludeStyles: e.target.value })}
-            />
-          </Field>
+        <Field label="Exclude styles" htmlFor={id("exclude")}>
+          <Input
+            id={id("exclude")}
+            placeholder="Styles to avoid"
+            value={value.excludeStyles}
+            onChange={(e) => onChange({ excludeStyles: e.target.value })}
+          />
+        </Field>
 
-          <Field label="Song title">
-            <Input
-              aria-label="Song title"
-              placeholder="Untitled"
-              value={value.songTitle}
-              onChange={(e) => onChange({ songTitle: e.target.value })}
-            />
-          </Field>
+        <Field label="Song title" htmlFor={id("title")}>
+          <Input
+            id={id("title")}
+            placeholder="Untitled"
+            value={value.songTitle}
+            onChange={(e) => onChange({ songTitle: e.target.value })}
+          />
+        </Field>
 
-          {/* No frontend proxy for GET /api/v1/workspaces yet (US-16.2 stub). */}
-          <Field label="Save to workspace">
-            <select aria-label="Save to workspace" className={cn(selectClass, "opacity-50")} disabled>
-              <option>Coming soon</option>
-            </select>
-          </Field>
-        </div>
-      )}
+        {/* No frontend proxy for GET /api/v1/workspaces yet (US-16.2 stub). */}
+        <Field label="Save to workspace" htmlFor={id("workspace")}>
+          <select id={id("workspace")} className={cn(SELECT_CLASS, "opacity-50")} disabled>
+            <option>Coming soon</option>
+          </select>
+        </Field>
+      </div>
     </div>
   )
 }

--- a/web/components/create/MoreOptionsSection.tsx
+++ b/web/components/create/MoreOptionsSection.tsx
@@ -1,0 +1,260 @@
+"use client"
+
+import { useId, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowDown01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { cn } from "@/lib/utils"
+import {
+  BPM_MAX,
+  BPM_MIN,
+  DURATION_MAX,
+  DURATION_MIN,
+  DURATION_PRESETS,
+  KEY_OPTIONS,
+  STYLE_INFLUENCE_MAX,
+  STYLE_INFLUENCE_MIN,
+  VALID_TIME_SIGNATURES,
+  WEIRDNESS_MAX,
+  WEIRDNESS_MIN,
+} from "@/lib/constants/generation"
+
+/** The generation parameters owned by the collapsible "More Options" section. */
+export type MoreOptions = {
+  bpmAuto: boolean
+  bpm: string
+  duration: string
+  weirdness: number
+  styleInfluence: number
+  seedRandom: boolean
+  seed: string
+  key: string
+  timeSignature: string
+  /** UI-only — not sent to the API. */
+  vocalGender: "male" | "female"
+  /** UI-only — not sent to the API. */
+  excludeStyles: string
+  /** UI-only — reserved for post-generation clip rename. */
+  songTitle: string
+}
+
+const selectClass =
+  "h-8 w-full rounded-lg border border-input bg-background px-2.5 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * The collapsible "More Options" section (US-16.2): every remaining generation
+ * parameter from spec section 4.4. Collapsed by default. Uses native `<select>`
+ * and range inputs (accessible, no extra dependencies). UI-only fields (vocal
+ * gender, exclude styles, song title) are held for completeness but never sent.
+ */
+export function MoreOptionsSection({
+  value,
+  onChange,
+}: {
+  value: MoreOptions
+  onChange: (patch: Partial<MoreOptions>) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const panelId = useId()
+
+  return (
+    <div className="flex flex-col gap-3 border-t pt-4">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-fit items-center gap-1.5 text-sm font-medium"
+      >
+        <HugeiconsIcon icon={open ? ArrowDown01Icon : ArrowRight01Icon} className="size-4" />
+        More Options
+      </button>
+
+      {open && (
+        <div id={panelId} className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Field label="BPM">
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                min={BPM_MIN}
+                max={BPM_MAX}
+                aria-label="BPM"
+                disabled={value.bpmAuto}
+                value={value.bpm}
+                onChange={(e) => onChange({ bpm: e.target.value })}
+              />
+              <div className="flex shrink-0 items-center gap-1.5">
+                <Switch
+                  id="bpm-auto"
+                  checked={value.bpmAuto}
+                  onCheckedChange={(c) => onChange({ bpmAuto: c })}
+                />
+                <Label htmlFor="bpm-auto">Auto</Label>
+              </div>
+            </div>
+          </Field>
+
+          <Field label="Duration (seconds)">
+            <div className="flex flex-col gap-1.5">
+              <Input
+                type="number"
+                min={DURATION_MIN}
+                max={DURATION_MAX}
+                aria-label="Duration"
+                placeholder="Auto"
+                value={value.duration}
+                onChange={(e) => onChange({ duration: e.target.value })}
+              />
+              <div className="flex flex-wrap gap-1.5">
+                {DURATION_PRESETS.map((preset) => (
+                  <Button
+                    key={preset}
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    onClick={() => onChange({ duration: String(preset) })}
+                  >
+                    {preset}s
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </Field>
+
+          <Field label={`Weirdness: ${value.weirdness}`}>
+            <input
+              type="range"
+              min={WEIRDNESS_MIN}
+              max={WEIRDNESS_MAX}
+              aria-label="Weirdness"
+              value={value.weirdness}
+              onChange={(e) => onChange({ weirdness: Number(e.target.value) })}
+              className="w-full"
+            />
+          </Field>
+
+          <Field label={`Style influence: ${value.styleInfluence}`}>
+            <input
+              type="range"
+              min={STYLE_INFLUENCE_MIN}
+              max={STYLE_INFLUENCE_MAX}
+              aria-label="Style influence"
+              value={value.styleInfluence}
+              onChange={(e) => onChange({ styleInfluence: Number(e.target.value) })}
+              className="w-full"
+            />
+          </Field>
+
+          <Field label="Key">
+            <select
+              aria-label="Key"
+              className={selectClass}
+              value={value.key}
+              onChange={(e) => onChange({ key: e.target.value })}
+            >
+              <option value="">Any</option>
+              {KEY_OPTIONS.map((k) => (
+                <option key={k} value={k}>
+                  {k}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Time signature">
+            <select
+              aria-label="Time signature"
+              className={selectClass}
+              value={value.timeSignature}
+              onChange={(e) => onChange({ timeSignature: e.target.value })}
+            >
+              <option value="">Any</option>
+              {VALID_TIME_SIGNATURES.map((ts) => (
+                <option key={ts} value={ts}>
+                  {ts}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Vocal gender">
+            <div className="flex gap-1.5">
+              {(["female", "male"] as const).map((gender) => (
+                <Button
+                  key={gender}
+                  type="button"
+                  size="sm"
+                  variant={value.vocalGender === gender ? "default" : "outline"}
+                  aria-pressed={value.vocalGender === gender}
+                  className="capitalize"
+                  onClick={() => onChange({ vocalGender: gender })}
+                >
+                  {gender}
+                </Button>
+              ))}
+            </div>
+          </Field>
+
+          <Field label="Seed">
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                aria-label="Seed"
+                placeholder="Random"
+                disabled={value.seedRandom}
+                value={value.seed}
+                onChange={(e) => onChange({ seed: e.target.value })}
+              />
+              <div className="flex shrink-0 items-center gap-1.5">
+                <Switch
+                  id="seed-random"
+                  checked={value.seedRandom}
+                  onCheckedChange={(c) => onChange({ seedRandom: c })}
+                />
+                <Label htmlFor="seed-random">Random</Label>
+              </div>
+            </div>
+          </Field>
+
+          <Field label="Exclude styles">
+            <Input
+              aria-label="Exclude styles"
+              placeholder="Styles to avoid"
+              value={value.excludeStyles}
+              onChange={(e) => onChange({ excludeStyles: e.target.value })}
+            />
+          </Field>
+
+          <Field label="Song title">
+            <Input
+              aria-label="Song title"
+              placeholder="Untitled"
+              value={value.songTitle}
+              onChange={(e) => onChange({ songTitle: e.target.value })}
+            />
+          </Field>
+
+          {/* No frontend proxy for GET /api/v1/workspaces yet (US-16.2 stub). */}
+          <Field label="Save to workspace">
+            <select aria-label="Save to workspace" className={cn(selectClass, "opacity-50")} disabled>
+              <option>Coming soon</option>
+            </select>
+          </Field>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/components/create/useUndoableField.test.ts
+++ b/web/components/create/useUndoableField.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { useUndoableField, UNDO_HISTORY_MAX } from "@/components/create/useUndoableField"
+
+describe("useUndoableField", () => {
+  it("starts at the initial value with nothing to undo", () => {
+    const { result } = renderHook(() => useUndoableField("hello"))
+    expect(result.current.value).toBe("hello")
+    expect(result.current.canUndo).toBe(false)
+  })
+
+  it("setValue updates the value and enables undo", () => {
+    const { result } = renderHook(() => useUndoableField(""))
+    act(() => result.current.setValue("a"))
+    expect(result.current.value).toBe("a")
+    expect(result.current.canUndo).toBe(true)
+  })
+
+  it("undo reverts to the previous value", () => {
+    const { result } = renderHook(() => useUndoableField("start"))
+    act(() => result.current.setValue("one"))
+    act(() => result.current.setValue("two"))
+    act(() => result.current.undo())
+    expect(result.current.value).toBe("one")
+    act(() => result.current.undo())
+    expect(result.current.value).toBe("start")
+    expect(result.current.canUndo).toBe(false)
+  })
+
+  it("undo at the initial state is a no-op", () => {
+    const { result } = renderHook(() => useUndoableField("x"))
+    act(() => result.current.undo())
+    expect(result.current.value).toBe("x")
+  })
+
+  it("ignores a setValue equal to the current value", () => {
+    const { result } = renderHook(() => useUndoableField("same"))
+    act(() => result.current.setValue("same"))
+    expect(result.current.canUndo).toBe(false)
+  })
+
+  it("caps history depth so undo cannot exceed the limit", () => {
+    const { result } = renderHook(() => useUndoableField("0"))
+    for (let i = 1; i <= UNDO_HISTORY_MAX + 5; i++) {
+      act(() => result.current.setValue(String(i)))
+    }
+    // Undo all the way down; the floor value is whatever survived the cap, never older.
+    for (let i = 0; i < UNDO_HISTORY_MAX + 10; i++) {
+      act(() => result.current.undo())
+    }
+    expect(result.current.canUndo).toBe(false)
+    expect(result.current.value).not.toBe("0") // the original was evicted by the cap
+  })
+})

--- a/web/components/create/useUndoableField.ts
+++ b/web/components/create/useUndoableField.ts
@@ -1,0 +1,38 @@
+"use client"
+
+import { useCallback, useState } from "react"
+
+/** Cap the per-field history so a long editing session can't grow unbounded. */
+export const UNDO_HISTORY_MAX = 20
+
+/**
+ * A string field with single-step undo backed by a small history stack (US-16.2).
+ * `setValue` pushes a new entry (skipping no-op repeats); `undo` pops back to the
+ * previous value. Lyrics and styles each own an instance. History is capped at
+ * {@link UNDO_HISTORY_MAX}; older entries are evicted, so undo reverts to the most
+ * recent retained state rather than growing without bound.
+ */
+export function useUndoableField(initial = "") {
+  const [history, setHistory] = useState<string[]>([initial])
+
+  const setValue = useCallback((next: string) => {
+    setHistory((h) => {
+      if (next === h[h.length - 1]) return h
+      const appended = [...h, next]
+      return appended.length > UNDO_HISTORY_MAX
+        ? appended.slice(appended.length - UNDO_HISTORY_MAX)
+        : appended
+    })
+  }, [])
+
+  const undo = useCallback(() => {
+    setHistory((h) => (h.length > 1 ? h.slice(0, -1) : h))
+  }, [])
+
+  return {
+    value: history[history.length - 1],
+    setValue,
+    undo,
+    canUndo: history.length > 1,
+  }
+}

--- a/web/lib/constants/generation.ts
+++ b/web/lib/constants/generation.ts
@@ -1,0 +1,60 @@
+/**
+ * Generation parameter bounds for the Advanced creation form (US-16.2).
+ *
+ * These mirror the backend's `GenerationRequest` constraints
+ * (`src/acemusic/constants.py`); the backend uses `extra="forbid"` and validates
+ * every range, so the form validates against the same numbers to surface errors
+ * before submission rather than as a round-trip 422.
+ */
+
+export const BPM_MIN = 60
+export const BPM_MAX = 180
+export const DURATION_MIN = 30
+export const DURATION_MAX = 240
+export const WEIRDNESS_MIN = 0
+export const WEIRDNESS_MAX = 100
+export const STYLE_INFLUENCE_MIN = 0
+export const STYLE_INFLUENCE_MAX = 100
+
+export const PROMPT_MAX_LENGTH = 2000
+export const STYLE_MAX_LENGTH = 1000
+export const LYRICS_MAX_LENGTH = 5000
+export const KEY_MAX_LENGTH = 50
+
+/** Mirrors backend VALID_TIME_SIGNATURES (order is the display order). */
+export const VALID_TIME_SIGNATURES = ["4/4", "3/4", "6/8", "5/4", "7/8"] as const
+
+/** Slider/control defaults (match the backend field defaults). */
+export const WEIRDNESS_DEFAULT = 50
+export const STYLE_INFLUENCE_DEFAULT = 50
+
+/** Duration preset shortcuts (seconds), all within [DURATION_MIN, DURATION_MAX]. */
+export const DURATION_PRESETS = [30, 60, 120, 240] as const
+
+/**
+ * Key options for the selector. "" is the "Any" choice (omitted from the
+ * payload). The rest are common major/minor keys kept well under KEY_MAX_LENGTH.
+ */
+export const KEY_OPTIONS = [
+  "C major",
+  "A minor",
+  "G major",
+  "E minor",
+  "D major",
+  "B minor",
+  "F major",
+  "D minor",
+] as const
+
+/** Common vocal languages; "" is the "Auto" / unset choice (omitted from payload). */
+export const VOCAL_LANGUAGES = [
+  "English",
+  "Spanish",
+  "French",
+  "German",
+  "Italian",
+  "Portuguese",
+  "Japanese",
+  "Korean",
+  "Chinese",
+] as const

--- a/web/lib/constants/ui.ts
+++ b/web/lib/constants/ui.ts
@@ -1,0 +1,6 @@
+/**
+ * Tailwind class for native `<select>` elements styled to match the Nova input
+ * look (US-16.2). Shared so the creation-form selects stay visually consistent.
+ */
+export const SELECT_CLASS =
+  "h-8 w-full rounded-lg border border-input bg-background px-2.5 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -1,8 +1,36 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { buildGenerationPayload, submitGeneration } from "@/lib/generate"
+import {
+  buildAdvancedPayload,
+  buildGenerationPayload,
+  submitGeneration,
+  validateAdvanced,
+  type AdvancedFormData,
+} from "@/lib/generate"
 
 afterEach(() => vi.restoreAllMocks())
+
+/** A valid baseline; individual tests override only what they exercise. */
+function advancedData(overrides: Partial<AdvancedFormData> = {}): AdvancedFormData {
+  return {
+    lyrics: "",
+    lyricsMode: "manual",
+    vocalLanguage: "",
+    styles: "",
+    selectedTags: [],
+    instrumental: false,
+    bpmAuto: true,
+    bpm: "",
+    key: "",
+    timeSignature: "",
+    duration: "",
+    weirdness: 50,
+    styleInfluence: 50,
+    seedRandom: true,
+    seed: "",
+    ...overrides,
+  }
+}
 
 describe("buildGenerationPayload", () => {
   it("maps description to prompt and joins tags into style", () => {
@@ -40,6 +68,130 @@ describe("buildGenerationPayload", () => {
     })
     expect(payload.prompt).toBe("first line\nsecond line")
     expect(payload.lyrics).toBe("first line\nsecond line")
+  })
+})
+
+describe("buildAdvancedPayload", () => {
+  it("combines free-text styles and tags into the style string and prompt", () => {
+    const payload = buildAdvancedPayload(
+      advancedData({ styles: "cinematic, epic", selectedTags: ["lo-fi", "ambient"] })
+    )
+    expect(payload.style).toBe("cinematic, epic, lo-fi, ambient")
+    // With no description field, the combined style string becomes the prompt.
+    expect(payload.prompt).toBe("cinematic, epic, lo-fi, ambient")
+  })
+
+  it("falls back to lyrics for the prompt when no styles are given (manual mode)", () => {
+    const payload = buildAdvancedPayload(
+      advancedData({ lyricsMode: "manual", lyrics: "[Verse]\nhello" })
+    )
+    expect(payload.prompt).toBe("[Verse]\nhello")
+    expect(payload.lyrics).toBe("[Verse]\nhello")
+  })
+
+  it("omits lyrics entirely in auto mode", () => {
+    const payload = buildAdvancedPayload(
+      advancedData({ styles: "jazz", lyricsMode: "auto", lyrics: "ignored" })
+    )
+    expect(payload).not.toHaveProperty("lyrics")
+  })
+
+  it("sends bpm 'auto' when the Auto toggle is on, otherwise the number", () => {
+    expect(buildAdvancedPayload(advancedData({ styles: "rock", bpmAuto: true })).bpm).toBe(
+      "auto"
+    )
+    expect(
+      buildAdvancedPayload(advancedData({ styles: "rock", bpmAuto: false, bpm: "120" })).bpm
+    ).toBe(120)
+  })
+
+  it("includes key, time_signature, duration, vocal_language, weirdness, style_influence and numeric seed", () => {
+    const payload = buildAdvancedPayload(
+      advancedData({
+        styles: "orchestral",
+        vocalLanguage: "English",
+        key: "C major",
+        timeSignature: "3/4",
+        duration: "90",
+        weirdness: 70,
+        styleInfluence: 30,
+        seedRandom: false,
+        seed: "42",
+      })
+    )
+    expect(payload).toMatchObject({
+      vocal_language: "English",
+      key: "C major",
+      time_signature: "3/4",
+      duration: 90,
+      weirdness: 70,
+      style_influence: 30,
+      seed: 42,
+    })
+  })
+
+  it("caps the lyrics-derived prompt at the backend's prompt limit", () => {
+    // Lyrics may be up to 5000 chars but prompt is capped at 2000; a lyrics-only
+    // submission must not build an over-long prompt that the backend would 422.
+    const payload = buildAdvancedPayload(
+      advancedData({ styles: "", lyricsMode: "manual", lyrics: "x".repeat(5000) })
+    )
+    expect(payload.prompt.length).toBe(2000)
+    expect(payload.lyrics).toHaveLength(5000)
+  })
+
+  it("omits seed when Random is selected", () => {
+    const payload = buildAdvancedPayload(
+      advancedData({ styles: "rock", seedRandom: true, seed: "42" })
+    )
+    expect(payload).not.toHaveProperty("seed")
+  })
+
+  it("never sends UI-only fields (backend forbids unknown keys)", () => {
+    const payload = buildAdvancedPayload(advancedData({ styles: "rock" }))
+    expect(payload).not.toHaveProperty("vocal_gender")
+    expect(payload).not.toHaveProperty("exclude_styles")
+    expect(payload).not.toHaveProperty("song_title")
+    expect(payload).not.toHaveProperty("workspace")
+  })
+})
+
+describe("validateAdvanced", () => {
+  it("accepts a valid form", () => {
+    expect(validateAdvanced(advancedData({ styles: "rock", bpmAuto: false, bpm: "120" }))).toBeNull()
+  })
+
+  it("requires a style or lyrics", () => {
+    expect(validateAdvanced(advancedData())).toMatch(/style or lyrics/i)
+  })
+
+  it("rejects an out-of-range BPM", () => {
+    expect(validateAdvanced(advancedData({ styles: "rock", bpmAuto: false, bpm: "300" }))).toMatch(
+      /bpm/i
+    )
+    expect(validateAdvanced(advancedData({ styles: "rock", bpmAuto: false, bpm: "10" }))).toMatch(
+      /bpm/i
+    )
+  })
+
+  it("ignores BPM bounds when Auto is on", () => {
+    expect(validateAdvanced(advancedData({ styles: "rock", bpmAuto: true, bpm: "300" }))).toBeNull()
+  })
+
+  it("rejects an out-of-range duration", () => {
+    expect(validateAdvanced(advancedData({ styles: "rock", duration: "5" }))).toMatch(/duration/i)
+    expect(validateAdvanced(advancedData({ styles: "rock", duration: "999" }))).toMatch(/duration/i)
+  })
+
+  it("rejects an over-long key", () => {
+    expect(validateAdvanced(advancedData({ styles: "rock", key: "x".repeat(60) }))).toMatch(/key/i)
+  })
+
+  it("rejects out-of-range weirdness and style influence", () => {
+    expect(validateAdvanced(advancedData({ styles: "rock", weirdness: 200 }))).toMatch(/weirdness/i)
+    expect(validateAdvanced(advancedData({ styles: "rock", styleInfluence: -1 }))).toMatch(
+      /influence/i
+    )
   })
 })
 

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -96,10 +96,10 @@ describe("buildAdvancedPayload", () => {
     expect(payload).not.toHaveProperty("lyrics")
   })
 
-  it("sends bpm 'auto' when the Auto toggle is on, otherwise the number", () => {
-    expect(buildAdvancedPayload(advancedData({ styles: "rock", bpmAuto: true })).bpm).toBe(
-      "auto"
-    )
+  it("omits bpm when Auto is on, and sends the number otherwise", () => {
+    expect(
+      buildAdvancedPayload(advancedData({ styles: "rock", bpmAuto: true }))
+    ).not.toHaveProperty("bpm")
     expect(
       buildAdvancedPayload(advancedData({ styles: "rock", bpmAuto: false, bpm: "120" })).bpm
     ).toBe(120)

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -118,18 +118,18 @@ export function buildAdvancedPayload(data: AdvancedFormData): GenerationPayload 
     instrumental: data.instrumental,
     weirdness: data.weirdness,
     style_influence: data.styleInfluence,
-    bpm: data.bpmAuto ? "auto" : Number(data.bpm),
   }
   if (style) payload.style = style
   if (lyrics) payload.lyrics = lyrics
   if (data.vocalLanguage) payload.vocal_language = data.vocalLanguage
+  // Auto = no tempo preference, so omit bpm entirely (matching every other
+  // optional field) rather than pinning "auto" — the backend's model_dump uses
+  // exclude_none, so an absent bpm and an explicit "auto" are NOT equivalent.
+  if (!data.bpmAuto && data.bpm.trim()) payload.bpm = Number(data.bpm)
   if (data.key) payload.key = data.key
   if (data.timeSignature) payload.time_signature = data.timeSignature
   if (data.duration.trim()) payload.duration = Number(data.duration)
   if (!data.seedRandom && data.seed.trim()) payload.seed = Number(data.seed)
-  // bpm "" with Auto off is invalid input; validateAdvanced blocks it first, so
-  // an unguarded NaN here never reaches the wire.
-  if (!data.bpmAuto && !data.bpm.trim()) delete payload.bpm
   return payload
 }
 

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -5,6 +5,21 @@
 // result handling are deferred to US-16.7 — here we just enqueue and report the
 // accepted job id (or the failure) back to the form.
 
+import {
+  BPM_MAX,
+  BPM_MIN,
+  DURATION_MAX,
+  DURATION_MIN,
+  KEY_MAX_LENGTH,
+  LYRICS_MAX_LENGTH,
+  PROMPT_MAX_LENGTH,
+  STYLE_INFLUENCE_MAX,
+  STYLE_INFLUENCE_MIN,
+  STYLE_MAX_LENGTH,
+  WEIRDNESS_MAX,
+  WEIRDNESS_MIN,
+} from "@/lib/constants/generation"
+
 /** The slice of form state needed to build a generation request. */
 export type GenerationFormData = {
   description: string
@@ -13,12 +28,20 @@ export type GenerationFormData = {
   selectedTags: string[]
 }
 
-/** Subset of the backend GenerationRequest this form sends (extra keys forbidden). */
+/** Subset of the backend GenerationRequest these forms send (extra keys forbidden). */
 export type GenerationPayload = {
   prompt: string
   style?: string
   lyrics?: string
   instrumental: boolean
+  vocal_language?: string
+  bpm?: number | "auto"
+  key?: string
+  time_signature?: string
+  duration?: number
+  weirdness?: number
+  style_influence?: number
+  seed?: number
 }
 
 export type SubmitResult =
@@ -49,6 +72,107 @@ export function buildGenerationPayload(
   return payload
 }
 
+/** Form state for the Advanced creation form (US-16.2). */
+export type AdvancedFormData = {
+  lyrics: string
+  /** "auto" lets the model write lyrics — user-entered lyrics are not sent. */
+  lyricsMode: "manual" | "auto"
+  vocalLanguage: string
+  /** Free-text, comma-separated styles. Combined with `selectedTags`. */
+  styles: string
+  selectedTags: string[]
+  instrumental: boolean
+  bpmAuto: boolean
+  /** Raw numeric-input string; "" means unset. */
+  bpm: string
+  key: string
+  timeSignature: string
+  duration: string
+  weirdness: number
+  styleInfluence: number
+  /** "Random" → no explicit seed is sent (the job picks one). */
+  seedRandom: boolean
+  seed: string
+}
+
+/** Combine the styles textarea and the selected tag pills into one style string. */
+export function combineStyles(styles: string, tags: string[]): string {
+  return [styles.trim(), ...tags].filter(Boolean).join(", ")
+}
+
+/**
+ * Build the backend payload from the Advanced form. There is no description
+ * field in Advanced mode, so the combined style string is the prompt (falling
+ * back to the lyrics). The lyrics fallback is capped to PROMPT_MAX_LENGTH — the
+ * backend allows longer lyrics than prompts, so an uncapped fallback would 422
+ * on lyrics-only submissions; the full lyrics still go in the `lyrics` field.
+ * UI-only fields (vocal gender, exclude styles, song title, workspace) are never
+ * included — the backend uses `extra="forbid"`.
+ */
+export function buildAdvancedPayload(data: AdvancedFormData): GenerationPayload {
+  const style = combineStyles(data.styles, data.selectedTags)
+  const lyrics = data.lyricsMode === "manual" ? data.lyrics.trim() : ""
+
+  const payload: GenerationPayload = {
+    prompt: (style || lyrics).slice(0, PROMPT_MAX_LENGTH),
+    instrumental: data.instrumental,
+    weirdness: data.weirdness,
+    style_influence: data.styleInfluence,
+    bpm: data.bpmAuto ? "auto" : Number(data.bpm),
+  }
+  if (style) payload.style = style
+  if (lyrics) payload.lyrics = lyrics
+  if (data.vocalLanguage) payload.vocal_language = data.vocalLanguage
+  if (data.key) payload.key = data.key
+  if (data.timeSignature) payload.time_signature = data.timeSignature
+  if (data.duration.trim()) payload.duration = Number(data.duration)
+  if (!data.seedRandom && data.seed.trim()) payload.seed = Number(data.seed)
+  // bpm "" with Auto off is invalid input; validateAdvanced blocks it first, so
+  // an unguarded NaN here never reaches the wire.
+  if (!data.bpmAuto && !data.bpm.trim()) delete payload.bpm
+  return payload
+}
+
+/**
+ * Validate the Advanced form against the backend's ranges before submitting, so
+ * a bad value surfaces inline instead of as a 422. Returns the first problem
+ * message, or null when the form is valid.
+ */
+export function validateAdvanced(data: AdvancedFormData): string | null {
+  const style = combineStyles(data.styles, data.selectedTags)
+  const lyrics = data.lyricsMode === "manual" ? data.lyrics.trim() : ""
+  if (!style && !lyrics) return "Add a style or lyrics to create."
+
+  if (style.length > STYLE_MAX_LENGTH) {
+    return `Styles must be ${STYLE_MAX_LENGTH} characters or fewer.`
+  }
+  if (lyrics.length > LYRICS_MAX_LENGTH) {
+    return `Lyrics must be ${LYRICS_MAX_LENGTH} characters or fewer.`
+  }
+  if (!data.bpmAuto && data.bpm.trim()) {
+    const bpm = Number(data.bpm)
+    if (!Number.isFinite(bpm) || bpm < BPM_MIN || bpm > BPM_MAX) {
+      return `BPM must be between ${BPM_MIN} and ${BPM_MAX}.`
+    }
+  }
+  if (data.duration.trim()) {
+    const duration = Number(data.duration)
+    if (!Number.isFinite(duration) || duration < DURATION_MIN || duration > DURATION_MAX) {
+      return `Duration must be between ${DURATION_MIN} and ${DURATION_MAX} seconds.`
+    }
+  }
+  if (data.key.length > KEY_MAX_LENGTH) {
+    return `Key must be ${KEY_MAX_LENGTH} characters or fewer.`
+  }
+  if (data.weirdness < WEIRDNESS_MIN || data.weirdness > WEIRDNESS_MAX) {
+    return `Weirdness must be between ${WEIRDNESS_MIN} and ${WEIRDNESS_MAX}.`
+  }
+  if (data.styleInfluence < STYLE_INFLUENCE_MIN || data.styleInfluence > STYLE_INFLUENCE_MAX) {
+    return `Style influence must be between ${STYLE_INFLUENCE_MIN} and ${STYLE_INFLUENCE_MAX}.`
+  }
+  return null
+}
+
 /** Pull a human-readable message out of a FastAPI error body (string or 422 list). */
 function extractDetail(body: unknown, fallback: string): string {
   if (body && typeof body === "object" && "detail" in body) {
@@ -64,9 +188,25 @@ function extractDetail(body: unknown, fallback: string): string {
   return fallback
 }
 
-/** Submit a generation request through the BFF proxy and classify the response. */
-export async function submitGeneration(
+/** Submit the Simple creation form through the BFF proxy. */
+export function submitGeneration(
   data: GenerationFormData,
+  accessToken: string
+): Promise<SubmitResult> {
+  return postGeneration(buildGenerationPayload(data), accessToken)
+}
+
+/** Submit the Advanced creation form through the BFF proxy. */
+export function submitAdvancedGeneration(
+  data: AdvancedFormData,
+  accessToken: string
+): Promise<SubmitResult> {
+  return postGeneration(buildAdvancedPayload(data), accessToken)
+}
+
+/** POST a built payload through the BFF proxy and classify the response. */
+async function postGeneration(
+  payload: GenerationPayload,
   accessToken: string
 ): Promise<SubmitResult> {
   let res: Response
@@ -77,7 +217,7 @@ export async function submitGeneration(
         "content-type": "application/json",
         authorization: `Bearer ${accessToken}`,
       },
-      body: JSON.stringify(buildGenerationPayload(data)),
+      body: JSON.stringify(payload),
     })
   } catch {
     // Network failure / aborted request — never let it bubble out and leave the


### PR DESCRIPTION
## US-16.2: Advanced Creation Mode

Closes #188. Builds the **Advanced** tab on `/create` (the tab switcher already existed from US-16.1; this replaces its "Coming soon." placeholder).

### What's included
- **Lyrics panel** — textarea with `[Verse]`/`[Chorus]` structure-tag placeholder, vocal-language `<select>`, manual/auto mode toggle, enhance input, undo, clear.
- **Styles panel** — comma-separated styles textarea + reused `InspirationTags` pills (both feed the `style` string), undo, clear, instrumental toggle.
- **More Options** — collapsible (collapsed by default) exposing every backend-accepted parameter: BPM (+Auto), duration (+30/60/120/240 presets), weirdness & style-influence sliders, seed (+Random), key, time signature, plus UI-only vocal gender / exclude styles / song title.
- **`lib/generate.ts`** — `buildAdvancedPayload` + `validateAdvanced` mirror the backend `GenerationRequest` bounds; both Simple and Advanced now share one `postGeneration` helper.
- **`useUndoableField`** hook backs single-step (history-stacked) undo for lyrics and styles.

### Acceptance criteria
- [x] Lyrics panel supports structured sections and vocal language selection
- [x] Enhance lyrics input triggers the enhance flow *(stub — see Known Limitations)*
- [x] Styles textarea and tag pills both contribute to the style string
- [x] More Options expands/collapses and exposes all generation parameters
- [x] BPM, key, duration, weirdness, and style influence validated before submission
- [x] Undo buttons revert their respective fields to the previous state

### Tests
171 web tests pass (Vitest); `typecheck`, `lint`, and `next build` all green locally. New coverage: payload builder, range validation, prompt-cap regression, undo hook, and full Advanced form behaviour. *(Reminder: `web/` is not in CI — verified locally.)*

### Known Limitations
- **No frontend API for these controls yet**, so they are stubbed with a "coming soon" notice / no-op (per the approved plan): **Enhance lyrics**, **Magic wand** style suggestions, **Save preset**, **Save to workspace**. They have no backend proxy (`/api/v1/presets`, `/api/v1/workspaces`) and there is no AI enhance/suggest endpoint.
- **UI-only fields** (vocal gender, exclude styles, song title) are held in state but never sent — the backend `GenerationRequest` uses `extra="forbid"`.

### Deviations from the CodeRabbit plan (which was written against an empty `web/`)
- `components/create/` (not `components/creation/`); `useState` (not `useReducer`) to match `SimpleCreationForm`.
- Native `<select>` / `<input type=range>` / `useState` collapsible instead of adding shadcn Select/Slider/Collapsible — zero new deps, criteria met identically.
- Reused `InspirationTags` for the style pills+shuffle.
