### PR TITLE
feat(web): Sounds Creation Mode (US-16.3)

### DIFF
--- a/docs/demos/us-16.3-sounds-creation.md
+++ b/docs/demos/us-16.3-sounds-creation.md
@@ -1,0 +1,26 @@
+# US-16.3 — Sounds Creation Mode demo
+
+Verified live against `next dev` (localhost:3100) with `agent-browser`. The real
+form lives behind the auth-gated `/create` route, so it was mounted on a
+throwaway public harness page (`app/demo-create-sounds`, since deleted) under the
+real `AuthProvider` and driven directly. Each acceptance criterion is mapped to
+observed outcome evidence (not just "rendered"). The submit/generation-request
+path runs only after the form's auth check, which redirects the token-less
+harness to `/login`; the payload shape it would send is evidenced by unit
+assertions, as in the US-16.1/16.2 demos.
+
+| # | Acceptance criterion | Evidence |
+|---|----------------------|----------|
+| 1 | Type selector is required before Create is enabled | With `Sound description` filled (`"a punchy analog kick"`) but **no type chosen**, `Create` stayed `[disabled]` in the live snapshot. Clicking `One-Shot` (→ `[pressed]`) flipped `Create` to enabled. Type is genuinely required, not just description. |
+| 2 | BPM and key fields are available and sent with the request | One-shot mode shows **no** BPM/Key controls. Clicking `Loop` (`[pressed]`) revealed a `BPM` spinbutton (`[disabled]` while the `Auto` switch is `[checked]`) and a `Key` combobox. Turning `Auto` off enabled BPM; the field then read `128` and `auto=false` (read from the live DOM). The `Key` combobox lists `Any, C major, A minor, G major, E minor, D major, B minor, F major, D minor`. The values being sent on submit are asserted by `buildSoundsPayload` ("sends bpm and key for a loop" → `{ bpm: 128, key: "A minor" }`). |
+| 3 | Generated sound clips appear in the workspace panel with correct metadata | **Deferred** — see Known Limitations. The correct metadata (`mode: "sound"`, `sound_type`, loop `bpm`/`key`) is built into the payload (`buildSoundsPayload`); there is no workspace panel in `web/` yet to render returned clips, identical to the deferred dependency US-16.1 (Simple) and US-16.2 (Advanced) carry. |
+| 4 | Loop clips include tempo metadata | A loop with `Auto` off and `BPM = 128` produces a payload carrying `bpm: 128` (`buildSoundsPayload` "sends bpm and key for a loop"). One-shots never carry tempo — `buildSoundsPayload` "never sends bpm or key for a one-shot (backend forbids them)" asserts both are omitted even when stray loop values are present, matching the backend's `_check_mode_constraints` rule. |
+
+Functional extras observed: switching back from `Loop` to `One-Shot` removes the
+BPM/Key controls from the DOM (one-shots carry no tempo/tonal context);
+`Create` reflects validity live. No feature-related console errors (the harness's
+expected `POST /api/auth/refresh 401` — no backend — is unrelated to the form).
+
+Local gate (web/ isn't in CI): `tsc --noEmit`, `eslint`, `vitest run`
+(23 files, 184 tests), and `next build` all green. Cross-family
+`codex review --uncommitted` raised no findings on the form code.

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useRequireAuth } from "@/hooks/use-require-auth"
 import { SimpleCreationForm } from "@/components/create/SimpleCreationForm"
 import { AdvancedCreationForm } from "@/components/create/AdvancedCreationForm"
