### PR TITLE
feat(web): Clip Card Component (US-16.6)

### DIFF
--- a/docs/demos/us-16.6-clip-card.md
+++ b/docs/demos/us-16.6-clip-card.md
@@ -1,0 +1,72 @@
+# US-16.6 — Clip Card Component (Demo)
+
+The clip card is a presentational React component reused across the workspace panel,
+library, and search results. It is not yet mounted on its own auth-gated page, so this
+demo verifies each acceptance criterion through behavioral tests that assert **real DOM
+and player-store outcomes** (rendered via React Testing Library + `userEvent`), not just
+"it rendered". Each criterion below names the test that proves it.
+
+Run from `web/`.
+
+## AC1 — Renders all metadata fields correctly
+
+Title, `mm:ss` duration, style tags, and the version/metadata badges (model → label,
+generation_mode → label) all render from a `Clip`.
+
+```bash
+cd web && npx vitest run components/workspace/ClipCard.test.tsx -t "renders title, duration, and style tags|renders version and metadata badges" --reporter=verbose 2>&1 | grep -E "✓|Tests "
+```
+
+## AC2 — Play button sends the clip to the global player
+
+Clicking Play dispatches `play/track`; a probe reading `usePlayer().state.current` flips
+from `none` to the clip id `c1`.
+
+```bash
+cd web && npx vitest run components/workspace/ClipCard.test.tsx -t "sends the clip to the global player" --reporter=verbose 2>&1 | grep -E "✓|Tests "
+```
+
+## AC3 — Inline title edit saves on blur or Enter
+
+Enter commits the rename (calls `onTitleChange("c1", "New Name")` and shows the new title);
+Escape reverts to the original and calls nothing.
+
+```bash
+cd web && npx vitest run components/workspace/ClipCard.test.tsx -t "saves an inline title edit on Enter|reverts an inline title edit on Escape" --reporter=verbose 2>&1 | grep -E "✓|Tests "
+```
+
+## AC4 — Like / dislike / share / publish trigger their actions
+
+Like toggles the player store (`aria-pressed` flips, label Like→Unlike); dislike/share fire
+their callbacks with the clip id; publish reports the next visibility `onPublishToggle("c1", true)`.
+
+```bash
+cd web && npx vitest run components/workspace/ClipCard.test.tsx -t "toggles like via the player store|fires dislike and share callbacks|toggles publish and reports the next visibility" --reporter=verbose 2>&1 | grep -E "✓|Tests "
+```
+
+## AC5 — More-options menu renders all spec §9.2 actions
+
+Opening the ⋯ menu shows every §9.2 label (Open in Studio, Open in Editor, Cover, Extend,
+Mashup, Sample from Song, Use as Inspiration, Send to Mastering, Export to DAW, Create Music
+Video, Delete) plus the Remix/Edit and Download submenus; a Download → WAV click dispatches
+`onMenuAction("download-wav", "c1")`.
+
+```bash
+cd web && npx vitest run components/workspace/ClipCard.test.tsx -t "renders all spec 9.2 actions|dispatches a menu action from the Remix|dispatches a download action with its format" --reporter=verbose 2>&1 | grep -E "✓|Tests "
+```
+
+## AC6 — "Get Full Song" only on clips under ~60s
+
+Rendered (and clickable → `onGetFullSong("c1")`) for a 30s clip; absent for a 120s clip.
+
+```bash
+cd web && npx vitest run components/workspace/ClipCard.test.tsx -t "shows Get Full Song only for clips under 60s" --reporter=verbose 2>&1 | grep -E "✓|Tests "
+```
+
+## Production safety regression — list still renders cards
+
+`ClipList`/`WorkspacePanel` render the upgraded card unchanged (no new required props).
+
+```bash
+cd web && npx vitest run components/workspace/ClipList.test.tsx components/workspace/WorkspacePanel.test.tsx --reporter=verbose 2>&1 | grep -E "Tests "
+```

--- a/web/components/workspace/ClipCard.test.tsx
+++ b/web/components/workspace/ClipCard.test.tsx
@@ -181,6 +181,23 @@ describe("ClipCard", () => {
     expect(menu).toBeInTheDocument()
   })
 
