### PR TITLE
feat(web): Create Button Behavior and Generation Flow (US-16.7)

### DIFF
--- a/web/app/api/jobs/[jobId]/route.test.ts
+++ b/web/app/api/jobs/[jobId]/route.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { GET } from "@/app/api/jobs/[jobId]/route"
+
+function req(init: RequestInit = {}): NextRequest {
+  return new Request(
+    "http://localhost/api/jobs/j1",
+    init
+  ) as unknown as NextRequest
+}
+
+const ctx = (jobId = "j1") => ({ params: Promise.resolve({ jobId }) })
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("GET /api/jobs/[jobId]", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await GET(req(), ctx())
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the Bearer token and passes the job status through", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            job_id: "j1",
+            status: "completed",
+            clip_ids: ["c1", "c2"],
+          }),
+          { status: 200 }
+        )
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await GET(
+      req({ headers: { authorization: "Bearer tok" } }),
+      ctx()
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({
+      status: "completed",
+      clip_ids: ["c1", "c2"],
+    })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/jobs/j1/status")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+  })
+
+  it("encodes the job id into the upstream URL", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("{}", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await GET(req({ headers: { authorization: "Bearer tok" } }), ctx("a/b"))
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/jobs/a%2Fb/status")
+  })
+
+  it("returns a controlled 502 when the upstream fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")))
+    const res = await GET(
+      req({ headers: { authorization: "Bearer tok" } }),
+      ctx()
+    )
+    expect(res.status).toBe(502)
+  })
+
+  it("surfaces a 404 verbatim", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ detail: "Job not found." }), {
+            status: 404,
+          })
+        )
+    )
+    const res = await GET(
+      req({ headers: { authorization: "Bearer tok" } }),
+      ctx()
+    )
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ detail: "Job not found." })
+  })
+})