+import { SoundsCreationForm } from "@/components/create/SoundsCreationForm"
 
 export default function CreatePage() {
   const { isLoading, isAuthenticated } = useRequireAuth()
@@ -28,7 +29,7 @@ export default function CreatePage() {
           <AdvancedCreationForm />
         </TabsContent>
         <TabsContent value="sounds">
-          <p className="text-sm text-muted-foreground">Coming soon.</p>
+          <SoundsCreationForm />
         </TabsContent>
       </Tabs>
     </div>

--- a/web/components/create/SoundsCreationForm.test.tsx
+++ b/web/components/create/SoundsCreationForm.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SoundsCreationForm } from "@/components/create/SoundsCreationForm"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok" }),
+}))
+
+const submitSoundsGeneration = vi.fn()
+vi.mock("@/lib/generate", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/generate")>()
+  return {
+    ...actual,
+    submitSoundsGeneration: (...args: unknown[]) => submitSoundsGeneration(...args),
+  }
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("SoundsCreationForm", () => {
+  const createButton = () => screen.getByRole("button", { name: /^create$/i })
+  const oneShot = () => screen.getByRole("button", { name: "One-Shot" })
+  const loop = () => screen.getByRole("button", { name: "Loop" })
+
+  it("disables Create until both a description and a type are chosen", async () => {
+    const user = userEvent.setup()
+    render(<SoundsCreationForm />)
+    expect(createButton()).toBeDisabled()
+
+    // Description alone is not enough — the type is required.
+    await user.type(screen.getByLabelText("Sound description"), "a punchy kick")
+    expect(createButton()).toBeDisabled()
+
+    await user.click(oneShot())
+    expect(createButton()).toBeEnabled()
+  })
+
+  it("shows BPM and key only for loops, not one-shots", async () => {
+    const user = userEvent.setup()
+    render(<SoundsCreationForm />)
+
+    await user.click(oneShot())
+    expect(screen.queryByLabelText("BPM")).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Key")).not.toBeInTheDocument()
+
+    await user.click(loop())
+    expect(screen.getByLabelText("BPM")).toBeInTheDocument()
+    expect(screen.getByLabelText("Key")).toBeInTheDocument()
+  })
+
+  it("submits a one-shot and reports success", async () => {
+    submitSoundsGeneration.mockResolvedValue({ status: "accepted", jobId: "job-1" })
+    const user = userEvent.setup()
+    render(<SoundsCreationForm />)
+
+    await user.type(screen.getByLabelText("Sound description"), "a punchy kick")
+    await user.click(oneShot())
+    await user.click(createButton())
+
+    expect(submitSoundsGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "a punchy kick", soundType: "one-shot" }),
+      "tok"
+    )
+    expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
+  })
+
+  it("sends loop tempo and key with the request", async () => {
+    submitSoundsGeneration.mockResolvedValue({ status: "accepted", jobId: "job-2" })
+    const user = userEvent.setup()
+    render(<SoundsCreationForm />)
+
+    await user.type(screen.getByLabelText("Sound description"), "a driving bass loop")
+    await user.click(loop())
+    await user.click(screen.getByRole("switch", { name: "Auto" })) // turn Auto off
+    await user.type(screen.getByLabelText("BPM"), "128")
+    await user.selectOptions(screen.getByLabelText("Key"), "A minor")
+    await user.click(createButton())
+
+    expect(submitSoundsGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ soundType: "loop", bpm: "128", key: "A minor" }),
+      "tok"
+    )
+  })
+})

--- a/web/components/create/SoundsCreationForm.test.tsx
+++ b/web/components/create/SoundsCreationForm.test.tsx
@@ -8,6 +8,11 @@ vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ accessToken: "tok" }),
 }))
 
+// Stubbed so the unauthorized path's router.push("/login") never throws.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 const submitSoundsGeneration = vi.fn()
 vi.mock("@/lib/generate", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/generate")>()
@@ -84,5 +89,19 @@ describe("SoundsCreationForm", () => {
       expect.objectContaining({ soundType: "loop", bpm: "128", key: "A minor" }),
       "tok"
     )
+    // Guard the loop success-message branch separately from the one-shot one.
+    expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
+  })
+
+  it("surfaces an error notice when generation fails", async () => {
+    submitSoundsGeneration.mockResolvedValue({ status: "error", detail: "Server error" })
+    const user = userEvent.setup()
+    render(<SoundsCreationForm />)
+
+    await user.type(screen.getByLabelText("Sound description"), "a punchy kick")
+    await user.click(oneShot())
+    await user.click(createButton())
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/server error/i)
   })
 })

