### PR TITLE
feat(web): Audio Input Modals (US-16.8)

### DIFF
--- a/web/components/create/AdvancedCreationForm.tsx
+++ b/web/components/create/AdvancedCreationForm.tsx
@@ -26,6 +26,11 @@ import { useUndoableField } from "@/components/create/useUndoableField"
 import { GenerationProgress } from "@/components/create/GenerationProgress"
 import { GenerationError } from "@/components/create/GenerationError"
 import {
+  AudioInputs,
+  EMPTY_AUDIO_INPUTS,
+  type AudioInputsValue,
+} from "@/components/create/AudioInputs"
+import {
   combineStyles,
   submitAdvancedGeneration,
   validateAdvanced,
@@ -76,6 +81,9 @@ export function AdvancedCreationForm({
   const [vocalLanguage, setVocalLanguage] = useState("")
   const [instrumental, setInstrumental] = useState(false)
   const [options, setOptions] = useState<MoreOptions>(initialOptions)
+  // Attached reference audio / voice / inspiration (US-16.8). Tracked here so
+  // Clear all resets them and they persist across Simple/Advanced tab switches.
+  const [inputs, setInputs] = useState<AudioInputsValue>(EMPTY_AUDIO_INPUTS)
   // Neutral notice (stub features) and pre-submit validation message, both kept
   // separate from the generation state machine.
   const [notice, setNotice] = useState<string | null>(null)
@@ -145,6 +153,7 @@ export function AdvancedCreationForm({
     setVocalLanguage("")
     setInstrumental(false)
     setOptions(initialOptions)
+    setInputs(EMPTY_AUDIO_INPUTS)
     setShowEnhance(false)
     setEnhancePrompt("")
     setNotice(null)
@@ -260,6 +269,11 @@ export function AdvancedCreationForm({
         <InspirationTags
           selectedTags={selectedTags}
           onChange={(next) => setSelectedTags(next)}
+        />
+        <AudioInputs
+          value={inputs}
+          onChange={(patch) => setInputs((v) => ({ ...v, ...patch }))}
+          disabled={busy}
         />
         <div className="flex flex-wrap items-center gap-2">
           <Button

--- a/web/components/create/AudioInputs.test.tsx
+++ b/web/components/create/AudioInputs.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AudioInputs,
+  EMPTY_AUDIO_INPUTS,
+  type AudioInputsValue,
+} from "@/components/create/AudioInputs"
+
+vi.mock("@/hooks/use-clips", () => ({ useClips: () => ({ data: null, loading: false }) }))
+vi.mock("@/hooks/use-workspaces", () => ({
+  useWorkspaces: () => ({ workspaces: [], defaultWorkspace: null }),
+}))
+
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => "blob:mock")
+  URL.revokeObjectURL = vi.fn()
+})
+
+afterEach(() => vi.clearAllMocks())
+
+// Stateful harness mirroring how the forms own the selections.
+function Harness() {
+  const [value, setValue] = useState<AudioInputsValue>(EMPTY_AUDIO_INPUTS)
+  return (
+    <AudioInputs
+      value={value}
+      onChange={(patch) => setValue((v) => ({ ...v, ...patch }))}
+    />
+  )
+}
+
+describe("AudioInputs", () => {
+  it("renders the three trigger buttons", () => {
+    render(<Harness />)
+    expect(screen.getByRole("button", { name: /audio/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /voice/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /inspiration/i })
+    ).toBeInTheDocument()
+  })
+
+  it("shows a removable chip after selecting a voice", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.click(screen.getByRole("button", { name: /voice/i }))
+    await user.click(screen.getByRole("button", { name: /aria/i }))
+
+    // Chip appears with the voice name.
+    const chips = screen.getByLabelText("Attached inputs")
+    expect(chips).toHaveTextContent("Aria")
+
+    // Removing it clears the chip.
+    await user.click(screen.getByRole("button", { name: /remove aria/i }))
+    expect(screen.queryByLabelText("Attached inputs")).not.toBeInTheDocument()
+  })
+})

--- a/web/components/create/AudioInputs.tsx
+++ b/web/components/create/AudioInputs.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  MusicNote01Icon,
+  Playlist01Icon,
+  VoiceIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { InputChip } from "@/components/create/InputChip"
+import { AddAudioModal } from "@/components/create/modals/AddAudioModal"
+import { AddVoiceModal } from "@/components/create/modals/AddVoiceModal"
+import { AddInspirationModal } from "@/components/create/modals/AddInspirationModal"
+import type {
+  AudioSelection,
+  InspirationSelection,
+  VoiceSelection,
+} from "@/lib/audio-inputs"
+
+export type AudioInputsValue = {
+  audio: AudioSelection | null
+  voice: VoiceSelection | null
+  inspiration: InspirationSelection | null
+}
+
+export const EMPTY_AUDIO_INPUTS: AudioInputsValue = {
+  audio: null,
+  voice: null,
+  inspiration: null,
+}
+
+/**
+ * The +Audio / +Voice / +Inspiration controls shared by the Simple and Advanced
+ * creation forms (US-16.8). Controlled: the parent owns the selections (so its
+ * "Clear all" can reset them and they persist across Simple/Advanced tab
+ * switches) and receives patches via `onChange`. Selected inputs render as
+ * removable chips; modal open/close is local UI state.
+ *
+ * ponytail: selections are surfaced to the parent but not yet sent in the
+ * generation payload — backend support for reference audio/voice/inspiration is
+ * out of scope for this UI story.
+ */
+export function AudioInputs({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: AudioInputsValue
+  onChange: (patch: Partial<AudioInputsValue>) => void
+  disabled?: boolean
+}) {
+  const [audioOpen, setAudioOpen] = useState(false)
+  const [voiceOpen, setVoiceOpen] = useState(false)
+  const [inspirationOpen, setInspirationOpen] = useState(false)
+
+  const hasChips = value.audio || value.voice || value.inspiration
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => setAudioOpen(true)}
+        >
+          <HugeiconsIcon icon={MusicNote01Icon} data-icon="inline-start" />
+          Audio
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => setVoiceOpen(true)}
+        >
+          <HugeiconsIcon icon={VoiceIcon} data-icon="inline-start" />
+          Voice
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => setInspirationOpen(true)}
+        >
+          <HugeiconsIcon icon={Playlist01Icon} data-icon="inline-start" />
+          Inspiration
+        </Button>
+      </div>
+
+      {hasChips && (
+        <div
+          className="flex flex-wrap items-center gap-2"
+          aria-label="Attached inputs"
+        >
+          {value.audio && (
+            <InputChip
+              type="audio"
+              label={value.audio.label}
+              onRemove={() => onChange({ audio: null })}
+            />
+          )}
+          {value.voice && (
+            <InputChip
+              type="voice"
+              label={value.voice.name}
+              onRemove={() => onChange({ voice: null })}
+            />
+          )}
+          {value.inspiration && (
+            <InputChip
+              type="inspiration"
+              label={value.inspiration.name}
+              onRemove={() => onChange({ inspiration: null })}
+            />
+          )}
+        </div>
+      )}
+
+      <AddAudioModal
+        open={audioOpen}
+        onOpenChange={setAudioOpen}
+        onSelect={(audio) => onChange({ audio })}
+      />
+      <AddVoiceModal
+        open={voiceOpen}
+        onOpenChange={setVoiceOpen}
+        onSelect={(voice) => onChange({ voice })}
+      />
+      <AddInspirationModal
+        open={inspirationOpen}
+        onOpenChange={setInspirationOpen}
+        onSelect={(inspiration) => onChange({ inspiration })}
+      />
+    </div>
+  )
+}

