### PR TITLE
feat(web): Workspace and Clip Library Panel (US-16.5)

### DIFF
--- a/docs/demos/us-16.5-workspace-panel.md
+++ b/docs/demos/us-16.5-workspace-panel.md
@@ -1,0 +1,32 @@
+# US-16.5 — Workspace and Clip Library Panel demo
+
+Verified live against `next dev` (localhost:3100) with `agent-browser`. The panel
+is data-driven (clips + workspaces) and lives on the auth-gated `/create` route,
+so it was mounted on a throwaway harness page (`app/demo-workspace`, since
+deleted) under a token'd `AuthContext` and the real `PlayerProvider`, with
+`window.fetch` stubbed to serve a seeded workspace ("My Beats") and 25 clips so
+the real `WorkspacePanel` + `useClips`/`useWorkspaces` hooks + client-side
+filtering all ran against live data. Each acceptance criterion is mapped to
+observed outcome evidence (not just "rendered").
+
+Seed shape: 25 clips, newest-first `c1…c25`. `c1` (Aurora) public/generate,
+`c2` (Bassline) private/upload **and** seeded into the player's liked set,
+`c3` (Crescendo) public/upload, `c4…c25` private/generate.
+
+| # | Acceptance criterion | Evidence |
+|---|----------------------|----------|
+| 1 | Workspace breadcrumb displays current workspace and navigates on click | Breadcrumb read live as `"Workspaces \| My Beats"` (the default workspace from `GET /api/workspaces`). Clicking the `Workspaces` root segment fired the wired `onNavigate` — captured console line `[demo] breadcrumb navigate clicked` (on the real `/create` page this is `router.push("/studio")`). |
+| 2 | Search filters clips in real time by title or metadata | Filling the search box with `Aurora` (debounced) narrowed the list from 20 cards to exactly `1 card: Aurora`. The term round-trips as the server `search` query param via `useClips`. |
+| 3 | Filter toggles (Liked, Public, Uploads) narrow the clip list | Opening **Filters** and toggling **Public** → `2 cards: Aurora, Crescendo` and the button badge showed `1`. **Liked** alone → `1 card: Bassline` (the seeded liked id `c2`, read from the player's `likedIds`). **Uploads** alone → `2 cards: Bassline, Crescendo` (`generation_mode === "upload"`). Clearing all → back to 20. |
+| 4 | Sort dropdown reorders clips | Default **Newest** showed first three `Aurora, Bassline, Crescendo`; selecting **Oldest** reordered the first three to `Track 25, Track 24, Track 23` (server `sort=oldest`). |
+| 5 | Pagination loads additional pages of clips | Footer read `Page 1 of 2` (25 clips / 20 per page) with **Previous** disabled. Clicking **Next** → `Page 2 of 2`, `5 cards` (`Track 21…25`), **Next** now disabled, **Previous** enabled. Clicking **Previous** returned to `Page 1 of 2`. |
+| 6 | Panel scrolls independently from the creation form | The panel's clip-list container is its own scroll context: live DOM read `scrollable=true scrollH=1632 clientH=532` (`overflow-y-auto` with a flex-constrained height), independent of the left form column. |
+
+Functional extras observed: with a filter active on a page whose clips don't
+match, the empty state reads **"No clips on this page match your filters."** —
+deliberately scoped to the page, because the Liked/Public/Uploads filters run
+client-side over the fetched page (the backend has no params for them yet; see
+Known Limitations in PR #240). No feature-related console errors (`0 captured`).
+
+Local gate (web/ isn't in CI): `npm run typecheck`, `npm run lint`,
+`npm test` (37 files, 238 tests), and `npm run build` all green.

--- a/web/app/api/clips/route.test.ts
+++ b/web/app/api/clips/route.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { GET } from "@/app/api/clips/route"
+
+function req(url: string, init: RequestInit = {}): NextRequest {
+  return new Request(url, init) as unknown as NextRequest
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("GET /api/clips", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await GET(req("http://localhost/api/clips"))
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the Bearer token and query string to the backend", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ clips: [], total: 0 }), { status: 200 })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await GET(
+      req("http://localhost/api/clips?workspace_id=w1&search=lofi&page=2", {
+        headers: { authorization: "Bearer tok" },
+      })
+    )
+    expect(res.status).toBe(200)
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips")
+    expect(url).toContain("workspace_id=w1")
+    expect(url).toContain("search=lofi")
+    expect(url).toContain("page=2")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+  })
+
+  it("passes the backend status through", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "boom" }), { status: 422 })
+      )
+    )
+    const res = await GET(
+      req("http://localhost/api/clips", {
+        headers: { authorization: "Bearer tok" },
+      })
+    )
+    expect(res.status).toBe(422)
+  })
+})

--- a/web/app/api/clips/route.ts
+++ b/web/app/api/clips/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/clips (US-16.5). The client holds the access
+// token in memory and sends it as a Bearer header; this route forwards it plus
+// the query string (search/sort/page/per_page/workspace_id) to the backend so
+// the backend URL stays server-side. Status/body pass through verbatim.
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const search = new URL(request.url).search
+  const res = await fetch(`${BACKEND_URL}/api/v1/clips${search}`, {
+    headers: { authorization: auth, accept: "application/json" },
+  })
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/workspaces/route.ts
+++ b/web/app/api/workspaces/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/workspaces (US-16.5). Forwards the Bearer
+// token to the backend so its URL stays server-side; status/body pass through.
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const res = await fetch(`${BACKEND_URL}/api/v1/workspaces`, {
+    headers: { authorization: auth, accept: "application/json" },
+  })
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,15 +1,19 @@
 "use client"
 
+import { useRouter } from "next/navigation"
+
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useRequireAuth } from "@/hooks/use-require-auth"
 import { SimpleCreationForm } from "@/components/create/SimpleCreationForm"
 import { AdvancedCreationForm } from "@/components/create/AdvancedCreationForm"
 import { SoundsCreationForm } from "@/components/create/SoundsCreationForm"
 import { ModelSelector } from "@/components/create/ModelSelector"