+  it("does not duplicate generation actions in the more-options menu", async () => {
+    renderCard()
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    // Each §9.2 item appears exactly once (no submenu re-listing the flat items).
+    expect(screen.getAllByText("Cover")).toHaveLength(1)
+    expect(screen.getAllByText("Open in Studio")).toHaveLength(1)
+    expect(screen.getAllByText("Sample from Song")).toHaveLength(1)
+  })
+
+  it("dispatches remix-edit from the more-options menu", async () => {
+    const onMenuAction = vi.fn()
+    renderCard({ onMenuAction })
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    await userEvent.click(screen.getByRole("menuitem", { name: "Remix / Edit" }))
+    expect(onMenuAction).toHaveBeenCalledWith("remix-edit", "c1")
+  })
+
   it("dispatches a menu action from the Remix/Edit primary CTA", async () => {
     const onMenuAction = vi.fn()
     renderCard({ onMenuAction })

--- a/web/components/workspace/ClipCard.test.tsx
+++ b/web/components/workspace/ClipCard.test.tsx
@@ -29,10 +29,15 @@ function clip(overrides: Partial<Clip> = {}): Clip {
   }
 }
 
-/** Surfaces the global player's current track id so play wiring is observable. */
+/** Surfaces the global player's current track so play wiring is observable. */
 function PlayerProbe() {
   const { state } = usePlayer()
-  return <div data-testid="current-track">{state.current?.id ?? "none"}</div>
+  return (
+    <>
+      <div data-testid="current-track">{state.current?.id ?? "none"}</div>
+      <div data-testid="current-title">{state.current?.title ?? "none"}</div>
+    </>
+  )
 }
 
 function renderCard(props: Partial<ClipCardProps> = {}) {
@@ -78,6 +83,17 @@ describe("ClipCard", () => {
     expect(screen.getByTestId("current-track")).toHaveTextContent("none")
     await userEvent.click(screen.getByRole("button", { name: /play/i }))
     expect(screen.getByTestId("current-track")).toHaveTextContent("c1")
+  })
+
+  it("sends the optimistic title to the player after a rename", async () => {
+    const onTitleChange = vi.fn()
+    renderCard({ onTitleChange })
+    await userEvent.click(screen.getByRole("button", { name: /edit title/i }))
+    const input = screen.getByRole("textbox", { name: /title/i })
+    await userEvent.clear(input)
+    await userEvent.type(input, "New Name{Enter}")
+    await userEvent.click(screen.getByRole("button", { name: /play/i }))
+    expect(screen.getByTestId("current-title")).toHaveTextContent("New Name")
   })
 
   it("saves an inline title edit on Enter", async () => {
@@ -137,16 +153,16 @@ describe("ClipCard", () => {
 
   it("shows Get Full Song only for clips under 60s", async () => {
     const onGetFullSong = vi.fn()
-    const { rerender } = render(
+    const { unmount } = render(
       <PlayerProvider>
         <ClipCard clip={clip({ duration: 30 })} onGetFullSong={onGetFullSong} />
       </PlayerProvider>
     )
-    const btn = screen.getByRole("button", { name: /get full song/i })
-    await userEvent.click(btn)
+    await userEvent.click(screen.getByRole("button", { name: /get full song/i }))
     expect(onGetFullSong).toHaveBeenCalledWith("c1")
+    unmount()
 
-    rerender(
+    render(
       <PlayerProvider>
         <ClipCard clip={clip({ duration: 120 })} onGetFullSong={onGetFullSong} />
       </PlayerProvider>

--- a/web/components/workspace/ClipCard.test.tsx
+++ b/web/components/workspace/ClipCard.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
 
-import { ClipCard } from "@/components/workspace/ClipCard"
+import { ClipCard, type ClipCardProps } from "@/components/workspace/ClipCard"
+import { PlayerProvider, usePlayer } from "@/contexts/player-context"
 import type { Clip } from "@/lib/workspace-clips"
 
 function clip(overrides: Partial<Clip> = {}): Clip {
@@ -27,16 +29,174 @@ function clip(overrides: Partial<Clip> = {}): Clip {
   }
 }
 
+/** Surfaces the global player's current track id so play wiring is observable. */
+function PlayerProbe() {
+  const { state } = usePlayer()
+  return <div data-testid="current-track">{state.current?.id ?? "none"}</div>
+}
+
+function renderCard(props: Partial<ClipCardProps> = {}) {
+  return render(
+    <PlayerProvider>
+      <ClipCard clip={clip()} {...props} />
+      <PlayerProbe />
+    </PlayerProvider>
+  )
+}
+
 describe("ClipCard", () => {
   it("renders title, duration, and style tags", () => {
-    render(<ClipCard clip={clip()} />)
+    renderCard()
     expect(screen.getByText("Midnight")).toBeInTheDocument()
     expect(screen.getByText("1:35")).toBeInTheDocument()
     expect(screen.getByText("lofi, chill")).toBeInTheDocument()
   })
 
   it("falls back to a placeholder title for untitled clips", () => {
-    render(<ClipCard clip={clip({ title: null })} />)
+    render(
+      <PlayerProvider>
+        <ClipCard clip={clip({ title: null })} />
+      </PlayerProvider>
+    )
     expect(screen.getByText("Untitled clip")).toBeInTheDocument()
+  })
+
+  it("renders version and metadata badges from model/generation_mode", () => {
+    render(
+      <PlayerProvider>
+        <ClipCard
+          clip={clip({ model: "ace-step-v1", generation_mode: "extend" })}
+        />
+      </PlayerProvider>
+    )
+    expect(screen.getByText("XL")).toBeInTheDocument()
+    expect(screen.getByText("Extend")).toBeInTheDocument()
+  })
+
+  it("sends the clip to the global player when Play is clicked", async () => {
+    renderCard()
+    expect(screen.getByTestId("current-track")).toHaveTextContent("none")
+    await userEvent.click(screen.getByRole("button", { name: /play/i }))
+    expect(screen.getByTestId("current-track")).toHaveTextContent("c1")
+  })
+
+  it("saves an inline title edit on Enter", async () => {
+    const onTitleChange = vi.fn()
+    renderCard({ onTitleChange })
+    await userEvent.click(screen.getByRole("button", { name: /edit title/i }))
+    const input = screen.getByRole("textbox", { name: /title/i })
+    await userEvent.clear(input)
+    await userEvent.type(input, "New Name{Enter}")
+    expect(onTitleChange).toHaveBeenCalledWith("c1", "New Name")
+    expect(screen.getByText("New Name")).toBeInTheDocument()
+  })
+
+  it("reverts an inline title edit on Escape", async () => {
+    const onTitleChange = vi.fn()
+    renderCard({ onTitleChange })
+    await userEvent.click(screen.getByRole("button", { name: /edit title/i }))
+    const input = screen.getByRole("textbox", { name: /title/i })
+    await userEvent.clear(input)
+    await userEvent.type(input, "Throwaway{Escape}")
+    expect(onTitleChange).not.toHaveBeenCalled()
+    expect(screen.getByText("Midnight")).toBeInTheDocument()
+  })
+
+  it("toggles like via the player store", async () => {
+    renderCard()
+    const like = screen.getByRole("button", { name: "Like" })
+    expect(like).toHaveAttribute("aria-pressed", "false")
+    await userEvent.click(like)
+    expect(screen.getByRole("button", { name: "Unlike" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
+  })
+
+  it("fires dislike and share callbacks", async () => {
+    const onDislike = vi.fn()
+    const onShare = vi.fn()
+    renderCard({ onDislike, onShare })
+    await userEvent.click(screen.getByRole("button", { name: /dislike/i }))
+    await userEvent.click(screen.getByRole("button", { name: /share/i }))
+    expect(onDislike).toHaveBeenCalledWith("c1")
+    expect(onShare).toHaveBeenCalledWith("c1")
+  })
+
+  it("toggles publish and reports the next visibility", async () => {
+    const onPublishToggle = vi.fn()
+    renderCard({ onPublishToggle })
+    const publish = screen.getByRole("button", { name: /publish|make public/i })
+    expect(publish).toHaveAttribute("aria-pressed", "false")
+    await userEvent.click(publish)
+    expect(onPublishToggle).toHaveBeenCalledWith("c1", true)
+    expect(
+      screen.getByRole("button", { name: /publish|make public|public/i })
+    ).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("shows Get Full Song only for clips under 60s", async () => {
+    const onGetFullSong = vi.fn()
+    const { rerender } = render(
+      <PlayerProvider>
+        <ClipCard clip={clip({ duration: 30 })} onGetFullSong={onGetFullSong} />
+      </PlayerProvider>
+    )
+    const btn = screen.getByRole("button", { name: /get full song/i })
+    await userEvent.click(btn)
+    expect(onGetFullSong).toHaveBeenCalledWith("c1")
+
+    rerender(
+      <PlayerProvider>
+        <ClipCard clip={clip({ duration: 120 })} onGetFullSong={onGetFullSong} />
+      </PlayerProvider>
+    )
+    expect(
+      screen.queryByRole("button", { name: /get full song/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders all spec 9.2 actions in the more-options menu", async () => {
+    renderCard()
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    const menu = screen.getByRole("menu")
+    for (const label of [
+      "Open in Studio",
+      "Open in Editor",
+      "Cover",
+      "Extend",
+      "Mashup",
+      "Sample from Song",
+      "Use as Inspiration",
+      "Send to Mastering",
+      "Export to DAW",
+      "Create Music Video",
+      "Delete",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+    // Remix/Edit and Download are submenus.
+    expect(screen.getByText("Remix / Edit")).toBeInTheDocument()
+    expect(screen.getByText("Download")).toBeInTheDocument()
+    expect(menu).toBeInTheDocument()
+  })
+
+  it("dispatches a menu action from the Remix/Edit primary CTA", async () => {
+    const onMenuAction = vi.fn()
+    renderCard({ onMenuAction })
+    await userEvent.click(
+      screen.getByRole("button", { name: /remix or edit/i })
+    )
+    await userEvent.click(screen.getByRole("menuitem", { name: "Cover" }))
+    expect(onMenuAction).toHaveBeenCalledWith("cover", "c1")
+  })
+
+  it("dispatches a download action with its format", async () => {
+    const onMenuAction = vi.fn()
+    renderCard({ onMenuAction })
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download" }))
+    await userEvent.click(screen.getByRole("menuitem", { name: "WAV" }))
+    expect(onMenuAction).toHaveBeenCalledWith("download-wav", "c1")
   })
 })

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -1,38 +1,436 @@
 "use client"
 
+import { useState } from "react"
 import { HugeiconsIcon } from "@hugeicons/react"
-import { MusicNote01Icon } from "@hugeicons/core-free-icons"
+import {
+  ArrowDown01Icon,
+  Delete02Icon,
+  Edit02Icon,
+  FavouriteIcon,
+  GlobeIcon,
+  MoreHorizontalIcon,
+  MusicNote01Icon,
+  PlayIcon,
+  Share01Icon,
+  ThumbsDownIcon,
+} from "@hugeicons/core-free-icons"
 
-import { formatTime } from "@/lib/clips"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { usePlayer } from "@/contexts/player-context"
+import { clipArtworkUrl, clipAudioUrl, formatTime, type Track } from "@/lib/clips"
+import { cn } from "@/lib/utils"
 import type { Clip } from "@/lib/workspace-clips"
 
-// ponytail: minimal list-view card. US-16.6 extends it with inline title edit,
-// play/like/menu action buttons, and full interactivity — out of scope here.
+// US-16.6: the reusable clip card. Play + Like are wired to the global player
+// store (the only backend-free actions that already have a home — see
+// LikeButton). Everything else is exposed as a callback prop because the backend
+// has no like/dislike/share/publish/title/menu endpoints proxied in web/ yet;
+// the parent (or a future hook) wires those when the routes land.
 
-/** Minimal clip card: thumbnail placeholder + duration, title, and style tags. */
-export function ClipCard({ clip }: { clip: Clip }) {
+/** Every action reachable from the clip card menus (spec §9.2). */
+export type ClipMenuAction =
+  | "remix-edit"
+  | "open-studio"
+  | "open-editor"
+  | "cover"
+  | "extend"
+  | "mashup"
+  | "sample"
+  | "use-inspiration"
+  | "send-mastering"
+  | "export-daw"
+  | "create-video"
+  | "download-mp3"
+  | "download-wav"
+  | "download-flac"
+  | "download-stems"
+  | "delete"
+
+export type ClipCardProps = {
+  clip: Clip
+  /** Inline-rename committed (blur/Enter). */
+  onTitleChange?: (id: string, title: string) => void
+  /** Any menu item from the Remix/Edit CTA or the ⋯ menu. */
+  onMenuAction?: (action: ClipMenuAction, clipId: string) => void
+  onGetFullSong?: (id: string) => void
+  onDislike?: (id: string) => void
+  onShare?: (id: string) => void
+  /** Publish toggle; `next` is the requested visibility. */
+  onPublishToggle?: (id: string, next: boolean) => void
+}
+
+const FULL_SONG_MAX_SECONDS = 60
+
+/** Model id → short version badge label. Unmapped models show their raw id. */
+const VERSION_LABELS: Record<string, string> = {
+  "ace-step-v1": "XL",
+  "ace-step-v1-turbo": "XL Turbo",
+}
+
+/** generation_mode → metadata badge label. Plain "generate"/null show nothing. */
+const MODE_LABELS: Record<string, string> = {
+  cover: "Cover",
+  extend: "Extend",
+  remix: "Remix",
+  mashup: "Mashup",
+  sample: "Sample",
+  upload: "Upload",
+  studio: "Studio",
+  mastered: "Mastered",
+  full_song: "Full Song",
+}
+
+/** Remix/Edit sub-options, shared by the primary CTA and the ⋯ submenu. */
+const REMIX_ITEMS: { action: ClipMenuAction; label: string; pro?: boolean }[] = [
+  { action: "open-studio", label: "Open in Studio" },
+  { action: "open-editor", label: "Open in Editor", pro: true },
+  { action: "cover", label: "Cover" },
+  { action: "extend", label: "Extend" },
+  { action: "mashup", label: "Mashup" },
+  { action: "sample", label: "Sample from Song" },
+]
+
+const DOWNLOAD_ITEMS: { action: ClipMenuAction; label: string }[] = [
+  { action: "download-mp3", label: "MP3" },
+  { action: "download-wav", label: "WAV" },
+  { action: "download-flac", label: "FLAC" },
+  { action: "download-stems", label: "Stems" },
+]
+
+/** Build a playable Track from a clip (artist/artwork are placeholders today). */
+function trackFromClip(clip: Clip): Track {
+  return {
+    id: clip.id,
+    title: clip.title ?? "Untitled clip",
+    artist: "Unknown artist",
+    audioUrl: clipAudioUrl(clip.id),
+    artworkUrl: clipArtworkUrl(clip.id),
+    duration: clip.duration ?? undefined,
+  }
+}
+
+/** Full clip card: metadata, playback, inline rename, and action menus. */
+export function ClipCard({
+  clip,
+  onTitleChange,
+  onMenuAction,
+  onGetFullSong,
+  onDislike,
+  onShare,
+  onPublishToggle,
+}: ClipCardProps) {
+  const { state, dispatch } = usePlayer()
+  const liked = state.likedIds.includes(clip.id)
+
+  const [title, setTitle] = useState(clip.title)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState("")
+  const [isPublic, setIsPublic] = useState(clip.is_public)
+
+  const versionLabel = clip.model
+    ? (VERSION_LABELS[clip.model] ?? clip.model)
+    : null
+  const metadataLabel = clip.generation_mode
+    ? MODE_LABELS[clip.generation_mode]
+    : null
+  const styleText = clip.style_tags.join(", ")
+  const showFullSong =
+    clip.duration != null && clip.duration < FULL_SONG_MAX_SECONDS
+
+  function startEdit() {
+    setDraft(title ?? "")
+    setEditing(true)
+  }
+
+  function commitEdit() {
+    if (!editing) return
+    setEditing(false)
+    const next = draft.trim()
+    if (next && next !== (title ?? "")) {
+      setTitle(next)
+      onTitleChange?.(clip.id, next)
+    }
+  }
+
+  function emitMenu(action: ClipMenuAction) {
+    onMenuAction?.(action, clip.id)
+  }
+
+  function togglePublish() {
+    const next = !isPublic
+    setIsPublic(next)
+    onPublishToggle?.(clip.id, next)
+  }
+
   return (
     <div
       data-testid="clip-card"
       className="flex gap-3 rounded-lg border border-border bg-card p-2"
     >
-      <div className="relative flex size-14 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-        <HugeiconsIcon icon={MusicNote01Icon} size={20} />
+      {/* Thumbnail with duration overlay + hover play. */}
+      <button
+        type="button"
+        aria-label="Play"
+        onClick={() => dispatch({ type: "play/track", track: trackFromClip(clip) })}
+        className="group/thumb relative flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-muted-foreground transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        <HugeiconsIcon
+          icon={MusicNote01Icon}
+          size={20}
+          className="group-hover/thumb:opacity-0"
+        />
+        <span className="absolute inset-0 flex items-center justify-center bg-background/40 opacity-0 transition-opacity group-hover/thumb:opacity-100">
+          <HugeiconsIcon icon={PlayIcon} size={20} className="fill-current" />
+        </span>
         {clip.duration != null && (
           <span className="absolute right-0.5 bottom-0.5 rounded bg-background/80 px-1 text-[10px] tabular-nums">
             {formatTime(clip.duration)}
           </span>
         )}
-      </div>
-      <div className="flex min-w-0 flex-col justify-center">
-        <p className="truncate text-sm font-medium">
-          {clip.title ?? "Untitled clip"}
-        </p>
-        {clip.style_tags.length > 0 && (
-          <p className="truncate text-xs text-muted-foreground">
-            {clip.style_tags.join(", ")}
+      </button>
+
+      <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
+        {/* Title (inline editable). */}
+        {editing ? (
+          <Input
+            aria-label="Title"
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onFocus={(e) => e.currentTarget.select()}
+            onBlur={commitEdit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitEdit()
+              else if (e.key === "Escape") setEditing(false)
+            }}
+            className="h-7"
+          />
+        ) : (
+          <button
+            type="button"
+            aria-label="Edit title"
+            onClick={startEdit}
+            className="flex min-w-0 items-center gap-1 text-left outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          >
+            <span className="truncate text-sm font-medium">
+              {title ?? "Untitled clip"}
+            </span>
+            <HugeiconsIcon
+              icon={Edit02Icon}
+              size={14}
+              className="shrink-0 text-muted-foreground"
+            />
+          </button>
+        )}
+
+        {/* Badges. */}
+        {(versionLabel || metadataLabel) && (
+          <div className="flex flex-wrap items-center gap-1">
+            {versionLabel && (
+              <Badge variant="secondary" className="text-[10px]">
+                {versionLabel}
+              </Badge>
+            )}
+            {metadataLabel && (
+              <Badge variant="outline" className="text-[10px]">
+                {metadataLabel}
+              </Badge>
+            )}
+          </div>
+        )}
+
+        {/* Style description (full text on hover via title attr). */}
+        {styleText && (
+          <p
+            title={styleText}
+            className="truncate text-xs text-muted-foreground"
+          >
+            {styleText}
           </p>
         )}
+
+        {/* Action row. */}
+        <div className="flex flex-wrap items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={liked ? "Unlike" : "Like"}
+            aria-pressed={liked}
+            onClick={() => dispatch({ type: "like/toggle", id: clip.id })}
+            className={cn(liked && "text-primary")}
+          >
+            <HugeiconsIcon
+              icon={FavouriteIcon}
+              size={16}
+              className={cn(liked && "fill-current")}
+            />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Dislike"
+            onClick={() => onDislike?.(clip.id)}
+          >
+            <HugeiconsIcon icon={ThumbsDownIcon} size={16} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Share"
+            onClick={() => onShare?.(clip.id)}
+          >
+            <HugeiconsIcon icon={Share01Icon} size={16} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={isPublic ? "Unpublish (make private)" : "Publish (make public)"}
+            aria-pressed={isPublic}
+            onClick={togglePublish}
+            className={cn(isPublic && "text-primary")}
+          >
+            <HugeiconsIcon icon={GlobeIcon} size={16} />
+          </Button>
+
+          {showFullSong && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="ml-1"
+              onClick={() => onGetFullSong?.(clip.id)}
+            >
+              Get Full Song
+            </Button>
+          )}
+
+          <div className="ml-auto flex items-center gap-1">
+            {/* Remix/Edit primary CTA. */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="sm" aria-label="Remix or edit clip">
+                  Remix
+                  <HugeiconsIcon icon={ArrowDown01Icon} size={14} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {REMIX_ITEMS.map((item) => (
+                  <DropdownMenuItem
+                    key={item.action}
+                    onSelect={() => emitMenu(item.action)}
+                  >
+                    {item.label}
+                    {item.pro && (
+                      <Badge variant="outline" className="ml-auto text-[10px]">
+                        Pro
+                      </Badge>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* More options (⋯) — full spec §9.2 list. */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon-sm" aria-label="More options">
+                  <HugeiconsIcon icon={MoreHorizontalIcon} size={16} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-52">
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>Remix / Edit</DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    {REMIX_ITEMS.map((item) => (
+                      <DropdownMenuItem
+                        key={item.action}
+                        onSelect={() => emitMenu(item.action)}
+                      >
+                        {item.label}
+                        {item.pro && (
+                          <Badge
+                            variant="outline"
+                            className="ml-auto text-[10px]"
+                          >
+                            Pro
+                          </Badge>
+                        )}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={() => emitMenu("open-studio")}>
+                  Open in Studio
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => emitMenu("open-editor")}>
+                  Open in Editor
+                  <Badge variant="outline" className="ml-auto text-[10px]">
+                    Pro
+                  </Badge>
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => emitMenu("cover")}>
+                  Cover
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => emitMenu("extend")}>
+                  Extend
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => emitMenu("mashup")}>
+                  Mashup
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => emitMenu("sample")}>
+                  Sample from Song
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => emitMenu("use-inspiration")}>
+                  Use as Inspiration
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={() => emitMenu("send-mastering")}>
+                  Send to Mastering
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => emitMenu("export-daw")}>
+                  Export to DAW
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => emitMenu("create-video")}>
+                  Create Music Video
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>Download</DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    {DOWNLOAD_ITEMS.map((item) => (
+                      <DropdownMenuItem
+                        key={item.action}
+                        onSelect={() => emitMenu(item.action)}
+                      >
+                        {item.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={() => emitMenu("delete")}
+                >
+                  <HugeiconsIcon icon={Delete02Icon} size={16} />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -159,8 +159,10 @@ export function ClipCard({
     setEditing(false)
     const next = draft.trim()
     if (next && next !== (title ?? "")) {
-      setTitle(next)
       onTitleChange?.(clip.id, next)
+      // Reflect the rename locally only when a parent can persist it — otherwise
+      // the edit has nowhere to go and shouldn't look saved.
+      if (onTitleChange) setTitle(next)
     }
   }
 
@@ -170,8 +172,9 @@ export function ClipCard({
 
   function togglePublish() {
     const next = !isPublic
-    setIsPublic(next)
     onPublishToggle?.(clip.id, next)
+    // Only reflect the new visibility when a parent persists it.
+    if (onPublishToggle) setIsPublic(next)
   }
 
   return (

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -201,7 +201,14 @@ export function ClipCard({
       <button
         type="button"
         aria-label="Play"
-        onClick={() => dispatch({ type: "play/track", track: trackFromClip(clip) })}
+        onClick={() =>
+          dispatch({
+            type: "play/track",
+            // Use the resolved (optimistic) title so the now-playing bar matches
+            // what the card shows after an inline rename.
+            track: { ...trackFromClip(clip), title: title ?? "Untitled clip" },
+          })
+        }
         className="group/thumb relative flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-muted-foreground transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
       >
         <HugeiconsIcon

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
   ArrowDown01Icon,
@@ -132,12 +132,21 @@ export function ClipCard({
   onPublishToggle,
 }: ClipCardProps) {
   const { state, dispatch } = usePlayer()
-  const liked = state.likedIds.includes(clip.id)
+  // likedIds re-renders every player tick; scan a Set (cf. applyClientFilters).
+  const likedSet = useMemo(() => new Set(state.likedIds), [state.likedIds])
+  const liked = likedSet.has(clip.id)
 
-  const [title, setTitle] = useState(clip.title)
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState("")
-  const [isPublic, setIsPublic] = useState(clip.is_public)
+  // Editing cancelled (Escape) — checked in the single onBlur commit path.
+  const cancelRef = useRef(false)
+  // Optimistic overlays: null means "show the prop". This keeps an idle card in
+  // sync with parent/refetch updates while still reflecting a user's own edit.
+  // A real resync (e.g. a failed save) lands when backend mutation routes exist.
+  const [optimisticTitle, setOptimisticTitle] = useState<string | null>(null)
+  const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
+  const title = optimisticTitle ?? clip.title
+  const isPublic = optimisticPublic ?? clip.is_public
 
   const versionLabel = clip.model
     ? (VERSION_LABELS[clip.model] ?? clip.model)
@@ -154,15 +163,21 @@ export function ClipCard({
     setEditing(true)
   }
 
+  // Single commit path: Enter/Escape both blur the input, so onBlur is the only
+  // place a rename is saved (cancelRef distinguishes Escape). Avoids the
+  // double-save / stale-closure race of committing from both keydown and blur.
   function commitEdit() {
-    if (!editing) return
     setEditing(false)
+    if (cancelRef.current) {
+      cancelRef.current = false
+      return
+    }
     const next = draft.trim()
     if (next && next !== (title ?? "")) {
       onTitleChange?.(clip.id, next)
       // Reflect the rename locally only when a parent can persist it — otherwise
       // the edit has nowhere to go and shouldn't look saved.
-      if (onTitleChange) setTitle(next)
+      if (onTitleChange) setOptimisticTitle(next)
     }
   }
 
@@ -174,7 +189,7 @@ export function ClipCard({
     const next = !isPublic
     onPublishToggle?.(clip.id, next)
     // Only reflect the new visibility when a parent persists it.
-    if (onPublishToggle) setIsPublic(next)
+    if (onPublishToggle) setOptimisticPublic(next)
   }
 
   return (
@@ -215,8 +230,11 @@ export function ClipCard({
             onFocus={(e) => e.currentTarget.select()}
             onBlur={commitEdit}
             onKeyDown={(e) => {
-              if (e.key === "Enter") commitEdit()
-              else if (e.key === "Escape") setEditing(false)
+              if (e.key === "Enter") e.currentTarget.blur()
+              else if (e.key === "Escape") {
+                cancelRef.current = true
+                e.currentTarget.blur()
+              }
             }}
             className="h-7"
           />
@@ -352,27 +370,11 @@ export function ClipCard({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-52">
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>Remix / Edit</DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    {REMIX_ITEMS.map((item) => (
-                      <DropdownMenuItem
-                        key={item.action}
-                        onSelect={() => emitMenu(item.action)}
-                      >
-                        {item.label}
-                        {item.pro && (
-                          <Badge
-                            variant="outline"
-                            className="ml-auto text-[10px]"
-                          >
-                            Pro
-                          </Badge>
-                        )}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
+                {/* Remix/Edit opens the remix flow; the generation actions below
+                    are the flat §9.2 items (the primary CTA is the shortcut). */}
+                <DropdownMenuItem onSelect={() => emitMenu("remix-edit")}>
+                  Remix / Edit
+                </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onSelect={() => emitMenu("open-studio")}>
                   Open in Studio

--- a/web/components/workspace/ClipList.test.tsx
+++ b/web/components/workspace/ClipList.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
 import { ClipList } from "@/components/workspace/ClipList"
+import { PlayerProvider } from "@/contexts/player-context"
 import type { Clip } from "@/lib/workspace-clips"
 
 function clip(id: string): Clip {
@@ -38,7 +39,11 @@ describe("ClipList", () => {
   })
 
   it("renders a card per clip", () => {
-    render(<ClipList clips={[clip("a"), clip("b")]} loading={false} />)
+    render(
+      <PlayerProvider>
+        <ClipList clips={[clip("a"), clip("b")]} loading={false} />
+      </PlayerProvider>
+    )
     expect(screen.getAllByTestId("clip-card")).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## US-16.6: Clip Card Component

Closes #192.

Extends the placeholder `components/workspace/ClipCard.tsx` (shipped in US-16.5 with a
`// ponytail: US-16.6 extends it` marker) into the full, reusable clip card used across
the workspace panel, library, and search results.

### What's included
- **Thumbnail** with `mm:ss` duration overlay and a hover **Play** button
- **Version badge** (`model` → label) and **metadata badge** (`generation_mode` → label), each hidden when empty
- **Style description** — joined `style_tags`, single-line truncation, full text on hover (native `title`)
- **Inline title edit** — pencil/title → input (autofocus + select-all), save on blur/Enter, revert on Escape
- **Action row** — Like (real, via player store), Dislike, Share, Publish toggle
- **Get Full Song** — only rendered for clips shorter than 60s
- **Remix/Edit** primary CTA dropdown + **More-options (⋯)** menu rendering the full spec §9.2 action list (Remix/Edit ▸, Open in Studio, Open in Editor [Pro], Cover, Extend, Mashup, Sample from Song, Use as Inspiration, Send to Mastering, Export to DAW, Create Music Video, Download ▸ MP3/WAV/FLAC/Stems, Delete)

### Acceptance criteria
- [x] Clip card renders all metadata fields correctly
- [x] Play button sends the clip to the global player
- [x] Inline title edit saves on blur or Enter key
- [x] Like/dislike/share/publish buttons trigger appropriate handlers
- [x] More options menu renders all actions from spec §9.2
- [x] "Get Full Song" button only visible on clips shorter than ~60s

### Deviation from the issue's CodeRabbit plan
That plan was authored when `web/` was empty and prescribed a new `components/clip-card/`
module with `use-clip-card`/`use-clip-actions` hooks calling `PATCH /clips`, extend/cover/
remix, and `DELETE`. Since then US-16.1→16.5 scaffolded the app, and **none of those API
routes are proxied in `web/`** (only `GET /api/clips`). So this PR adapts to the live
patterns: extend the existing flat component in place, wire Play + Like to the global
player store (mirroring `LikeButton`), and expose the rest as **callback props** (the
issue's approved Design Choices 1 & 2). The two hook files were dropped as YAGNI until
those backend routes land.

### Known limitations (no backend route yet)
- **Audio streaming**: Play dispatches a `Track` whose `audioUrl` is `clipAudioUrl()` →
  `/api/v1/clips/{id}/audio`, which has no same-origin proxy yet (an authenticated media
  proxy is the "later story" already noted in `lib/clips.ts` from US-15.6). The clip is
  correctly sent to the player; end-to-end streaming awaits that proxy.
- **dislike / share / publish / title-save / menu actions** fire their callback props;
  optimistic title/publish UI updates are gated on the handler being present so the card
  never shows a change it can't persist. Backend wiring lands with the relevant endpoints.

### Testing
- `vitest run` — 253 passing (13 new ClipCard cases covering every AC)
- `tsc --noEmit`, `eslint`, `next build` — all clean (web is not in CI; run locally)