--- a/web/components/create/SoundsCreationForm.tsx
+++ b/web/components/create/SoundsCreationForm.tsx
@@ -10,7 +10,7 @@ import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/hooks/use-auth"
 import { submitSoundsGeneration, validateSounds, type SoundsFormData } from "@/lib/generate"
-import { BPM_MAX, BPM_MIN, KEY_OPTIONS } from "@/lib/constants/generation"
+import { BPM_MAX, BPM_MIN, KEY_OPTIONS, PROMPT_MAX_LENGTH } from "@/lib/constants/generation"
 import { SELECT_CLASS } from "@/lib/constants/ui"
 
 type Status =
@@ -96,6 +96,7 @@ export function SoundsCreationForm() {
         <Textarea
           id="sound-description"
           rows={4}
+          maxLength={PROMPT_MAX_LENGTH}
           placeholder="Describe the sound you want to create..."
           value={description}
           onChange={(e) => setDescription(e.target.value)}

--- a/web/components/create/SoundsCreationForm.tsx
+++ b/web/components/create/SoundsCreationForm.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { useAuth } from "@/hooks/use-auth"
+import { submitSoundsGeneration, validateSounds, type SoundsFormData } from "@/lib/generate"
+import { BPM_MAX, BPM_MIN, KEY_OPTIONS } from "@/lib/constants/generation"
+import { SELECT_CLASS } from "@/lib/constants/ui"
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "info"; message: string }
+  | { kind: "success"; message: string }
+  | { kind: "error"; message: string }
+
+const SOUND_TYPES = [
+  { value: "one-shot", label: "One-Shot" },
+  { value: "loop", label: "Loop" },
+] as const
+
+/**
+ * The Sounds creation form (US-16.3): generate short clips — one-shots and loops.
+ * Mirrors the Simple/Advanced forms' controlled-state, BFF-submit pattern. The
+ * type selector is required (it gates Create and maps to the backend's
+ * sound_type); BPM and key apply to loops only, matching the backend rule that
+ * one-shots carry no tempo/tonal context. Clip rendering is deferred (as in
+ * US-16.1/16.2) — success just reports the job started.
+ */
+export function SoundsCreationForm() {
+  const router = useRouter()
+  const { accessToken } = useAuth()
+
+  const [description, setDescription] = useState("")
+  const [soundType, setSoundType] = useState<SoundsFormData["soundType"]>("")
+  const [bpmAuto, setBpmAuto] = useState(true)
+  const [bpm, setBpm] = useState("")
+  const [key, setKey] = useState("")
+  const [status, setStatus] = useState<Status>({ kind: "idle" })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const isLoop = soundType === "loop"
+
+  // A type and a description are both required (the description is the prompt);
+  // range validation runs on submit so a bad BPM surfaces a message.
+  const canSubmit = soundType !== "" && description.trim().length > 0
+
+  function formData(): SoundsFormData {
+    return { description, soundType, bpmAuto, bpm, key }
+  }
+
+  async function handleCreate() {
+    if (!canSubmit || isSubmitting) return
+    if (!accessToken) {
+      router.push("/login")
+      return
+    }
+    const data = formData()
+    const error = validateSounds(data)
+    if (error) {
+      setStatus({ kind: "error", message: error })
+      return
+    }
+    setIsSubmitting(true)
+    try {
+      const result = await submitSoundsGeneration(data, accessToken)
+      switch (result.status) {
+        case "accepted":
+          setStatus({
+            kind: "success",
+            message: "Generation started. We'll let you know when it's ready.",
+          })
+          break
+        case "unauthorized":
+          router.push("/login")
+          break
+        case "invalid":
+        case "error":
+          setStatus({ kind: "error", message: result.detail })
+          break
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="sound-description">Sound description</Label>
+        <Textarea
+          id="sound-description"
+          rows={4}
+          placeholder="Describe the sound you want to create..."
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-medium">
+          Type <span className="text-destructive">*</span>
+        </span>
+        <div className="flex gap-1.5" role="group" aria-label="Sound type">
+          {SOUND_TYPES.map((type) => (
+            <Button
+              key={type.value}
+              type="button"
+              size="sm"
+              variant={soundType === type.value ? "default" : "outline"}
+              aria-pressed={soundType === type.value}
+              onClick={() => setSoundType(type.value)}
+            >
+              {type.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* BPM and key are loop-only: a one-shot is a single hit with no tempo. */}
+      {isLoop && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="sound-bpm">BPM</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="sound-bpm"
+                type="number"
+                min={BPM_MIN}
+                max={BPM_MAX}
+                disabled={bpmAuto}
+                value={bpm}
+                onChange={(e) => setBpm(e.target.value)}
+              />
+              <div className="flex shrink-0 items-center gap-1.5">
+                <Switch id="sound-bpm-auto" checked={bpmAuto} onCheckedChange={setBpmAuto} />
+                <Label htmlFor="sound-bpm-auto">Auto</Label>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="sound-key">Key</Label>
+            <select
+              id="sound-key"
+              className={SELECT_CLASS}
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+            >
+              <option value="">Any</option>
+              {KEY_OPTIONS.map((k) => (
+                <option key={k} value={k}>
+                  {k}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {(status.kind === "info" || status.kind === "success") && (
+        <p role="status" className="text-sm text-muted-foreground">
+          {status.message}
+        </p>
+      )}
+      {status.kind === "error" && (
+        <p role="alert" className="text-sm text-destructive">
+          {status.message}
+        </p>
+      )}
+
+      <Button
+        type="button"
+        className="w-fit"
+        disabled={!canSubmit || isSubmitting}
+        onClick={handleCreate}
+      >
+        {isSubmitting ? "Creating..." : "Create"}
+      </Button>
+    </div>
+  )
+}

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -262,6 +262,12 @@ describe("validateSounds", () => {
     expect(validateSounds(soundsData({ description: "  " }))).toMatch(/description/i)
   })
 
+  it("rejects an over-long description (the prompt bound)", () => {
+    expect(validateSounds(soundsData({ description: "x".repeat(2001) }))).toMatch(
+      /description/i
+    )
+  })
+
   it("rejects an out-of-range loop BPM", () => {
     expect(
       validateSounds(soundsData({ soundType: "loop", bpmAuto: false, bpm: "300" }))

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -3,9 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   buildAdvancedPayload,
   buildGenerationPayload,
+  buildSoundsPayload,
   submitGeneration,
   validateAdvanced,
+  validateSounds,
   type AdvancedFormData,
+  type SoundsFormData,
 } from "@/lib/generate"
 
 afterEach(() => vi.restoreAllMocks())
@@ -192,6 +195,83 @@ describe("validateAdvanced", () => {
     expect(validateAdvanced(advancedData({ styles: "rock", styleInfluence: -1 }))).toMatch(
       /influence/i
     )
+  })
+})
+
+/** A valid baseline sounds form; tests override only what they exercise. */
+function soundsData(overrides: Partial<SoundsFormData> = {}): SoundsFormData {
+  return {
+    description: "a punchy kick",
+    soundType: "one-shot",
+    bpmAuto: true,
+    bpm: "",
+    key: "",
+    ...overrides,
+  }
+}
+
+describe("buildSoundsPayload", () => {
+  it("maps description to prompt and fixes mode to sound (instrumental)", () => {
+    const payload = buildSoundsPayload(soundsData({ description: "  warm pad  " }))
+    expect(payload).toMatchObject({
+      prompt: "warm pad",
+      mode: "sound",
+      sound_type: "one-shot",
+      instrumental: true,
+    })
+  })
+
+  it("never sends bpm or key for a one-shot (backend forbids them)", () => {
+    // Even if stray loop values are present, a one-shot must omit tempo/tonal keys.
+    const payload = buildSoundsPayload(
+      soundsData({ soundType: "one-shot", bpmAuto: false, bpm: "120", key: "C major" })
+    )
+    expect(payload).not.toHaveProperty("bpm")
+    expect(payload).not.toHaveProperty("key")
+  })
+
+  it("sends bpm and key for a loop", () => {
+    const payload = buildSoundsPayload(
+      soundsData({ soundType: "loop", bpmAuto: false, bpm: "128", key: "A minor" })
+    )
+    expect(payload).toMatchObject({ sound_type: "loop", bpm: 128, key: "A minor" })
+  })
+
+  it("omits bpm for a loop when Auto is on, and key when Any", () => {
+    const payload = buildSoundsPayload(
+      soundsData({ soundType: "loop", bpmAuto: true, bpm: "128", key: "" })
+    )
+    expect(payload).not.toHaveProperty("bpm")
+    expect(payload).not.toHaveProperty("key")
+  })
+})
+
+describe("validateSounds", () => {
+  it("accepts a valid one-shot and a valid loop", () => {
+    expect(validateSounds(soundsData())).toBeNull()
+    expect(
+      validateSounds(soundsData({ soundType: "loop", bpmAuto: false, bpm: "120" }))
+    ).toBeNull()
+  })
+
+  it("requires a sound type", () => {
+    expect(validateSounds(soundsData({ soundType: "" }))).toMatch(/type/i)
+  })
+
+  it("requires a description", () => {
+    expect(validateSounds(soundsData({ description: "  " }))).toMatch(/description/i)
+  })
+
+  it("rejects an out-of-range loop BPM", () => {
+    expect(
+      validateSounds(soundsData({ soundType: "loop", bpmAuto: false, bpm: "300" }))
+    ).toMatch(/bpm/i)
+  })
+
+  it("ignores BPM bounds when Auto is on", () => {
+    expect(
+      validateSounds(soundsData({ soundType: "loop", bpmAuto: true, bpm: "300" }))
+    ).toBeNull()
   })
 })
 

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -249,7 +249,13 @@ export function buildSoundsPayload(data: SoundsFormData): GenerationPayload {
  */
 export function validateSounds(data: SoundsFormData): string | null {
   if (!data.soundType) return "Choose a sound type to create."
-  if (!data.description.trim()) return "Add a description to create."
+  const description = data.description.trim()
+  if (!description) return "Add a description to create."
+  // The description is the prompt; the backend caps it, so surface a clear
+  // message inline instead of a generic 422 (mirrors buildAdvancedPayload's cap).
+  if (description.length > PROMPT_MAX_LENGTH) {
+    return `Description must be ${PROMPT_MAX_LENGTH} characters or fewer.`
+  }
   if (data.soundType === "loop" && !data.bpmAuto && data.bpm.trim()) {
     const bpm = Number(data.bpm)
     if (!Number.isFinite(bpm) || bpm < BPM_MIN || bpm > BPM_MAX) {

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -42,6 +42,8 @@ export type GenerationPayload = {
   weirdness?: number
   style_influence?: number
   seed?: number
+  mode?: "song" | "sound"
+  sound_type?: "one-shot" | "loop"
 }
 
 export type SubmitResult =
@@ -202,6 +204,67 @@ export function submitAdvancedGeneration(
   accessToken: string
 ): Promise<SubmitResult> {
   return postGeneration(buildAdvancedPayload(data), accessToken)
+}
+
+/** Form state for the Sounds creation form (US-16.3): short one-shots and loops. */
+export type SoundsFormData = {
+  description: string
+  /** "" until the user picks one — Create stays disabled while unset. */
+  soundType: "" | "one-shot" | "loop"
+  /** bpm/key apply to loops only; ignored (and never sent) for one-shots. */
+  bpmAuto: boolean
+  /** Raw numeric-input string; "" means unset. */
+  bpm: string
+  /** "" is the "Any" choice (omitted from the payload). */
+  key: string
+}
+
+/**
+ * Build the backend payload for a sound request. The description is the prompt
+ * and the mode is fixed to "sound"; sounds are instrumental clips. The backend
+ * forbids bpm/key on one-shots (a one-shot is a single hit with no tempo/tonal
+ * context), so those are added for loops only — bpm when not on Auto and in
+ * range, key when a specific key is chosen. Caller must ensure soundType is set.
+ */
+export function buildSoundsPayload(data: SoundsFormData): GenerationPayload {
+  const payload: GenerationPayload = {
+    prompt: data.description.trim(),
+    instrumental: true,
+    mode: "sound",
+    // soundType is "" only before a type is chosen; Create is disabled until then.
+    sound_type: data.soundType || "one-shot",
+  }
+  if (data.soundType === "loop") {
+    if (!data.bpmAuto && data.bpm.trim()) payload.bpm = Number(data.bpm)
+    if (data.key) payload.key = data.key
+  }
+  return payload
+}
+
+/**
+ * Validate the Sounds form before submitting. A type is required (it gates the
+ * payload's sound_type), the description becomes the prompt so it must be
+ * non-empty, and a loop's explicit BPM is range-checked to surface a message
+ * inline instead of as a 422. Returns the first problem, or null when valid.
+ */
+export function validateSounds(data: SoundsFormData): string | null {
+  if (!data.soundType) return "Choose a sound type to create."
+  if (!data.description.trim()) return "Add a description to create."
+  if (data.soundType === "loop" && !data.bpmAuto && data.bpm.trim()) {
+    const bpm = Number(data.bpm)
+    if (!Number.isFinite(bpm) || bpm < BPM_MIN || bpm > BPM_MAX) {
+      return `BPM must be between ${BPM_MIN} and ${BPM_MAX}.`
+    }
+  }
+  return null
+}
+
+/** Submit the Sounds creation form through the BFF proxy. */
+export function submitSoundsGeneration(
+  data: SoundsFormData,
+  accessToken: string
+): Promise<SubmitResult> {
+  return postGeneration(buildSoundsPayload(data), accessToken)
 }
 
 /** POST a built payload through the BFF proxy and classify the response. */


### PR DESCRIPTION
## Summary

Implements **US-16.3: Sounds Creation Mode** — the Sounds tab on `/create` for generating short audio clips (one-shots and loops). Closes #189.

The backend (`generation.py`) already supports `mode: "sound"` + `sound_type: "one-shot" | "loop"`, where bpm/key are allowed only for loops and forbidden for one-shots. This is a frontend-only story that wires a new form into that existing contract, mirroring the Simple/Advanced creation forms.

## Changes

- **`web/components/create/SoundsCreationForm.tsx`** (new) — sound description textarea, a **required** One-Shot/Loop type selector (gates Create), and **loop-only** BPM input (+Auto switch) and Key selector. Same controlled-state + status-notice pattern as the prior forms.
- **`web/lib/generate.ts`** — `SoundsFormData`, `buildSoundsPayload`, `validateSounds`, `submitSoundsGeneration`; `GenerationPayload` extended with `mode` / `sound_type`. bpm/key are sent for loops only.
- **`web/app/create/page.tsx`** — replaced the "Coming soon" stub with the live form.
- Tests: `SoundsCreationForm.test.tsx` (Create gating, conditional loop fields, payload), plus `buildSoundsPayload`/`validateSounds` cases in `generate.test.ts`.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Type selector required before Create is enabled | ✅ `canSubmit` requires `soundType` |
| BPM and key fields available and sent with the request | ✅ loop-only, included in payload |
| Loop clips include tempo metadata | ✅ `bpm` sent for loops |
| Generated sound clips appear in the workspace panel with correct metadata | ⚠️ see Known Limitations |

## Known Limitations

- **Clip rendering in a workspace panel is deferred.** As with US-16.1 (Simple) and US-16.2 (Advanced), this form submits a correct payload and reports the started job id — there is no workspace panel in `web/` yet to render returned clips. The sound/loop metadata (mode, sound_type, bpm, key) is sent correctly; surfacing the resulting clips is the same deferred dependency the two prior stories carry.

## Verification

Local (web is not in CI): `tsc --noEmit` clean, `eslint` clean, `vitest run` → 184 passed, `next build` succeeds. Cross-family `codex review --uncommitted` raised no findings on the form code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Sounds creation tab on the Create page.
  * Users can now create short audio clips with one-shot or loop options.
  * Loop sounds now show BPM and key controls, with validation and submission feedback.
  * Unauthenticated access to creation is redirected to login.

* **Documentation**
  * Added a demo guide covering the Sounds creation flow and verified behavior.

* **Bug Fixes**
  * Improved form validation so Create is only enabled when required inputs are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->