+import { WorkspacePanel } from "@/components/workspace/WorkspacePanel"
 import { ModelSelectionProvider } from "@/contexts/model-selection-context"
 
 export default function CreatePage() {
   const { isLoading, isAuthenticated } = useRequireAuth()
+  const router = useRouter()
 
   // ponytail: render nothing until authed — useRequireAuth redirects otherwise,
   // and this avoids flashing protected content during the check.
@@ -19,27 +23,37 @@ export default function CreatePage() {
     // The provider wraps the tabs so the selected model persists across tab
     // switches (US-16.4); the selector sits in the header, outside the Tabs.
     <ModelSelectionProvider>
-      <div className="p-8">
-        <div className="mb-6 flex items-center justify-between gap-4">
-          <h1 className="text-2xl font-semibold">Create</h1>
-          <ModelSelector />
+      <div className="flex h-full">
+        <div className="min-w-0 flex-1 overflow-y-auto p-8">
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <h1 className="text-2xl font-semibold">Create</h1>
+            <ModelSelector />
+          </div>
+          <Tabs defaultValue="simple">
+            <TabsList>
+              <TabsTrigger value="simple">Simple</TabsTrigger>
+              <TabsTrigger value="advanced">Advanced</TabsTrigger>
+              <TabsTrigger value="sounds">Sounds</TabsTrigger>
+            </TabsList>
+            <TabsContent value="simple">
+              <SimpleCreationForm />
+            </TabsContent>
+            <TabsContent value="advanced">
+              <AdvancedCreationForm />
+            </TabsContent>
+            <TabsContent value="sounds">
+              <SoundsCreationForm />
+            </TabsContent>
+          </Tabs>
         </div>
-        <Tabs defaultValue="simple">
-          <TabsList>
-            <TabsTrigger value="simple">Simple</TabsTrigger>
-            <TabsTrigger value="advanced">Advanced</TabsTrigger>
-            <TabsTrigger value="sounds">Sounds</TabsTrigger>
-          </TabsList>
-          <TabsContent value="simple">
-            <SimpleCreationForm />
-          </TabsContent>
-          <TabsContent value="advanced">
-            <AdvancedCreationForm />
-          </TabsContent>
-          <TabsContent value="sounds">
-            <SoundsCreationForm />
-          </TabsContent>
-        </Tabs>
+        {/* Clip library (US-16.5). Hidden below lg to keep the form usable at
+            the minimum supported width, mirroring the app shell's RightPanel. */}
+        <aside
+          aria-label="Clip library"
+          className="hidden w-80 shrink-0 flex-col border-l border-border p-4 lg:flex"
+        >
+          <WorkspacePanel onNavigateWorkspaces={() => router.push("/studio")} />
+        </aside>
       </div>
     </ModelSelectionProvider>
   )

--- a/web/components/ui/popover.tsx
+++ b/web/components/ui/popover.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-lg bg-popover p-4 text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-none duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/web/components/workspace/ClipCard.test.tsx
+++ b/web/components/workspace/ClipCard.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ClipCard } from "@/components/workspace/ClipCard"
+import type { Clip } from "@/lib/workspace-clips"
+
+function clip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "c1",
+    workspace_id: "w1",
+    title: "Midnight",
+    format: "wav",
+    duration: 95,
+    bpm: 120,
+    key: "C",
+    style_tags: ["lofi", "chill"],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: "generate",
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("ClipCard", () => {
+  it("renders title, duration, and style tags", () => {
+    render(<ClipCard clip={clip()} />)
+    expect(screen.getByText("Midnight")).toBeInTheDocument()
+    expect(screen.getByText("1:35")).toBeInTheDocument()
+    expect(screen.getByText("lofi, chill")).toBeInTheDocument()
+  })
+
+  it("falls back to a placeholder title for untitled clips", () => {
+    render(<ClipCard clip={clip({ title: null })} />)
+    expect(screen.getByText("Untitled clip")).toBeInTheDocument()
+  })
+})

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { MusicNote01Icon } from "@hugeicons/core-free-icons"
+
+import { formatTime } from "@/lib/clips"
+import type { Clip } from "@/lib/workspace-clips"
+
+// ponytail: minimal list-view card. US-16.6 extends it with inline title edit,
+// play/like/menu action buttons, and full interactivity — out of scope here.
+
+/** Minimal clip card: thumbnail placeholder + duration, title, and style tags. */
+export function ClipCard({ clip }: { clip: Clip }) {
+  return (
+    <div
+      data-testid="clip-card"
+      className="flex gap-3 rounded-lg border border-border bg-card p-2"
+    >
+      <div className="relative flex size-14 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+        <HugeiconsIcon icon={MusicNote01Icon} size={20} />
+        {clip.duration != null && (
+          <span className="absolute right-0.5 bottom-0.5 rounded bg-background/80 px-1 text-[10px] tabular-nums">
+            {formatTime(clip.duration)}
+          </span>
+        )}
+      </div>
+      <div className="flex min-w-0 flex-col justify-center">
+        <p className="truncate text-sm font-medium">
+          {clip.title ?? "Untitled clip"}
+        </p>
+        {clip.style_tags.length > 0 && (
+          <p className="truncate text-xs text-muted-foreground">
+            {clip.style_tags.join(", ")}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/components/workspace/ClipList.test.tsx
+++ b/web/components/workspace/ClipList.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ClipList } from "@/components/workspace/ClipList"
+import type { Clip } from "@/lib/workspace-clips"
+
+function clip(id: string): Clip {
+  return {
+    id,
+    workspace_id: "w1",
+    title: id,
+    format: "wav",
+    duration: 60,
+    bpm: null,
+    key: null,
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: null,
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+  }
+}
+
+describe("ClipList", () => {
+  it("shows a skeleton while loading", () => {
+    render(<ClipList clips={[]} loading />)
+    expect(screen.getByTestId("clip-list-skeleton")).toBeInTheDocument()
+  })
+
+  it("shows the empty message when there are no clips", () => {
+    render(<ClipList clips={[]} loading={false} emptyMessage="Nothing here." />)
+    expect(screen.getByText("Nothing here.")).toBeInTheDocument()
+  })
+
+  it("renders a card per clip", () => {
+    render(<ClipList clips={[clip("a"), clip("b")]} loading={false} />)
+    expect(screen.getAllByTestId("clip-card")).toHaveLength(2)
+  })
+})

--- a/web/components/workspace/ClipList.tsx
+++ b/web/components/workspace/ClipList.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { ClipCard } from "@/components/workspace/ClipCard"
+import type { Clip } from "@/lib/workspace-clips"
+
+/** Renders clip cards, a loading skeleton, or an empty-state message. */
+export function ClipList({
+  clips,
+  loading,
+  emptyMessage = "No clips found.",
+}: {
+  clips: Clip[]
+  loading: boolean
+  emptyMessage?: string
+}) {
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="clip-list-skeleton">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-[72px] animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+    )
+  }
+
+  if (clips.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        {emptyMessage}
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {clips.map((clip) => (
+        <ClipCard key={clip.id} clip={clip} />
+      ))}
+    </div>
+  )
+}

--- a/web/components/workspace/ClipSearchInput.test.tsx
+++ b/web/components/workspace/ClipSearchInput.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { ClipSearchInput } from "@/components/workspace/ClipSearchInput"
+
+describe("ClipSearchInput", () => {
+  it("reflects the controlled value and emits changes", async () => {
+    const onChange = vi.fn()
+    render(<ClipSearchInput value="" onChange={onChange} />)
+    await userEvent.type(screen.getByLabelText("Search clips"), "a")
+    expect(onChange).toHaveBeenCalledWith("a")
+  })
+
+  it("shows a clear button only when there is a value, and clears on click", async () => {
+    const onChange = vi.fn()
+    const { rerender } = render(<ClipSearchInput value="" onChange={onChange} />)
+    expect(screen.queryByLabelText("Clear search")).not.toBeInTheDocument()
+
+    rerender(<ClipSearchInput value="lofi" onChange={onChange} />)
+    await userEvent.click(screen.getByLabelText("Clear search"))
+    expect(onChange).toHaveBeenCalledWith("")
+  })
+})

--- a/web/components/workspace/ClipSearchInput.tsx
+++ b/web/components/workspace/ClipSearchInput.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Cancel01Icon, Search01Icon } from "@hugeicons/core-free-icons"
+
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+
+/** Controlled search box with a leading search icon and a trailing clear button. */
+export function ClipSearchInput({
+  value,
+  onChange,
+  className,
+}: {
+  value: string
+  onChange: (value: string) => void
+  className?: string
+}) {
+  return (
+    <div className={cn("relative", className)}>
+      <HugeiconsIcon
+        icon={Search01Icon}
+        size={16}
+        className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+      />
+      <Input
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search clips"
+        aria-label="Search clips"
+        className="px-9"
+      />
+      {value && (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={() => onChange("")}
+          className="absolute top-1/2 right-2 -translate-y-1/2 rounded-sm p-1 text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+        >
+          <HugeiconsIcon icon={Cancel01Icon} size={14} />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/components/workspace/FiltersButton.test.tsx
+++ b/web/components/workspace/FiltersButton.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { FiltersButton } from "@/components/workspace/FiltersButton"
+import { EMPTY_FILTERS } from "@/lib/workspace-clips"
+
+describe("FiltersButton", () => {
+  it("shows the active-filter count badge", () => {
+    render(
+      <FiltersButton
+        filters={{ liked: true, public: false, uploads: true }}
+        onFiltersChange={vi.fn()}
+      />
+    )
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("omits the badge when no filters are active", () => {
+    render(<FiltersButton filters={EMPTY_FILTERS} onFiltersChange={vi.fn()} />)
+    expect(screen.queryByText("0")).not.toBeInTheDocument()
+  })
+
+  it("toggling a switch emits the updated filters", async () => {
+    const onFiltersChange = vi.fn()
+    render(
+      <FiltersButton filters={EMPTY_FILTERS} onFiltersChange={onFiltersChange} />
+    )
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }))
+    await userEvent.click(screen.getByLabelText("Liked"))
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      liked: true,
+      public: false,
+      uploads: false,
+    })
+  })
+})

--- a/web/components/workspace/FiltersButton.tsx
+++ b/web/components/workspace/FiltersButton.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { FilterIcon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { Switch } from "@/components/ui/switch"
+import { activeFilterCount, type ClipFilters } from "@/lib/workspace-clips"
+
+const TOGGLES: { key: keyof ClipFilters; label: string }[] = [
+  { key: "liked", label: "Liked" },
+  { key: "public", label: "Public" },
+  { key: "uploads", label: "Uploads" },
+]
+
+/**
+ * Filters button + popover with Liked/Public/Uploads switches. The badge shows
+ * the active-filter count. Filtering is applied client-side by the panel — see
+ * applyClientFilters; the backend has no params for these yet.
+ */
+export function FiltersButton({
+  filters,
+  onFiltersChange,
+}: {
+  filters: ClipFilters
+  onFiltersChange: (filters: ClipFilters) => void
+}) {
+  const count = activeFilterCount(filters)
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <HugeiconsIcon icon={FilterIcon} size={14} />
+          Filters
+          {count > 0 && (
+            <Badge variant="secondary" className="ml-0.5 px-1.5">
+              {count}
+            </Badge>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56">
+        <div className="flex flex-col gap-3">
+          {TOGGLES.map(({ key, label }) => (
+            <div key={key} className="flex items-center justify-between gap-4">
+              <Label htmlFor={`filter-${key}`}>{label}</Label>
+              <Switch
+                id={`filter-${key}`}
+                checked={filters[key]}
+                onCheckedChange={(checked) =>
+                  onFiltersChange({ ...filters, [key]: checked })
+                }
+              />
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/web/components/workspace/PaginationControls.test.tsx
+++ b/web/components/workspace/PaginationControls.test.tsx
@@ -21,6 +21,12 @@ describe("PaginationControls", () => {
     expect(screen.getByLabelText("Next page")).toBeDisabled()
   })
 
+  it("clamps an empty result to 'Page 1 of 1' and disables Next", () => {
+    render(<PaginationControls page={1} totalPages={0} onPageChange={vi.fn()} />)
+    expect(screen.getByText("Page 1 of 1")).toBeInTheDocument()
+    expect(screen.getByLabelText("Next page")).toBeDisabled()
+  })
+
   it("requests the next/previous page on click", async () => {
     const onPageChange = vi.fn()
     render(<PaginationControls page={2} totalPages={5} onPageChange={onPageChange} />)

--- a/web/components/workspace/PaginationControls.test.tsx
+++ b/web/components/workspace/PaginationControls.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { PaginationControls } from "@/components/workspace/PaginationControls"
+
+describe("PaginationControls", () => {
+  it("shows the page indicator", () => {
+    render(<PaginationControls page={2} totalPages={5} onPageChange={vi.fn()} />)
+    expect(screen.getByText("Page 2 of 5")).toBeInTheDocument()
+  })
+
+  it("disables Prev on the first page and Next on the last", () => {
+    const { rerender } = render(
+      <PaginationControls page={1} totalPages={3} onPageChange={vi.fn()} />
+    )
+    expect(screen.getByLabelText("Previous page")).toBeDisabled()
+    expect(screen.getByLabelText("Next page")).toBeEnabled()
+
+    rerender(<PaginationControls page={3} totalPages={3} onPageChange={vi.fn()} />)
+    expect(screen.getByLabelText("Next page")).toBeDisabled()
+  })
+
+  it("requests the next/previous page on click", async () => {
+    const onPageChange = vi.fn()
+    render(<PaginationControls page={2} totalPages={5} onPageChange={onPageChange} />)
+    await userEvent.click(screen.getByLabelText("Next page"))
+    expect(onPageChange).toHaveBeenCalledWith(3)
+    await userEvent.click(screen.getByLabelText("Previous page"))
+    expect(onPageChange).toHaveBeenCalledWith(1)
+  })
+})

--- a/web/components/workspace/PaginationControls.tsx
+++ b/web/components/workspace/PaginationControls.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+
+/** Previous/Next pager with a "Page X of Y" indicator. */
+export function PaginationControls({
+  page,
+  totalPages,
+  onPageChange,
+}: {
+  page: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+        aria-label="Previous page"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} size={14} />
+        Prev
+      </Button>
+      <span className="text-sm text-muted-foreground" aria-live="polite">
+        Page {page} of {Math.max(totalPages, 1)}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+        aria-label="Next page"
+      >
+        Next
+        <HugeiconsIcon icon={ArrowRight01Icon} size={14} />
+      </Button>
+    </div>
+  )
+}

--- a/web/components/workspace/PaginationControls.tsx
+++ b/web/components/workspace/PaginationControls.tsx
@@ -15,6 +15,9 @@ export function PaginationControls({
   totalPages: number
   onPageChange: (page: number) => void
 }) {
+  // Clamp once so an empty result (total_pages: 0) shows "Page 1 of 1" *and*
+  // disables Next, rather than leaving Next clickable into an empty page 2.
+  const clampedTotalPages = Math.max(totalPages, 1)
   return (
     <div className="flex items-center justify-between gap-2">
       <Button
@@ -28,12 +31,12 @@ export function PaginationControls({
         Prev
       </Button>
       <span className="text-sm text-muted-foreground" aria-live="polite">
-        Page {page} of {Math.max(totalPages, 1)}
+        Page {page} of {clampedTotalPages}
       </span>
       <Button
         variant="outline"
         size="sm"
-        disabled={page >= totalPages}
+        disabled={page >= clampedTotalPages}
         onClick={() => onPageChange(page + 1)}
         aria-label="Next page"
       >

--- a/web/components/workspace/SortDropdown.test.tsx
+++ b/web/components/workspace/SortDropdown.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { SortDropdown } from "@/components/workspace/SortDropdown"
+
+describe("SortDropdown", () => {
+  it("shows the current sort label", () => {
+    render(<SortDropdown value="oldest" onChange={vi.fn()} />)
+    expect(screen.getByRole("button", { name: /oldest/i })).toBeInTheDocument()
+  })
+
+  it("emits the chosen sort order", async () => {
+    const onChange = vi.fn()
+    render(<SortDropdown value="newest" onChange={onChange} />)
+    await userEvent.click(screen.getByRole("button", { name: /newest/i }))
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Oldest" }))
+    expect(onChange).toHaveBeenCalledWith("oldest")
+  })
+})

--- a/web/components/workspace/SortDropdown.tsx
+++ b/web/components/workspace/SortDropdown.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import type { SortOrder } from "@/lib/workspace-clips"
+
+const LABELS: Record<SortOrder, string> = {
+  newest: "Newest",
+  oldest: "Oldest",
+}
+
+/** Newest/Oldest sort selector. Built on the dropdown-menu radio primitive. */
+export function SortDropdown({
+  value,
+  onChange,
+}: {
+  value: SortOrder
+  onChange: (value: SortOrder) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1">
+          {LABELS[value]}
+          <HugeiconsIcon icon={ArrowDown01Icon} size={14} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={value}
+          onValueChange={(v) => onChange(v as SortOrder)}
+        >
+          <DropdownMenuRadioItem value="newest">Newest</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="oldest">Oldest</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/components/workspace/WorkspaceBreadcrumb.test.tsx
+++ b/web/components/workspace/WorkspaceBreadcrumb.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { WorkspaceBreadcrumb } from "@/components/workspace/WorkspaceBreadcrumb"
+import type { Workspace } from "@/lib/workspace-clips"
+
+const workspace: Workspace = {
+  id: "w1",
+  name: "My Beats",
+  clip_count: 3,
+  is_default: true,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: null,
+}
+
+describe("WorkspaceBreadcrumb", () => {
+  it("shows the current workspace name", () => {
+    render(<WorkspaceBreadcrumb workspace={workspace} />)
+    expect(screen.getByText("My Beats")).toBeInTheDocument()
+  })
+
+  it("renders a placeholder when no workspace is set", () => {
+    render(<WorkspaceBreadcrumb workspace={null} />)
+    expect(screen.getByText("—")).toBeInTheDocument()
+  })
+
+  it("fires onNavigate when the root segment is clicked", async () => {
+    const onNavigate = vi.fn()
+    render(<WorkspaceBreadcrumb workspace={workspace} onNavigate={onNavigate} />)
+    await userEvent.click(screen.getByRole("button", { name: /workspaces/i }))
+    expect(onNavigate).toHaveBeenCalledOnce()
+  })
+})

--- a/web/components/workspace/WorkspaceBreadcrumb.tsx
+++ b/web/components/workspace/WorkspaceBreadcrumb.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowRight01Icon, Home01Icon } from "@hugeicons/core-free-icons"
+
+import type { Workspace } from "@/lib/workspace-clips"
+
+/**
+ * "Workspaces > {name}" breadcrumb. The root segment is a button that fires
+ * `onNavigate` (e.g. back to a workspace picker); the current workspace name is
+ * the trailing, non-interactive segment.
+ */
+export function WorkspaceBreadcrumb({
+  workspace,
+  onNavigate,
+}: {
+  workspace: Workspace | null
+  onNavigate?: () => void
+}) {
+  return (
+    <nav aria-label="Workspace breadcrumb" className="flex items-center gap-1 text-sm">
+      <button
+        type="button"
+        onClick={onNavigate}
+        className="flex items-center gap-1 rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+      >
+        <HugeiconsIcon icon={Home01Icon} size={14} />
+        Workspaces
+      </button>
+      <HugeiconsIcon
+        icon={ArrowRight01Icon}
+        size={14}
+        className="text-muted-foreground"
+      />
+      <span className="truncate font-medium text-foreground">
+        {workspace?.name ?? "—"}
+      </span>
+    </nav>
+  )
+}

--- a/web/components/workspace/WorkspacePanel.test.tsx
+++ b/web/components/workspace/WorkspacePanel.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { WorkspacePanel } from "@/components/workspace/WorkspacePanel"
+import type { Clip, Workspace } from "@/lib/workspace-clips"
+
+let clipsResult: { data: unknown; loading: boolean; fetching: boolean; error: boolean }
+let wsResult: { defaultWorkspace: Workspace | null; loading: boolean }
+let likedIds: string[]
+
+vi.mock("@/hooks/use-clips", () => ({ useClips: () => clipsResult }))
+vi.mock("@/hooks/use-workspaces", () => ({ useWorkspaces: () => wsResult }))
+vi.mock("@/contexts/player-context", () => ({
+  usePlayer: () => ({ state: { likedIds } }),
+}))
+
+function clip(id: string, overrides: Partial<Clip> = {}): Clip {
+  return {
+    id,
+    workspace_id: "w1",
+    title: id,
+    format: "wav",
+    duration: 60,
+    bpm: null,
+    key: null,
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: "generate",
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+const workspace: Workspace = {
+  id: "w1",
+  name: "My Beats",
+  clip_count: 3,
+  is_default: true,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: null,
+}
+
+beforeEach(() => {
+  likedIds = []
+  wsResult = { defaultWorkspace: workspace, loading: false }
+  clipsResult = {
+    data: {
+      clips: [
+        clip("public-one", { is_public: true }),
+        clip("private-two", { is_public: false }),
+        clip("uploaded-three", { generation_mode: "upload" }),
+      ],
+      total: 3,
+      page: 1,
+      per_page: 20,
+      total_pages: 1,
+    },
+    loading: false,
+    fetching: false,
+    error: false,
+  }
+})
+
+afterEach(() => vi.clearAllMocks())
+
+describe("WorkspacePanel", () => {
+  it("renders the workspace breadcrumb and one card per clip", () => {
+    render(<WorkspacePanel />)
+    expect(screen.getByText("My Beats")).toBeInTheDocument()
+    expect(screen.getAllByTestId("clip-card")).toHaveLength(3)
+  })
+
+  it("narrows the list with the client-side Public filter", async () => {
+    render(<WorkspacePanel />)
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }))
+    await userEvent.click(screen.getByLabelText("Public"))
+    expect(screen.getAllByTestId("clip-card")).toHaveLength(1)
+    expect(screen.getByText("public-one")).toBeInTheDocument()
+  })
+
+  it("narrows to liked clips using the player's likedIds", async () => {
+    likedIds = ["uploaded-three"]
+    render(<WorkspacePanel />)
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }))
+    await userEvent.click(screen.getByLabelText("Liked"))
+    expect(screen.getAllByTestId("clip-card")).toHaveLength(1)
+    expect(screen.getByText("uploaded-three")).toBeInTheDocument()
+  })
+
+  it("shows a filtered empty message when nothing matches", async () => {
+    render(<WorkspacePanel />)
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }))
+    await userEvent.click(screen.getByLabelText("Liked")) // no liked ids
+    expect(
+      screen.getByText("No clips on this page match your filters.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders the pagination indicator", () => {
+    render(<WorkspacePanel />)
+    expect(within(screen.getByTestId("workspace-panel")).getByText("Page 1 of 1")).toBeInTheDocument()
+  })
+})

--- a/web/components/workspace/WorkspacePanel.test.tsx
+++ b/web/components/workspace/WorkspacePanel.test.tsx
@@ -103,6 +103,14 @@ describe("WorkspacePanel", () => {
     ).toBeInTheDocument()
   })
 
+  it("surfaces a load error instead of an empty-library message", () => {
+    clipsResult = { data: null, loading: false, fetching: false, error: true }
+    render(<WorkspacePanel />)
+    expect(
+      screen.getByText("Couldn't load clips. Please try again.")
+    ).toBeInTheDocument()
+  })
+
   it("renders the pagination indicator", () => {
     render(<WorkspacePanel />)
     expect(within(screen.getByTestId("workspace-panel")).getByText("Page 1 of 1")).toBeInTheDocument()

--- a/web/components/workspace/WorkspacePanel.tsx
+++ b/web/components/workspace/WorkspacePanel.tsx
@@ -60,15 +60,27 @@ export function WorkspacePanel({
     setSort(value)
     setPage(1)
   }
+  // Filters run client-side over the fetched page, so jump back to the first
+  // page when one changes (mirrors search/sort) — otherwise a filter toggled on
+  // a later page would narrow an unrelated slice of clips.
+  const onFiltersChange = (next: ClipFilters) => {
+    setFilters(next)
+    setPage(1)
+  }
 
   const { defaultWorkspace, loading: workspacesLoading } = useWorkspaces()
-  const { data, loading: clipsLoading } = useClips({
-    workspace_id: defaultWorkspace?.id,
-    search: debouncedSearch,
-    sort,
-    page,
-    per_page: PER_PAGE,
-  })
+  // Defer the clip fetch until the workspace is known, so we don't briefly fetch
+  // unscoped clips across all workspaces before refetching with the workspace id.
+  const { data, loading: clipsLoading } = useClips(
+    {
+      workspace_id: defaultWorkspace?.id,
+      search: debouncedSearch,
+      sort,
+      page,
+      per_page: PER_PAGE,
+    },
+    { enabled: !workspacesLoading }
+  )
 
   const { state } = usePlayer()
   const visibleClips = useMemo(
@@ -78,7 +90,9 @@ export function WorkspacePanel({
 
   const loading = workspacesLoading || clipsLoading
   const totalPages = data?.total_pages ?? 1
-  const narrowed = activeFilterCount(filters) > 0 || debouncedSearch.length > 0
+  // Use the live search term (not the debounced one) for the empty-state copy so
+  // the wording is right immediately while a new search is still debouncing.
+  const narrowed = activeFilterCount(filters) > 0 || search.length > 0
 
   return (
     <div data-testid="workspace-panel" className="flex h-full flex-col gap-3">
@@ -88,7 +102,7 @@ export function WorkspacePanel({
       />
       <ClipSearchInput value={search} onChange={onSearchChange} />
       <div className="flex items-center justify-between gap-2">
-        <FiltersButton filters={filters} onFiltersChange={setFilters} />
+        <FiltersButton filters={filters} onFiltersChange={onFiltersChange} />
         <SortDropdown value={sort} onChange={onSortChange} />
       </div>
 

--- a/web/components/workspace/WorkspacePanel.tsx
+++ b/web/components/workspace/WorkspacePanel.tsx
@@ -69,9 +69,11 @@ export function WorkspacePanel({
   }
 
   const { defaultWorkspace, loading: workspacesLoading } = useWorkspaces()
-  // Defer the clip fetch until the workspace is known, so we don't briefly fetch
-  // unscoped clips across all workspaces before refetching with the workspace id.
-  const { data, loading: clipsLoading } = useClips(
+  // Defer the clip fetch until a workspace is resolved, so we never fetch
+  // unscoped clips (across all workspaces). Gating on `defaultWorkspace` also
+  // covers the workspace-fetch-error and zero-workspace cases, where
+  // `workspacesLoading` is false but the id is still unknown.
+  const { data, loading: clipsLoading, error: clipsError } = useClips(
     {
       workspace_id: defaultWorkspace?.id,
       search: debouncedSearch,
@@ -79,7 +81,7 @@ export function WorkspacePanel({
       page,
       per_page: PER_PAGE,
     },
-    { enabled: !workspacesLoading }
+    { enabled: defaultWorkspace !== null }
   )
 
   const { state } = usePlayer()
@@ -111,10 +113,15 @@ export function WorkspacePanel({
           clips={visibleClips}
           loading={loading}
           emptyMessage={
-            // Filters run client-side over the fetched page (the backend has no
-            // params for them yet), so scope the wording to this page rather
-            // than implying the whole library is empty.
-            narrowed ? "No clips on this page match your filters." : "No clips yet."
+            // A failed load shouldn't masquerade as an empty library. Filters
+            // run client-side over the fetched page (the backend has no params
+            // for them yet), so scope that wording to this page rather than
+            // implying the whole library is empty.
+            clipsError
+              ? "Couldn't load clips. Please try again."
+              : narrowed
+                ? "No clips on this page match your filters."
+                : "No clips yet."
           }
         />
       </div>

--- a/web/components/workspace/WorkspacePanel.tsx
+++ b/web/components/workspace/WorkspacePanel.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { ClipList } from "@/components/workspace/ClipList"
+import { ClipSearchInput } from "@/components/workspace/ClipSearchInput"
+import { FiltersButton } from "@/components/workspace/FiltersButton"
+import { PaginationControls } from "@/components/workspace/PaginationControls"
+import { SortDropdown } from "@/components/workspace/SortDropdown"
+import { WorkspaceBreadcrumb } from "@/components/workspace/WorkspaceBreadcrumb"
+import { usePlayer } from "@/contexts/player-context"
+import { useClips } from "@/hooks/use-clips"
+import { useWorkspaces } from "@/hooks/use-workspaces"
+import {
+  activeFilterCount,
+  applyClientFilters,
+  EMPTY_FILTERS,
+  type ClipFilters,
+  type SortOrder,
+} from "@/lib/workspace-clips"
+
+const PER_PAGE = 20
+
+/** Debounce a rapidly-changing value (search keystrokes). */
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(t)
+  }, [value, delayMs])
+  return debounced
+}
+
+/**
+ * Right-side clip library for the Create page (US-16.5). Owns search/filter/
+ * sort/page state; search and sort drive the server query (via useClips) while
+ * the Liked/Public/Uploads filters are applied client-side over the fetched page
+ * (the backend has no params for them — see applyClientFilters). Has its own
+ * scroll container so it scrolls independently of the creation form.
+ */
+export function WorkspacePanel({
+  onNavigateWorkspaces,
+}: {
+  onNavigateWorkspaces?: () => void
+}) {
+  const [search, setSearch] = useState("")
+  const [filters, setFilters] = useState<ClipFilters>(EMPTY_FILTERS)
+  const [sort, setSort] = useState<SortOrder>("newest")
+  const [page, setPage] = useState(1)
+
+  const debouncedSearch = useDebouncedValue(search, 300)
+
+  // A new search term or sort order restarts paging from the first page (reset
+  // in the handlers rather than an effect to avoid a cascading render).
+  const onSearchChange = (value: string) => {
+    setSearch(value)
+    setPage(1)
+  }
+  const onSortChange = (value: SortOrder) => {
+    setSort(value)
+    setPage(1)
+  }
+
+  const { defaultWorkspace, loading: workspacesLoading } = useWorkspaces()
+  const { data, loading: clipsLoading } = useClips({
+    workspace_id: defaultWorkspace?.id,
+    search: debouncedSearch,
+    sort,
+    page,
+    per_page: PER_PAGE,
+  })
+
+  const { state } = usePlayer()
+  const visibleClips = useMemo(
+    () => applyClientFilters(data?.clips ?? [], filters, state.likedIds),
+    [data, filters, state.likedIds]
+  )
+
+  const loading = workspacesLoading || clipsLoading
+  const totalPages = data?.total_pages ?? 1
+  const narrowed = activeFilterCount(filters) > 0 || debouncedSearch.length > 0
+
+  return (
+    <div data-testid="workspace-panel" className="flex h-full flex-col gap-3">
+      <WorkspaceBreadcrumb
+        workspace={defaultWorkspace}
+        onNavigate={onNavigateWorkspaces}
+      />
+      <ClipSearchInput value={search} onChange={onSearchChange} />
+      <div className="flex items-center justify-between gap-2">
+        <FiltersButton filters={filters} onFiltersChange={setFilters} />
+        <SortDropdown value={sort} onChange={onSortChange} />
+      </div>
+
+      <div className="-mr-1 flex-1 overflow-y-auto pr-1">
+        <ClipList
+          clips={visibleClips}
+          loading={loading}
+          emptyMessage={
+            // Filters run client-side over the fetched page (the backend has no
+            // params for them yet), so scope the wording to this page rather
+            // than implying the whole library is empty.
+            narrowed ? "No clips on this page match your filters." : "No clips yet."
+          }
+        />
+      </div>
+
+      <PaginationControls page={page} totalPages={totalPages} onPageChange={setPage} />
+    </div>
+  )
+}

--- a/web/hooks/use-clips.test.tsx
+++ b/web/hooks/use-clips.test.tsx
@@ -64,4 +64,39 @@ describe("useClips", () => {
     const { result } = renderHook(() => useClips({}), { wrapper })
     await waitFor(() => expect(result.current.error).toBe(true))
   })
+
+  it("does not fetch while disabled, then fetches when enabled", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(listRes())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result, rerender } = renderHook(
+      (p: { enabled: boolean }) => useClips({ workspace_id: "w1" }, { enabled: p.enabled }),
+      { wrapper, initialProps: { enabled: false } }
+    )
+    // Deferred: no fetch yet, and the hook reports loading so the caller shows a skeleton.
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(true)
+
+    rerender({ enabled: true })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+  })
+
+  it("shows the skeleton again on the next query after an error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 500 }))
+      .mockResolvedValue(listRes([{ id: "c1" }]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result, rerender } = renderHook((p: { search: string }) => useClips(p), {
+      wrapper,
+      initialProps: { search: "a" },
+    })
+    await waitFor(() => expect(result.current.error).toBe(true))
+
+    // A new query supersedes the stale error: loading flips back on for the retry.
+    rerender({ search: "b" })
+    await waitFor(() => expect(result.current.loading).toBe(true))
+    await waitFor(() => expect(result.current.data?.clips).toHaveLength(1))
+  })
 })

--- a/web/hooks/use-clips.test.tsx
+++ b/web/hooks/use-clips.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+import { useClips } from "@/hooks/use-clips"
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+}
+
+function listRes(clips: unknown[] = []) {
+  return new Response(
+    JSON.stringify({ clips, total: clips.length, page: 1, per_page: 20, total_pages: 1 }),
+    { status: 200 }
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("useClips", () => {
+  it("fetches with the Bearer token and the serialized query", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(listRes([{ id: "c1" }]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(
+      () => useClips({ workspace_id: "w1", sort: "oldest", page: 2 }),
+      { wrapper }
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.data?.clips).toHaveLength(1)
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/clips?workspace_id=w1&sort=oldest&page=2")
+    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+  })
+
+  it("refetches when the query params change", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(listRes())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result, rerender } = renderHook((p: { search: string }) => useClips(p), {
+      wrapper,
+      initialProps: { search: "a" },
+    })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    rerender({ search: "b" })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/clips?search=b")
+  })
+
+  it("flags an error when the fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })))
+    const { result } = renderHook(() => useClips({}), { wrapper })
+    await waitFor(() => expect(result.current.error).toBe(true))
+  })
+})

--- a/web/hooks/use-clips.ts
+++ b/web/hooks/use-clips.ts
@@ -1,0 +1,54 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import {
+  buildClipQuery,
+  type ClipListResponse,
+  type ClipSearchParams,
+} from "@/lib/workspace-clips"
+
+/**
+ * Fetch a page of clips from the same-origin BFF (/api/clips) with the in-memory
+ * access token. Refetches whenever the serialized query (workspace/search/sort/
+ * page) changes. Previous data is kept across refetches so paging/typing doesn't
+ * blank the list. Use behind an auth guard (e.g. useRequireAuth).
+ *
+ * Search debouncing is the caller's job — pass an already-debounced `search`.
+ */
+export function useClips(params: ClipSearchParams) {
+  const { accessToken, isLoading: authLoading } = useAuth()
+  const query = buildClipQuery(params)
+  const [data, setData] = useState<ClipListResponse | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (authLoading || !accessToken) return
+    let active = true
+    fetch(`/api/clips${query ? `?${query}` : ""}`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("fetch failed")
+        return (await res.json()) as ClipListResponse
+      })
+      .then((next) => {
+        if (active) {
+          setData(next)
+          setError(false)
+        }
+      })
+      .catch(() => {
+        if (active) setError(true)
+      })
+    return () => {
+      active = false
+    }
+  }, [query, accessToken, authLoading])
+
+  // First load (no data yet) shows the skeleton; later refetches keep prior data.
+  const loading = authLoading || (!!accessToken && data === null && !error)
+
+  return { data, loading, error }
+}

--- a/web/hooks/use-clips.ts
+++ b/web/hooks/use-clips.ts
@@ -15,16 +15,25 @@ import {
  * page) changes. Previous data is kept across refetches so paging/typing doesn't
  * blank the list. Use behind an auth guard (e.g. useRequireAuth).
  *
+ * Pass `enabled: false` to defer the fetch (e.g. until the workspace id is known)
+ * — while deferred the hook reports `loading` so the caller shows a skeleton
+ * rather than a spurious unscoped fetch.
+ *
  * Search debouncing is the caller's job — pass an already-debounced `search`.
  */
-export function useClips(params: ClipSearchParams) {
+export function useClips(
+  params: ClipSearchParams,
+  { enabled = true }: { enabled?: boolean } = {}
+) {
   const { accessToken, isLoading: authLoading } = useAuth()
   const query = buildClipQuery(params)
   const [data, setData] = useState<ClipListResponse | null>(null)
-  const [error, setError] = useState(false)
+  // The query a fetch error belongs to; a later query change makes it stale so
+  // the skeleton shows again on the next attempt (instead of being suppressed).
+  const [errorQuery, setErrorQuery] = useState<string | null>(null)
 
   useEffect(() => {
-    if (authLoading || !accessToken) return
+    if (!enabled || authLoading || !accessToken) return
     let active = true
     fetch(`/api/clips${query ? `?${query}` : ""}`, {
       headers: { authorization: `Bearer ${accessToken}` },
@@ -36,19 +45,25 @@ export function useClips(params: ClipSearchParams) {
       .then((next) => {
         if (active) {
           setData(next)
-          setError(false)
+          setErrorQuery(null)
         }
       })
       .catch(() => {
-        if (active) setError(true)
+        if (active) setErrorQuery(query)
       })
     return () => {
       active = false
     }
-  }, [query, accessToken, authLoading])
+  }, [query, enabled, accessToken, authLoading])
 
-  // First load (no data yet) shows the skeleton; later refetches keep prior data.
-  const loading = authLoading || (!!accessToken && data === null && !error)
+  const error = errorQuery === query
+  // Deferred (not yet enabled), first load (no data), and changed-query states
+  // show the skeleton; later refetches keep prior data. A failed first load
+  // drops out of loading so the empty/error state can show instead of an endless
+  // skeleton.
+  const loading =
+    authLoading ||
+    (!!accessToken && (!enabled || (data === null && !error)))
 
   return { data, loading, error }
 }

--- a/web/hooks/use-workspaces.test.tsx
+++ b/web/hooks/use-workspaces.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+import { useWorkspaces } from "@/hooks/use-workspaces"
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+}
+
+function ws(id: string, is_default = false) {
+  return {
+    id,
+    name: id,
+    clip_count: 0,
+    is_default,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: null,
+  }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("useWorkspaces", () => {
+  it("loads workspaces and picks the default one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ workspaces: [ws("a"), ws("b", true)], total: 2 }),
+          { status: 200 }
+        )
+      )
+    )
+    const { result } = renderHook(() => useWorkspaces(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.workspaces).toHaveLength(2)
+    expect(result.current.defaultWorkspace?.id).toBe("b")
+  })
+
+  it("falls back to the first workspace when none is default", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ workspaces: [ws("a"), ws("b")], total: 2 }), {
+          status: 200,
+        })
+      )
+    )
+    const { result } = renderHook(() => useWorkspaces(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.defaultWorkspace?.id).toBe("a")
+  })
+
+  it("flags an error on failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })))
+    const { result } = renderHook(() => useWorkspaces(), { wrapper })
+    await waitFor(() => expect(result.current.error).toBe(true))
+  })
+})

--- a/web/hooks/use-workspaces.ts
+++ b/web/hooks/use-workspaces.ts
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import type { Workspace, WorkspaceListResponse } from "@/lib/workspace-clips"
+
+/**
+ * Load the user's workspaces from the BFF (/api/workspaces). Exposes the list
+ * plus the default workspace (the one flagged `is_default`, else the first) for
+ * the panel breadcrumb and the initial clip query. Use behind an auth guard.
+ */
+export function useWorkspaces() {
+  const { accessToken, isLoading: authLoading } = useAuth()
+  const [workspaces, setWorkspaces] = useState<Workspace[] | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (authLoading || !accessToken) return
+    let active = true
+    fetch("/api/workspaces", {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("fetch failed")
+        return (await res.json()) as WorkspaceListResponse
+      })
+      .then((body) => {
+        if (active) {
+          setWorkspaces(body.workspaces)
+          setError(false)
+        }
+      })
+      .catch(() => {
+        if (active) setError(true)
+      })
+    return () => {
+      active = false
+    }
+  }, [accessToken, authLoading])
+
+  const defaultWorkspace = useMemo(
+    () => workspaces?.find((w) => w.is_default) ?? workspaces?.[0] ?? null,
+    [workspaces]
+  )
+
+  const loading = authLoading || (!!accessToken && workspaces === null && !error)
+
+  return { workspaces: workspaces ?? [], defaultWorkspace, loading, error }
+}

--- a/web/lib/workspace-clips.test.ts
+++ b/web/lib/workspace-clips.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  activeFilterCount,
+  applyClientFilters,
+  buildClipQuery,
+  EMPTY_FILTERS,
+  type Clip,
+} from "@/lib/workspace-clips"
+
+function clip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "c1",
+    workspace_id: "w1",
+    title: "Song",
+    format: "wav",
+    duration: 60,
+    bpm: 120,
+    key: "C",
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: "generate",
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("buildClipQuery", () => {
+  it("includes only the params that are set", () => {
+    expect(buildClipQuery({ workspace_id: "w1", page: 2 })).toBe(
+      "workspace_id=w1&page=2"
+    )
+  })
+
+  it("trims search and omits it when blank", () => {
+    expect(buildClipQuery({ search: "  lofi  " })).toBe("search=lofi")
+    expect(buildClipQuery({ search: "   " })).toBe("")
+  })
+
+  it("serializes sort and per_page", () => {
+    expect(buildClipQuery({ sort: "oldest", per_page: 20 })).toBe(
+      "sort=oldest&per_page=20"
+    )
+  })
+})
+
+describe("activeFilterCount", () => {
+  it("counts enabled toggles", () => {
+    expect(activeFilterCount(EMPTY_FILTERS)).toBe(0)
+    expect(activeFilterCount({ liked: true, public: false, uploads: true })).toBe(2)
+  })
+})
+
+describe("applyClientFilters", () => {
+  const clips = [
+    clip({ id: "a", is_public: true, generation_mode: "generate" }),
+    clip({ id: "b", is_public: false, generation_mode: "upload" }),
+    clip({ id: "c", is_public: true, generation_mode: "upload" }),
+  ]
+
+  it("returns all clips when no filter is active", () => {
+    expect(applyClientFilters(clips, EMPTY_FILTERS, [])).toHaveLength(3)
+  })
+
+  it("narrows to liked clips using the likedIds set", () => {
+    const out = applyClientFilters(clips, { ...EMPTY_FILTERS, liked: true }, ["c"])
+    expect(out.map((c) => c.id)).toEqual(["c"])
+  })
+
+  it("narrows to public clips", () => {
+    const out = applyClientFilters(clips, { ...EMPTY_FILTERS, public: true }, [])
+    expect(out.map((c) => c.id)).toEqual(["a", "c"])
+  })
+
+  it("narrows to uploads via generation_mode", () => {
+    const out = applyClientFilters(clips, { ...EMPTY_FILTERS, uploads: true }, [])
+    expect(out.map((c) => c.id)).toEqual(["b", "c"])
+  })
+
+  it("AND-combines active toggles", () => {
+    const out = applyClientFilters(
+      clips,
+      { liked: true, public: true, uploads: true },
+      ["c"]
+    )
+    expect(out.map((c) => c.id)).toEqual(["c"])
+  })
+})

--- a/web/lib/workspace-clips.ts
+++ b/web/lib/workspace-clips.ts
@@ -1,0 +1,116 @@
+// Types + client helpers for the workspace clip-library panel (US-16.5).
+//
+// Mirrors the backend ClipResponse/WorkspaceResponse shapes
+// (src/acemusic/api/routers/clips.py, workspaces.py). Search, sort, and
+// pagination are server-driven; the Liked/Public/Uploads filters are applied
+// client-side (see applyClientFilters) because the backend GET /clips endpoint
+// has no query params for them yet.
+
+export type SortOrder = "newest" | "oldest"
+
+/** A clip as returned by GET /api/v1/clips (ClipResponse). No `updated_at`. */
+export type Clip = {
+  id: string
+  workspace_id: string
+  title: string | null
+  format: string | null
+  duration: number | null
+  bpm: number | null
+  key: string | null
+  style_tags: string[]
+  lyrics: string | null
+  vocal_language: string | null
+  model: string | null
+  seed: number | null
+  inference_steps: number | null
+  parent_clip_ids: string[]
+  generation_mode: string | null
+  is_public: boolean
+  created_at: string
+}
+
+/** A workspace as returned by GET /api/v1/workspaces (WorkspaceResponse). */
+export type Workspace = {
+  id: string
+  name: string
+  clip_count: number
+  is_default: boolean
+  created_at: string
+  updated_at: string | null
+}
+
+export type ClipListResponse = {
+  clips: Clip[]
+  total: number
+  page: number
+  per_page: number
+  total_pages: number
+}
+
+export type WorkspaceListResponse = {
+  workspaces: Workspace[]
+  total: number
+}
+
+/** The three filter toggles in the panel header. */
+export type ClipFilters = {
+  liked: boolean
+  public: boolean
+  uploads: boolean
+}
+
+export const EMPTY_FILTERS: ClipFilters = {
+  liked: false,
+  public: false,
+  uploads: false,
+}
+
+/** Server-supported query parameters for GET /api/clips. */
+export type ClipSearchParams = {
+  workspace_id?: string
+  search?: string
+  sort?: SortOrder
+  page?: number
+  per_page?: number
+}
+
+/** Build the query string for GET /api/clips from server-supported params. */
+export function buildClipQuery(params: ClipSearchParams): string {
+  const q = new URLSearchParams()
+  if (params.workspace_id) q.set("workspace_id", params.workspace_id)
+  const search = params.search?.trim()
+  if (search) q.set("search", search)
+  if (params.sort) q.set("sort", params.sort)
+  if (params.page) q.set("page", String(params.page))
+  if (params.per_page) q.set("per_page", String(params.per_page))
+  return q.toString()
+}
+
+/** Number of active filter toggles, for the Filters button badge. */
+export function activeFilterCount(filters: ClipFilters): number {
+  return (
+    Number(filters.liked) + Number(filters.public) + Number(filters.uploads)
+  )
+}
+
+/**
+ * Apply the Liked/Public/Uploads toggles client-side.
+ *
+ * ponytail: backend GET /clips has no liked/public/uploads params, so these
+ * narrow the *fetched page* in the browser — server-side filtering is a backend
+ * follow-up. `liked` is sourced from the player's localStorage-backed likedIds
+ * set (the only place "liked" exists today). Enabled toggles are AND-combined.
+ */
+export function applyClientFilters(
+  clips: Clip[],
+  filters: ClipFilters,
+  likedIds: readonly string[]
+): Clip[] {
+  const liked = new Set(likedIds)
+  return clips.filter((c) => {
+    if (filters.liked && !liked.has(c.id)) return false
+    if (filters.public && !c.is_public) return false
+    if (filters.uploads && c.generation_mode !== "upload") return false
+    return true
+  })
+}


### PR DESCRIPTION
## US-16.5: Workspace and Clip Library Panel

Closes #191.

Adds the right-side clip library to the **Create** page: a workspace breadcrumb,
debounced search, Liked/Public/Uploads filters, Newest/Oldest sort, pagination,
and a minimal clip card/list — in a two-column layout that scrolls independently
of the creation form.

> [!NOTE]
> The CodeRabbit issue plan was written when `web/` was empty and uses
> `web/src/...` paths and an `items` response key. It's **stale**. This PR is
> adapted to the real app: flat structure (`app/`, `components/`, `lib/`,
> `hooks/`), PascalCase components, co-located vitest tests, and the actual
> backend contract.

### How it works
- **Search / sort / pagination** are server-driven via `GET /api/v1/clips`
  (params `search`, `sort`, `page`, `per_page`, `workspace_id`), reached through
  new same-origin BFF proxy routes (`/api/clips`, `/api/workspaces`) that forward
  the Bearer token — the established pattern (`app/api/users/me/route.ts`).
- **Breadcrumb** uses `GET /api/v1/workspaces` (default workspace) and navigates
  to `/studio` on click.
- **Filters** are applied **client-side** (the backend has no `liked/public/
  uploads` params): Liked reuses the player's localStorage `likedIds`, Public
  uses `is_public`, Uploads uses `generation_mode === "upload"`. This was an
  explicit, approved interim choice.

### Acceptance criteria
- [x] Breadcrumb displays current workspace + navigates on click
- [x] Search filters in real time (debounced, server `search`)
- [x] Filter toggles (Liked / Public / Uploads) narrow the list
- [x] Sort dropdown reorders clips (server `sort`)
- [x] Pagination loads pages (server `page`)
- [x] Panel scrolls independently of the creation form

### Tests
27 new files; `npm test` → **238 passed**. Typecheck, lint, and `next build`
all clean locally (web is not in CI).

### Known limitations
- **Client-side filters apply to the fetched page only.** Because the backend
  has no `liked/public/uploads` query params, filtering happens after server
  pagination — matches on other pages aren't pulled in, and `totalPages` reflects
  the unfiltered set (raised as P2 by `codex review`; the empty-state wording is
  scoped to "this page" to avoid implying the whole library is empty). Promoting
  these to real server-side filters is a backend follow-up.
- **`ClipCard` is intentionally minimal** — inline edit, play/like/menu actions,
  and full interactivity are US-16.6.
- **No "liked" backend exists**; the Liked filter is only as complete as the
  player's local liked set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace clip library panel with search, filters, sorting, pagination, and empty/loading states.
  * Workspace navigation now includes a breadcrumb, plus a clearer clip card view with duration and tags.
  * Introduced backend-backed workspace and clip loading for authenticated users.

* **Bug Fixes**
  * Improved handling of missing clip titles by showing a friendly fallback.
  * Added consistent unauthorized responses when workspace or clip data is accessed without authentication.

* **Tests & Documentation**
  * Expanded automated coverage for search, filters, pagination, and data loading.
  * Added demo documentation with verified live-test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->