--- a/web/components/create/AudioPreview.test.tsx
+++ b/web/components/create/AudioPreview.test.tsx
@@ -4,13 +4,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { AudioPreview } from "@/components/create/AudioPreview"
 
+const originalCreateObjectURL = URL.createObjectURL
+const originalRevokeObjectURL = URL.revokeObjectURL
+
 beforeEach(() => {
   // jsdom doesn't implement object URLs.
   URL.createObjectURL = vi.fn(() => "blob:mock")
   URL.revokeObjectURL = vi.fn()
 })
 
-afterEach(() => vi.clearAllMocks())
+afterEach(() => {
+  // Restore the globals so the mock doesn't leak into later suites.
+  URL.createObjectURL = originalCreateObjectURL
+  URL.revokeObjectURL = originalRevokeObjectURL
+  vi.clearAllMocks()
+})
 
 describe("AudioPreview", () => {
   it("renders an audio element with a string source", () => {

--- a/web/components/create/AudioPreview.test.tsx
+++ b/web/components/create/AudioPreview.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AudioPreview } from "@/components/create/AudioPreview"
+
+beforeEach(() => {
+  // jsdom doesn't implement object URLs.
+  URL.createObjectURL = vi.fn(() => "blob:mock")
+  URL.revokeObjectURL = vi.fn()
+})
+
+afterEach(() => vi.clearAllMocks())
+
+describe("AudioPreview", () => {
+  it("renders an audio element with a string source", () => {
+    render(<AudioPreview source="/audio/clip.mp3" label="Clip" />)
+    expect(screen.getByLabelText("Preview Clip")).toHaveAttribute(
+      "src",
+      "/audio/clip.mp3"
+    )
+  })
+
+  it("creates an object URL for a Blob source", () => {
+    const blob = new Blob(["x"], { type: "audio/webm" })
+    render(<AudioPreview source={blob} />)
+    expect(URL.createObjectURL).toHaveBeenCalledWith(blob)
+  })
+
+  it("calls onClear when Clear is clicked", async () => {
+    const onClear = vi.fn()
+    const user = userEvent.setup()
+    render(<AudioPreview source="/a.mp3" onClear={onClear} />)
+    await user.click(screen.getByRole("button", { name: /clear/i }))
+    expect(onClear).toHaveBeenCalledOnce()
+  })
+})

--- a/web/components/create/AudioPreview.tsx
+++ b/web/components/create/AudioPreview.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import { Button } from "@/components/ui/button"
+
+/**
+ * Preview an attached audio source in the Upload/Record tabs (US-16.8). Uses the
+ * native <audio controls> element (play/pause/scrub/duration come for free) and,
+ * for File/Blob sources, an object URL set straight onto the element via a ref
+ * (no component state) and revoked on change/unmount. An optional Clear button
+ * lets the user re-upload or re-record.
+ */
+export function AudioPreview({
+  source,
+  label,
+  onClear,
+}: {
+  source: File | Blob | string
+  label?: string
+  onClear?: () => void
+}) {
+  const audioRef = useRef<HTMLAudioElement>(null)
+
+  useEffect(() => {
+    const el = audioRef.current
+    if (!el) return
+    if (typeof source === "string") {
+      el.src = source
+      return
+    }
+    const objectUrl = URL.createObjectURL(source)
+    el.src = objectUrl
+    return () => URL.revokeObjectURL(objectUrl)
+  }, [source])
+
+  return (
+    <div className="flex flex-col gap-2">
+      {label && (
+        <span className="truncate text-sm font-medium" title={label}>
+          {label}
+        </span>
+      )}
+      <audio
+        ref={audioRef}
+        controls
+        aria-label={label ? `Preview ${label}` : "Audio preview"}
+        className="w-full"
+      />
+      {onClear && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="w-fit"
+          onClick={onClear}
+        >
+          Clear
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/web/components/create/InputChip.test.tsx
+++ b/web/components/create/InputChip.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { InputChip } from "@/components/create/InputChip"
+
+describe("InputChip", () => {
+  it("renders the label", () => {
+    render(<InputChip type="audio" label="My clip" onRemove={() => {}} />)
+    expect(screen.getByText("My clip")).toBeInTheDocument()
+  })
+
+  it("fires onRemove when the remove button is clicked", async () => {
+    const onRemove = vi.fn()
+    const user = userEvent.setup()
+    render(<InputChip type="voice" label="Aria" onRemove={onRemove} />)
+
+    await user.click(screen.getByRole("button", { name: /remove aria/i }))
+    expect(onRemove).toHaveBeenCalledOnce()
+  })
+})

--- a/web/components/create/InputChip.tsx
+++ b/web/components/create/InputChip.tsx
@@ -37,7 +37,9 @@ export function InputChip({
   return (
     <Badge variant="secondary" className="max-w-[14rem] gap-1.5 pr-1">
       <HugeiconsIcon icon={ICONS[type]} className="shrink-0" />
-      <span className="truncate" title={label}>
+      {/* min-w-0 lets the label shrink so `truncate` actually clips inside the
+          flex badge instead of overflowing. */}
+      <span className="min-w-0 truncate" title={label}>
         {label}
       </span>
       <button

--- a/web/components/create/InputChip.tsx
+++ b/web/components/create/InputChip.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Cancel01Icon,
+  MusicNote01Icon,
+  Playlist01Icon,
+  VoiceIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+
+export type InputChipType = "audio" | "voice" | "inspiration"
+
+const ICONS: Record<InputChipType, typeof MusicNote01Icon> = {
+  audio: MusicNote01Icon,
+  voice: VoiceIcon,
+  inspiration: Playlist01Icon,
+}
+
+/**
+ * A removable badge for a selected creation input (US-16.8): an audio reference,
+ * a voice model, or an inspiration playlist. Uses the `secondary` Badge variant
+ * to stay visually distinct from the `outline` style-tag pills. The X button
+ * fires `onRemove`; the label truncates so long clip/playlist titles don't blow
+ * out the row.
+ */
+export function InputChip({
+  type,
+  label,
+  onRemove,
+}: {
+  type: InputChipType
+  label: string
+  onRemove: () => void
+}) {
+  return (
+    <Badge variant="secondary" className="max-w-[14rem] gap-1.5 pr-1">
+      <HugeiconsIcon icon={ICONS[type]} className="shrink-0" />
+      <span className="truncate" title={label}>
+        {label}
+      </span>
+      <button
+        type="button"
+        aria-label={`Remove ${label}`}
+        onClick={onRemove}
+        className="rounded-sm opacity-70 transition-opacity hover:opacity-100"
+      >
+        <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+      </button>
+    </Badge>
+  )
+}

--- a/web/components/create/SimpleCreationForm.test.tsx
+++ b/web/components/create/SimpleCreationForm.test.tsx
@@ -165,11 +165,24 @@ describe("SimpleCreationForm", () => {
     expect(createButton()).toBeDisabled()
   })
 
-  it("shows the +Audio placeholder as a neutral notice, not an error", async () => {
+  it("opens the Add audio modal from the +Audio button", async () => {
     const user = userEvent.setup()
     render(<SimpleCreationForm />)
     await user.click(screen.getByRole("button", { name: /audio/i }))
-    expect(screen.getByRole("status")).toHaveTextContent(/coming soon/i)
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    expect(
+      await screen.findByRole("dialog", { name: /add audio/i })
+    ).toBeInTheDocument()
+  })
+
+  it("attaches a voice as a removable chip and Clear all wipes it", async () => {
+    const user = userEvent.setup()
+    render(<SimpleCreationForm />)
+
+    await user.click(screen.getByRole("button", { name: /voice/i }))
+    await user.click(screen.getByRole("button", { name: /aria/i }))
+    expect(screen.getByLabelText("Attached inputs")).toHaveTextContent("Aria")
+
+    await user.click(screen.getByRole("button", { name: /clear all/i }))
+    expect(screen.queryByLabelText("Attached inputs")).not.toBeInTheDocument()
   })
 })

--- a/web/components/create/SimpleCreationForm.tsx
+++ b/web/components/create/SimpleCreationForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
-import { Add01Icon, MusicNote01Icon } from "@hugeicons/core-free-icons"
+import { Add01Icon } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
@@ -16,6 +16,11 @@ import { submitGeneration } from "@/lib/generate"
 import { InspirationTags } from "@/components/create/InspirationTags"
 import { GenerationProgress } from "@/components/create/GenerationProgress"
 import { GenerationError } from "@/components/create/GenerationError"
+import {
+  AudioInputs,
+  EMPTY_AUDIO_INPUTS,
+  type AudioInputsValue,
+} from "@/components/create/AudioInputs"
 
 /**
  * The Simple creation form (US-16.1): describe a song in plain language and go.
@@ -37,8 +42,11 @@ export function SimpleCreationForm({
   const [lyrics, setLyrics] = useState("")
   const [showLyrics, setShowLyrics] = useState(false)
   const [selectedTags, setSelectedTags] = useState<string[]>([])
-  // Neutral notice for non-generation messages (e.g. the +Audio placeholder),
-  // kept separate from the generation state machine.
+  // Attached reference audio / voice / inspiration (US-16.8). Tracked here so
+  // Clear all resets them and they persist across Simple/Advanced tab switches.
+  const [inputs, setInputs] = useState<AudioInputsValue>(EMPTY_AUDIO_INPUTS)
+  // Neutral notice for non-generation messages, kept separate from the
+  // generation state machine.
   const [notice, setNotice] = useState<string | null>(null)
 
   // Lyrics only count when the field is open — hiding it shouldn't keep Create
@@ -79,6 +87,7 @@ export function SimpleCreationForm({
     setLyrics("")
     setShowLyrics(false)
     setSelectedTags([])
+    setInputs(EMPTY_AUDIO_INPUTS)
     setNotice(null)
     generation.reset()
   }
@@ -110,16 +119,11 @@ export function SimpleCreationForm({
       )}
 
       <div className="flex flex-wrap items-center gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
+        <AudioInputs
+          value={inputs}
+          onChange={(patch) => setInputs((v) => ({ ...v, ...patch }))}
           disabled={busy}
-          onClick={() => setNotice("Audio input is coming soon.")}
-        >
-          <HugeiconsIcon icon={MusicNote01Icon} data-icon="inline-start" />
-          Audio
-        </Button>
+        />
         <Button
           type="button"
           variant="outline"

--- a/web/components/create/modals/AddAudioModal.test.tsx
+++ b/web/components/create/modals/AddAudioModal.test.tsx
@@ -37,6 +37,9 @@ function clip(partial: Partial<Clip> & { id: string }): Clip {
   }
 }
 
+const originalCreateObjectURL = URL.createObjectURL
+const originalRevokeObjectURL = URL.revokeObjectURL
+
 beforeEach(() => {
   URL.createObjectURL = vi.fn(() => "blob:mock")
   URL.revokeObjectURL = vi.fn()
@@ -50,7 +53,11 @@ beforeEach(() => {
   })
 })
 
-afterEach(() => vi.clearAllMocks())
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL
+  URL.revokeObjectURL = originalRevokeObjectURL
+  vi.clearAllMocks()
+})
 
 describe("AddAudioModal", () => {
   it("opens with Remix, Upload, and Record tabs", () => {
@@ -149,6 +156,42 @@ describe("AddAudioModal", () => {
       expect.objectContaining({ kind: "record", label: "Recording" })
     )
     expect(trackStop).toHaveBeenCalled()
+  })
+
+  it("releases the mic if the tab unmounts before getUserMedia resolves", async () => {
+    let resolveStream: (s: unknown) => void = () => {}
+    const trackStop = vi.fn()
+    const getUserMedia = vi.fn(
+      () => new Promise((res) => (resolveStream = res))
+    )
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia },
+    })
+    const recorderCtor = vi.fn()
+    class FakeMediaRecorder {
+      state = "inactive"
+      constructor() {
+        recorderCtor()
+      }
+      start() {}
+      stop() {}
+    }
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder)
+
+    const user = userEvent.setup()
+    const { unmount } = render(
+      <AddAudioModal open onOpenChange={() => {}} onSelect={() => {}} />
+    )
+    await user.click(screen.getByRole("tab", { name: "Record" }))
+    await user.click(screen.getByRole("button", { name: /^record$/i }))
+
+    // Tab/modal goes away while the permission prompt is still open.
+    unmount()
+    resolveStream({ getTracks: () => [{ stop: trackStop }] })
+
+    await waitFor(() => expect(trackStop).toHaveBeenCalled())
+    expect(recorderCtor).not.toHaveBeenCalled()
   })
 
   it("shows a permission-denied message when the mic is blocked", async () => {

--- a/web/components/create/modals/AddAudioModal.test.tsx
+++ b/web/components/create/modals/AddAudioModal.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AddAudioModal } from "@/components/create/modals/AddAudioModal"
+import type { Clip } from "@/lib/workspace-clips"
+
+const useClipsMock = vi.fn()
+const useWorkspacesMock = vi.fn()
+
+vi.mock("@/hooks/use-clips", () => ({
+  useClips: (...args: unknown[]) => useClipsMock(...args),
+}))
+vi.mock("@/hooks/use-workspaces", () => ({
+  useWorkspaces: () => useWorkspacesMock(),
+}))
+
+function clip(partial: Partial<Clip> & { id: string }): Clip {
+  return {
+    workspace_id: "w1",
+    title: null,
+    format: null,
+    duration: 90,
+    bpm: 120,
+    key: null,
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: null,
+    is_public: false,
+    created_at: "2026-01-01",
+    ...partial,
+  }
+}
+
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => "blob:mock")
+  URL.revokeObjectURL = vi.fn()
+  useWorkspacesMock.mockReturnValue({
+    workspaces: [{ id: "w1", name: "My Workspace" }],
+    defaultWorkspace: { id: "w1" },
+  })
+  useClipsMock.mockReturnValue({
+    data: { clips: [clip({ id: "c1", title: "Sunset Drive" })] },
+    loading: false,
+  })
+})
+
+afterEach(() => vi.clearAllMocks())
+
+describe("AddAudioModal", () => {
+  it("opens with Remix, Upload, and Record tabs", () => {
+    render(<AddAudioModal open onOpenChange={() => {}} onSelect={() => {}} />)
+    expect(screen.getByRole("tab", { name: "Remix" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "Upload" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "Record" })).toBeInTheDocument()
+  })
+
+  it("selects a clip from the Remix tab", async () => {
+    const onSelect = vi.fn()
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <AddAudioModal open onOpenChange={onOpenChange} onSelect={onSelect} />
+    )
+
+    await user.click(screen.getByRole("button", { name: /sunset drive/i }))
+    expect(onSelect).toHaveBeenCalledWith({
+      kind: "clip",
+      clipId: "c1",
+      label: "Sunset Drive",
+    })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("validates and rejects an unsupported upload", async () => {
+    const user = userEvent.setup()
+    render(<AddAudioModal open onOpenChange={() => {}} onSelect={() => {}} />)
+
+    await user.click(screen.getByRole("tab", { name: "Upload" }))
+    // fireEvent bypasses the input's `accept` filter, exercising the JS
+    // validation backstop that guards the drag-drop path.
+    fireEvent.change(screen.getByLabelText("Upload audio file"), {
+      target: { files: [new File(["x"], "notes.txt", { type: "text/plain" })] },
+    })
+    expect(screen.getByRole("alert")).toHaveTextContent(/unsupported/i)
+  })
+
+  it("previews and attaches a valid upload", async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+    render(<AddAudioModal open onOpenChange={() => {}} onSelect={onSelect} />)
+
+    await user.click(screen.getByRole("tab", { name: "Upload" }))
+    const file = new File(["x"], "loop.mp3", { type: "audio/mpeg" })
+    await user.upload(screen.getByLabelText("Upload audio file"), file)
+
+    expect(screen.getByLabelText("Preview loop.mp3")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /attach/i }))
+    expect(onSelect).toHaveBeenCalledWith({
+      kind: "upload",
+      file,
+      label: "loop.mp3",
+    })
+  })
+
+  it("records via the microphone and uses the recording", async () => {
+    const trackStop = vi.fn()
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValue({ getTracks: () => [{ stop: trackStop }] })
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia },
+    })
+
+    class FakeMediaRecorder {
+      state = "inactive"
+      ondataavailable: ((e: { data: Blob }) => void) | null = null
+      onstop: (() => void) | null = null
+      start() {
+        this.state = "recording"
+      }
+      stop() {
+        this.state = "inactive"
+        this.ondataavailable?.({ data: new Blob(["x"], { type: "audio/webm" }) })
+        this.onstop?.()
+      }
+    }
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder)
+
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+    render(<AddAudioModal open onOpenChange={() => {}} onSelect={onSelect} />)
+
+    await user.click(screen.getByRole("tab", { name: "Record" }))
+    await user.click(screen.getByRole("button", { name: /^record$/i }))
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument()
+    )
+    await user.click(screen.getByRole("button", { name: /stop/i }))
+
+    await user.click(screen.getByRole("button", { name: /use recording/i }))
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "record", label: "Recording" })
+    )
+    expect(trackStop).toHaveBeenCalled()
+  })
+
+  it("shows a permission-denied message when the mic is blocked", async () => {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia: vi.fn().mockRejectedValue(new Error("denied")) },
+    })
+    const user = userEvent.setup()
+    render(<AddAudioModal open onOpenChange={() => {}} onSelect={() => {}} />)
+
+    await user.click(screen.getByRole("tab", { name: "Record" }))
+    await user.click(screen.getByRole("button", { name: /^record$/i }))
+    expect(await screen.findByRole("alert")).toHaveTextContent(/denied/i)
+  })
+})

--- a/web/components/create/modals/AddAudioModal.tsx
+++ b/web/components/create/modals/AddAudioModal.tsx
@@ -287,13 +287,23 @@ function RecordTab({
     }
   }
 
-  // Stop any in-flight recording / timer when the modal closes or unmounts.
+  // Stop any in-flight recording when the modal closes (active=false) or the tab
+  // unmounts — otherwise the microphone keeps capturing until the browser tears
+  // the stream down. The recorder's onstop stops the stream tracks, so stopping
+  // the recorder also ends the getUserMedia capture. Inlined (refs are stable) to
+  // keep the dependency array honest.
   useEffect(() => {
-    if (!active) {
-      if (recorderRef.current?.state === "recording") recorderRef.current.stop()
-      stopTimer()
+    function teardown() {
+      if (recorderRef.current?.state === "recording") {
+        recorderRef.current.stop()
+      }
+      if (timerRef.current) {
+        clearInterval(timerRef.current)
+        timerRef.current = null
+      }
     }
-    return stopTimer
+    if (!active) teardown()
+    return teardown
   }, [active])
 
   async function start() {

--- a/web/components/create/modals/AddAudioModal.tsx
+++ b/web/components/create/modals/AddAudioModal.tsx
@@ -1,0 +1,377 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  RecordIcon,
+  StopIcon,
+  Upload04Icon,
+} from "@hugeicons/core-free-icons"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useClips } from "@/hooks/use-clips"
+import { useWorkspaces } from "@/hooks/use-workspaces"
+import { SELECT_CLASS } from "@/lib/constants/ui"
+import {
+  ACCEPTED_AUDIO_EXTENSIONS,
+  isAcceptedAudioFile,
+  type AudioSelection,
+} from "@/lib/audio-inputs"
+import { AudioPreview } from "@/components/create/AudioPreview"
+
+// Sentinel workspace id for the "Public Songs" option — queries clips without a
+// workspace scope. ponytail: simplest mapping until a dedicated public feed lands.
+const PUBLIC = "__public__"
+
+function formatDuration(seconds: number | null): string {
+  if (seconds == null) return "—"
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${m}:${s.toString().padStart(2, "0")}`
+}
+
+/**
+ * Add Audio modal (US-16.8): attach a reference audio via one of three tabs —
+ * Remix (pick an existing clip), Upload (a local file), or Record (the mic).
+ * Controlled via `open`/`onOpenChange`; `onSelect` receives the chosen
+ * AudioSelection and the caller closes the modal.
+ */
+export function AddAudioModal({
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (selection: AudioSelection) => void
+}) {
+  function choose(selection: AudioSelection) {
+    onSelect(selection)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add audio</DialogTitle>
+          <DialogDescription>
+            Remix an existing clip, upload a file, or record from your
+            microphone.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs defaultValue="remix">
+          <TabsList>
+            <TabsTrigger value="remix">Remix</TabsTrigger>
+            <TabsTrigger value="upload">Upload</TabsTrigger>
+            <TabsTrigger value="record">Record</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="remix">
+            <RemixTab onSelect={choose} active={open} />
+          </TabsContent>
+          <TabsContent value="upload">
+            <UploadTab onSelect={choose} />
+          </TabsContent>
+          <TabsContent value="record">
+            <RecordTab onSelect={choose} active={open} />
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RemixTab({
+  onSelect,
+  active,
+}: {
+  onSelect: (selection: AudioSelection) => void
+  active: boolean
+}) {
+  const { workspaces, defaultWorkspace } = useWorkspaces()
+  // `selected` is null until the user picks; the effective workspace falls back
+  // to their default. Deriving (rather than syncing via an effect) keeps this
+  // clear of the react-hooks/set-state-in-effect rule.
+  const [selected, setSelected] = useState<string | null>(null)
+  const [search, setSearch] = useState("")
+
+  const workspaceId = selected ?? defaultWorkspace?.id ?? ""
+  const isPublic = workspaceId === PUBLIC
+  const { data, loading } = useClips(
+    {
+      workspace_id: isPublic ? undefined : workspaceId || undefined,
+      search: search || undefined,
+    },
+    { enabled: active && (isPublic || !!workspaceId) }
+  )
+  const clips = data?.clips ?? []
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          aria-label="Workspace"
+          className={`${SELECT_CLASS} w-auto`}
+          value={workspaceId}
+          onChange={(e) => setSelected(e.target.value)}
+        >
+          {workspaces.map((w) => (
+            <option key={w.id} value={w.id}>
+              {w.name}
+            </option>
+          ))}
+          <option value={PUBLIC}>Public Songs</option>
+        </select>
+        <Input
+          aria-label="Search clips"
+          placeholder="Search by title or style..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1"
+        />
+      </div>
+
+      <ul className="flex max-h-72 flex-col gap-1 overflow-y-auto">
+        {loading && (
+          <li className="px-2 py-3 text-sm text-muted-foreground">Loading…</li>
+        )}
+        {!loading && clips.length === 0 && (
+          <li className="px-2 py-3 text-sm text-muted-foreground">
+            No clips found.
+          </li>
+        )}
+        {clips.map((clip) => {
+          const title = clip.title || "Untitled clip"
+          return (
+            <li key={clip.id}>
+              <button
+                type="button"
+                onClick={() =>
+                  onSelect({ kind: "clip", clipId: clip.id, label: title })
+                }
+                className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm hover:bg-muted"
+              >
+                <span className="truncate">{title}</span>
+                <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                  {formatDuration(clip.duration)}
+                  {clip.bpm ? ` · ${clip.bpm} BPM` : ""}
+                </span>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+function UploadTab({
+  onSelect,
+}: {
+  onSelect: (selection: AudioSelection) => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [dragging, setDragging] = useState(false)
+
+  function accept(candidate: File | undefined) {
+    if (!candidate) return
+    if (!isAcceptedAudioFile(candidate.name)) {
+      setFile(null)
+      setError(
+        `Unsupported file type. Use ${ACCEPTED_AUDIO_EXTENSIONS.join(", ")}.`
+      )
+      return
+    }
+    setError(null)
+    setFile(candidate)
+  }
+
+  if (file) {
+    return (
+      <div className="flex flex-col gap-3">
+        <AudioPreview
+          source={file}
+          label={file.name}
+          onClear={() => setFile(null)}
+        />
+        <Button
+          type="button"
+          className="w-fit"
+          onClick={() =>
+            onSelect({ kind: "upload", file, label: file.name })
+          }
+        >
+          Attach
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        onDragOver={(e) => {
+          e.preventDefault()
+          setDragging(true)
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault()
+          setDragging(false)
+          accept(e.dataTransfer.files[0])
+        }}
+        className={`flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground ${
+          dragging ? "border-primary bg-primary/5" : "border-border"
+        }`}
+      >
+        <HugeiconsIcon icon={Upload04Icon} size={24} />
+        <p>Drag and drop an audio file here</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => inputRef.current?.click()}
+        >
+          Browse files
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED_AUDIO_EXTENSIONS.join(",")}
+          aria-label="Upload audio file"
+          className="hidden"
+          onChange={(e) => accept(e.target.files?.[0])}
+        />
+      </div>
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function RecordTab({
+  onSelect,
+  active,
+}: {
+  onSelect: (selection: AudioSelection) => void
+  active: boolean
+}) {
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [recording, setRecording] = useState(false)
+  const [seconds, setSeconds] = useState(0)
+  const [blob, setBlob] = useState<Blob | null>(null)
+  const [denied, setDenied] = useState(false)
+
+  function stopTimer() {
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  // Stop any in-flight recording / timer when the modal closes or unmounts.
+  useEffect(() => {
+    if (!active) {
+      if (recorderRef.current?.state === "recording") recorderRef.current.stop()
+      stopTimer()
+    }
+    return stopTimer
+  }, [active])
+
+  async function start() {
+    setDenied(false)
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      const recorder = new MediaRecorder(stream)
+      chunksRef.current = []
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data)
+      }
+      recorder.onstop = () => {
+        setBlob(new Blob(chunksRef.current, { type: "audio/webm" }))
+        stream.getTracks().forEach((t) => t.stop())
+      }
+      recorderRef.current = recorder
+      recorder.start()
+      setBlob(null)
+      setSeconds(0)
+      setRecording(true)
+      timerRef.current = setInterval(() => setSeconds((s) => s + 1), 1000)
+    } catch {
+      setDenied(true)
+    }
+  }
+
+  function stop() {
+    recorderRef.current?.stop()
+    stopTimer()
+    setRecording(false)
+  }
+
+  if (denied) {
+    return (
+      <p role="alert" className="px-2 py-6 text-sm text-destructive">
+        Microphone access was denied. Enable it in your browser settings to
+        record.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3 py-4">
+      {blob && !recording ? (
+        <div className="flex w-full flex-col gap-3">
+          <AudioPreview
+            source={blob}
+            label="Recording"
+            onClear={() => setBlob(null)}
+          />
+          <Button
+            type="button"
+            className="w-fit"
+            onClick={() =>
+              onSelect({ kind: "record", blob, label: "Recording" })
+            }
+          >
+            Use recording
+          </Button>
+        </div>
+      ) : (
+        <>
+          <span className="font-mono text-2xl tabular-nums">
+            {formatDuration(seconds)}
+          </span>
+          {recording ? (
+            <Button type="button" variant="destructive" onClick={stop}>
+              <HugeiconsIcon icon={StopIcon} data-icon="inline-start" />
+              Stop
+            </Button>
+          ) : (
+            <Button type="button" onClick={start}>
+              <HugeiconsIcon icon={RecordIcon} data-icon="inline-start" />
+              Record
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/components/create/modals/AddAudioModal.tsx
+++ b/web/components/create/modals/AddAudioModal.tsx
@@ -186,10 +186,17 @@ function UploadTab({
   const [error, setError] = useState<string | null>(null)
   const [dragging, setDragging] = useState(false)
 
+  // Clearing React state isn't enough: an <input type=file> keeps its value, so
+  // re-picking the same file wouldn't fire onChange again. Reset it too.
+  function resetInput() {
+    if (inputRef.current) inputRef.current.value = ""
+  }
+
   function accept(candidate: File | undefined) {
     if (!candidate) return
     if (!isAcceptedAudioFile(candidate.name)) {
       setFile(null)
+      resetInput()
       setError(
         `Unsupported file type. Use ${ACCEPTED_AUDIO_EXTENSIONS.join(", ")}.`
       )
@@ -205,7 +212,10 @@ function UploadTab({
         <AudioPreview
           source={file}
           label={file.name}
-          onClear={() => setFile(null)}
+          onClear={() => {
+            setFile(null)
+            resetInput()
+          }}
         />
         <Button
           type="button"
@@ -275,10 +285,20 @@ function RecordTab({
   const recorderRef = useRef<MediaRecorder | null>(null)
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Set once the tab unmounts, so a getUserMedia() that resolves after teardown
+  // doesn't arm a recorder/timer (or touch state) with no UI left to stop them.
+  const disposedRef = useRef(false)
   const [recording, setRecording] = useState(false)
+  const [starting, setStarting] = useState(false)
   const [seconds, setSeconds] = useState(0)
   const [blob, setBlob] = useState<Blob | null>(null)
   const [denied, setDenied] = useState(false)
+
+  useEffect(() => {
+    return () => {
+      disposedRef.current = true
+    }
+  }, [])
 
   function stopTimer() {
     if (timerRef.current) {
@@ -308,8 +328,15 @@ function RecordTab({
 
   async function start() {
     setDenied(false)
+    setStarting(true)
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      // The tab may have unmounted while the permission prompt was open — if so,
+      // release the stream immediately instead of arming a recorder no one owns.
+      if (disposedRef.current) {
+        stream.getTracks().forEach((t) => t.stop())
+        return
+      }
       const recorder = new MediaRecorder(stream)
       chunksRef.current = []
       recorder.ondataavailable = (e) => {
@@ -326,7 +353,9 @@ function RecordTab({
       setRecording(true)
       timerRef.current = setInterval(() => setSeconds((s) => s + 1), 1000)
     } catch {
-      setDenied(true)
+      if (!disposedRef.current) setDenied(true)
+    } finally {
+      if (!disposedRef.current) setStarting(false)
     }
   }
 
@@ -375,7 +404,7 @@ function RecordTab({
               Stop
             </Button>
           ) : (
-            <Button type="button" onClick={start}>
+            <Button type="button" onClick={start} disabled={starting}>
               <HugeiconsIcon icon={RecordIcon} data-icon="inline-start" />
               Record
             </Button>

--- a/web/components/create/modals/AddInspirationModal.test.tsx
+++ b/web/components/create/modals/AddInspirationModal.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { AddInspirationModal } from "@/components/create/modals/AddInspirationModal"
+import { MOCK_PLAYLISTS } from "@/lib/audio-inputs"
+
+afterEach(() => vi.clearAllMocks())
+
+describe("AddInspirationModal", () => {
+  it("lists the user's playlists", () => {
+    render(
+      <AddInspirationModal open onOpenChange={() => {}} onSelect={() => {}} />
+    )
+    for (const playlist of MOCK_PLAYLISTS) {
+      expect(screen.getByText(playlist.name)).toBeInTheDocument()
+    }
+  })
+
+  it("selects a playlist and closes", async () => {
+    const onSelect = vi.fn()
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <AddInspirationModal
+        open
+        onOpenChange={onOpenChange}
+        onSelect={onSelect}
+      />
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /late night drive/i })
+    )
+    expect(onSelect).toHaveBeenCalledWith({
+      id: "pl-latenight",
+      name: "Late Night Drive",
+    })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/web/components/create/modals/AddInspirationModal.tsx
+++ b/web/components/create/modals/AddInspirationModal.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Playlist01Icon } from "@hugeicons/core-free-icons"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { MOCK_PLAYLISTS, type InspirationSelection } from "@/lib/audio-inputs"
+
+/**
+ * Add Inspiration modal (US-16.8): reference one of the user's playlists as
+ * inspirational context. Playlists have no backend yet, so the list comes from
+ * MOCK_PLAYLISTS; selecting one closes the modal via `onSelect`.
+ */
+export function AddInspirationModal({
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (selection: InspirationSelection) => void
+}) {
+  const playlists = MOCK_PLAYLISTS
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add inspiration</DialogTitle>
+          <DialogDescription>
+            Reference a playlist to inspire your generation.
+          </DialogDescription>
+        </DialogHeader>
+
+        {playlists.length === 0 ? (
+          <p className="px-2 py-6 text-sm text-muted-foreground">
+            No playlists yet. Create one in your Library.
+          </p>
+        ) : (
+          <ul className="flex max-h-80 flex-col gap-1 overflow-y-auto">
+            {playlists.map((playlist) => (
+              <li key={playlist.id}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onSelect({ id: playlist.id, name: playlist.name })
+                    onOpenChange(false)
+                  }}
+                  className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-left hover:bg-muted"
+                >
+                  <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                    <HugeiconsIcon icon={Playlist01Icon} size={18} />
+                  </span>
+                  <span className="flex flex-col">
+                    <span className="text-sm font-medium">{playlist.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {playlist.trackCount} tracks
+                    </span>
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/create/modals/AddVoiceModal.test.tsx
+++ b/web/components/create/modals/AddVoiceModal.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AddVoiceModal } from "@/components/create/modals/AddVoiceModal"
+import { MOCK_VOICES } from "@/lib/audio-inputs"
+
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => "blob:mock")
+  URL.revokeObjectURL = vi.fn()
+})
+
+afterEach(() => vi.clearAllMocks())
+
+describe("AddVoiceModal", () => {
+  it("lists the available voice models", () => {
+    render(<AddVoiceModal open onOpenChange={() => {}} onSelect={() => {}} />)
+    for (const voice of MOCK_VOICES) {
+      expect(screen.getByText(voice.name)).toBeInTheDocument()
+    }
+  })
+
+  it("selects a voice and closes", async () => {
+    const onSelect = vi.fn()
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <AddVoiceModal open onOpenChange={onOpenChange} onSelect={onSelect} />
+    )
+
+    await user.click(screen.getByRole("button", { name: /aria/i }))
+    expect(onSelect).toHaveBeenCalledWith({ id: "voice-aria", name: "Aria" })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/web/components/create/modals/AddVoiceModal.test.tsx
+++ b/web/components/create/modals/AddVoiceModal.test.tsx
@@ -5,12 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { AddVoiceModal } from "@/components/create/modals/AddVoiceModal"
 import { MOCK_VOICES } from "@/lib/audio-inputs"
 
+const originalCreateObjectURL = URL.createObjectURL
+const originalRevokeObjectURL = URL.revokeObjectURL
+
 beforeEach(() => {
   URL.createObjectURL = vi.fn(() => "blob:mock")
   URL.revokeObjectURL = vi.fn()
 })
 
-afterEach(() => vi.clearAllMocks())
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL
+  URL.revokeObjectURL = originalRevokeObjectURL
+  vi.clearAllMocks()
+})
 
 describe("AddVoiceModal", () => {
   it("lists the available voice models", () => {

--- a/web/components/create/modals/AddVoiceModal.tsx
+++ b/web/components/create/modals/AddVoiceModal.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { AudioPreview } from "@/components/create/AudioPreview"
+import { MOCK_VOICES, type VoiceSelection } from "@/lib/audio-inputs"
+
+/**
+ * Add Voice modal (US-16.8): pick a custom voice model to sing the generation.
+ * Voice models have no backend yet, so the list comes from MOCK_VOICES; each row
+ * has an inline preview and selecting one closes the modal via `onSelect`.
+ */
+export function AddVoiceModal({
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (selection: VoiceSelection) => void
+}) {
+  const voices = MOCK_VOICES
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add voice</DialogTitle>
+          <DialogDescription>
+            Choose a custom voice model for your generation.
+          </DialogDescription>
+        </DialogHeader>
+
+        {voices.length === 0 ? (
+          <p className="px-2 py-6 text-sm text-muted-foreground">
+            No custom voices yet. Train a voice in Settings.
+          </p>
+        ) : (
+          <ul className="flex max-h-80 flex-col gap-2 overflow-y-auto">
+            {voices.map((voice) => (
+              <li
+                key={voice.id}
+                className="flex flex-col gap-2 rounded-lg border p-3"
+              >
+                <button
+                  type="button"
+                  onClick={() => {
+                    onSelect({ id: voice.id, name: voice.name })
+                    onOpenChange(false)
+                  }}
+                  className="flex flex-col items-start text-left"
+                >
+                  <span className="text-sm font-medium">{voice.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {voice.description}
+                  </span>
+                </button>
+                <AudioPreview source={voice.previewUrl} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/lib/audio-inputs.ts
+++ b/web/lib/audio-inputs.ts
@@ -14,6 +14,7 @@ export const ACCEPTED_AUDIO_EXTENSIONS = [
   ".ogg",
   ".aac",
   ".aiff",
+  ".aif",
 ] as const
 
 /** A reference audio the user attached, by source. `label` is what the chip shows. */

--- a/web/lib/audio-inputs.ts
+++ b/web/lib/audio-inputs.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared types and placeholder data for the creation-page input modals (US-16.8):
+ * Add Audio (remix a clip / upload a file / record from mic), Add Voice, and
+ * Add Inspiration. Voice models and playlists have no backend yet, so the modals
+ * read from the MOCK_* arrays below — shaped to match the eventual API responses
+ * so swapping in a real fetch is a one-line change.
+ */
+
+/** Accepted upload formats for the Add Audio → Upload tab. */
+export const ACCEPTED_AUDIO_EXTENSIONS = [
+  ".wav",
+  ".flac",
+  ".mp3",
+  ".ogg",
+  ".aac",
+  ".aiff",
+] as const
+
+/** A reference audio the user attached, by source. `label` is what the chip shows. */
+export type AudioSelection =
+  | { kind: "clip"; clipId: string; label: string }
+  | { kind: "upload"; file: File; label: string }
+  | { kind: "record"; blob: Blob; label: string }
+
+export type VoiceSelection = { id: string; name: string }
+
+export type InspirationSelection = { id: string; name: string }
+
+export type VoiceModel = {
+  id: string
+  name: string
+  description: string
+  previewUrl: string
+}
+
+export type Playlist = {
+  id: string
+  name: string
+  trackCount: number
+  thumbnailUrl?: string
+}
+
+// ponytail: placeholder data — replace with a fetch once the voices/playlists
+// APIs exist. Shapes match the planned responses so callers don't change.
+export const MOCK_VOICES: VoiceModel[] = [
+  {
+    id: "voice-aria",
+    name: "Aria",
+    description: "Warm female pop vocal",
+    previewUrl: "/audio/voices/aria.mp3",
+  },
+  {
+    id: "voice-rex",
+    name: "Rex",
+    description: "Gritty male rock vocal",
+    previewUrl: "/audio/voices/rex.mp3",
+  },
+  {
+    id: "voice-lumen",
+    name: "Lumen",
+    description: "Airy androgynous synth vocal",
+    previewUrl: "/audio/voices/lumen.mp3",
+  },
+]
+
+export const MOCK_PLAYLISTS: Playlist[] = [
+  { id: "pl-latenight", name: "Late Night Drive", trackCount: 12 },
+  { id: "pl-focus", name: "Deep Focus", trackCount: 28 },
+  { id: "pl-summer", name: "Summer Anthems", trackCount: 7 },
+]
+
+/** True if `name` ends in one of the accepted audio extensions (case-insensitive). */
+export function isAcceptedAudioFile(name: string): boolean {
+  const lower = name.toLowerCase()
+  return ACCEPTED_AUDIO_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}


### PR DESCRIPTION
## US-16.8: Audio Input Modals

Closes #194. Adds the three audio input modals to the creation pages (Simple +
Advanced), letting a musician attach reference audio, a custom voice, and an
inspiration playlist to a generation.

### What's included
- **Add Audio modal** (`AddAudioModal`) with three tabs:
  - **Remix** — search/select a clip from a workspace (reuses `useClips` /
    `useWorkspaces`); includes a "Public Songs" option.
  - **Upload** — drag-and-drop or file picker, audio-extension validation
    (WAV/FLAC/MP3/OGG/AAC/AIFF), inline preview before attach.
  - **Record** — browser microphone capture via `MediaRecorder`, live timer,
    preview, and a mic permission-denied state.
- **Add Voice modal** (`AddVoiceModal`) — lists voice models with inline preview,
  empty state.
- **Add Inspiration modal** (`AddInspirationModal`) — lists playlists, empty state.
- **`InputChip`** — removable badge (Badge-based) for each selected input.
- **`AudioInputs`** — shared +Audio/+Voice/+Inspiration controls + chips row,
  wired into both `SimpleCreationForm` and `AdvancedCreationForm`. Selections live
  in each form's state, so **Clear all** resets them and they persist across tab
  switches.
- **`AudioPreview`** — native `<audio controls>` player (object URL set via ref,
  revoked on cleanup).

### Acceptance criteria
- [x] Add Audio modal opens with Remix, Upload, and Record tabs
- [x] Uploading a file shows a preview and attaches it to the form
- [x] Recording audio works via browser microphone API
- [x] Add Voice modal lists available voice models
- [x] Add Inspiration modal lists user's playlists
- [x] Selected inputs appear as removable badges on the creation form

### Known limitations / deviations
- **Voice models and playlists use mock data** (`MOCK_VOICES` / `MOCK_PLAYLISTS`
  in `lib/audio-inputs.ts`), shaped to the expected API responses — those
  backends don't exist yet (per the issue's design choice 1).
- **Selections are NOT yet sent in the generation payload** — backend schema
  changes for reference audio/voice/inspiration are out of scope for this UI
  story (design choice 2). They're tracked in form state and shown as chips.
- Followed the live codebase, not the (stale) plan paths: components under
  `web/components/create/` (no `src/`), data via `/api/clips` & `/api/workspaces`
  hooks (not `/api/v1/*`), PascalCase filenames, native `<audio>` for preview.

### Testing
- `npm run typecheck`, `npm run lint`, `npm run build` — all clean.
- `npm run test` — 307 passing (new: InputChip, AudioPreview, AudioInputs,
  AddAudioModal incl. upload validation + mocked MediaRecorder record flow,
  AddVoice, AddInspiration; updated SimpleCreationForm).
- Cross-family `codex review` pass: 1 P2 (mic stream not stopped on unmount)
  found and fixed in 6f13401.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching audio, voice, and inspiration inputs during creation.
  * Introduced dialogs for choosing existing audio, uploading files, recording new audio, selecting a voice, and picking an inspiration playlist.
  * Added audio previews and removable attached-item chips in the creation flow.

* **Bug Fixes**
  * “Clear all” now removes attached inputs as well as other creation settings.
  * Audio uploads now validate supported file types and show clearer feedback for invalid files.

* **Tests**
  * Added coverage for the new input picker, previews, and modal selection flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->