### PR TITLE
feat(web): Model and Version Selector (US-16.4)

### DIFF
--- a/docs/demos/us-16.4-model-selector.md
+++ b/docs/demos/us-16.4-model-selector.md
@@ -1,0 +1,66 @@
+# US-16.4 — Model and Version Selector demo
+
+Each acceptance criterion is mapped to observed outcome evidence (not just
+"rendered" / "exit 0"). The backend endpoint is demoed **live** in-process; the
+selector itself lives behind the auth-gated `/create` route, so its criteria are
+evidenced by behavior-asserting component/context tests (real rendered DOM and
+real request payloads via Testing Library + jsdom), the same approach the
+US-16.1/16.2 demos used for that route.
+
+## Live backend — `GET /api/v1/models`
+
+Driven against the real FastAPI app over `httpx` ASGITransport
+(`scripts/demo_us_16_4_models.py`), no DB or auth:
+
+```
+GET /api/v1/models -> 200 (no Authorization header sent)
+
+  turbo     Turbo Model                      cat=Turbo      ~2.4GB
+  base      Standard Model                   cat=Standard   ~2.4GB
+  sft       Standard Model (Fine-tuned)      cat=Standard   ~2.4GB
+  xl-base   Latest Model (XL)                cat=XL           ~8GB  [Pro]
+  xl-sft    Latest Model (XL, Fine-tuned)    cat=XL           ~8GB  [Pro]
+  xl-turbo  Turbo XL                         cat=XL           ~8GB  [Pro]
+
+  models returned: 6  ==  registry size: 6: True
+  pro-only (lock + badge for free tier): ['xl-base', 'xl-sft', 'xl-turbo']
+```
+
+The endpoint is public (200 with no token), returns all six registry models with
+display metadata, and flags the three XL variants `pro_only` — the data the
+frontend selector renders.
+
+## Acceptance criteria
+
+| # | Acceptance criterion | Evidence |
+|---|----------------------|----------|
+| 1 | Model selector is accessible from Simple, Advanced, and Sounds tabs | `app/create/page.tsx` renders `<ModelSelector />` in the page header **inside** `<ModelSelectionProvider>` but **outside** `<Tabs>`, so it is visible on every tab. `ModelSelector.test.tsx` ("shows the selected model's display name on the trigger") asserts the trigger renders the live model name; the three form tests each mount under the mocked context and submit successfully, confirming each tab consumes the selection. |
+| 2 | Selecting a model updates the generation request payload | `generate.test.ts` ("includes the selected model in the payload (US-16.4)") submits with `"xl-base"` and asserts `JSON.parse(body).model === "xl-base"`; the companion test asserts `model` is **omitted** when none is selected (so the backend default applies). `ModelSelector.test.tsx` ("selecting a model calls setSelectedModel with its key") asserts clicking an option writes the choice; each form test asserts `submit*Generation` is called with the selected model as the third arg (`"base"`). |
+| 3 | Pro-only models show a badge or lock indicator for free-tier users | Live endpoint marks `xl-base`/`xl-sft`/`xl-turbo` `pro_only: true` (above). `ModelSelector.test.tsx` ("lists models with a Pro badge on pro-only options") opens the dropdown as a free-tier user and asserts the `xl-base` option renders the `Pro` badge (with lock icon) **and remains selectable** (display-only, no enforcement — by design). |
+| 4 | Selected model persists when switching between creation tabs | The provider wraps the tabs and never unmounts on tab switch, so `selectedModel` state is stable. `model-selection-context.test.tsx` ("keeps a user's pick over a late-arriving saved default") asserts an explicit pick survives, and ("stays loading until the profile seed resolves, then applies the saved default") asserts the saved default seeds the selection once loaded. |
+
+## Extras
+
+- **Default model in settings** (functional requirement): `settings/page.test.tsx`
+  ("saves the chosen default model (US-16.4)") selects `xl-base` and asserts the
+  `PATCH /api/users/me` body is `{ default_model: "xl-base" }`.
+- **Saved-default race fix** (codex review): the selector reports `isLoading`
+  until both the models list and the profile seed settle; the three Create
+  buttons disable while loading, so a user with a saved default can't submit
+  `"base"` in the pre-seed window.
+
+## Known limitations
+
+- **Pro models are selectable by free-tier users** — the badge/lock is display
+  only; the backend does not yet gate generation by tier (deliberate, matches the
+  issue's Design Choice 2). Tier enforcement is a separate future change.
+- The selector exposes the six real backend models grouped into XL / Standard /
+  Turbo. The issue's aspirational groups ("Create Custom Model (Beta)", "Legacy
+  Models") have no backing models and were intentionally not fabricated.
+
+## Gates
+
+- Backend: `tests/test_models_api.py` (4) + `tests/test_users_api.py` (29, incl.
+  4 new `default_model`) green; ruff + black clean.
+- Frontend (web/ isn't in CI): `npm run typecheck`, `npm run lint`,
+  `npm test` (25 files, 195 tests), `npm run build` all green.

--- a/scripts/demo_us_16_4_models.py
+++ b/scripts/demo_us_16_4_models.py
@@ -7,7 +7,6 @@ Pro-only flags the UI renders.
 """
 
 import asyncio
-import json
 
 import httpx
 

--- a/scripts/demo_us_16_4_models.py
+++ b/scripts/demo_us_16_4_models.py
@@ -27,7 +27,9 @@ async def main() -> None:
             pro = "  [Pro]" if m["pro_only"] else ""
             print(f"  {m['key']:<9} {m['display_name']:<32} cat={m['category']:<9} {m['vram']:>7}{pro}")
         keys = {m["key"] for m in body["models"]}
-        print(f"\n  models returned: {len(body['models'])}  ==  registry size: {len(MODELS)}: {keys == set(MODELS.keys())}")
+        print(
+            f"\n  models returned: {len(body['models'])}  ==  registry size: {len(MODELS)}: {keys == set(MODELS.keys())}"
+        )
         pro_keys = sorted(m["key"] for m in body["models"] if m["pro_only"])
         print(f"  pro-only (lock + badge for free tier): {pro_keys}")
 

--- a/scripts/demo_us_16_4_models.py
+++ b/scripts/demo_us_16_4_models.py
@@ -1,0 +1,36 @@
+"""US-16.4 demo: live response from GET /api/v1/models (no DB required).
+
+Drives the real FastAPI app over httpx ASGITransport — the same code path the
+server serves — and prints the actual JSON the frontend selector consumes,
+proving the endpoint returns all six models with display metadata and the
+Pro-only flags the UI renders.
+"""
+
+import asyncio
+import json
+
+import httpx
+
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.settings import ApiSettings
+from acemusic.constants import MODELS
+
+
+async def main() -> None:
+    app = create_app(ApiSettings(jwt_secret_key="demo-secret-key-at-least-32-bytes-long-xx"))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://demo") as client:
+        resp = await client.get(f"{API_V1_PREFIX}/models")
+        print(f"GET {API_V1_PREFIX}/models -> {resp.status_code} (no Authorization header sent)\n")
+        body = resp.json()
+        for m in body["models"]:
+            pro = "  [Pro]" if m["pro_only"] else ""
+            print(f"  {m['key']:<9} {m['display_name']:<32} cat={m['category']:<9} {m['vram']:>7}{pro}")
+        keys = {m["key"] for m in body["models"]}
+        print(f"\n  models returned: {len(body['models'])}  ==  registry size: {len(MODELS)}: {keys == set(MODELS.keys())}")
+        pro_keys = sorted(m["key"] for m in body["models"] if m["pro_only"])
+        print(f"  pro-only (lock + badge for free tier): {pro_keys}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -36,6 +36,7 @@ from .routers import (
     iterative,
     jobs,
     mastering,
+    models,
     presets,
     queue,
     releases,
@@ -180,6 +181,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(health.router, prefix=API_V1_PREFIX)
     app.include_router(auth.router, prefix=API_V1_PREFIX)
     app.include_router(users.router, prefix=API_V1_PREFIX)
+    app.include_router(models.router, prefix=API_V1_PREFIX)
     app.include_router(generation.router, prefix=API_V1_PREFIX)
     app.include_router(jobs.router, prefix=API_V1_PREFIX)
     app.include_router(clips.router, prefix=API_V1_PREFIX)

--- a/src/acemusic/api/models/user.py
+++ b/src/acemusic/api/models/user.py
@@ -37,6 +37,10 @@ class User(Document):
     bio: str | None = None
     style_tags: list[str] = Field(default_factory=list)
     avatar_url: str | None = None
+    # US-16.4: the user's preferred default generation model (a key in
+    # constants.MODELS), used to seed the creation-page model selector. Null
+    # means "no preference"; the UI falls back to its own default.
+    default_model: str | None = None
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime | None = None
 

--- a/src/acemusic/api/routers/models.py
+++ b/src/acemusic/api/routers/models.py
@@ -75,7 +75,12 @@ def _build_models() -> list[ModelInfo]:
     return out
 
 
+# MODELS and _DISPLAY are immutable module constants, so the response is built
+# once at import time rather than per request.
+_MODELS_LIST: list[ModelInfo] = _build_models()
+
+
 @router.get("", response_model=ModelsListResponse)
 def list_models() -> ModelsListResponse:
     """Return all model variants with display metadata for the UI selector."""
-    return ModelsListResponse(models=_build_models())
+    return ModelsListResponse(models=_MODELS_LIST)

--- a/src/acemusic/api/routers/models.py
+++ b/src/acemusic/api/routers/models.py
@@ -1,0 +1,81 @@
+"""Public models-list router (US-16.4), mounted under ``/api/v1/models``.
+
+Exposes the ACE-Step model registry (:data:`acemusic.constants.MODELS`) with
+display-friendly metadata so the web creation UI can render a model selector
+without hard-coding model details on the frontend. Keeping display name,
+category, and the Pro-tier flag server-side means new models or re-grouping
+ship without a frontend change.
+
+The endpoint is **public** (no auth): model info is not sensitive, and the
+selector renders before a user is necessarily authenticated. The ``pro_only``
+flag is a display hint only — generation requests are not yet tier-enforced.
+"""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from acemusic.constants import MODELS
+
+router = APIRouter(prefix="/models", tags=["models"])
+
+# Display metadata layered over the raw MODELS registry. Keyed by model key.
+# ``category`` drives the UI grouping; ``pro_only`` marks the premium XL tier.
+# Source-of-truth model data (description, vram, steps, dit_size) still comes
+# from constants.MODELS so the two can't drift on the technical facts.
+_DISPLAY: dict[str, dict[str, object]] = {
+    "turbo": {"display_name": "Turbo Model", "category": "Turbo", "pro_only": False},
+    "base": {"display_name": "Standard Model", "category": "Standard", "pro_only": False},
+    "sft": {"display_name": "Standard Model (Fine-tuned)", "category": "Standard", "pro_only": False},
+    "xl-base": {"display_name": "Latest Model (XL)", "category": "XL", "pro_only": True},
+    "xl-sft": {"display_name": "Latest Model (XL, Fine-tuned)", "category": "XL", "pro_only": True},
+    "xl-turbo": {"display_name": "Turbo XL", "category": "XL", "pro_only": True},
+}
+
+
+class ModelInfo(BaseModel):
+    """One selectable model variant with display + technical metadata."""
+
+    key: str
+    display_name: str
+    category: str
+    description: str
+    pro_only: bool
+    vram: str
+    steps: str
+    dit_size: str
+
+
+class ModelsListResponse(BaseModel):
+    """All available models for the creation-mode selector."""
+
+    models: list[ModelInfo]
+
+
+def _build_models() -> list[ModelInfo]:
+    out: list[ModelInfo] = []
+    for key, meta in MODELS.items():
+        display = _DISPLAY.get(
+            key,
+            # Fallback so a model added to MODELS without display metadata still
+            # renders (un-grouped, non-Pro) rather than vanishing from the list.
+            {"display_name": key, "category": "Other", "pro_only": False},
+        )
+        out.append(
+            ModelInfo(
+                key=key,
+                display_name=str(display["display_name"]),
+                category=str(display["category"]),
+                description=meta["description"],
+                pro_only=bool(display["pro_only"]),
+                vram=meta["vram"],
+                steps=meta["steps"],
+                dit_size=meta["dit_size"],
+            )
+        )
+    return out
+
+
+@router.get("", response_model=ModelsListResponse)
+def list_models() -> ModelsListResponse:
+    """Return all model variants with display metadata for the UI selector."""
+    return ModelsListResponse(models=_build_models())

--- a/src/acemusic/api/routers/users.py
+++ b/src/acemusic/api/routers/users.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import CreditTransaction, User
 from ..services import credits as credits_service, users as user_service
+from ._validators import validate_model
 
 # Free-text profile fields are stored verbatim and re-served on every
 # GET /users/me, so cap them: one PATCH must not be able to bloat the document
@@ -46,6 +47,7 @@ class UserProfileResponse(BaseModel):
     style_tags: list[str]
     avatar_url: str | None
     subscription_tier: str
+    default_model: str | None
     created_at: datetime
     updated_at: datetime | None
 
@@ -61,6 +63,7 @@ class UserProfileResponse(BaseModel):
             style_tags=user.style_tags,
             avatar_url=user.avatar_url,
             subscription_tier=user.subscription_tier,
+            default_model=user.default_model,
             created_at=user.created_at,
             updated_at=user.updated_at,
         )
@@ -85,6 +88,15 @@ class UserProfileUpdate(BaseModel):
         ]
         | None
     ) = None
+    # US-16.4: preferred default generation model. Null clears the preference.
+    default_model: str | None = None
+
+    @field_validator("default_model")
+    @classmethod
+    def _check_default_model(cls, value: str | None) -> str | None:
+        # Reuses the generation schema's model validator so the allowed set has
+        # one home (constants.VALID_MODELS). None passes through (clear preference).
+        return validate_model(value)
 
     @field_validator("handle")
     @classmethod

--- a/src/acemusic/api/services/users.py
+++ b/src/acemusic/api/services/users.py
@@ -26,7 +26,7 @@ _HANDLE_PATTERN = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$")
 # Only these fields are writable through the profile-update path. Everything else
 # on the User document (email, subscription_tier, oauth_*) is off-limits here so a
 # PATCH body cannot escalate privileges or hijack an OAuth identity.
-_UPDATABLE_FIELDS = ("display_name", "handle", "bio", "style_tags")
+_UPDATABLE_FIELDS = ("display_name", "handle", "bio", "style_tags", "default_model")
 
 
 class HandleValidationError(ValueError):

--- a/tests/test_models_api.py
+++ b/tests/test_models_api.py
@@ -1,0 +1,63 @@
+"""Tests for the public models-list endpoint (US-16.4).
+
+The endpoint is a pure read over :data:`acemusic.constants.MODELS` enriched with
+display metadata, so these tests need no database — they drive the app directly.
+"""
+
+import httpx
+import pytest
+
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.settings import ApiSettings
+from acemusic.constants import MODELS
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def app():
+    # No Mongo needed; minimal settings with a valid-length JWT secret.
+    settings = ApiSettings(jwt_secret_key="test-secret-key-at-least-32-bytes-long-xx")
+    return create_app(settings)
+
+
+@pytest.fixture
+async def client(app):
+    async with _async_client(app) as ac:
+        yield ac
+
+
+class TestListModels:
+    async def test_public_no_auth_required(self, client):
+        resp = await client.get(f"{API_V1_PREFIX}/models")
+        assert resp.status_code == 200
+
+    async def test_returns_all_registry_models(self, client):
+        resp = await client.get(f"{API_V1_PREFIX}/models")
+        body = resp.json()
+        keys = {m["key"] for m in body["models"]}
+        assert keys == set(MODELS.keys())
+
+    async def test_each_model_has_display_and_technical_metadata(self, client):
+        resp = await client.get(f"{API_V1_PREFIX}/models")
+        for m in resp.json()["models"]:
+            for field in ("key", "display_name", "category", "description", "pro_only", "vram", "steps", "dit_size"):
+                assert field in m, f"{m['key']} missing {field}"
+            # Technical fields mirror the constants registry exactly.
+            assert m["description"] == MODELS[m["key"]]["description"]
+            assert m["vram"] == MODELS[m["key"]]["vram"]
+            assert m["dit_size"] == MODELS[m["key"]]["dit_size"]
+
+    async def test_xl_variants_marked_pro_only(self, client):
+        resp = await client.get(f"{API_V1_PREFIX}/models")
+        by_key = {m["key"]: m for m in resp.json()["models"]}
+        assert by_key["xl-base"]["pro_only"] is True
+        assert by_key["xl-sft"]["pro_only"] is True
+        assert by_key["xl-turbo"]["pro_only"] is True
+        # Non-XL variants are available to all tiers.
+        assert by_key["base"]["pro_only"] is False
+        assert by_key["turbo"]["pro_only"] is False
+        assert by_key["sft"]["pro_only"] is False

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -79,6 +79,46 @@ class TestUpdateProfile:
         assert body["bio"] == "b"
         assert body["style_tags"] == ["edm"]
 
+    async def test_default_model_defaults_to_null(self, client, settings):
+        user = await _make_user("dm-default@example.com")
+        resp = await client.get(f"{API_V1_PREFIX}/users/me", headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert resp.json()["default_model"] is None
+
+    async def test_updates_default_model(self, client, settings):
+        user = await _make_user("dm-set@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"default_model": "xl-base"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["default_model"] == "xl-base"
+
+    async def test_invalid_default_model_returns_422(self, client, settings):
+        user = await _make_user("dm-bad@example.com")
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"default_model": "not-a-real-model"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_default_model_can_be_cleared(self, client, settings):
+        user = await _make_user("dm-clear@example.com")
+        await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"default_model": "turbo"},
+            headers=_auth_headers(user, settings),
+        )
+        resp = await client.patch(
+            f"{API_V1_PREFIX}/users/me",
+            json={"default_model": None},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["default_model"] is None
+
     async def test_invalid_handle_returns_422(self, client, settings):
         user = await _make_user("bad-handle@example.com")
         resp = await client.patch(

--- a/web/app/api/models/route.ts
+++ b/web/app/api/models/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for the public models list (US-16.4). The backend endpoint
+// requires no auth (model metadata is not sensitive), so this route forwards no
+// Authorization header — it just keeps the backend URL server-side. Backend
+// status/body pass through verbatim.
+
+const TARGET = `${BACKEND_URL}/api/v1/models`
+
+export async function GET(): Promise<NextResponse> {
+  let res: Response
+  try {
+    res = await fetch(TARGET, { headers: { accept: "application/json" } })
+  } catch {
+    return NextResponse.json(
+      { detail: "Model service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/models/route.ts
+++ b/web/app/api/models/route.ts
@@ -9,10 +9,19 @@ import { BACKEND_URL } from "@/lib/auth-server"
 
 const TARGET = `${BACKEND_URL}/api/v1/models`
 
+// The list only changes on deploy, so cache the proxied response — every Create
+// page visit otherwise incurs a backend round-trip.
+export const revalidate = 3600
+
 export async function GET(): Promise<NextResponse> {
   let res: Response
   try {
-    res = await fetch(TARGET, { headers: { accept: "application/json" } })
+    // Bound the upstream call so a hung backend can't block this route
+    // indefinitely — the catch returns the 502 fallback promptly.
+    res = await fetch(TARGET, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    })
   } catch {
     return NextResponse.json(
       { detail: "Model service is unavailable." },

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -5,6 +5,8 @@ import { useRequireAuth } from "@/hooks/use-require-auth"
 import { SimpleCreationForm } from "@/components/create/SimpleCreationForm"
 import { AdvancedCreationForm } from "@/components/create/AdvancedCreationForm"
 import { SoundsCreationForm } from "@/components/create/SoundsCreationForm"
+import { ModelSelector } from "@/components/create/ModelSelector"
+import { ModelSelectionProvider } from "@/contexts/model-selection-context"
 
 export default function CreatePage() {
   const { isLoading, isAuthenticated } = useRequireAuth()
@@ -14,24 +16,31 @@ export default function CreatePage() {
   if (isLoading || !isAuthenticated) return null
 
   return (
-    <div className="p-8">
-      <h1 className="mb-6 text-2xl font-semibold">Create</h1>
-      <Tabs defaultValue="simple">
-        <TabsList>
-          <TabsTrigger value="simple">Simple</TabsTrigger>
-          <TabsTrigger value="advanced">Advanced</TabsTrigger>
-          <TabsTrigger value="sounds">Sounds</TabsTrigger>
-        </TabsList>
-        <TabsContent value="simple">
-          <SimpleCreationForm />
-        </TabsContent>
-        <TabsContent value="advanced">
-          <AdvancedCreationForm />
-        </TabsContent>
-        <TabsContent value="sounds">
-          <SoundsCreationForm />
-        </TabsContent>
-      </Tabs>
-    </div>
+    // The provider wraps the tabs so the selected model persists across tab
+    // switches (US-16.4); the selector sits in the header, outside the Tabs.
+    <ModelSelectionProvider>
+      <div className="p-8">
+        <div className="mb-6 flex items-center justify-between gap-4">
+          <h1 className="text-2xl font-semibold">Create</h1>
+          <ModelSelector />
+        </div>
+        <Tabs defaultValue="simple">
+          <TabsList>
+            <TabsTrigger value="simple">Simple</TabsTrigger>
+            <TabsTrigger value="advanced">Advanced</TabsTrigger>
+            <TabsTrigger value="sounds">Sounds</TabsTrigger>
+          </TabsList>
+          <TabsContent value="simple">
+            <SimpleCreationForm />
+          </TabsContent>
+          <TabsContent value="advanced">
+            <AdvancedCreationForm />
+          </TabsContent>
+          <TabsContent value="sounds">
+            <SoundsCreationForm />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </ModelSelectionProvider>
   )
 }

--- a/web/app/settings/page.test.tsx
+++ b/web/app/settings/page.test.tsx
@@ -146,6 +146,23 @@ describe("SettingsPage", () => {
     expect(JSON.parse(patch[1].body)).toEqual({ default_model: "xl-base" })
   })
 
+  it("disables the default-model select when the models list fails to load", async () => {
+    // Route /api/models to a 500 so the dropdown can't populate; the select must
+    // disable rather than show "No preference" over a still-set saved value.
+    const fetchMock = vi.fn((url: unknown) =>
+      Promise.resolve(
+        typeof url === "string" && url.includes("/api/models")
+          ? jsonRes({}, 500)
+          : jsonRes(PROFILE)
+      )
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    renderPage()
+
+    const select = await screen.findByLabelText("Default model")
+    expect(select).toBeDisabled()
+  })
+
   it("gives real-time format feedback on the handle as you type", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(PROFILE)))
     const user = userEvent.setup()

--- a/web/app/settings/page.test.tsx
+++ b/web/app/settings/page.test.tsx
@@ -43,6 +43,51 @@ function jsonRes(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { status })
 }
 
+const MODELS = [
+  {
+    key: "base",
+    display_name: "Standard Model",
+    category: "Standard",
+    description: "Balanced quality/speed",
+    pro_only: false,
+    vram: "~2.4GB",
+    steps: "32-64",
+    dit_size: "2B",
+  },
+  {
+    key: "xl-base",
+    display_name: "Latest Model (XL)",
+    category: "XL",
+    description: "Highest quality",
+    pro_only: true,
+    vram: "~8GB",
+    steps: "32-64",
+    dit_size: "4B",
+  },
+]
+
+// fetch mock that routes /api/models (the default-model dropdown, US-16.4) to a
+// fixed model list and serves the given responses, in order, for /api/users/me.
+// This keeps model-list loading from disturbing the profile load/save sequence.
+function meFetch(...meResponses: Response[]) {
+  let i = 0
+  return vi.fn((url: unknown) => {
+    if (typeof url === "string" && url.includes("/api/models")) {
+      return Promise.resolve(jsonRes({ models: MODELS }))
+    }
+    const res = meResponses[Math.min(i, meResponses.length - 1)]
+    i += 1
+    return Promise.resolve(res)
+  })
+}
+
+// The PATCH/GET calls to /api/users/me, filtered out from the models call.
+function meCalls(mock: ReturnType<typeof vi.fn>) {
+  return mock.mock.calls.filter(
+    ([url]) => typeof url === "string" && url.includes("/api/users/me")
+  )
+}
+
 afterEach(() => vi.restoreAllMocks())
 
 describe("SettingsPage", () => {
@@ -57,10 +102,10 @@ describe("SettingsPage", () => {
   })
 
   it("saves changed fields and shows a success message", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonRes(PROFILE))
-      .mockResolvedValueOnce(jsonRes({ ...PROFILE, display_name: "Ada L" }))
+    const fetchMock = meFetch(
+      jsonRes(PROFILE),
+      jsonRes({ ...PROFILE, display_name: "Ada L" })
+    )
     vi.stubGlobal("fetch", fetchMock)
     const user = userEvent.setup()
     renderPage()
@@ -73,9 +118,32 @@ describe("SettingsPage", () => {
     await waitFor(() =>
       expect(screen.getByRole("status")).toHaveTextContent("Saved.")
     )
-    const patch = fetchMock.mock.calls[1]
+    const patch = meCalls(fetchMock)[1]
     expect(patch[1].method).toBe("PATCH")
     expect(JSON.parse(patch[1].body)).toEqual({ display_name: "Ada L" })
+  })
+
+  it("saves the chosen default model (US-16.4)", async () => {
+    const fetchMock = meFetch(
+      jsonRes(PROFILE),
+      jsonRes({ ...PROFILE, default_model: "xl-base" })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    renderPage()
+
+    const select = await screen.findByLabelText("Default model")
+    // The options populate after fetchModels() resolves.
+    await screen.findByRole("option", { name: /Latest Model \(XL\)/ })
+    await user.selectOptions(select, "xl-base")
+    await user.click(screen.getByRole("button", { name: /Save changes/ }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Saved.")
+    )
+    const patch = meCalls(fetchMock)[1]
+    expect(patch[1].method).toBe("PATCH")
+    expect(JSON.parse(patch[1].body)).toEqual({ default_model: "xl-base" })
   })
 
   it("gives real-time format feedback on the handle as you type", async () => {
@@ -113,10 +181,7 @@ describe("SettingsPage", () => {
   })
 
   it("hides 'Looks good' when a save fails with a form-level error", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonRes(PROFILE))
-      .mockResolvedValueOnce(jsonRes({}, 500))
+    const fetchMock = meFetch(jsonRes(PROFILE), jsonRes({}, 500))
     vi.stubGlobal("fetch", fetchMock)
     const user = userEvent.setup()
     renderPage()
@@ -136,10 +201,7 @@ describe("SettingsPage", () => {
   })
 
   it("shows an inline error when the handle is already taken (409)", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonRes(PROFILE))
-      .mockResolvedValueOnce(jsonRes({ detail: "taken" }, 409))
+    const fetchMock = meFetch(jsonRes(PROFILE), jsonRes({ detail: "taken" }, 409))
     vi.stubGlobal("fetch", fetchMock)
     const user = userEvent.setup()
     renderPage()
@@ -197,7 +259,7 @@ describe("SettingsPage", () => {
   })
 
   it("skips the network round-trip when only trailing whitespace changed", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(jsonRes(PROFILE))
+    const fetchMock = meFetch(jsonRes(PROFILE))
     vi.stubGlobal("fetch", fetchMock)
     const user = userEvent.setup()
     renderPage()
@@ -209,7 +271,7 @@ describe("SettingsPage", () => {
     await waitFor(() =>
       expect(screen.getByRole("status")).toHaveTextContent("Saved.")
     )
-    // Only the mount GET fired — no PATCH.
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // Only the mount GET fired against /api/users/me — no PATCH.
+    expect(meCalls(fetchMock)).toHaveLength(1)
   })
 })

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -35,12 +35,15 @@ import {
   type UserProfile,
   type UserProfileUpdate,
 } from "@/lib/profile"
+import { fetchModels, type ModelInfo } from "@/lib/models"
 
 type FormState = {
   display_name: string
   handle: string
   bio: string
   style_tags: string[]
+  /** "" = no preference (cleared); otherwise a model key (US-16.4). */
+  default_model: string
 }
 
 function toForm(p: UserProfile): FormState {
@@ -49,6 +52,7 @@ function toForm(p: UserProfile): FormState {
     handle: p.handle ?? "",
     bio: p.bio ?? "",
     style_tags: p.style_tags,
+    default_model: p.default_model ?? "",
   }
 }
 
@@ -62,6 +66,7 @@ function SettingsForm({
   const initial = useMemo(() => toForm(profile), [profile])
   const [form, setForm] = useState<FormState>(initial)
   const [baseline, setBaseline] = useState<FormState>(initial)
+  const [models, setModels] = useState<ModelInfo[]>([])
   const [errors, setErrors] = useState<FieldErrors>({})
   const [handleHint, setHandleHint] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
@@ -72,6 +77,20 @@ function SettingsForm({
     () => JSON.stringify(form) !== JSON.stringify(baseline),
     [form, baseline]
   )
+
+  // Populate the default-model dropdown (US-16.4). Failure leaves it empty, so
+  // the field just shows "No preference" and the rest of the form still works.
+  useEffect(() => {
+    let active = true
+    fetchModels()
+      .then((list) => {
+        if (active) setModels(list)
+      })
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [])
 
   // Real-time (debounced) handle format feedback. Server uniqueness is only
   // known on save, surfaced as a 409 below.
@@ -122,6 +141,9 @@ function SettingsForm({
     if (trimmedBio !== baseline.bio) payload.bio = trimmedBio
     if (JSON.stringify(form.style_tags) !== JSON.stringify(baseline.style_tags))
       payload.style_tags = form.style_tags
+    // "" means "clear preference" → send null so the backend unsets it.
+    if (form.default_model !== baseline.default_model)
+      payload.default_model = form.default_model === "" ? null : form.default_model
 
     // Nothing actually changed once normalized — just re-sync the form to the
     // trimmed values and report success without a wasted round-trip.
@@ -268,6 +290,27 @@ function SettingsForm({
                 onChange={(next) => update("style_tags", next)}
               />
               <FieldError message={errors.style_tags} />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="default_model">Default model</Label>
+              <select
+                id="default_model"
+                value={form.default_model}
+                onChange={(e) => update("default_model", e.target.value)}
+                className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              >
+                <option value="">No preference</option>
+                {models.map((m) => (
+                  <option key={m.key} value={m.key}>
+                    {m.display_name}
+                    {m.pro_only ? " (Pro)" : ""}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">
+                Used as the starting model on the Create page.
+              </p>
             </div>
           </fieldset>
         </CardContent>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -294,11 +294,15 @@ function SettingsForm({
 
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="default_model">Default model</Label>
+              {/* Disabled until the list loads: with an empty list the select
+                  would show "No preference" while the saved value is still set,
+                  so a click could silently clear the user's real preference. */}
               <select
                 id="default_model"
                 value={form.default_model}
                 onChange={(e) => update("default_model", e.target.value)}
-                className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                disabled={models.length === 0}
+                className="h-9 rounded-md border border-input bg-transparent px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <option value="">No preference</option>
                 {models.map((m) => (

--- a/web/components/create/AdvancedCreationForm.test.tsx
+++ b/web/components/create/AdvancedCreationForm.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ accessToken: "tok" }),
 }))
 
+vi.mock("@/contexts/model-selection-context", () => ({
+  useModelSelection: () => ({ selectedModel: "base" }),
+}))
+
 const submitAdvancedGeneration = vi.fn()
 vi.mock("@/lib/generate", async (importActual) => {
   const actual = await importActual<typeof import("@/lib/generate")>()
@@ -105,7 +109,8 @@ describe("AdvancedCreationForm", () => {
 
     expect(submitAdvancedGeneration).toHaveBeenCalledWith(
       expect.objectContaining({ styles: "orchestral" }),
-      "tok"
+      "tok",
+      "base"
     )
     expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
   })

--- a/web/components/create/AdvancedCreationForm.test.tsx
+++ b/web/components/create/AdvancedCreationForm.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@/hooks/use-auth", () => ({
 }))
 
 vi.mock("@/contexts/model-selection-context", () => ({
-  useModelSelection: () => ({ selectedModel: "base" }),
+  useModelSelection: () => ({ selectedModel: "base", isLoading: false }),
 }))
 
 const submitAdvancedGeneration = vi.fn()

--- a/web/components/create/AdvancedCreationForm.tsx
+++ b/web/components/create/AdvancedCreationForm.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/hooks/use-auth"
+import { useModelSelection } from "@/contexts/model-selection-context"
 import { InspirationTags } from "@/components/create/InspirationTags"
 import { MoreOptionsSection, type MoreOptions } from "@/components/create/MoreOptionsSection"
 import { useUndoableField } from "@/components/create/useUndoableField"
@@ -59,6 +60,7 @@ const initialOptions: MoreOptions = {
 export function AdvancedCreationForm() {
   const router = useRouter()
   const { accessToken } = useAuth()
+  const { selectedModel } = useModelSelection()
 
   const lyricsField = useUndoableField("")
   const stylesField = useUndoableField("")
@@ -115,7 +117,7 @@ export function AdvancedCreationForm() {
     }
     setIsSubmitting(true)
     try {
-      const result = await submitAdvancedGeneration(data, accessToken)
+      const result = await submitAdvancedGeneration(data, accessToken, selectedModel)
       switch (result.status) {
         case "accepted":
           setStatus({

--- a/web/components/create/AdvancedCreationForm.tsx
+++ b/web/components/create/AdvancedCreationForm.tsx
@@ -60,7 +60,7 @@ const initialOptions: MoreOptions = {
 export function AdvancedCreationForm() {
   const router = useRouter()
   const { accessToken } = useAuth()
-  const { selectedModel } = useModelSelection()
+  const { selectedModel, isLoading: modelLoading } = useModelSelection()
 
   const lyricsField = useUndoableField("")
   const stylesField = useUndoableField("")
@@ -104,7 +104,7 @@ export function AdvancedCreationForm() {
   }
 
   async function handleCreate() {
-    if (!canSubmit || isSubmitting) return
+    if (!canSubmit || isSubmitting || modelLoading) return
     if (!accessToken) {
       router.push("/login")
       return
@@ -285,7 +285,7 @@ export function AdvancedCreationForm() {
       <Button
         type="button"
         className="w-fit"
-        disabled={!canSubmit || isSubmitting}
+        disabled={!canSubmit || isSubmitting || modelLoading}
         onClick={handleCreate}
       >
         {isSubmitting ? "Creating..." : "Create"}

--- a/web/components/create/ModelSelector.test.tsx
+++ b/web/components/create/ModelSelector.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ModelSelector } from "@/components/create/ModelSelector"
+import type { ModelInfo } from "@/lib/models"
+
+const setSelectedModel = vi.fn()
+let ctx: {
+  models: ModelInfo[]
+  selectedModel: string
+  setSelectedModel: typeof setSelectedModel
+  subscriptionTier: string
+  isLoading: boolean
+}
+
+vi.mock("@/contexts/model-selection-context", () => ({
+  useModelSelection: () => ctx,
+}))
+
+const MODELS: ModelInfo[] = [
+  {
+    key: "base",
+    display_name: "Standard Model",
+    category: "Standard",
+    description: "Balanced quality/speed",
+    pro_only: false,
+    vram: "~2.4GB",
+    steps: "32-64",
+    dit_size: "2B",
+  },
+  {
+    key: "xl-base",
+    display_name: "Latest Model (XL)",
+    category: "XL",
+    description: "Highest quality",
+    pro_only: true,
+    vram: "~8GB",
+    steps: "32-64",
+    dit_size: "4B",
+  },
+]
+
+function setCtx(overrides: Partial<typeof ctx> = {}) {
+  ctx = {
+    models: MODELS,
+    selectedModel: "base",
+    setSelectedModel,
+    subscriptionTier: "free",
+    isLoading: false,
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("ModelSelector", () => {
+  it("shows the selected model's display name on the trigger", () => {
+    setCtx({ selectedModel: "xl-base" })
+    render(<ModelSelector />)
+    expect(
+      screen.getByTestId("model-selector-trigger")
+    ).toHaveTextContent("Latest Model (XL)")
+  })
+
+  it("lists models with a Pro badge on pro-only options", async () => {
+    setCtx()
+    const user = userEvent.setup()
+    render(<ModelSelector />)
+
+    await user.click(screen.getByTestId("model-selector-trigger"))
+    expect(screen.getByTestId("model-option-base")).toBeInTheDocument()
+    const pro = screen.getByTestId("model-option-xl-base")
+    expect(pro).toHaveTextContent("Pro")
+    // Free-tier users still see (and can select) Pro models — display only.
+    expect(pro).not.toBeDisabled()
+  })
+
+  it("selecting a model calls setSelectedModel with its key", async () => {
+    setCtx()
+    const user = userEvent.setup()
+    render(<ModelSelector />)
+
+    await user.click(screen.getByTestId("model-selector-trigger"))
+    await user.click(screen.getByTestId("model-option-xl-base"))
+    expect(setSelectedModel).toHaveBeenCalledWith("xl-base")
+  })
+
+  it("renders an empty state when no models are available", async () => {
+    setCtx({ models: [] })
+    const user = userEvent.setup()
+    render(<ModelSelector />)
+
+    await user.click(screen.getByTestId("model-selector-trigger"))
+    expect(screen.getByText(/no models available/i)).toBeInTheDocument()
+  })
+})

--- a/web/components/create/ModelSelector.tsx
+++ b/web/components/create/ModelSelector.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowDown01Icon, LockIcon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useModelSelection } from "@/contexts/model-selection-context"
+import { groupByCategory } from "@/lib/models"
+
+/**
+ * Model/version selector (US-16.4). A badge-style dropdown showing the current
+ * model, with options grouped by category. Pro-only models display a Pro badge
+ * and a lock icon for free-tier users (display only — selection is not yet
+ * tier-enforced on the backend). Rendered once above the creation tabs so the
+ * choice persists as the user switches between Simple, Advanced, and Sounds.
+ */
+export function ModelSelector() {
+  const { models, selectedModel, setSelectedModel, subscriptionTier } =
+    useModelSelection()
+  const isFreeTier = subscriptionTier !== "pro"
+
+  const current = models.find((m) => m.key === selectedModel)
+  const triggerLabel = current?.display_name ?? "Select model"
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label="Select model"
+          data-testid="model-selector-trigger"
+        >
+          {triggerLabel}
+          <HugeiconsIcon icon={ArrowDown01Icon} data-icon="inline-end" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        {models.length === 0 ? (
+          <DropdownMenuItem disabled>No models available</DropdownMenuItem>
+        ) : (
+          groupByCategory(models).map(([category, group], groupIndex) => (
+            <div key={category}>
+              {groupIndex > 0 && <DropdownMenuSeparator />}
+              <DropdownMenuLabel>{category}</DropdownMenuLabel>
+              {group.map((model) => {
+                const locked = model.pro_only && isFreeTier
+                return (
+                  <DropdownMenuItem
+                    key={model.key}
+                    onSelect={() => setSelectedModel(model.key)}
+                    className="flex flex-col items-start gap-0.5"
+                    data-testid={`model-option-${model.key}`}
+                    data-selected={model.key === selectedModel}
+                  >
+                    <div className="flex w-full items-center gap-2">
+                      <span className="font-medium">{model.display_name}</span>
+                      {model.pro_only && (
+                        <Badge variant="secondary" className="ml-auto">
+                          {locked && (
+                            <HugeiconsIcon
+                              icon={LockIcon}
+                              data-icon="inline-start"
+                            />
+                          )}
+                          Pro
+                        </Badge>
+                      )}
+                    </div>
+                    <span className="line-clamp-1 text-xs text-muted-foreground">
+                      {model.description}
+                    </span>
+                  </DropdownMenuItem>
+                )
+              })}
+            </div>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/components/create/SimpleCreationForm.test.tsx
+++ b/web/components/create/SimpleCreationForm.test.tsx
@@ -9,7 +9,7 @@ vi.mock("@/hooks/use-auth", () => ({
 }))
 
 vi.mock("@/contexts/model-selection-context", () => ({
-  useModelSelection: () => ({ selectedModel: "base" }),
+  useModelSelection: () => ({ selectedModel: "base", isLoading: false }),
 }))
 
 const submitGeneration = vi.fn()

--- a/web/components/create/SimpleCreationForm.test.tsx
+++ b/web/components/create/SimpleCreationForm.test.tsx
@@ -8,6 +8,10 @@ vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ accessToken: "tok" }),
 }))
 
+vi.mock("@/contexts/model-selection-context", () => ({
+  useModelSelection: () => ({ selectedModel: "base" }),
+}))
+
 const submitGeneration = vi.fn()
 vi.mock("@/lib/generate", () => ({
   submitGeneration: (...args: unknown[]) => submitGeneration(...args),
@@ -83,7 +87,8 @@ describe("SimpleCreationForm", () => {
 
     expect(submitGeneration).toHaveBeenCalledWith(
       expect.objectContaining({ description: "dreamy", instrumental: true }),
-      "tok"
+      "tok",
+      "base"
     )
     expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
   })

--- a/web/components/create/SimpleCreationForm.tsx
+++ b/web/components/create/SimpleCreationForm.tsx
@@ -32,7 +32,7 @@ type Status =
 export function SimpleCreationForm() {
   const router = useRouter()
   const { accessToken } = useAuth()
-  const { selectedModel } = useModelSelection()
+  const { selectedModel, isLoading: modelLoading } = useModelSelection()
 
   const [description, setDescription] = useState("")
   const [instrumental, setInstrumental] = useState(false)
@@ -52,7 +52,8 @@ export function SimpleCreationForm() {
     description.trim().length > 0 || effectiveLyrics.trim().length > 0
 
   async function handleCreate() {
-    if (!canSubmit || isSubmitting) return
+    // Block until the model context settles so a saved default isn't missed.
+    if (!canSubmit || isSubmitting || modelLoading) return
     if (!accessToken) {
       router.push("/login")
       return
@@ -161,7 +162,7 @@ export function SimpleCreationForm() {
       <Button
         type="button"
         className="w-fit"
-        disabled={!canSubmit || isSubmitting}
+        disabled={!canSubmit || isSubmitting || modelLoading}
         onClick={handleCreate}
       >
         {isSubmitting ? "Creating..." : "Create"}

--- a/web/components/create/SimpleCreationForm.tsx
+++ b/web/components/create/SimpleCreationForm.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/hooks/use-auth"
+import { useModelSelection } from "@/contexts/model-selection-context"
 import { submitGeneration } from "@/lib/generate"
 import { InspirationTags } from "@/components/create/InspirationTags"
 
@@ -31,6 +32,7 @@ type Status =
 export function SimpleCreationForm() {
   const router = useRouter()
   const { accessToken } = useAuth()
+  const { selectedModel } = useModelSelection()
 
   const [description, setDescription] = useState("")
   const [instrumental, setInstrumental] = useState(false)
@@ -59,7 +61,8 @@ export function SimpleCreationForm() {
     try {
       const result = await submitGeneration(
         { description, lyrics: effectiveLyrics, instrumental, selectedTags },
-        accessToken
+        accessToken,
+        selectedModel
       )
       switch (result.status) {
         case "accepted":

--- a/web/components/create/SoundsCreationForm.test.tsx
+++ b/web/components/create/SoundsCreationForm.test.tsx
@@ -8,6 +8,10 @@ vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ accessToken: "tok" }),
 }))
 
+vi.mock("@/contexts/model-selection-context", () => ({
+  useModelSelection: () => ({ selectedModel: "base" }),
+}))
+
 // Stubbed so the unauthorized path's router.push("/login") never throws.
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -68,7 +72,8 @@ describe("SoundsCreationForm", () => {
 
     expect(submitSoundsGeneration).toHaveBeenCalledWith(
       expect.objectContaining({ description: "a punchy kick", soundType: "one-shot" }),
-      "tok"
+      "tok",
+      "base"
     )
     expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
   })
@@ -87,7 +92,8 @@ describe("SoundsCreationForm", () => {
 
     expect(submitSoundsGeneration).toHaveBeenCalledWith(
       expect.objectContaining({ soundType: "loop", bpm: "128", key: "A minor" }),
-      "tok"
+      "tok",
+      "base"
     )
     // Guard the loop success-message branch separately from the one-shot one.
     expect(await screen.findByRole("status")).toHaveTextContent(/started/i)

--- a/web/components/create/SoundsCreationForm.test.tsx
+++ b/web/components/create/SoundsCreationForm.test.tsx
@@ -9,7 +9,7 @@ vi.mock("@/hooks/use-auth", () => ({
 }))
 
 vi.mock("@/contexts/model-selection-context", () => ({
-  useModelSelection: () => ({ selectedModel: "base" }),
+  useModelSelection: () => ({ selectedModel: "base", isLoading: false }),
 }))
 
 // Stubbed so the unauthorized path's router.push("/login") never throws.

--- a/web/components/create/SoundsCreationForm.tsx
+++ b/web/components/create/SoundsCreationForm.tsx
@@ -36,7 +36,7 @@ const SOUND_TYPES = [
 export function SoundsCreationForm() {
   const router = useRouter()
   const { accessToken } = useAuth()
-  const { selectedModel } = useModelSelection()
+  const { selectedModel, isLoading: modelLoading } = useModelSelection()
 
   const [description, setDescription] = useState("")
   const [soundType, setSoundType] = useState<SoundsFormData["soundType"]>("")
@@ -57,7 +57,7 @@ export function SoundsCreationForm() {
   }
 
   async function handleCreate() {
-    if (!canSubmit || isSubmitting) return
+    if (!canSubmit || isSubmitting || modelLoading) return
     if (!accessToken) {
       router.push("/login")
       return
@@ -180,7 +180,7 @@ export function SoundsCreationForm() {
       <Button
         type="button"
         className="w-fit"
-        disabled={!canSubmit || isSubmitting}
+        disabled={!canSubmit || isSubmitting || modelLoading}
         onClick={handleCreate}
       >
         {isSubmitting ? "Creating..." : "Create"}

--- a/web/components/create/SoundsCreationForm.tsx
+++ b/web/components/create/SoundsCreationForm.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/hooks/use-auth"
+import { useModelSelection } from "@/contexts/model-selection-context"
 import { submitSoundsGeneration, validateSounds, type SoundsFormData } from "@/lib/generate"
 import { BPM_MAX, BPM_MIN, KEY_OPTIONS, PROMPT_MAX_LENGTH } from "@/lib/constants/generation"
 import { SELECT_CLASS } from "@/lib/constants/ui"
@@ -35,6 +36,7 @@ const SOUND_TYPES = [
 export function SoundsCreationForm() {
   const router = useRouter()
   const { accessToken } = useAuth()
+  const { selectedModel } = useModelSelection()
 
   const [description, setDescription] = useState("")
   const [soundType, setSoundType] = useState<SoundsFormData["soundType"]>("")
@@ -68,7 +70,7 @@ export function SoundsCreationForm() {
     }
     setIsSubmitting(true)
     try {
-      const result = await submitSoundsGeneration(data, accessToken)
+      const result = await submitSoundsGeneration(data, accessToken, selectedModel)
       switch (result.status) {
         case "accepted":
           setStatus({

--- a/web/contexts/model-selection-context.test.tsx
+++ b/web/contexts/model-selection-context.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  ModelSelectionProvider,
+  useModelSelection,
+} from "@/contexts/model-selection-context"
+
+let auth: { accessToken: string | null; isLoading: boolean }
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => auth,
+}))
+
+function jsonRes(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status })
+}
+
+const MODELS = [
+  {
+    key: "base",
+    display_name: "Standard Model",
+    category: "Standard",
+    description: "Balanced",
+    pro_only: false,
+    vram: "~2.4GB",
+    steps: "32-64",
+    dit_size: "2B",
+  },
+  {
+    key: "xl-base",
+    display_name: "Latest Model (XL)",
+    category: "XL",
+    description: "Highest quality",
+    pro_only: true,
+    vram: "~8GB",
+    steps: "32-64",
+    dit_size: "4B",
+  },
+]
+
+function Probe() {
+  const { selectedModel, isLoading, setSelectedModel } = useModelSelection()
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="selected">{selectedModel}</span>
+      <button onClick={() => setSelectedModel("xl-base")}>pick-xl</button>
+    </div>
+  )
+}
+
+// Routes /api/models and /api/users/me; the profile call resolves only when
+// `releaseProfile` is invoked, so we can observe the pre-seed window.
+function routedFetch(profile: unknown) {
+  let release: (() => void) | null = null
+  const ready = new Promise<void>((r) => {
+    release = r
+  })
+  const fetchMock = vi.fn(async (url: unknown) => {
+    if (typeof url === "string" && url.includes("/api/models")) {
+      return jsonRes({ models: MODELS })
+    }
+    await ready // gate the profile response
+    return jsonRes(profile)
+  })
+  return { fetchMock, releaseProfile: () => release?.() }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("ModelSelectionProvider", () => {
+  it("stays loading until the profile seed resolves, then applies the saved default", async () => {
+    auth = { accessToken: "tok", isLoading: false }
+    const { fetchMock, releaseProfile } = routedFetch({
+      subscription_tier: "free",
+      default_model: "xl-base",
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(
+      <ModelSelectionProvider>
+        <Probe />
+      </ModelSelectionProvider>
+    )
+
+    // Before the profile resolves, the context must report loading so consumers
+    // don't submit the provisional "base" over the user's saved default.
+    await waitFor(() =>
+      expect(screen.getByTestId("loading")).toHaveTextContent("true")
+    )
+
+    releaseProfile()
+    await waitFor(() =>
+      expect(screen.getByTestId("loading")).toHaveTextContent("false")
+    )
+    expect(screen.getByTestId("selected")).toHaveTextContent("xl-base")
+  })
+
+  it("keeps a user's pick over a late-arriving saved default", async () => {
+    auth = { accessToken: "tok", isLoading: false }
+    const { fetchMock, releaseProfile } = routedFetch({
+      subscription_tier: "free",
+      default_model: "base",
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+
+    render(
+      <ModelSelectionProvider>
+        <Probe />
+      </ModelSelectionProvider>
+    )
+
+    await user.click(await screen.findByRole("button", { name: "pick-xl" }))
+    releaseProfile()
+    // The profile default ("base") must not clobber the explicit pick.
+    await waitFor(() =>
+      expect(screen.getByTestId("loading")).toHaveTextContent("false")
+    )
+    expect(screen.getByTestId("selected")).toHaveTextContent("xl-base")
+  })
+})

--- a/web/contexts/model-selection-context.tsx
+++ b/web/contexts/model-selection-context.tsx
@@ -74,8 +74,13 @@ export function ModelSelectionProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (authLoading || !accessToken) return
     let active = true
+    // Bound the fetch: isLoading is gated on seedResolved (set in .finally), so a
+    // hung profile request would otherwise leave the Create buttons permanently
+    // disabled. On abort, .catch keeps the default model/free tier and .finally
+    // still resolves the seed.
     fetch("/api/users/me", {
       headers: { authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(5000),
     })
       .then(async (res) => (res.ok ? ((await res.json()) as UserProfile) : null))
       .then((profile) => {

--- a/web/contexts/model-selection-context.tsx
+++ b/web/contexts/model-selection-context.tsx
@@ -71,6 +71,12 @@ export function ModelSelectionProvider({ children }: { children: ReactNode }) {
   // their tier for Pro-lock display). Skipped if the user already picked one.
   // The no-token case is handled in the isLoading derivation below (no seeding
   // to wait for), so this effect only runs the authenticated fetch.
+  //
+  // ponytail: deliberately does NOT reset seedResolved/userTouched when
+  // accessToken changes. In this app accessToken flips null→token once on mount
+  // (auth-context restores it once; logout navigates away and unmounts this
+  // provider), so the re-fetch window never occurs in practice — and resetting
+  // userTouched would risk clobbering a model the user explicitly picked.
   useEffect(() => {
     if (authLoading || !accessToken) return
     let active = true

--- a/web/contexts/model-selection-context.tsx
+++ b/web/contexts/model-selection-context.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import { DEFAULT_MODEL_KEY, fetchModels, type ModelInfo } from "@/lib/models"
+import type { UserProfile } from "@/lib/profile"
+
+// Session-scoped model selection (US-16.4). Mounted at the Create page so the
+// chosen model persists across the Simple/Advanced/Sounds tabs (the selector
+// lives outside the Tabs, so its state survives tab switches). Deliberately NOT
+// persisted to localStorage — the requirement is "within the same session".
+
+type ModelSelectionValue = {
+  models: ModelInfo[]
+  selectedModel: string
+  setSelectedModel: (key: string) => void
+  /** Subscription tier of the current user ("free" until the profile loads). */
+  subscriptionTier: string
+  isLoading: boolean
+}
+
+const ModelSelectionContext = createContext<ModelSelectionValue | null>(null)
+
+export function ModelSelectionProvider({ children }: { children: ReactNode }) {
+  const { accessToken } = useAuth()
+  const [models, setModels] = useState<ModelInfo[]>([])
+  const [selectedModel, setSelectedModelState] = useState<string>(DEFAULT_MODEL_KEY)
+  const [subscriptionTier, setSubscriptionTier] = useState("free")
+  const [isLoading, setIsLoading] = useState(true)
+  // Once the user picks a model, a late-arriving profile default must not clobber
+  // their choice — this guards the default-seeding effect.
+  const userTouched = useRef(false)
+
+  const setSelectedModel = (key: string) => {
+    userTouched.current = true
+    setSelectedModelState(key)
+  }
+
+  // Fetch the public models list once on mount.
+  useEffect(() => {
+    let active = true
+    fetchModels()
+      .then((list) => {
+        if (active) setModels(list)
+      })
+      .catch(() => {
+        // Leave models empty; the selector renders a graceful empty state.
+      })
+      .finally(() => {
+        if (active) setIsLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  // Seed the initial selection from the user's saved default_model (and read
+  // their tier for Pro-lock display). Skipped if the user already picked one.
+  useEffect(() => {
+    if (!accessToken) return
+    let active = true
+    fetch("/api/users/me", {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+      .then(async (res) => (res.ok ? ((await res.json()) as UserProfile) : null))
+      .then((profile) => {
+        if (!active || !profile) return
+        setSubscriptionTier(profile.subscription_tier)
+        if (!userTouched.current && profile.default_model) {
+          setSelectedModelState(profile.default_model)
+        }
+      })
+      .catch(() => {
+        // No profile → keep the fallback default and "free" tier.
+      })
+    return () => {
+      active = false
+    }
+  }, [accessToken])
+
+  return (
+    <ModelSelectionContext.Provider
+      value={{ models, selectedModel, setSelectedModel, subscriptionTier, isLoading }}
+    >
+      {children}
+    </ModelSelectionContext.Provider>
+  )
+}
+
+/** Access the model selection context. Throws if used outside the provider. */
+export function useModelSelection(): ModelSelectionValue {
+  const ctx = useContext(ModelSelectionContext)
+  if (!ctx)
+    throw new Error("useModelSelection must be used within a ModelSelectionProvider")
+  return ctx
+}

--- a/web/contexts/model-selection-context.tsx
+++ b/web/contexts/model-selection-context.tsx
@@ -30,11 +30,16 @@ type ModelSelectionValue = {
 const ModelSelectionContext = createContext<ModelSelectionValue | null>(null)
 
 export function ModelSelectionProvider({ children }: { children: ReactNode }) {
-  const { accessToken } = useAuth()
+  const { accessToken, isLoading: authLoading } = useAuth()
   const [models, setModels] = useState<ModelInfo[]>([])
   const [selectedModel, setSelectedModelState] = useState<string>(DEFAULT_MODEL_KEY)
   const [subscriptionTier, setSubscriptionTier] = useState("free")
-  const [isLoading, setIsLoading] = useState(true)
+  // Two independent fetches gate readiness: the public models list and the
+  // profile (which seeds the saved default). isLoading stays true until BOTH
+  // settle so a user with a saved default can't submit "base" in the window
+  // before the profile arrives — consumers disable submission while loading.
+  const [modelsLoading, setModelsLoading] = useState(true)
+  const [seedResolved, setSeedResolved] = useState(false)
   // Once the user picks a model, a late-arriving profile default must not clobber
   // their choice — this guards the default-seeding effect.
   const userTouched = useRef(false)
@@ -55,7 +60,7 @@ export function ModelSelectionProvider({ children }: { children: ReactNode }) {
         // Leave models empty; the selector renders a graceful empty state.
       })
       .finally(() => {
-        if (active) setIsLoading(false)
+        if (active) setModelsLoading(false)
       })
     return () => {
       active = false
@@ -64,8 +69,10 @@ export function ModelSelectionProvider({ children }: { children: ReactNode }) {
 
   // Seed the initial selection from the user's saved default_model (and read
   // their tier for Pro-lock display). Skipped if the user already picked one.
+  // The no-token case is handled in the isLoading derivation below (no seeding
+  // to wait for), so this effect only runs the authenticated fetch.
   useEffect(() => {
-    if (!accessToken) return
+    if (authLoading || !accessToken) return
     let active = true
     fetch("/api/users/me", {
       headers: { authorization: `Bearer ${accessToken}` },
@@ -81,10 +88,19 @@ export function ModelSelectionProvider({ children }: { children: ReactNode }) {
       .catch(() => {
         // No profile → keep the fallback default and "free" tier.
       })
+      .finally(() => {
+        if (active) setSeedResolved(true)
+      })
     return () => {
       active = false
     }
-  }, [accessToken])
+  }, [accessToken, authLoading])
+
+  // Loading until the models list settles and — when there's a user whose saved
+  // default could still arrive — the profile seed resolves. With no token (auth
+  // settled) there's no default to wait for, so only the models gate applies.
+  const isLoading =
+    authLoading || modelsLoading || (!!accessToken && !seedResolved)
 
   return (
     <ModelSelectionContext.Provider

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -308,6 +308,28 @@ describe("submitGeneration", () => {
     expect(JSON.parse(opts.body)).toEqual({ prompt: "song", instrumental: false })
   })
 
+  it("includes the selected model in the payload (US-16.4)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ job_id: "job-9" }), { status: 202 })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await submitGeneration(data, "tok", "xl-base")
+    const [, opts] = fetchMock.mock.calls[0]
+    expect(JSON.parse(opts.body).model).toBe("xl-base")
+  })
+
+  it("omits model when none is selected so the backend default applies", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ job_id: "job-9" }), { status: 202 })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await submitGeneration(data, "tok", "")
+    const [, opts] = fetchMock.mock.calls[0]
+    expect("model" in JSON.parse(opts.body)).toBe(false)
+  })
+
   it("treats a 202 with no job id as an error", async () => {
     vi.stubGlobal(
       "fetch",

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -4,7 +4,9 @@ import {
   buildAdvancedPayload,
   buildGenerationPayload,
   buildSoundsPayload,
+  submitAdvancedGeneration,
   submitGeneration,
+  submitSoundsGeneration,
   validateAdvanced,
   validateSounds,
   type AdvancedFormData,
@@ -328,6 +330,23 @@ describe("submitGeneration", () => {
     await submitGeneration(data, "tok", "")
     const [, opts] = fetchMock.mock.calls[0]
     expect("model" in JSON.parse(opts.body)).toBe(false)
+  })
+
+  it("threads the model through the Advanced and Sounds submitters too", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ job_id: "j" }), { status: 202 })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await submitAdvancedGeneration(advancedData({ styles: "rock" }), "tok", "xl-sft")
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).model).toBe("xl-sft")
+
+    await submitSoundsGeneration(
+      soundsData({ description: "kick", soundType: "one-shot" }),
+      "tok",
+      "turbo"
+    )
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).model).toBe("turbo")
   })
 
   it("treats a 202 with no job id as an error", async () => {

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -198,7 +198,7 @@ function extractDetail(body: unknown, fallback: string): string {
  * `model` would 422). Returns a new object so the caller's payload is untouched.
  */
 function withModel(payload: GenerationPayload, model?: string): GenerationPayload {
-  return model ? { ...payload, model } : payload
+  return model ? { ...payload, model } : { ...payload }
 }
 
 /** Submit the Simple creation form through the BFF proxy. */

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -193,12 +193,12 @@ function extractDetail(body: unknown, fallback: string): string {
 }
 
 /**
- * Attach the selected model (US-16.4) to a built payload. A falsy model is
- * omitted so the backend applies its own default (an empty `model` would 422).
+ * Return a copy of the payload with the selected model (US-16.4) attached. A
+ * falsy model is omitted so the backend applies its own default (an empty
+ * `model` would 422). Returns a new object so the caller's payload is untouched.
  */
 function withModel(payload: GenerationPayload, model?: string): GenerationPayload {
-  if (model) payload.model = model
-  return payload
+  return model ? { ...payload, model } : payload
 }
 
 /** Submit the Simple creation form through the BFF proxy. */

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -31,6 +31,8 @@ export type GenerationFormData = {
 /** Subset of the backend GenerationRequest these forms send (extra keys forbidden). */
 export type GenerationPayload = {
   prompt: string
+  /** Model variant key (US-16.4); omitted lets the backend pick its default. */
+  model?: string
   style?: string
   lyrics?: string
   instrumental: boolean
@@ -190,20 +192,31 @@ function extractDetail(body: unknown, fallback: string): string {
   return fallback
 }
 
+/**
+ * Attach the selected model (US-16.4) to a built payload. A falsy model is
+ * omitted so the backend applies its own default (an empty `model` would 422).
+ */
+function withModel(payload: GenerationPayload, model?: string): GenerationPayload {
+  if (model) payload.model = model
+  return payload
+}
+
 /** Submit the Simple creation form through the BFF proxy. */
 export function submitGeneration(
   data: GenerationFormData,
-  accessToken: string
+  accessToken: string,
+  model?: string
 ): Promise<SubmitResult> {
-  return postGeneration(buildGenerationPayload(data), accessToken)
+  return postGeneration(withModel(buildGenerationPayload(data), model), accessToken)
 }
 
 /** Submit the Advanced creation form through the BFF proxy. */
 export function submitAdvancedGeneration(
   data: AdvancedFormData,
-  accessToken: string
+  accessToken: string,
+  model?: string
 ): Promise<SubmitResult> {
-  return postGeneration(buildAdvancedPayload(data), accessToken)
+  return postGeneration(withModel(buildAdvancedPayload(data), model), accessToken)
 }
 
 /** Form state for the Sounds creation form (US-16.3): short one-shots and loops. */
@@ -268,9 +281,10 @@ export function validateSounds(data: SoundsFormData): string | null {
 /** Submit the Sounds creation form through the BFF proxy. */
 export function submitSoundsGeneration(
   data: SoundsFormData,
-  accessToken: string
+  accessToken: string,
+  model?: string
 ): Promise<SubmitResult> {
-  return postGeneration(buildSoundsPayload(data), accessToken)
+  return postGeneration(withModel(buildSoundsPayload(data), model), accessToken)
 }
 
 /** POST a built payload through the BFF proxy and classify the response. */

--- a/web/lib/models.ts
+++ b/web/lib/models.ts
@@ -1,0 +1,40 @@
+// Model registry types + client for the creation-mode model selector (US-16.4).
+// Mirrors the backend ModelInfo schema (src/acemusic/api/routers/models.py).
+// The list is public, so fetchModels() goes through the unauthenticated BFF
+// proxy at /api/models.
+
+/** One selectable model variant, as returned by GET /api/v1/models. */
+export type ModelInfo = {
+  key: string
+  display_name: string
+  category: string
+  description: string
+  pro_only: boolean
+  vram: string
+  steps: string
+  dit_size: string
+}
+
+/** The fallback selection when a user has no saved default model preference. */
+export const DEFAULT_MODEL_KEY = "base"
+
+/** Fetch the available models through the same-origin BFF proxy. */
+export async function fetchModels(): Promise<ModelInfo[]> {
+  const res = await fetch("/api/models", {
+    headers: { accept: "application/json" },
+  })
+  if (!res.ok) throw new Error("Failed to load models")
+  const body = (await res.json()) as { models?: ModelInfo[] }
+  return body.models ?? []
+}
+
+/** Group models by category, preserving first-seen category order. */
+export function groupByCategory(models: ModelInfo[]): [string, ModelInfo[]][] {
+  const groups = new Map<string, ModelInfo[]>()
+  for (const m of models) {
+    const list = groups.get(m.category)
+    if (list) list.push(m)
+    else groups.set(m.category, [m])
+  }
+  return [...groups.entries()]
+}

--- a/web/lib/profile.ts
+++ b/web/lib/profile.ts
@@ -14,6 +14,7 @@ export type UserProfile = {
   style_tags: string[]
   avatar_url: string | null
   subscription_tier: string
+  default_model: string | null
   created_at: string
   updated_at: string | null
 }
@@ -24,6 +25,7 @@ export type UserProfileUpdate = {
   handle?: string | null
   bio?: string
   style_tags?: string[]
+  default_model?: string | null
 }
 
 export const DISPLAY_NAME_MAX_LENGTH = 100


### PR DESCRIPTION
## US-16.4: Model and Version Selector

Closes #190.

Adds a model/version selector accessible from all three creation tabs (Simple, Advanced, Sounds), with the chosen model persisting across tab switches and flowing into the generation payload.

> **Note on the issue plan:** CodeRabbit's auto-generated plan was stale — it assumed `web/` was empty and proposed bootstrapping Next.js with separate `/create/simple|advanced|sounds` routes. In reality the frontend is fully built (US-16.1/16.2/16.3 merged) and the creation modes are a **single page with Shadcn Tabs**. The plan was adapted to that reality, which makes "persist across tabs" trivial (the selector lives outside the tabs).

### Backend
- **New public `GET /api/v1/models`** (`routers/models.py`) — returns the 6 real model variants from `constants.MODELS`, enriched with display metadata (`display_name`, `category`, `pro_only`). XL variants are marked `pro_only`. `vram`/`steps` are kept as strings (no lossy `"32-64"`→int conversion). No auth (model info isn't sensitive).
- **`default_model` user preference** — added to the `User` document, `UserProfileResponse`, and `UserProfileUpdate` (`PATCH /users/me`), validated against `VALID_MODELS` via the existing `validate_model()` helper.

### Frontend
- **`ModelSelectionContext`** (session-scoped) — fetches the models list, seeds the initial selection from the user's saved `default_model` (falling back to `"base"`), and exposes the user's tier for Pro display.
- **`ModelSelector`** dropdown — groups models by category, shows a Pro badge + lock icon for free-tier users on `pro_only` models, and writes the selection into the shared context.
- Wired into the create page above the tabs; each form includes `model` in its generation payload.
- **Settings page** gains a default-model dropdown (functional requirement).

### Acceptance criteria
- [x] Model selector accessible from Simple, Advanced, and Sounds tabs
- [x] Selecting a model updates the generation request payload
- [x] Pro-only models show a badge/lock indicator for free-tier users
- [x] Selected model persists when switching between creation tabs

### Testing
- Backend: `tests/test_models_api.py` (4) + extended `tests/test_users_api.py` (default_model: set/clear/validate/default) — all green, ruff + black clean.
- Frontend: 195 vitest tests green (new `ModelSelector`, `model-selection-context`, payload-`model`, settings default-model tests); typecheck + lint + build clean.

### Reviews addressed
- **codex (cross-family, P2):** a user with a saved `default_model` could submit `"base"` in the window before `/api/users/me` resolved. Fixed — the context reports `isLoading` until both the models list and the profile seed settle, and the Create buttons disable while loading (covered by `model-selection-context.test.tsx`).
- **Internal review (minor):** `withModel` now returns a copy instead of mutating its argument.

### Known limitations
- **Pro models remain selectable by free-tier users** (display-only badge/lock, no enforcement). This is the deliberate design (matches the issue's Design Choice 2): the backend does not yet gate generation by tier. Tier enforcement is a separate, future change.
- The selector exposes the 6 real backend models grouped into XL / Standard / Turbo categories. The issue's aspirational groups ("Create Custom Model (Beta)", "Legacy Models") have no backing models and were intentionally not fabricated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a model picker on the Create page, letting users choose a generation model before starting.
  * Added a default model preference in account settings, with a “No preference” option.

* **Bug Fixes**
  * Model choices now persist across Create page tabs and are included in generation requests.
  * Saving a default model is now validated and stored correctly, including clearing the preference.

* **Documentation / Tests**
  * Added coverage for model listing, model selection, and profile default-model updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->