--- a/web/app/api/jobs/[jobId]/route.ts
+++ b/web/app/api/jobs/[jobId]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/jobs/{job_id}/status (US-16.7). The client
+// holds the access token in memory and sends it as a Bearer header; this route
+// forwards it so the backend URL stays server-side. The creation form polls this
+// after a 202 to drive progress → completed/failed. Status/body pass through
+// verbatim (200 with the job status, 401, 404 when the job is unknown).
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ jobId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { jobId } = await ctx.params
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/jobs/${encodeURIComponent(jobId)}/status`,
+      {
+        headers: { authorization: auth, accept: "application/json" },
+      }
+    )
+  } catch {
+    // Backend unreachable — a controlled 502 the poller can treat as transient
+    // instead of an opaque 500 that would read as a failed generation.
+    return NextResponse.json(
+      { detail: "Job service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useCallback, useState } from "react"
 import { useRouter } from "next/navigation"
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -14,6 +15,12 @@ import { ModelSelectionProvider } from "@/contexts/model-selection-context"
 export default function CreatePage() {
   const { isLoading, isAuthenticated } = useRequireAuth()
   const router = useRouter()
+
+  // Bumped whenever a creation form finishes a generation, so the workspace panel
+  // refetches and the new clips appear (US-16.7). Stable callback so it doesn't
+  // re-create the forms' generation hooks each render.
+  const [refreshKey, setRefreshKey] = useState(0)
+  const onGenerated = useCallback(() => setRefreshKey((k) => k + 1), [])
 
   // ponytail: render nothing until authed — useRequireAuth redirects otherwise,
   // and this avoids flashing protected content during the check.
@@ -36,13 +43,13 @@ export default function CreatePage() {
               <TabsTrigger value="sounds">Sounds</TabsTrigger>
             </TabsList>
             <TabsContent value="simple">
-              <SimpleCreationForm />
+              <SimpleCreationForm onGenerated={onGenerated} />
             </TabsContent>
             <TabsContent value="advanced">
-              <AdvancedCreationForm />
+              <AdvancedCreationForm onGenerated={onGenerated} />
             </TabsContent>
             <TabsContent value="sounds">
-              <SoundsCreationForm />
+              <SoundsCreationForm onGenerated={onGenerated} />
             </TabsContent>
           </Tabs>
         </div>
@@ -52,7 +59,10 @@ export default function CreatePage() {
           aria-label="Clip library"
           className="hidden w-80 shrink-0 flex-col border-l border-border p-4 lg:flex"
         >
-          <WorkspacePanel onNavigateWorkspaces={() => router.push("/studio")} />
+          <WorkspacePanel
+            onNavigateWorkspaces={() => router.push("/studio")}
+            refreshKey={refreshKey}
+          />
         </aside>
       </div>
     </ModelSelectionProvider>

--- a/web/components/create/AdvancedCreationForm.test.tsx
+++ b/web/components/create/AdvancedCreationForm.test.tsx
@@ -10,7 +10,11 @@ vi.mock("@/hooks/use-auth", () => ({
 }))
 
 vi.mock("@/contexts/model-selection-context", () => ({
-  useModelSelection: () => ({ selectedModel: "base", isLoading: false }),
+  useModelSelection: () => ({
+    models: [{ key: "base", display_name: "Base" }],
+    selectedModel: "base",
+    isLoading: false,
+  }),
 }))
 
 const submitAdvancedGeneration = vi.fn()
@@ -18,9 +22,15 @@ vi.mock("@/lib/generate", async (importActual) => {
   const actual = await importActual<typeof import("@/lib/generate")>()
   return {
     ...actual,
-    submitAdvancedGeneration: (...args: unknown[]) => submitAdvancedGeneration(...args),
+    submitAdvancedGeneration: (...args: unknown[]) =>
+      submitAdvancedGeneration(...args),
   }
 })
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
 
 afterEach(() => vi.clearAllMocks())
 
@@ -32,7 +42,9 @@ describe("AdvancedCreationForm", () => {
   it("renders the lyrics panel with structure-tag placeholder and a vocal language selector", () => {
     render(<AdvancedCreationForm />)
     expect(screen.getByPlaceholderText(/\[Verse 1\]/)).toBeInTheDocument()
-    expect(screen.getByRole("combobox", { name: /vocal language/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("combobox", { name: /vocal language/i })
+    ).toBeInTheDocument()
   })
 
   it("keeps Create disabled until there is a style or lyrics", async () => {
@@ -51,7 +63,9 @@ describe("AdvancedCreationForm", () => {
     const pill = screen
       .getAllByRole("button")
       .find((b) =>
-        (STYLE_SUGGESTIONS as readonly string[]).includes(b.textContent?.trim() ?? "")
+        (STYLE_SUGGESTIONS as readonly string[]).includes(
+          b.textContent?.trim() ?? ""
+        )
       )
     expect(pill).toBeDefined()
     await user.click(pill!)
@@ -79,11 +93,15 @@ describe("AdvancedCreationForm", () => {
     await user.type(styles, "rock")
 
     const stylesSection = screen.getByRole("region", { name: "Styles panel" })
-    await user.click(within(stylesSection).getByRole("button", { name: /clear/i }))
+    await user.click(
+      within(stylesSection).getByRole("button", { name: /clear/i })
+    )
     expect(styles).toHaveValue("")
 
     // Undo pops the empty entry pushed by Clear, restoring the prior text.
-    await user.click(within(stylesSection).getByRole("button", { name: /undo/i }))
+    await user.click(
+      within(stylesSection).getByRole("button", { name: /undo/i })
+    )
     expect(screen.getByLabelText("Styles")).toHaveValue("rock")
   })
 
@@ -100,10 +118,19 @@ describe("AdvancedCreationForm", () => {
     expect(submitAdvancedGeneration).not.toHaveBeenCalled()
   })
 
-  it("submits a valid form and reports success", async () => {
-    submitAdvancedGeneration.mockResolvedValue({ status: "accepted", jobId: "job-1" })
+  it("submits a valid form, polls, and surfaces the completed clips", async () => {
+    submitAdvancedGeneration.mockResolvedValue({
+      status: "accepted",
+      jobId: "job-1",
+      estimatedSeconds: 20,
+    })
+    fetchJobStatus.mockResolvedValue({
+      kind: "completed",
+      clipIds: ["c1", "c2"],
+    })
+    const onGenerated = vi.fn()
     const user = userEvent.setup()
-    render(<AdvancedCreationForm />)
+    render(<AdvancedCreationForm onGenerated={onGenerated} />)
     await user.type(screen.getByLabelText("Styles"), "orchestral")
     await user.click(createButton())
 
@@ -112,14 +139,53 @@ describe("AdvancedCreationForm", () => {
       "tok",
       "base"
     )
-    expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
+    expect(await screen.findByText(/clips are ready/i)).toBeInTheDocument()
+    expect(onGenerated).toHaveBeenCalledOnce()
+  })
+
+  it("shows a model-aware estimate while polling and recovers via Retry", async () => {
+    submitAdvancedGeneration.mockResolvedValue({
+      status: "accepted",
+      jobId: "job-1",
+      estimatedSeconds: 45,
+    })
+    fetchJobStatus.mockResolvedValueOnce({
+      kind: "failed",
+      error: "Generation failed.",
+    })
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    await user.type(screen.getByLabelText("Styles"), "orchestral")
+    await user.click(createButton())
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Generation failed."
+    )
+    fetchJobStatus.mockResolvedValue({ kind: "pending" })
+    await user.click(screen.getByRole("button", { name: /retry/i }))
+    const status = await screen.findByRole("status")
+    expect(status).toHaveTextContent(/Base/)
+    expect(status).toHaveTextContent(/~45s/)
+  })
+
+  it("Clear all resets the styles field", async () => {
+    const user = userEvent.setup()
+    render(<AdvancedCreationForm />)
+    const styles = screen.getByLabelText("Styles")
+    await user.type(styles, "orchestral")
+    await user.click(screen.getByRole("button", { name: /clear all/i }))
+    expect(screen.getByLabelText("Styles")).toHaveValue("")
+    expect(createButton()).toBeDisabled()
   })
 
   it("shows the enhance input and a coming-soon notice on apply", async () => {
     const user = userEvent.setup()
     render(<AdvancedCreationForm />)
     await user.click(screen.getByRole("button", { name: /enhance/i }))
-    await user.type(screen.getByLabelText(/enhancement prompt/i), "make it darker")
+    await user.type(
+      screen.getByLabelText(/enhancement prompt/i),
+      "make it darker"
+    )
     await user.click(screen.getByRole("button", { name: /apply/i }))
     expect(screen.getByRole("status")).toHaveTextContent(/coming soon/i)
   })

--- a/web/components/create/AdvancedCreationForm.tsx
+++ b/web/components/create/AdvancedCreationForm.tsx
@@ -3,7 +3,11 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
-import { ArrowTurnBackwardIcon, MagicWand01Icon, SparklesIcon } from "@hugeicons/core-free-icons"
+import {
+  ArrowTurnBackwardIcon,
+  MagicWand01Icon,
+  SparklesIcon,
+} from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -11,10 +15,16 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/hooks/use-auth"
+import { useGeneration } from "@/hooks/use-generation"
 import { useModelSelection } from "@/contexts/model-selection-context"
 import { InspirationTags } from "@/components/create/InspirationTags"
-import { MoreOptionsSection, type MoreOptions } from "@/components/create/MoreOptionsSection"
+import {
+  MoreOptionsSection,
+  type MoreOptions,
+} from "@/components/create/MoreOptionsSection"
 import { useUndoableField } from "@/components/create/useUndoableField"
+import { GenerationProgress } from "@/components/create/GenerationProgress"
+import { GenerationError } from "@/components/create/GenerationError"
 import {
   combineStyles,
   submitAdvancedGeneration,
@@ -27,12 +37,6 @@ import {
   WEIRDNESS_DEFAULT,
 } from "@/lib/constants/generation"
 import { SELECT_CLASS } from "@/lib/constants/ui"
-
-type Status =
-  | { kind: "idle" }
-  | { kind: "info"; message: string }
-  | { kind: "success"; message: string }
-  | { kind: "error"; message: string }
 
 const STUB_NOTICE = "This feature is coming soon."
 
@@ -57,10 +61,13 @@ const initialOptions: MoreOptions = {
  * parameter the backend accepts. Mirrors SimpleCreationForm's controlled-state,
  * BFF-submit pattern; lyrics and styles each get single-step undo.
  */
-export function AdvancedCreationForm() {
+export function AdvancedCreationForm({
+  onGenerated,
+}: { onGenerated?: () => void } = {}) {
   const router = useRouter()
   const { accessToken } = useAuth()
-  const { selectedModel, isLoading: modelLoading } = useModelSelection()
+  const { models, selectedModel, isLoading: modelLoading } = useModelSelection()
+  const generation = useGeneration({ onComplete: onGenerated })
 
   const lyricsField = useUndoableField("")
   const stylesField = useUndoableField("")
@@ -69,8 +76,10 @@ export function AdvancedCreationForm() {
   const [vocalLanguage, setVocalLanguage] = useState("")
   const [instrumental, setInstrumental] = useState(false)
   const [options, setOptions] = useState<MoreOptions>(initialOptions)
-  const [status, setStatus] = useState<Status>({ kind: "idle" })
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  // Neutral notice (stub features) and pre-submit validation message, both kept
+  // separate from the generation state machine.
+  const [notice, setNotice] = useState<string | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
   const [showEnhance, setShowEnhance] = useState(false)
   const [enhancePrompt, setEnhancePrompt] = useState("")
 
@@ -81,7 +90,12 @@ export function AdvancedCreationForm() {
   const effectiveLyrics = lyricsMode === "manual" ? lyricsField.value : ""
   // Enabled the moment there's a style or lyrics to build a prompt from; range
   // validation runs on submit so out-of-range values surface a message.
-  const canSubmit = effectiveStyle.trim().length > 0 || effectiveLyrics.trim().length > 0
+  const canSubmit =
+    effectiveStyle.trim().length > 0 || effectiveLyrics.trim().length > 0
+  const busy =
+    generation.state.phase === "submitting" ||
+    generation.state.phase === "polling"
+  const modelName = models.find((m) => m.key === selectedModel)?.display_name
 
   function formData(): AdvancedFormData {
     return {
@@ -104,7 +118,7 @@ export function AdvancedCreationForm() {
   }
 
   async function handleCreate() {
-    if (!canSubmit || isSubmitting || modelLoading) return
+    if (!canSubmit || busy || modelLoading) return
     if (!accessToken) {
       router.push("/login")
       return
@@ -112,30 +126,30 @@ export function AdvancedCreationForm() {
     const data = formData()
     const error = validateAdvanced(data)
     if (error) {
-      setStatus({ kind: "error", message: error })
+      setFormError(error)
       return
     }
-    setIsSubmitting(true)
-    try {
-      const result = await submitAdvancedGeneration(data, accessToken, selectedModel)
-      switch (result.status) {
-        case "accepted":
-          setStatus({
-            kind: "success",
-            message: "Generation started. We'll let you know when it's ready.",
-          })
-          break
-        case "unauthorized":
-          router.push("/login")
-          break
-        case "invalid":
-        case "error":
-          setStatus({ kind: "error", message: result.detail })
-          break
-      }
-    } finally {
-      setIsSubmitting(false)
-    }
+    setFormError(null)
+    setNotice(null)
+    await generation.submit(
+      () => submitAdvancedGeneration(data, accessToken, selectedModel),
+      accessToken
+    )
+  }
+
+  function clearAll() {
+    lyricsField.setValue("")
+    stylesField.setValue("")
+    setSelectedTags([])
+    setLyricsMode("manual")
+    setVocalLanguage("")
+    setInstrumental(false)
+    setOptions(initialOptions)
+    setShowEnhance(false)
+    setEnhancePrompt("")
+    setNotice(null)
+    setFormError(null)
+    generation.reset()
   }
 
   return (
@@ -199,10 +213,18 @@ export function AdvancedCreationForm() {
             disabled={!lyricsField.canUndo}
             onClick={lyricsField.undo}
           >
-            <HugeiconsIcon icon={ArrowTurnBackwardIcon} data-icon="inline-start" />
+            <HugeiconsIcon
+              icon={ArrowTurnBackwardIcon}
+              data-icon="inline-start"
+            />
             Undo
           </Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => lyricsField.setValue("")}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => lyricsField.setValue("")}
+          >
             Clear
           </Button>
         </div>
@@ -217,7 +239,7 @@ export function AdvancedCreationForm() {
             <Button
               type="button"
               size="sm"
-              onClick={() => setStatus({ kind: "info", message: STUB_NOTICE })}
+              onClick={() => setNotice(STUB_NOTICE)}
             >
               Apply
             </Button>
@@ -244,7 +266,7 @@ export function AdvancedCreationForm() {
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => setStatus({ kind: "info", message: STUB_NOTICE })}
+            onClick={() => setNotice(STUB_NOTICE)}
           >
             <HugeiconsIcon icon={MagicWand01Icon} data-icon="inline-start" />
             Magic wand
@@ -256,14 +278,26 @@ export function AdvancedCreationForm() {
             disabled={!stylesField.canUndo}
             onClick={stylesField.undo}
           >
-            <HugeiconsIcon icon={ArrowTurnBackwardIcon} data-icon="inline-start" />
+            <HugeiconsIcon
+              icon={ArrowTurnBackwardIcon}
+              data-icon="inline-start"
+            />
             Undo
           </Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => stylesField.setValue("")}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => stylesField.setValue("")}
+          >
             Clear
           </Button>
           <div className="ml-auto flex items-center gap-2">
-            <Switch id="adv-instrumental" checked={instrumental} onCheckedChange={setInstrumental} />
+            <Switch
+              id="adv-instrumental"
+              checked={instrumental}
+              onCheckedChange={setInstrumental}
+            />
             <Label htmlFor="adv-instrumental">Instrumental</Label>
           </div>
         </div>
@@ -271,25 +305,56 @@ export function AdvancedCreationForm() {
 
       <MoreOptionsSection value={options} onChange={updateOptions} />
 
-      {(status.kind === "info" || status.kind === "success") && (
+      {notice && (
         <p role="status" className="text-sm text-muted-foreground">
-          {status.message}
+          {notice}
         </p>
       )}
-      {status.kind === "error" && (
+      {formError && (
         <p role="alert" className="text-sm text-destructive">
-          {status.message}
+          {formError}
         </p>
+      )}
+      {generation.state.phase === "polling" && (
+        <GenerationProgress
+          estimatedSeconds={generation.state.estimatedSeconds}
+          modelName={modelName}
+          progress={generation.state.progress}
+        />
+      )}
+      {generation.state.phase === "success" && (
+        <p role="status" className="text-sm text-muted-foreground">
+          Your new clips are ready in the workspace.
+        </p>
+      )}
+      {generation.state.phase === "error" && (
+        <GenerationError
+          message={generation.state.message}
+          onRetry={generation.retry}
+          onDismiss={generation.reset}
+        />
       )}
 
-      <Button
-        type="button"
-        className="w-fit"
-        disabled={!canSubmit || isSubmitting || modelLoading}
-        onClick={handleCreate}
-      >
-        {isSubmitting ? "Creating..." : "Create"}
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          className="w-fit"
+          disabled={!canSubmit || busy || modelLoading}
+          onClick={handleCreate}
+        >
+          {busy ? "Creating..." : "Create"}
+        </Button>
+        {/* ponytail: inline Clear all — resets every Advanced field to its default. */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          onClick={clearAll}
+        >
+          Clear all
+        </Button>
+      </div>
     </div>
   )
 }

--- a/web/components/create/GenerationError.test.tsx
+++ b/web/components/create/GenerationError.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { GenerationError } from "@/components/create/GenerationError"
+
+describe("GenerationError", () => {
+  it("shows the message and wires Retry / Dismiss", async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    const onDismiss = vi.fn()
+    render(
+      <GenerationError
+        message="Not enough credits."
+        onRetry={onRetry}
+        onDismiss={onDismiss}
+      />
+    )
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Not enough credits.")
+    await user.click(screen.getByRole("button", { name: /retry/i }))
+    expect(onRetry).toHaveBeenCalledOnce()
+    await user.click(screen.getByRole("button", { name: /dismiss/i }))
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/web/components/create/GenerationError.tsx
+++ b/web/components/create/GenerationError.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+
+/**
+ * Failed-generation state (US-16.7): a meaningful message plus Retry (resubmit the
+ * same request) and Dismiss (clear back to idle). Used by all three creation forms.
+ */
+export function GenerationError({
+  message,
+  onRetry,
+  onDismiss,
+}: {
+  message: string
+  onRetry: () => void
+  onDismiss: () => void
+}) {
+  return (
+    <div role="alert" className="flex flex-col gap-2 text-sm text-destructive">
+      <p>{message}</p>
+      <div className="flex gap-2">
+        <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+          Retry
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/components/create/GenerationProgress.test.tsx
+++ b/web/components/create/GenerationProgress.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { GenerationProgress } from "@/components/create/GenerationProgress"
+
+describe("GenerationProgress", () => {
+  it("shows the model name and time estimate", () => {
+    render(<GenerationProgress estimatedSeconds={30} modelName="Turbo" />)
+    const status = screen.getByRole("status")
+    expect(status).toHaveTextContent(/Turbo/)
+    expect(status).toHaveTextContent(/~30s/)
+  })
+
+  it("omits the estimate when zero", () => {
+    render(<GenerationProgress estimatedSeconds={0} modelName="Base" />)
+    expect(screen.getByRole("status")).not.toHaveTextContent(/~/)
+  })
+
+  it("renders per-step progress when provided", () => {
+    render(<GenerationProgress estimatedSeconds={10} progress="step 2 of 5" />)
+    expect(screen.getByRole("status")).toHaveTextContent("step 2 of 5")
+  })
+})

--- a/web/components/create/GenerationProgress.tsx
+++ b/web/components/create/GenerationProgress.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+/**
+ * In-flight generation indicator (US-16.7). Shown while the job is polling, with
+ * the backend's model-aware time estimate and (when known) the model name, so the
+ * estimate visibly reflects the selected model. `progress` carries optional
+ * per-step text for long multi-step jobs.
+ */
+export function GenerationProgress({
+  estimatedSeconds,
+  modelName,
+  progress,
+}: {
+  estimatedSeconds: number
+  modelName?: string
+  progress?: string
+}) {
+  const withModel = modelName ? ` with ${modelName}` : ""
+  const estimate = estimatedSeconds > 0 ? ` ~${estimatedSeconds}s` : ""
+  return (
+    <div
+      role="status"
+      className="flex flex-col gap-1 text-sm text-muted-foreground"
+    >
+      <span className="flex items-center gap-2">
+        <HugeiconsIcon
+          icon={Loading03Icon}
+          className="animate-spin"
+          data-icon="inline-start"
+        />
+        Generating{withModel}…{estimate}
+      </span>
+      {progress && <span className="text-xs">{progress}</span>}
+    </div>
+  )
+}

--- a/web/components/create/SimpleCreationForm.test.tsx
+++ b/web/components/create/SimpleCreationForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -9,12 +9,21 @@ vi.mock("@/hooks/use-auth", () => ({
 }))
 
 vi.mock("@/contexts/model-selection-context", () => ({
-  useModelSelection: () => ({ selectedModel: "base", isLoading: false }),
+  useModelSelection: () => ({
+    models: [{ key: "base", display_name: "Base" }],
+    selectedModel: "base",
+    isLoading: false,
+  }),
 }))
 
 const submitGeneration = vi.fn()
 vi.mock("@/lib/generate", () => ({
   submitGeneration: (...args: unknown[]) => submitGeneration(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
 }))
 
 afterEach(() => {
@@ -23,7 +32,7 @@ afterEach(() => {
 
 describe("SimpleCreationForm", () => {
   function createButton() {
-    return screen.getByRole("button", { name: /create/i })
+    return screen.getByRole("button", { name: /^creat/i })
   }
 
   it("disables Create when description and lyrics are both empty", () => {
@@ -76,10 +85,19 @@ describe("SimpleCreationForm", () => {
     expect(toggle).toHaveAttribute("aria-checked", "true")
   })
 
-  it("submits the form state and reports success", async () => {
-    submitGeneration.mockResolvedValue({ status: "accepted", jobId: "job-1" })
+  it("submits, polls, and surfaces the completed clips", async () => {
+    submitGeneration.mockResolvedValue({
+      status: "accepted",
+      jobId: "job-1",
+      estimatedSeconds: 5,
+    })
+    fetchJobStatus.mockResolvedValue({
+      kind: "completed",
+      clipIds: ["c1", "c2"],
+    })
+    const onGenerated = vi.fn()
     const user = userEvent.setup()
-    render(<SimpleCreationForm />)
+    render(<SimpleCreationForm onGenerated={onGenerated} />)
 
     await user.type(screen.getByLabelText("Song description"), "dreamy")
     await user.click(screen.getByRole("switch", { name: "Instrumental" }))
@@ -90,7 +108,61 @@ describe("SimpleCreationForm", () => {
       "tok",
       "base"
     )
-    expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
+    expect(await screen.findByText(/clips are ready/i)).toBeInTheDocument()
+    expect(onGenerated).toHaveBeenCalledOnce()
+  })
+
+  it("shows a model-aware time estimate while generating", async () => {
+    submitGeneration.mockResolvedValue({
+      status: "accepted",
+      jobId: "job-1",
+      estimatedSeconds: 30,
+    })
+    fetchJobStatus.mockResolvedValue({ kind: "pending" })
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+
+    await user.type(screen.getByLabelText("Song description"), "dreamy")
+    await user.click(createButton())
+
+    const status = await screen.findByRole("status")
+    expect(status).toHaveTextContent(/Base/)
+    expect(status).toHaveTextContent(/~30s/)
+  })
+
+  it("shows an error with a working Retry when the job fails", async () => {
+    submitGeneration.mockResolvedValue({
+      status: "accepted",
+      jobId: "job-1",
+      estimatedSeconds: 5,
+    })
+    fetchJobStatus.mockResolvedValue({
+      kind: "failed",
+      error: "Generation failed.",
+    })
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+
+    await user.type(screen.getByLabelText("Song description"), "dreamy")
+    await user.click(createButton())
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Generation failed."
+    )
+    await user.click(screen.getByRole("button", { name: /retry/i }))
+    await waitFor(() => expect(submitGeneration).toHaveBeenCalledTimes(2))
+  })
+
+  it("Clear all resets the form fields", async () => {
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+    const description = screen.getByLabelText("Song description")
+    await user.type(description, "dreamy")
+    expect(description).toHaveValue("dreamy")
+
+    await user.click(screen.getByRole("button", { name: /clear all/i }))
+    expect(screen.getByLabelText("Song description")).toHaveValue("")
+    expect(createButton()).toBeDisabled()
   })
 
   it("shows the +Audio placeholder as a neutral notice, not an error", async () => {

--- a/web/components/create/SimpleCreationForm.tsx
+++ b/web/components/create/SimpleCreationForm.tsx
@@ -10,37 +10,36 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/hooks/use-auth"
+import { useGeneration } from "@/hooks/use-generation"
 import { useModelSelection } from "@/contexts/model-selection-context"
 import { submitGeneration } from "@/lib/generate"
 import { InspirationTags } from "@/components/create/InspirationTags"
-
-// A user-facing message only. Whether a request is in flight is tracked
-// separately (isSubmitting) so a non-error notice — e.g. the +Audio placeholder
-// — can't clobber the in-flight state and re-enable Create mid-request.
-type Status =
-  | { kind: "idle" }
-  | { kind: "info"; message: string }
-  | { kind: "success"; message: string }
-  | { kind: "error"; message: string }
+import { GenerationProgress } from "@/components/create/GenerationProgress"
+import { GenerationError } from "@/components/create/GenerationError"
 
 /**
  * The Simple creation form (US-16.1): describe a song in plain language and go.
  * A controlled form whose Create button enables as soon as there's a description
- * or lyrics, then enqueues a generation request through the BFF proxy. Progress
- * and result rendering are deferred to US-16.7 — success just reports the job id.
+ * or lyrics, then drives the full generation lifecycle (US-16.7) via useGeneration:
+ * submit → poll → progress/estimate → clips. `onGenerated` fires once clips exist
+ * so the Create page can refresh the workspace panel.
  */
-export function SimpleCreationForm() {
+export function SimpleCreationForm({
+  onGenerated,
+}: { onGenerated?: () => void } = {}) {
   const router = useRouter()
   const { accessToken } = useAuth()
-  const { selectedModel, isLoading: modelLoading } = useModelSelection()
+  const { models, selectedModel, isLoading: modelLoading } = useModelSelection()
+  const generation = useGeneration({ onComplete: onGenerated })
 
   const [description, setDescription] = useState("")
   const [instrumental, setInstrumental] = useState(false)
   const [lyrics, setLyrics] = useState("")
   const [showLyrics, setShowLyrics] = useState(false)
   const [selectedTags, setSelectedTags] = useState<string[]>([])
-  const [status, setStatus] = useState<Status>({ kind: "idle" })
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  // Neutral notice for non-generation messages (e.g. the +Audio placeholder),
+  // kept separate from the generation state machine.
+  const [notice, setNotice] = useState<string | null>(null)
 
   // Lyrics only count when the field is open — hiding it shouldn't keep Create
   // enabled (and then submit an empty prompt). Use this one value everywhere.
@@ -50,39 +49,38 @@ export function SimpleCreationForm() {
   // toggle don't gate submission (per the acceptance criteria).
   const canSubmit =
     description.trim().length > 0 || effectiveLyrics.trim().length > 0
+  const busy =
+    generation.state.phase === "submitting" ||
+    generation.state.phase === "polling"
+  const modelName = models.find((m) => m.key === selectedModel)?.display_name
 
   async function handleCreate() {
     // Block until the model context settles so a saved default isn't missed.
-    if (!canSubmit || isSubmitting || modelLoading) return
+    if (!canSubmit || busy || modelLoading) return
     if (!accessToken) {
       router.push("/login")
       return
     }
-    setIsSubmitting(true)
-    try {
-      const result = await submitGeneration(
-        { description, lyrics: effectiveLyrics, instrumental, selectedTags },
-        accessToken,
-        selectedModel
-      )
-      switch (result.status) {
-        case "accepted":
-          setStatus({
-            kind: "success",
-            message: "Generation started. We'll let you know when it's ready.",
-          })
-          break
-        case "unauthorized":
-          router.push("/login")
-          break
-        case "invalid":
-        case "error":
-          setStatus({ kind: "error", message: result.detail })
-          break
-      }
-    } finally {
-      setIsSubmitting(false)
-    }
+    setNotice(null)
+    await generation.submit(
+      () =>
+        submitGeneration(
+          { description, lyrics: effectiveLyrics, instrumental, selectedTags },
+          accessToken,
+          selectedModel
+        ),
+      accessToken
+    )
+  }
+
+  function clearAll() {
+    setDescription("")
+    setInstrumental(false)
+    setLyrics("")
+    setShowLyrics(false)
+    setSelectedTags([])
+    setNotice(null)
+    generation.reset()
   }
 
   return (
@@ -116,10 +114,8 @@ export function SimpleCreationForm() {
           type="button"
           variant="outline"
           size="sm"
-          disabled={isSubmitting}
-          onClick={() =>
-            setStatus({ kind: "info", message: "Audio input is coming soon." })
-          }
+          disabled={busy}
+          onClick={() => setNotice("Audio input is coming soon.")}
         >
           <HugeiconsIcon icon={MusicNote01Icon} data-icon="inline-start" />
           Audio
@@ -146,27 +142,51 @@ export function SimpleCreationForm() {
 
       <InspirationTags selectedTags={selectedTags} onChange={setSelectedTags} />
 
-      {/* Neutral notices (info/success) are polite status; only real failures
-          use the assertive, destructive alert. */}
-      {(status.kind === "info" || status.kind === "success") && (
+      {notice && (
         <p role="status" className="text-sm text-muted-foreground">
-          {status.message}
+          {notice}
         </p>
       )}
-      {status.kind === "error" && (
-        <p role="alert" className="text-sm text-destructive">
-          {status.message}
+      {generation.state.phase === "polling" && (
+        <GenerationProgress
+          estimatedSeconds={generation.state.estimatedSeconds}
+          modelName={modelName}
+          progress={generation.state.progress}
+        />
+      )}
+      {generation.state.phase === "success" && (
+        <p role="status" className="text-sm text-muted-foreground">
+          Your new clips are ready in the workspace.
         </p>
+      )}
+      {generation.state.phase === "error" && (
+        <GenerationError
+          message={generation.state.message}
+          onRetry={generation.retry}
+          onDismiss={generation.reset}
+        />
       )}
 
-      <Button
-        type="button"
-        className="w-fit"
-        disabled={!canSubmit || isSubmitting || modelLoading}
-        onClick={handleCreate}
-      >
-        {isSubmitting ? "Creating..." : "Create"}
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          className="w-fit"
+          disabled={!canSubmit || busy || modelLoading}
+          onClick={handleCreate}
+        >
+          {busy ? "Creating..." : "Create"}
+        </Button>
+        {/* ponytail: inline Clear all — a one-line reset, no component needed. */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          onClick={clearAll}
+        >
+          Clear all
+        </Button>
+      </div>
     </div>
   )
 }

--- a/web/components/create/SoundsCreationForm.test.tsx
+++ b/web/components/create/SoundsCreationForm.test.tsx
@@ -9,7 +9,11 @@ vi.mock("@/hooks/use-auth", () => ({
 }))
 
 vi.mock("@/contexts/model-selection-context", () => ({
-  useModelSelection: () => ({ selectedModel: "base", isLoading: false }),
+  useModelSelection: () => ({
+    models: [{ key: "base", display_name: "Base" }],
+    selectedModel: "base",
+    isLoading: false,
+  }),
 }))
 
 // Stubbed so the unauthorized path's router.push("/login") never throws.
@@ -22,9 +26,15 @@ vi.mock("@/lib/generate", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/generate")>()
   return {
     ...actual,
-    submitSoundsGeneration: (...args: unknown[]) => submitSoundsGeneration(...args),
+    submitSoundsGeneration: (...args: unknown[]) =>
+      submitSoundsGeneration(...args),
   }
 })
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -61,29 +71,53 @@ describe("SoundsCreationForm", () => {
     expect(screen.getByLabelText("Key")).toBeInTheDocument()
   })
 
-  it("submits a one-shot and reports success", async () => {
-    submitSoundsGeneration.mockResolvedValue({ status: "accepted", jobId: "job-1" })
+  it("submits a one-shot, polls, and surfaces the completed clips", async () => {
+    submitSoundsGeneration.mockResolvedValue({
+      status: "accepted",
+      jobId: "job-1",
+      estimatedSeconds: 5,
+    })
+    fetchJobStatus.mockResolvedValue({
+      kind: "completed",
+      clipIds: ["c1", "c2"],
+    })
+    const onGenerated = vi.fn()
     const user = userEvent.setup()
-    render(<SoundsCreationForm />)
+    render(<SoundsCreationForm onGenerated={onGenerated} />)
 
     await user.type(screen.getByLabelText("Sound description"), "a punchy kick")
     await user.click(oneShot())
     await user.click(createButton())
 
     expect(submitSoundsGeneration).toHaveBeenCalledWith(
-      expect.objectContaining({ description: "a punchy kick", soundType: "one-shot" }),
+      expect.objectContaining({
+        description: "a punchy kick",
+        soundType: "one-shot",
+      }),
       "tok",
       "base"
     )
-    expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
+    expect(await screen.findByText(/clips are ready/i)).toBeInTheDocument()
+    expect(onGenerated).toHaveBeenCalledOnce()
   })
 
   it("sends loop tempo and key with the request", async () => {
-    submitSoundsGeneration.mockResolvedValue({ status: "accepted", jobId: "job-2" })
+    submitSoundsGeneration.mockResolvedValue({
+      status: "accepted",
+      jobId: "job-2",
+      estimatedSeconds: 5,
+    })
+    fetchJobStatus.mockResolvedValue({
+      kind: "completed",
+      clipIds: ["c1", "c2"],
+    })
     const user = userEvent.setup()
     render(<SoundsCreationForm />)
 
-    await user.type(screen.getByLabelText("Sound description"), "a driving bass loop")
+    await user.type(
+      screen.getByLabelText("Sound description"),
+      "a driving bass loop"
+    )
     await user.click(loop())
     await user.click(screen.getByRole("switch", { name: "Auto" })) // turn Auto off
     await user.type(screen.getByLabelText("BPM"), "128")
@@ -91,16 +125,22 @@ describe("SoundsCreationForm", () => {
     await user.click(createButton())
 
     expect(submitSoundsGeneration).toHaveBeenCalledWith(
-      expect.objectContaining({ soundType: "loop", bpm: "128", key: "A minor" }),
+      expect.objectContaining({
+        soundType: "loop",
+        bpm: "128",
+        key: "A minor",
+      }),
       "tok",
       "base"
     )
-    // Guard the loop success-message branch separately from the one-shot one.
-    expect(await screen.findByRole("status")).toHaveTextContent(/started/i)
+    expect(await screen.findByText(/clips are ready/i)).toBeInTheDocument()
   })
 
   it("surfaces an error notice when generation fails", async () => {
-    submitSoundsGeneration.mockResolvedValue({ status: "error", detail: "Server error" })
+    submitSoundsGeneration.mockResolvedValue({
+      status: "error",
+      detail: "Server error",
+    })
     const user = userEvent.setup()
     render(<SoundsCreationForm />)
 
@@ -109,5 +149,18 @@ describe("SoundsCreationForm", () => {
     await user.click(createButton())
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/server error/i)
+  })
+
+  it("Clear all resets the description and type", async () => {
+    const user = userEvent.setup()
+    render(<SoundsCreationForm />)
+    const description = screen.getByLabelText("Sound description")
+    await user.type(description, "a punchy kick")
+    await user.click(oneShot())
+    expect(createButton()).toBeEnabled()
+
+    await user.click(screen.getByRole("button", { name: /clear all/i }))
+    expect(screen.getByLabelText("Sound description")).toHaveValue("")
+    expect(createButton()).toBeDisabled()
   })
 })

--- a/web/components/create/SoundsCreationForm.tsx
+++ b/web/components/create/SoundsCreationForm.tsx
@@ -9,16 +9,22 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/hooks/use-auth"
+import { useGeneration } from "@/hooks/use-generation"
 import { useModelSelection } from "@/contexts/model-selection-context"
-import { submitSoundsGeneration, validateSounds, type SoundsFormData } from "@/lib/generate"
-import { BPM_MAX, BPM_MIN, KEY_OPTIONS, PROMPT_MAX_LENGTH } from "@/lib/constants/generation"
+import {
+  submitSoundsGeneration,
+  validateSounds,
+  type SoundsFormData,
+} from "@/lib/generate"
+import {
+  BPM_MAX,
+  BPM_MIN,
+  KEY_OPTIONS,
+  PROMPT_MAX_LENGTH,
+} from "@/lib/constants/generation"
 import { SELECT_CLASS } from "@/lib/constants/ui"
-
-type Status =
-  | { kind: "idle" }
-  | { kind: "info"; message: string }
-  | { kind: "success"; message: string }
-  | { kind: "error"; message: string }
+import { GenerationProgress } from "@/components/create/GenerationProgress"
+import { GenerationError } from "@/components/create/GenerationError"
 
 const SOUND_TYPES = [
   { value: "one-shot", label: "One-Shot" },
@@ -33,31 +39,38 @@ const SOUND_TYPES = [
  * one-shots carry no tempo/tonal context. Clip rendering is deferred (as in
  * US-16.1/16.2) — success just reports the job started.
  */
-export function SoundsCreationForm() {
+export function SoundsCreationForm({
+  onGenerated,
+}: { onGenerated?: () => void } = {}) {
   const router = useRouter()
   const { accessToken } = useAuth()
-  const { selectedModel, isLoading: modelLoading } = useModelSelection()
+  const { models, selectedModel, isLoading: modelLoading } = useModelSelection()
+  const generation = useGeneration({ onComplete: onGenerated })
 
   const [description, setDescription] = useState("")
   const [soundType, setSoundType] = useState<SoundsFormData["soundType"]>("")
   const [bpmAuto, setBpmAuto] = useState(true)
   const [bpm, setBpm] = useState("")
   const [key, setKey] = useState("")
-  const [status, setStatus] = useState<Status>({ kind: "idle" })
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  // Pre-submit validation message, separate from the generation state machine.
+  const [formError, setFormError] = useState<string | null>(null)
 
   const isLoop = soundType === "loop"
 
   // A type and a description are both required (the description is the prompt);
   // range validation runs on submit so a bad BPM surfaces a message.
   const canSubmit = soundType !== "" && description.trim().length > 0
+  const busy =
+    generation.state.phase === "submitting" ||
+    generation.state.phase === "polling"
+  const modelName = models.find((m) => m.key === selectedModel)?.display_name
 
   function formData(): SoundsFormData {
     return { description, soundType, bpmAuto, bpm, key }
   }
 
   async function handleCreate() {
-    if (!canSubmit || isSubmitting || modelLoading) return
+    if (!canSubmit || busy || modelLoading) return
     if (!accessToken) {
       router.push("/login")
       return
@@ -65,30 +78,24 @@ export function SoundsCreationForm() {
     const data = formData()
     const error = validateSounds(data)
     if (error) {
-      setStatus({ kind: "error", message: error })
+      setFormError(error)
       return
     }
-    setIsSubmitting(true)
-    try {
-      const result = await submitSoundsGeneration(data, accessToken, selectedModel)
-      switch (result.status) {
-        case "accepted":
-          setStatus({
-            kind: "success",
-            message: "Generation started. We'll let you know when it's ready.",
-          })
-          break
-        case "unauthorized":
-          router.push("/login")
-          break
-        case "invalid":
-        case "error":
-          setStatus({ kind: "error", message: result.detail })
-          break
-      }
-    } finally {
-      setIsSubmitting(false)
-    }
+    setFormError(null)
+    await generation.submit(
+      () => submitSoundsGeneration(data, accessToken, selectedModel),
+      accessToken
+    )
+  }
+
+  function clearAll() {
+    setDescription("")
+    setSoundType("")
+    setBpmAuto(true)
+    setBpm("")
+    setKey("")
+    setFormError(null)
+    generation.reset()
   }
 
   return (
@@ -141,7 +148,11 @@ export function SoundsCreationForm() {
                 onChange={(e) => setBpm(e.target.value)}
               />
               <div className="flex shrink-0 items-center gap-1.5">
-                <Switch id="sound-bpm-auto" checked={bpmAuto} onCheckedChange={setBpmAuto} />
+                <Switch
+                  id="sound-bpm-auto"
+                  checked={bpmAuto}
+                  onCheckedChange={setBpmAuto}
+                />
                 <Label htmlFor="sound-bpm-auto">Auto</Label>
               </div>
             </div>
@@ -166,25 +177,51 @@ export function SoundsCreationForm() {
         </div>
       )}
 
-      {(status.kind === "info" || status.kind === "success") && (
-        <p role="status" className="text-sm text-muted-foreground">
-          {status.message}
+      {formError && (
+        <p role="alert" className="text-sm text-destructive">
+          {formError}
         </p>
       )}
-      {status.kind === "error" && (
-        <p role="alert" className="text-sm text-destructive">
-          {status.message}
+      {generation.state.phase === "polling" && (
+        <GenerationProgress
+          estimatedSeconds={generation.state.estimatedSeconds}
+          modelName={modelName}
+          progress={generation.state.progress}
+        />
+      )}
+      {generation.state.phase === "success" && (
+        <p role="status" className="text-sm text-muted-foreground">
+          Your new clips are ready in the workspace.
         </p>
+      )}
+      {generation.state.phase === "error" && (
+        <GenerationError
+          message={generation.state.message}
+          onRetry={generation.retry}
+          onDismiss={generation.reset}
+        />
       )}
 
-      <Button
-        type="button"
-        className="w-fit"
-        disabled={!canSubmit || isSubmitting || modelLoading}
-        onClick={handleCreate}
-      >
-        {isSubmitting ? "Creating..." : "Create"}
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          className="w-fit"
+          disabled={!canSubmit || busy || modelLoading}
+          onClick={handleCreate}
+        >
+          {busy ? "Creating..." : "Create"}
+        </Button>
+        {/* ponytail: inline Clear all — resets every Sounds field to its default. */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          onClick={clearAll}
+        >
+          Clear all
+        </Button>
+      </div>
     </div>
   )
 }

--- a/web/components/workspace/WorkspacePanel.tsx
+++ b/web/components/workspace/WorkspacePanel.tsx
@@ -40,8 +40,11 @@ function useDebouncedValue<T>(value: T, delayMs: number): T {
  */
 export function WorkspacePanel({
   onNavigateWorkspaces,
+  refreshKey,
 }: {
   onNavigateWorkspaces?: () => void
+  /** Bumped by the Create page on a completed generation to refetch clips (US-16.7). */
+  refreshKey?: number
 }) {
   const [search, setSearch] = useState("")
   const [filters, setFilters] = useState<ClipFilters>(EMPTY_FILTERS)
@@ -73,7 +76,11 @@ export function WorkspacePanel({
   // unscoped clips (across all workspaces). Gating on `defaultWorkspace` also
   // covers the workspace-fetch-error and zero-workspace cases, where
   // `workspacesLoading` is false but the id is still unknown.
-  const { data, loading: clipsLoading, error: clipsError } = useClips(
+  const {
+    data,
+    loading: clipsLoading,
+    error: clipsError,
+  } = useClips(
     {
       workspace_id: defaultWorkspace?.id,
       search: debouncedSearch,
@@ -81,7 +88,7 @@ export function WorkspacePanel({
       page,
       per_page: PER_PAGE,
     },
-    { enabled: defaultWorkspace !== null }
+    { enabled: defaultWorkspace !== null, refreshKey }
   )
 
   const { state } = usePlayer()
@@ -126,7 +133,11 @@ export function WorkspacePanel({
         />
       </div>
 
-      <PaginationControls page={page} totalPages={totalPages} onPageChange={setPage} />
+      <PaginationControls
+        page={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+      />
     </div>
   )
 }

--- a/web/hooks/use-clips.test.tsx
+++ b/web/hooks/use-clips.test.tsx
@@ -16,12 +16,20 @@ const authValue = {
 }
 
 function wrapper({ children }: { children: ReactNode }) {
-  return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+  return (
+    <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+  )
 }
 
 function listRes(clips: unknown[] = []) {
   return new Response(
-    JSON.stringify({ clips, total: clips.length, page: 1, per_page: 20, total_pages: 1 }),
+    JSON.stringify({
+      clips,
+      total: clips.length,
+      page: 1,
+      per_page: 20,
+      total_pages: 1,
+    }),
     { status: 200 }
   )
 }
@@ -42,25 +50,49 @@ describe("useClips", () => {
     expect(result.current.data?.clips).toHaveLength(1)
     const [url, opts] = fetchMock.mock.calls[0]
     expect(url).toBe("/api/clips?workspace_id=w1&sort=oldest&page=2")
-    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
   })
 
   it("refetches when the query params change", async () => {
     const fetchMock = vi.fn().mockResolvedValue(listRes())
     vi.stubGlobal("fetch", fetchMock)
 
-    const { result, rerender } = renderHook((p: { search: string }) => useClips(p), {
-      wrapper,
-      initialProps: { search: "a" },
-    })
+    const { result, rerender } = renderHook(
+      (p: { search: string }) => useClips(p),
+      {
+        wrapper,
+        initialProps: { search: "a" },
+      }
+    )
     await waitFor(() => expect(result.current.loading).toBe(false))
     rerender({ search: "b" })
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
     expect(fetchMock.mock.calls[1][0]).toBe("/api/clips?search=b")
   })
 
+  it("refetches when refreshKey is bumped (without changing the query)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(listRes())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result, rerender } = renderHook(
+      (p: { refreshKey: number }) => useClips({ workspace_id: "w1" }, p),
+      { wrapper, initialProps: { refreshKey: 0 } }
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchMock).toHaveBeenCalledOnce()
+
+    rerender({ refreshKey: 1 })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/clips?workspace_id=w1")
+  })
+
   it("flags an error when the fetch fails", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })))
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("", { status: 500 }))
+    )
     const { result } = renderHook(() => useClips({}), { wrapper })
     await waitFor(() => expect(result.current.error).toBe(true))
   })
@@ -70,7 +102,8 @@ describe("useClips", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     const { result, rerender } = renderHook(
-      (p: { enabled: boolean }) => useClips({ workspace_id: "w1" }, { enabled: p.enabled }),
+      (p: { enabled: boolean }) =>
+        useClips({ workspace_id: "w1" }, { enabled: p.enabled }),
       { wrapper, initialProps: { enabled: false } }
     )
     // Deferred: no fetch yet, and the hook reports loading so the caller shows a skeleton.
@@ -88,10 +121,13 @@ describe("useClips", () => {
       .mockResolvedValue(listRes([{ id: "c1" }]))
     vi.stubGlobal("fetch", fetchMock)
 
-    const { result, rerender } = renderHook((p: { search: string }) => useClips(p), {
-      wrapper,
-      initialProps: { search: "a" },
-    })
+    const { result, rerender } = renderHook(
+      (p: { search: string }) => useClips(p),
+      {
+        wrapper,
+        initialProps: { search: "a" },
+      }
+    )
     await waitFor(() => expect(result.current.error).toBe(true))
 
     // A new query supersedes the stale error: loading flips back on for the retry.

--- a/web/hooks/use-clips.ts
+++ b/web/hooks/use-clips.ts
@@ -23,7 +23,10 @@ import {
  */
 export function useClips(
   params: ClipSearchParams,
-  { enabled = true }: { enabled?: boolean } = {}
+  {
+    enabled = true,
+    refreshKey = 0,
+  }: { enabled?: boolean; refreshKey?: number } = {}
 ) {
   const { accessToken, isLoading: authLoading } = useAuth()
   const query = buildClipQuery(params)
@@ -32,6 +35,8 @@ export function useClips(
   // the skeleton shows again on the next attempt (instead of being suppressed).
   const [errorQuery, setErrorQuery] = useState<string | null>(null)
 
+  // `refreshKey` forces a refetch without changing the query — bumped by the
+  // Create page when a generation completes so new clips appear (US-16.7).
   useEffect(() => {
     if (!enabled || authLoading || !accessToken) return
     let active = true
@@ -54,7 +59,7 @@ export function useClips(
     return () => {
       active = false
     }
-  }, [query, enabled, accessToken, authLoading])
+  }, [query, enabled, accessToken, authLoading, refreshKey])
 
   const error = errorQuery === query
   // Deferred (not yet enabled), first load (no data), and changed-query states
@@ -62,8 +67,7 @@ export function useClips(
   // drops out of loading so the empty/error state can show instead of an endless
   // skeleton.
   const loading =
-    authLoading ||
-    (!!accessToken && (!enabled || (data === null && !error)))
+    authLoading || (!!accessToken && (!enabled || (data === null && !error)))
 
   return { data, loading, error }
 }

--- a/web/hooks/use-generation.test.tsx
+++ b/web/hooks/use-generation.test.tsx
@@ -1,0 +1,141 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useGeneration } from "@/hooks/use-generation"
+import type { SubmitResult } from "@/lib/generate"
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+const make = (result: SubmitResult) => vi.fn().mockResolvedValue(result)
+
+describe("useGeneration", () => {
+  it("submits, polls, and reaches success — calling onComplete with the clips", async () => {
+    const onComplete = vi.fn()
+    fetchJobStatus.mockResolvedValue({
+      kind: "completed",
+      clipIds: ["c1", "c2"],
+    })
+    const { result } = renderHook(() => useGeneration({ onComplete }))
+
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "accepted", jobId: "j1", estimatedSeconds: 12 }),
+        "tok"
+      )
+    })
+
+    await waitFor(() => expect(result.current.state.phase).toBe("success"))
+    expect(result.current.state).toEqual({
+      phase: "success",
+      clipIds: ["c1", "c2"],
+    })
+    expect(onComplete).toHaveBeenCalledOnce()
+    expect(fetchJobStatus).toHaveBeenCalledWith("j1", "tok")
+  })
+
+  it("exposes the backend time estimate while polling", async () => {
+    fetchJobStatus.mockResolvedValue({ kind: "pending" })
+    const { result } = renderHook(() => useGeneration())
+
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "accepted", jobId: "j1", estimatedSeconds: 30 }),
+        "tok"
+      )
+    })
+
+    expect(result.current.state).toMatchObject({
+      phase: "polling",
+      estimatedSeconds: 30,
+    })
+    act(() => result.current.reset())
+  })
+
+  it("surfaces a failed job as an error", async () => {
+    fetchJobStatus.mockResolvedValue({ kind: "failed", error: "boom" })
+    const { result } = renderHook(() => useGeneration())
+
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "accepted", jobId: "j1", estimatedSeconds: 5 }),
+        "tok"
+      )
+    })
+
+    await waitFor(() =>
+      expect(result.current.state).toEqual({ phase: "error", message: "boom" })
+    )
+  })
+
+  it("surfaces a rejected submission (422/error) as an error", async () => {
+    const { result } = renderHook(() => useGeneration())
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "invalid", detail: "bad input" }),
+        "tok"
+      )
+    })
+    expect(result.current.state).toEqual({
+      phase: "error",
+      message: "bad input",
+    })
+  })
+
+  it("redirects to login when submission is unauthorized", async () => {
+    const { result } = renderHook(() => useGeneration())
+    await act(async () => {
+      await result.current.submit(make({ status: "unauthorized" }), "tok")
+    })
+    expect(push).toHaveBeenCalledWith("/login")
+  })
+
+  it("redirects to login when a poll returns unauthorized", async () => {
+    fetchJobStatus.mockResolvedValue({ kind: "unauthorized" })
+    const { result } = renderHook(() => useGeneration())
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "accepted", jobId: "j1", estimatedSeconds: 5 }),
+        "tok"
+      )
+    })
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/login"))
+  })
+
+  it("retry replays the last submission", async () => {
+    fetchJobStatus.mockResolvedValue({ kind: "failed", error: "boom" })
+    const submitFn = make({
+      status: "accepted",
+      jobId: "j1",
+      estimatedSeconds: 5,
+    })
+    const { result } = renderHook(() => useGeneration())
+
+    await act(async () => {
+      await result.current.submit(submitFn, "tok")
+    })
+    await waitFor(() => expect(result.current.state.phase).toBe("error"))
+
+    await act(async () => {
+      result.current.retry()
+    })
+    expect(submitFn).toHaveBeenCalledTimes(2)
+  })
+
+  it("reset returns to idle", async () => {
+    const { result } = renderHook(() => useGeneration())
+    await act(async () => {
+      await result.current.submit(make({ status: "error", detail: "x" }), "tok")
+    })
+    expect(result.current.state.phase).toBe("error")
+    act(() => result.current.reset())
+    expect(result.current.state).toEqual({ phase: "idle" })
+  })
+})

--- a/web/hooks/use-generation.ts
+++ b/web/hooks/use-generation.ts
@@ -1,0 +1,174 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { fetchJobStatus } from "@/lib/job-status"
+import type { SubmitResult } from "@/lib/generate"
+
+const POLL_INTERVAL_MS = 2000
+// Cap polling so a stuck or vanished job surfaces an error instead of spinning
+// forever. 150 × 2s ≈ 5 min — well past the slowest model's estimate (XL ~30-60s).
+// ponytail: fixed cap; raise if real jobs ever run longer than this.
+const MAX_POLLS = 150
+
+/** The creation flow's state machine: idle → submitting → polling → success|error. */
+export type GenerationState =
+  | { phase: "idle" }
+  | { phase: "submitting" }
+  | { phase: "polling"; estimatedSeconds: number; progress?: string }
+  | { phase: "success"; clipIds: string[] }
+  | { phase: "error"; message: string }
+
+/** A per-form closure that builds + submits the request, returning the 202 result. */
+export type SubmitFn = () => Promise<SubmitResult>
+
+export type UseGeneration = {
+  state: GenerationState
+  /** Submit a request and drive it to completion. `accessToken` is reused for polling. */
+  submit: (makeRequest: SubmitFn, accessToken: string) => Promise<void>
+  /** Re-run the last submit (for the error state's Retry). No-op if nothing was submitted. */
+  retry: () => void
+  /** Clear back to idle (dismiss an error / reset after success). */
+  reset: () => void
+}
+
+/**
+ * Owns one creation's lifecycle (US-16.7). After the 202 it polls the job through
+ * the BFF proxy until completed/failed, exposing progress + the backend's
+ * model-aware time estimate, and calls `onComplete` once clips exist so the
+ * caller can refresh the workspace. Each of the three creation forms uses its own
+ * instance; the form supplies the request builder so per-tab payloads stay local.
+ */
+export function useGeneration({
+  onComplete,
+}: { onComplete?: () => void } = {}): UseGeneration {
+  const router = useRouter()
+  const [state, setState] = useState<GenerationState>({ phase: "idle" })
+
+  // The active job. A ref (not state) so the poll loop reads the latest without
+  // re-subscribing; cleared the moment the job is superseded or terminal.
+  const jobRef = useRef<{ id: string; token: string; polls: number } | null>(
+    null
+  )
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The last submission's args, stored so Retry can replay it verbatim.
+  const lastArgsRef = useRef<{
+    makeRequest: SubmitFn
+    accessToken: string
+  } | null>(null)
+  // Held in a ref so the poll loop's identity doesn't churn with the callback.
+  const onCompleteRef = useRef(onComplete)
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+  })
+
+  // Holds the latest `poll` so the scheduled timeout can call it without `poll`
+  // referencing itself (which the hook-immutability lint forbids).
+  const pollRef = useRef<() => void>(() => {})
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  // Clean up a pending poll if the component unmounts mid-generation.
+  useEffect(() => clearTimer, [])
+
+  const poll = useCallback(async () => {
+    const job = jobRef.current
+    if (!job) return
+    const result = await fetchJobStatus(job.id, job.token)
+    // A reset/retry between the request and its response supersedes this job.
+    if (jobRef.current?.id !== job.id) return
+
+    switch (result.kind) {
+      case "completed":
+        jobRef.current = null
+        clearTimer()
+        setState({ phase: "success", clipIds: result.clipIds })
+        onCompleteRef.current?.()
+        return
+      case "failed":
+        jobRef.current = null
+        clearTimer()
+        setState({ phase: "error", message: result.error })
+        return
+      case "unauthorized":
+        jobRef.current = null
+        clearTimer()
+        router.push("/login")
+        return
+      case "pending":
+      case "transient":
+        job.polls += 1
+        if (job.polls >= MAX_POLLS) {
+          jobRef.current = null
+          clearTimer()
+          setState({
+            phase: "error",
+            message: "Generation timed out. Please try again.",
+          })
+          return
+        }
+        if (result.kind === "pending" && result.progress) {
+          const { progress } = result
+          setState((s) => (s.phase === "polling" ? { ...s, progress } : s))
+        }
+        timerRef.current = setTimeout(
+          () => void pollRef.current(),
+          POLL_INTERVAL_MS
+        )
+        return
+    }
+  }, [router])
+
+  useEffect(() => {
+    pollRef.current = poll
+  })
+
+  const submit = useCallback(
+    async (makeRequest: SubmitFn, accessToken: string) => {
+      lastArgsRef.current = { makeRequest, accessToken }
+      clearTimer()
+      jobRef.current = null
+      setState({ phase: "submitting" })
+
+      const result = await makeRequest()
+      switch (result.status) {
+        case "accepted":
+          jobRef.current = { id: result.jobId, token: accessToken, polls: 0 }
+          setState({
+            phase: "polling",
+            estimatedSeconds: result.estimatedSeconds,
+          })
+          // Poll immediately so a fast job doesn't sit idle for the first interval.
+          void poll()
+          return
+        case "unauthorized":
+          router.push("/login")
+          return
+        case "invalid":
+        case "error":
+          setState({ phase: "error", message: result.detail })
+          return
+      }
+    },
+    [poll, router]
+  )
+
+  const retry = useCallback(() => {
+    const args = lastArgsRef.current
+    if (args) void submit(args.makeRequest, args.accessToken)
+  }, [submit])
+
+  const reset = useCallback(() => {
+    clearTimer()
+    jobRef.current = null
+    setState({ phase: "idle" })
+  }, [])
+
+  return { state, submit, retry, reset }
+}

--- a/web/lib/generate.test.ts
+++ b/web/lib/generate.test.ts
@@ -16,7 +16,9 @@ import {
 afterEach(() => vi.restoreAllMocks())
 
 /** A valid baseline; individual tests override only what they exercise. */
-function advancedData(overrides: Partial<AdvancedFormData> = {}): AdvancedFormData {
+function advancedData(
+  overrides: Partial<AdvancedFormData> = {}
+): AdvancedFormData {
   return {
     lyrics: "",
     lyricsMode: "manual",
@@ -79,7 +81,10 @@ describe("buildGenerationPayload", () => {
 describe("buildAdvancedPayload", () => {
   it("combines free-text styles and tags into the style string and prompt", () => {
     const payload = buildAdvancedPayload(
-      advancedData({ styles: "cinematic, epic", selectedTags: ["lo-fi", "ambient"] })
+      advancedData({
+        styles: "cinematic, epic",
+        selectedTags: ["lo-fi", "ambient"],
+      })
     )
     expect(payload.style).toBe("cinematic, epic, lo-fi, ambient")
     // With no description field, the combined style string becomes the prompt.
@@ -106,7 +111,9 @@ describe("buildAdvancedPayload", () => {
       buildAdvancedPayload(advancedData({ styles: "rock", bpmAuto: true }))
     ).not.toHaveProperty("bpm")
     expect(
-      buildAdvancedPayload(advancedData({ styles: "rock", bpmAuto: false, bpm: "120" })).bpm
+      buildAdvancedPayload(
+        advancedData({ styles: "rock", bpmAuto: false, bpm: "120" })
+      ).bpm
     ).toBe(120)
   })
 
@@ -139,7 +146,11 @@ describe("buildAdvancedPayload", () => {
     // Lyrics may be up to 5000 chars but prompt is capped at 2000; a lyrics-only
     // submission must not build an over-long prompt that the backend would 422.
     const payload = buildAdvancedPayload(
-      advancedData({ styles: "", lyricsMode: "manual", lyrics: "x".repeat(5000) })
+      advancedData({
+        styles: "",
+        lyricsMode: "manual",
+        lyrics: "x".repeat(5000),
+      })
     )
     expect(payload.prompt.length).toBe(2000)
     expect(payload.lyrics).toHaveLength(5000)
@@ -163,7 +174,11 @@ describe("buildAdvancedPayload", () => {
 
 describe("validateAdvanced", () => {
   it("accepts a valid form", () => {
-    expect(validateAdvanced(advancedData({ styles: "rock", bpmAuto: false, bpm: "120" }))).toBeNull()
+    expect(
+      validateAdvanced(
+        advancedData({ styles: "rock", bpmAuto: false, bpm: "120" })
+      )
+    ).toBeNull()
   })
 
   it("requires a style or lyrics", () => {
@@ -171,32 +186,48 @@ describe("validateAdvanced", () => {
   })
 
   it("rejects an out-of-range BPM", () => {
-    expect(validateAdvanced(advancedData({ styles: "rock", bpmAuto: false, bpm: "300" }))).toMatch(
-      /bpm/i
-    )
-    expect(validateAdvanced(advancedData({ styles: "rock", bpmAuto: false, bpm: "10" }))).toMatch(
-      /bpm/i
-    )
+    expect(
+      validateAdvanced(
+        advancedData({ styles: "rock", bpmAuto: false, bpm: "300" })
+      )
+    ).toMatch(/bpm/i)
+    expect(
+      validateAdvanced(
+        advancedData({ styles: "rock", bpmAuto: false, bpm: "10" })
+      )
+    ).toMatch(/bpm/i)
   })
 
   it("ignores BPM bounds when Auto is on", () => {
-    expect(validateAdvanced(advancedData({ styles: "rock", bpmAuto: true, bpm: "300" }))).toBeNull()
+    expect(
+      validateAdvanced(
+        advancedData({ styles: "rock", bpmAuto: true, bpm: "300" })
+      )
+    ).toBeNull()
   })
 
   it("rejects an out-of-range duration", () => {
-    expect(validateAdvanced(advancedData({ styles: "rock", duration: "5" }))).toMatch(/duration/i)
-    expect(validateAdvanced(advancedData({ styles: "rock", duration: "999" }))).toMatch(/duration/i)
+    expect(
+      validateAdvanced(advancedData({ styles: "rock", duration: "5" }))
+    ).toMatch(/duration/i)
+    expect(
+      validateAdvanced(advancedData({ styles: "rock", duration: "999" }))
+    ).toMatch(/duration/i)
   })
 
   it("rejects an over-long key", () => {
-    expect(validateAdvanced(advancedData({ styles: "rock", key: "x".repeat(60) }))).toMatch(/key/i)
+    expect(
+      validateAdvanced(advancedData({ styles: "rock", key: "x".repeat(60) }))
+    ).toMatch(/key/i)
   })
 
   it("rejects out-of-range weirdness and style influence", () => {
-    expect(validateAdvanced(advancedData({ styles: "rock", weirdness: 200 }))).toMatch(/weirdness/i)
-    expect(validateAdvanced(advancedData({ styles: "rock", styleInfluence: -1 }))).toMatch(
-      /influence/i
-    )
+    expect(
+      validateAdvanced(advancedData({ styles: "rock", weirdness: 200 }))
+    ).toMatch(/weirdness/i)
+    expect(
+      validateAdvanced(advancedData({ styles: "rock", styleInfluence: -1 }))
+    ).toMatch(/influence/i)
   })
 })
 
@@ -214,7 +245,9 @@ function soundsData(overrides: Partial<SoundsFormData> = {}): SoundsFormData {
 
 describe("buildSoundsPayload", () => {
   it("maps description to prompt and fixes mode to sound (instrumental)", () => {
-    const payload = buildSoundsPayload(soundsData({ description: "  warm pad  " }))
+    const payload = buildSoundsPayload(
+      soundsData({ description: "  warm pad  " })
+    )
     expect(payload).toMatchObject({
       prompt: "warm pad",
       mode: "sound",
@@ -226,7 +259,12 @@ describe("buildSoundsPayload", () => {
   it("never sends bpm or key for a one-shot (backend forbids them)", () => {
     // Even if stray loop values are present, a one-shot must omit tempo/tonal keys.
     const payload = buildSoundsPayload(
-      soundsData({ soundType: "one-shot", bpmAuto: false, bpm: "120", key: "C major" })
+      soundsData({
+        soundType: "one-shot",
+        bpmAuto: false,
+        bpm: "120",
+        key: "C major",
+      })
     )
     expect(payload).not.toHaveProperty("bpm")
     expect(payload).not.toHaveProperty("key")
@@ -234,9 +272,18 @@ describe("buildSoundsPayload", () => {
 
   it("sends bpm and key for a loop", () => {
     const payload = buildSoundsPayload(
-      soundsData({ soundType: "loop", bpmAuto: false, bpm: "128", key: "A minor" })
+      soundsData({
+        soundType: "loop",
+        bpmAuto: false,
+        bpm: "128",
+        key: "A minor",
+      })
     )
-    expect(payload).toMatchObject({ sound_type: "loop", bpm: 128, key: "A minor" })
+    expect(payload).toMatchObject({
+      sound_type: "loop",
+      bpm: 128,
+      key: "A minor",
+    })
   })
 
   it("omits bpm for a loop when Auto is on, and key when Any", () => {
@@ -252,7 +299,9 @@ describe("validateSounds", () => {
   it("accepts a valid one-shot and a valid loop", () => {
     expect(validateSounds(soundsData())).toBeNull()
     expect(
-      validateSounds(soundsData({ soundType: "loop", bpmAuto: false, bpm: "120" }))
+      validateSounds(
+        soundsData({ soundType: "loop", bpmAuto: false, bpm: "120" })
+      )
     ).toBeNull()
   })
 
@@ -261,24 +310,30 @@ describe("validateSounds", () => {
   })
 
   it("requires a description", () => {
-    expect(validateSounds(soundsData({ description: "  " }))).toMatch(/description/i)
-  })
-
-  it("rejects an over-long description (the prompt bound)", () => {
-    expect(validateSounds(soundsData({ description: "x".repeat(2001) }))).toMatch(
+    expect(validateSounds(soundsData({ description: "  " }))).toMatch(
       /description/i
     )
   })
 
+  it("rejects an over-long description (the prompt bound)", () => {
+    expect(
+      validateSounds(soundsData({ description: "x".repeat(2001) }))
+    ).toMatch(/description/i)
+  })
+
   it("rejects an out-of-range loop BPM", () => {
     expect(
-      validateSounds(soundsData({ soundType: "loop", bpmAuto: false, bpm: "300" }))
+      validateSounds(
+        soundsData({ soundType: "loop", bpmAuto: false, bpm: "300" })
+      )
     ).toMatch(/bpm/i)
   })
 
   it("ignores BPM bounds when Auto is on", () => {
     expect(
-      validateSounds(soundsData({ soundType: "loop", bpmAuto: true, bpm: "300" }))
+      validateSounds(
+        soundsData({ soundType: "loop", bpmAuto: true, bpm: "300" })
+      )
     ).toBeNull()
   })
 })
@@ -291,29 +346,43 @@ describe("submitGeneration", () => {
     selectedTags: [],
   }
 
-  it("returns the job id on 202 and sends the Bearer token", async () => {
+  it("returns the job id and time estimate on 202, sending the Bearer token", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ job_id: "job-123", status: "queued" }), {
-        status: 202,
-      })
+      new Response(
+        JSON.stringify({
+          job_id: "job-123",
+          status: "queued",
+          estimated_time_seconds: 12,
+        }),
+        { status: 202 }
+      )
     )
     vi.stubGlobal("fetch", fetchMock)
 
     const result = await submitGeneration(data, "tok")
-    expect(result).toEqual({ status: "accepted", jobId: "job-123" })
+    expect(result).toEqual({
+      status: "accepted",
+      jobId: "job-123",
+      estimatedSeconds: 12,
+    })
 
     const [url, opts] = fetchMock.mock.calls[0]
     expect(url).toBe("/api/generate")
     expect((opts.headers as Record<string, string>).authorization).toBe(
       "Bearer tok"
     )
-    expect(JSON.parse(opts.body)).toEqual({ prompt: "song", instrumental: false })
+    expect(JSON.parse(opts.body)).toEqual({
+      prompt: "song",
+      instrumental: false,
+    })
   })
 
   it("includes the selected model in the payload (US-16.4)", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ job_id: "job-9" }), { status: 202 })
-    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ job_id: "job-9" }), { status: 202 })
+      )
     vi.stubGlobal("fetch", fetchMock)
 
     await submitGeneration(data, "tok", "xl-base")
@@ -322,9 +391,11 @@ describe("submitGeneration", () => {
   })
 
   it("omits model when none is selected so the backend default applies", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ job_id: "job-9" }), { status: 202 })
-    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ job_id: "job-9" }), { status: 202 })
+      )
     vi.stubGlobal("fetch", fetchMock)
 
     await submitGeneration(data, "tok", "")
@@ -333,12 +404,18 @@ describe("submitGeneration", () => {
   })
 
   it("threads the model through the Advanced and Sounds submitters too", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ job_id: "j" }), { status: 202 })
-    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ job_id: "j" }), { status: 202 })
+      )
     vi.stubGlobal("fetch", fetchMock)
 
-    await submitAdvancedGeneration(advancedData({ styles: "rock" }), "tok", "xl-sft")
+    await submitAdvancedGeneration(
+      advancedData({ styles: "rock" }),
+      "tok",
+      "xl-sft"
+    )
     expect(JSON.parse(fetchMock.mock.calls[0][1].body).model).toBe("xl-sft")
 
     await submitSoundsGeneration(

--- a/web/lib/generate.ts
+++ b/web/lib/generate.ts
@@ -49,7 +49,9 @@ export type GenerationPayload = {
 }
 
 export type SubmitResult =
-  | { status: "accepted"; jobId: string }
+  // `estimatedSeconds` is the backend's model-aware time estimate from the 202
+  // body; the form shows it during polling (US-16.7). 0 when absent.
+  | { status: "accepted"; jobId: string; estimatedSeconds: number }
   | { status: "unauthorized" }
   | { status: "invalid"; detail: string }
   | { status: "error"; detail: string }
@@ -113,7 +115,9 @@ export function combineStyles(styles: string, tags: string[]): string {
  * UI-only fields (vocal gender, exclude styles, song title, workspace) are never
  * included — the backend uses `extra="forbid"`.
  */
-export function buildAdvancedPayload(data: AdvancedFormData): GenerationPayload {
+export function buildAdvancedPayload(
+  data: AdvancedFormData
+): GenerationPayload {
   const style = combineStyles(data.styles, data.selectedTags)
   const lyrics = data.lyricsMode === "manual" ? data.lyrics.trim() : ""
 
@@ -161,7 +165,11 @@ export function validateAdvanced(data: AdvancedFormData): string | null {
   }
   if (data.duration.trim()) {
     const duration = Number(data.duration)
-    if (!Number.isFinite(duration) || duration < DURATION_MIN || duration > DURATION_MAX) {
+    if (
+      !Number.isFinite(duration) ||
+      duration < DURATION_MIN ||
+      duration > DURATION_MAX
+    ) {
       return `Duration must be between ${DURATION_MIN} and ${DURATION_MAX} seconds.`
     }
   }
@@ -171,7 +179,10 @@ export function validateAdvanced(data: AdvancedFormData): string | null {
   if (data.weirdness < WEIRDNESS_MIN || data.weirdness > WEIRDNESS_MAX) {
     return `Weirdness must be between ${WEIRDNESS_MIN} and ${WEIRDNESS_MAX}.`
   }
-  if (data.styleInfluence < STYLE_INFLUENCE_MIN || data.styleInfluence > STYLE_INFLUENCE_MAX) {
+  if (
+    data.styleInfluence < STYLE_INFLUENCE_MIN ||
+    data.styleInfluence > STYLE_INFLUENCE_MAX
+  ) {
     return `Style influence must be between ${STYLE_INFLUENCE_MIN} and ${STYLE_INFLUENCE_MAX}.`
   }
   return null
@@ -197,7 +208,10 @@ function extractDetail(body: unknown, fallback: string): string {
  * falsy model is omitted so the backend applies its own default (an empty
  * `model` would 422). Returns a new object so the caller's payload is untouched.
  */
-function withModel(payload: GenerationPayload, model?: string): GenerationPayload {
+function withModel(
+  payload: GenerationPayload,
+  model?: string
+): GenerationPayload {
   return model ? { ...payload, model } : { ...payload }
 }
 
@@ -207,7 +221,10 @@ export function submitGeneration(
   accessToken: string,
   model?: string
 ): Promise<SubmitResult> {
-  return postGeneration(withModel(buildGenerationPayload(data), model), accessToken)
+  return postGeneration(
+    withModel(buildGenerationPayload(data), model),
+    accessToken
+  )
 }
 
 /** Submit the Advanced creation form through the BFF proxy. */
@@ -216,7 +233,10 @@ export function submitAdvancedGeneration(
   accessToken: string,
   model?: string
 ): Promise<SubmitResult> {
-  return postGeneration(withModel(buildAdvancedPayload(data), model), accessToken)
+  return postGeneration(
+    withModel(buildAdvancedPayload(data), model),
+    accessToken
+  )
 }
 
 /** Form state for the Sounds creation form (US-16.3): short one-shots and loops. */
@@ -310,19 +330,32 @@ async function postGeneration(
 
   if (res.status === 202) {
     const body = await res.json().catch(() => ({}))
-    const jobId = (body as { job_id?: string }).job_id
+    const { job_id: jobId, estimated_time_seconds: estimated } = body as {
+      job_id?: string
+      estimated_time_seconds?: number
+    }
     // A 202 with no usable job id is unexpected (non-JSON body, schema drift) —
     // treat it as an error rather than report a hollow success US-16.7 can't poll.
     if (!jobId) {
-      return { status: "error", detail: "Server returned an unexpected response." }
+      return {
+        status: "error",
+        detail: "Server returned an unexpected response.",
+      }
     }
-    return { status: "accepted", jobId }
+    return {
+      status: "accepted",
+      jobId,
+      estimatedSeconds: typeof estimated === "number" ? estimated : 0,
+    }
   }
   if (res.status === 401) return { status: "unauthorized" }
 
   const body = await res.json().catch(() => ({}))
   if (res.status === 422) {
-    return { status: "invalid", detail: extractDetail(body, "Please check your input.") }
+    return {
+      status: "invalid",
+      detail: extractDetail(body, "Please check your input."),
+    }
   }
   return {
     status: "error",

--- a/web/lib/job-status.test.ts
+++ b/web/lib/job-status.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { fetchJobStatus } from "@/lib/job-status"
+
+function mockFetch(body: unknown, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status }))
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("fetchJobStatus", () => {
+  it("sends the Bearer token to the job proxy", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ status: "queued" }), { status: 200 })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await fetchJobStatus("j1", "tok")
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/jobs/j1")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+  })
+
+  it("maps completed → clip ids", async () => {
+    mockFetch({ status: "completed", clip_ids: ["c1", "c2"] })
+    expect(await fetchJobStatus("j1", "tok")).toEqual({
+      kind: "completed",
+      clipIds: ["c1", "c2"],
+    })
+  })
+
+  it("maps failed → error message", async () => {
+    mockFetch({ status: "failed", error: "boom" })
+    expect(await fetchJobStatus("j1", "tok")).toEqual({
+      kind: "failed",
+      error: "boom",
+    })
+  })
+
+  it("falls back to a generic message when failed has no error", async () => {
+    mockFetch({ status: "failed" })
+    const result = await fetchJobStatus("j1", "tok")
+    expect(result).toMatchObject({ kind: "failed" })
+    if (result.kind === "failed") expect(result.error).toMatch(/failed/i)
+  })
+
+  it("maps queued/processing → pending (with progress)", async () => {
+    mockFetch({ status: "processing", progress: "step 2 of 5" })
+    expect(await fetchJobStatus("j1", "tok")).toEqual({
+      kind: "pending",
+      progress: "step 2 of 5",
+    })
+  })
+
+  it("maps 401 → unauthorized", async () => {
+    mockFetch({ detail: "no" }, 401)
+    expect(await fetchJobStatus("j1", "tok")).toEqual({ kind: "unauthorized" })
+  })
+
+  it("fails fast on a 404 (unknown/not-owned job) instead of polling", async () => {
+    mockFetch({ detail: "Job not found." }, 404)
+    const result = await fetchJobStatus("j1", "tok")
+    expect(result).toMatchObject({ kind: "failed" })
+  })
+
+  it("treats a 5xx as transient (keep polling)", async () => {
+    mockFetch({ detail: "down" }, 502)
+    expect(await fetchJobStatus("j1", "tok")).toEqual({ kind: "transient" })
+  })
+
+  it("treats a network failure as transient", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")))
+    expect(await fetchJobStatus("j1", "tok")).toEqual({ kind: "transient" })
+  })
+})

--- a/web/lib/job-status.ts
+++ b/web/lib/job-status.ts
@@ -1,0 +1,66 @@
+// Client-side job-status polling for the creation flow (US-16.7). After a 202
+// the form polls GET /api/jobs/{jobId} (the BFF proxy) until the job reaches a
+// terminal state. The raw backend status is classified into a small result the
+// poller switches on: keep-polling (pending/transient), done (completed/failed),
+// or auth (redirect to login).
+
+/** The backend job lifecycle states (mirrors api JobStatus). */
+export type JobStatus = "queued" | "processing" | "completed" | "failed"
+
+/** A single poll's outcome, classified for the generation state machine. */
+export type JobPollResult =
+  | { kind: "pending"; progress?: string }
+  | { kind: "completed"; clipIds: string[] }
+  | { kind: "failed"; error: string }
+  | { kind: "unauthorized" }
+  // Network blip / 5xx — not a real failure; the poller retries (up to its cap).
+  | { kind: "transient" }
+
+type JobStatusBody = {
+  status?: JobStatus
+  progress?: string
+  clip_ids?: string[]
+  error?: string
+}
+
+/** Poll one job's status through the BFF proxy and classify the response. */
+export async function fetchJobStatus(
+  jobId: string,
+  accessToken: string
+): Promise<JobPollResult> {
+  let res: Response
+  try {
+    res = await fetch(`/api/jobs/${encodeURIComponent(jobId)}`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+  } catch {
+    return { kind: "transient" }
+  }
+
+  if (res.status === 401) return { kind: "unauthorized" }
+  // A 4xx other than 401 is terminal: the backend returns 404 for an unknown or
+  // not-owned job, which polling can never recover from — fail fast instead of
+  // spinning until the cap. 5xx and network errors stay transient (retried).
+  if (res.status >= 400 && res.status < 500) {
+    return { kind: "failed", error: "Generation failed. Please try again." }
+  }
+  if (!res.ok) return { kind: "transient" }
+
+  const body = (await res.json().catch(() => ({}))) as JobStatusBody
+  switch (body.status) {
+    case "completed":
+      return { kind: "completed", clipIds: body.clip_ids ?? [] }
+    case "failed":
+      return {
+        kind: "failed",
+        error: body.error || "Generation failed. Please try again.",
+      }
+    case "queued":
+    case "processing":
+      return { kind: "pending", progress: body.progress }
+    default:
+      // Unknown/missing status — treat as transient so a one-off odd body doesn't
+      // abort an otherwise-healthy job.
+      return { kind: "transient" }
+  }
+}


### PR DESCRIPTION
## US-16.7: Create Button Behavior and Generation Flow

Closes #193.

Wires the Create button across all three creation modes to the full generation lifecycle.

### Plan adaptation
The issue's CodeRabbit plan assumed **TanStack Query + react-hook-form**. The web app uses neither — it uses custom `useState`/`useEffect` fetch hooks (`useClips`, `useWorkspaces`) behind a **BFF proxy** (`/api/*` → backend `/api/v1/*`), and the forms already submit via `submitGeneration` and already validate. This PR fills the real gap — the **job polling lifecycle** — against the established architecture, adding no new dependencies.

### What's included
- **BFF route** `GET /api/jobs/[jobId]` → backend `/api/v1/jobs/{id}/status`
- **`lib/job-status.ts`** — typed `fetchJobStatus` poll classifier (completed / failed / pending / unauthorized / transient; 404 fails fast, 5xx + network retried)
- **`useGeneration` hook** — `idle → submitting → polling → success | error` state machine with `retry`, `reset`, immediate-first-poll, a 5-min poll cap, and an `onComplete` hook
- **`GenerationProgress` / `GenerationError`** components
- Threads the backend's model-aware `estimated_time_seconds` through the 202 result
- **`useClips`** gains a `refreshKey` so a completed generation refetches the workspace clips
- Refactors Simple / Advanced / Sounds forms onto `useGeneration`; adds a **Clear all** button per form and an `onGenerated` prop wired from the Create page

### Acceptance criteria
| # | Criterion | Status |
|---|-----------|--------|
| 1 | Create disabled when empty / enabled when valid | ✅ (already present, preserved) |
| 2 | Progress indicator during generation | ✅ `GenerationProgress` while polling |
| 3 | Time estimate reflects the selected model | ✅ backend estimate (computed per model) + model name shown |
| 4 | 2 new clip cards appear in the workspace on success | ✅ poll → completed → `refreshKey` refetch |
| 5 | Error state with a meaningful message + retry | ✅ `GenerationError` (Retry / Dismiss) |
| 6 | "Clear all" resets the active tab's fields | ✅ per-form Clear all |

### Quality
- typecheck, eslint, **289 vitest tests**, and `next build` all green locally (web is not in CI — run locally).
- Cross-family review: `codex review --base main` — one [P2] (404 should fail fast, not poll to timeout) found and fixed.

### Known limitations
- **Credits counter** — a functional requirement of the story but **not an acceptance criterion**. There is no credits widget anywhere in the web UI today; the backend already deducts credits on generation. Surfacing a balance is out of scope for this story and deferred to whichever story introduces the credits UI.
- Polling is verified with mocked `fetchJobStatus`; there is no end-to-end test against a live backend job (no test backend wired into `web/`).
