### PR TITLE
feat(web): Song Detail Page (US-17.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ AI-powered music generation platform built on **ACE-Step-1.5** (fork: `github.co
 3. **Layer 3 — Web UI** (Stages 15–21): Next.js frontend
 4. **Layer 4 — Advanced Integrations** (Stages 22–28): VST3 plugin, music video, voice models, credits, moderation
 
-**Current progress:** Stages 1–14 complete on `main`; Stage 15 in progress (US-15.1 Next.js Nova scaffold). Layer 1 CLI (Stages 1–7): generation, workspace management, audio processing, DAW export. Layer 2 API (Stages 8–14): FastAPI with OAuth2 auth, async jobs, clip streaming, workspace/clip/preset CRUD, credits, compute routing (RunPod), mastering pipeline (Dolby/LANDR/Bakuage), cover art, SoundCloud distribution, release management, DAW export endpoint, playback queue, range-request streaming, similar-clips discovery. Layer 3 Web UI (Stage 15): Next.js Shadcn Nova scaffold (US-15.1).
+**Current progress:** Stages 1–16 complete on `main`; Stage 17 in progress (US-17.1 Song Detail Page). Layer 1 CLI (Stages 1–7): generation, workspace management, audio processing, DAW export. Layer 2 API (Stages 8–14): FastAPI with OAuth2 auth, async jobs, clip streaming, workspace/clip/preset CRUD, credits, compute routing (RunPod), mastering pipeline (Dolby/LANDR/Bakuage), cover art, SoundCloud distribution, release management, DAW export endpoint, playback queue, range-request streaming, similar-clips discovery. Layer 3 Web UI (Stages 15–16): Next.js Nova scaffold, app shell, OAuth login, sidebar nav, global playbar, profile settings, creation flow (simple/advanced/sounds), model selector, workspace panel, clip cards, audio input modals.
 
 ## Commands
 
@@ -138,7 +138,7 @@ tests/
   test_workspace.py # Workspace command tests
   features/         # pytest-bdd feature files (not yet populated)
 
-web/                # Next.js frontend (Layer 3) — Shadcn Nova scaffold (US-15.1)
+web/                # Next.js frontend (Layer 3) — Stages 15–16 complete; Stage 17 in progress (US-17.1)
 plugin/             # JUCE VST3 plugin (placeholder, Layer 4)
 docs/               # Demo docs, spec evidence, and story artifacts
 ```
@@ -230,7 +230,7 @@ Package manager: `uv` with `hatchling` build backend
 ## Agent Notes
 
 - The `plugin/` directory is a placeholder — don't expect working code there yet
-- `web/` is the scaffolded Next.js app (US-15.1, Shadcn Nova); run with `cd web && npm install && npm run dev`
+- `web/` is the Next.js app (Stages 15–16 complete, Stage 17 in progress); run with `cd web && npm install && npm run dev`
 - User stories are numbered `US-{stage}.{sequence}` (e.g., US-2.1 = Stage 2, first story)
 - Integration tests are gated behind `@pytest.mark.integration` and skip gracefully without a server
 - The `.beads/` directory is local-only (gitignored) for issue tracking across sessions

--- a/web/README.md
+++ b/web/README.md
@@ -34,6 +34,43 @@ A persistent bottom player that keeps playing across client-side navigation.
 - `lib/clips.ts` builds the backend media URLs; `lib/demo-tracks.ts` +
   `public/demo/sample.wav` seed a demo queue until a clip-browsing UI exists.
 
+## Song Detail Page (US-17.1)
+
+The `/song/[id]` route renders a full-page view of a single clip.
+
+- `app/song/[id]/page.tsx` — thin route shim: extracts `id` from params and
+  delegates to `SongDetail`.
+- `components/song/SongDetail.tsx` — top-level component; owns auth guard, data
+  fetching, and the three-column layout (header + player + metadata / lyrics /
+  related songs).
+- `components/song/SongHeader.tsx` — title, artist placeholder, style/version/
+  mode badges, and the inline like/dislike/share/publish row.
+- `components/song/SongPlayer.tsx` — play/pause + `SongWaveform` + time readout,
+  driven through the global `usePlayer` store.
+- `components/song/SongWaveform.tsx` — canvas waveform (deterministic bars
+  seeded by clip id via `lib/waveform.ts`); click-to-seek when the clip is the
+  current player track.
+- `components/song/SongMetadata.tsx` — model/BPM/key/duration/created/visibility
+  grid (null fields omitted).
+- `components/song/SongLyrics.tsx` — scrollable lyrics with structure tags
+  (`[Verse]`/`[Chorus]`) formatted as section labels.
+- `components/song/RelatedSongs.tsx` — "Related songs" panel fed by
+  `useSimilarClips`.
+- `hooks/use-clip.ts` — fetches a single clip from the same-origin BFF; tags
+  results with the requested id to prevent stale renders across `/song/:id`
+  navigations.
+- `hooks/use-similar-clips.ts` — fetches similar clips from the BFF.
+- `app/api/clips/[id]/route.ts` — same-origin BFF proxy for
+  `GET /api/v1/clips/{id}`; forwards the Bearer token, keeps the backend URL
+  server-side.
+- `app/api/clips/[id]/similar/route.ts` — same-origin BFF proxy for
+  `GET /api/v1/clips/{id}/similar`; whitelists and bounds `scope`/`limit`
+  before forwarding.
+- `lib/waveform.ts` — `barHeights`, the seeded waveform bar generator (shared
+  with the player `MiniWaveform`).
+- `lib/clip-labels.ts` — display-label maps for clip model/generation_mode.
+- `lib/proxy-fetch.ts` — `fetchWithTimeout` used by BFF routes.
+
 ## Adding components
 
 To add components to your app, run the following command:

--- a/web/app/api/clips/[id]/route.test.ts
+++ b/web/app/api/clips/[id]/route.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { GET } from "@/app/api/clips/[id]/route"
+
+function req(url: string, init: RequestInit = {}): NextRequest {
+  return new Request(url, init) as unknown as NextRequest
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("GET /api/clips/[id]", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await GET(req("http://localhost/api/clips/c1"), ctx("c1"))
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the Bearer token and clip id to the backend", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "c1" }), { status: 200 })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await GET(
+      req("http://localhost/api/clips/c1", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(200)
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips/c1")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+  })
+
+  it("passes a 404 through for an unknown clip", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "not found" }), { status: 404 })
+      )
+    )
+    const res = await GET(
+      req("http://localhost/api/clips/missing", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("missing")
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 502 when the backend is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+    )
+    const res = await GET(
+      req("http://localhost/api/clips/c1", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(502)
+  })
+})

--- a/web/app/api/clips/[id]/route.test.ts
+++ b/web/app/api/clips/[id]/route.test.ts
@@ -9,7 +9,10 @@ function req(url: string, init: RequestInit = {}): NextRequest {
 
 const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 describe("GET /api/clips/[id]", () => {
   it("401s without an Authorization header", async () => {

--- a/web/app/api/clips/[id]/route.ts
+++ b/web/app/api/clips/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/clips/{clip_id} (US-17.1). The client holds
+// the access token in memory and sends it as a Bearer header; this route
+// forwards it so the backend URL stays server-side. The song-detail page fetches
+// a single clip through here. Status/body pass through verbatim (200 with the
+// clip, 401, 404 when the clip is unknown or not owned).
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { id } = await ctx.params
+  let res: Response
+  try {
+    res = await fetch(`${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}`, {
+      headers: { authorization: auth, accept: "application/json" },
+    })
+  } catch {
+    return NextResponse.json(
+      { detail: "Clip service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/clips/[id]/route.ts
+++ b/web/app/api/clips/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 
 import { BACKEND_URL } from "@/lib/auth-server"
+import { fetchWithTimeout } from "@/lib/proxy-fetch"
 
 // Same-origin proxy for GET /api/v1/clips/{clip_id} (US-17.1). The client holds
 // the access token in memory and sends it as a Bearer header; this route
@@ -20,9 +21,10 @@ export async function GET(
   const { id } = await ctx.params
   let res: Response
   try {
-    res = await fetch(`${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}`, {
-      headers: { authorization: auth, accept: "application/json" },
-    })
+    res = await fetchWithTimeout(
+      `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}`,
+      { headers: { authorization: auth, accept: "application/json" } }
+    )
   } catch {
     return NextResponse.json(
       { detail: "Clip service is unavailable." },

--- a/web/app/api/clips/[id]/similar/route.test.ts
+++ b/web/app/api/clips/[id]/similar/route.test.ts
@@ -9,7 +9,10 @@ function req(url: string, init: RequestInit = {}): NextRequest {
 
 const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 describe("GET /api/clips/[id]/similar", () => {
   it("401s without an Authorization header", async () => {
@@ -45,6 +48,47 @@ describe("GET /api/clips/[id]/similar", () => {
     expect((opts.headers as Record<string, string>).authorization).toBe(
       "Bearer tok"
     )
+  })
+
+  it("forwards only whitelisted params and bounds the limit", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ clips: [] }), { status: 200 })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await GET(
+      req(
+        "http://localhost/api/clips/c1/similar?scope=public&limit=9999&workspace_id=other&bogus=1",
+        { headers: { authorization: "Bearer tok" } }
+      ),
+      ctx("c1")
+    )
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toContain("scope=public")
+    expect(url).toContain("limit=20") // 9999 clamped to MAX_SIMILAR_LIMIT
+    expect(url).not.toContain("workspace_id")
+    expect(url).not.toContain("bogus")
+  })
+
+  it("drops an invalid scope value", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ clips: [] }), { status: 200 })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await GET(
+      req("http://localhost/api/clips/c1/similar?scope=everyone", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).not.toContain("scope")
   })
 
   it("returns 502 when the backend is unreachable", async () => {

--- a/web/app/api/clips/[id]/similar/route.test.ts
+++ b/web/app/api/clips/[id]/similar/route.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { GET } from "@/app/api/clips/[id]/similar/route"
+
+function req(url: string, init: RequestInit = {}): NextRequest {
+  return new Request(url, init) as unknown as NextRequest
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("GET /api/clips/[id]/similar", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await GET(
+      req("http://localhost/api/clips/c1/similar"),
+      ctx("c1")
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the token, clip id, and query string", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ clips: [], total: 0, limit: 6 }), {
+          status: 200,
+        })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await GET(
+      req("http://localhost/api/clips/c1/similar?scope=mine&limit=6", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(200)
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips/c1/similar")
+    expect(url).toContain("scope=mine")
+    expect(url).toContain("limit=6")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+  })
+
+  it("returns 502 when the backend is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+    )
+    const res = await GET(
+      req("http://localhost/api/clips/c1/similar", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(502)
+  })
+})

--- a/web/app/api/clips/[id]/similar/route.ts
+++ b/web/app/api/clips/[id]/similar/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/clips/{clip_id}/similar (US-17.1). Forwards
+// the Bearer token plus the query string (scope/limit) so the song-detail
+// "Related songs" panel can fetch suggestions without exposing the backend URL.
+// Status/body pass through verbatim.
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { id } = await ctx.params
+  const search = new URL(request.url).search
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}/similar${search}`,
+      {
+        headers: { authorization: auth, accept: "application/json" },
+      }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Clip service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/clips/[id]/similar/route.ts
+++ b/web/app/api/clips/[id]/similar/route.ts
@@ -1,11 +1,31 @@
 import { NextResponse, type NextRequest } from "next/server"
 
 import { BACKEND_URL } from "@/lib/auth-server"
+import { fetchWithTimeout } from "@/lib/proxy-fetch"
 
 // Same-origin proxy for GET /api/v1/clips/{clip_id}/similar (US-17.1). Forwards
-// the Bearer token plus the query string (scope/limit) so the song-detail
-// "Related songs" panel can fetch suggestions without exposing the backend URL.
-// Status/body pass through verbatim.
+// the Bearer token so the song-detail "Related songs" panel can fetch
+// suggestions without exposing the backend URL. Only the intended query params
+// (scope, bounded limit) are relayed — the raw client query string is NOT
+// forwarded, so the client can't smuggle undocumented backend params. Status/
+// body pass through verbatim.
+
+const MAX_SIMILAR_LIMIT = 20
+const ALLOWED_SCOPES = new Set(["mine", "public", "all"])
+
+/** Whitelist + bound the query params we forward to the backend. */
+function safeSearch(url: string): string {
+  const incoming = new URL(url).searchParams
+  const out = new URLSearchParams()
+  const scope = incoming.get("scope")
+  if (scope && ALLOWED_SCOPES.has(scope)) out.set("scope", scope)
+  const limit = Number(incoming.get("limit"))
+  if (Number.isFinite(limit) && limit > 0) {
+    out.set("limit", String(Math.min(Math.floor(limit), MAX_SIMILAR_LIMIT)))
+  }
+  const qs = out.toString()
+  return qs ? `?${qs}` : ""
+}
 
 export async function GET(
   request: NextRequest,
@@ -17,14 +37,12 @@ export async function GET(
   }
 
   const { id } = await ctx.params
-  const search = new URL(request.url).search
+  const search = safeSearch(request.url)
   let res: Response
   try {
-    res = await fetch(
+    res = await fetchWithTimeout(
       `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}/similar${search}`,
-      {
-        headers: { authorization: auth, accept: "application/json" },
-      }
+      { headers: { authorization: auth, accept: "application/json" } }
     )
   } catch {
     return NextResponse.json(

--- a/web/app/song/[id]/page.tsx
+++ b/web/app/song/[id]/page.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { useParams } from "next/navigation"
+
+import { SongDetail } from "@/components/song/SongDetail"
+
+// Song detail route /song/[id] (US-17.1). Thin shim: pull the id from the route
+// and hand off to SongDetail, which owns auth, data fetching, and layout.
+
+export default function SongPage() {
+  const params = useParams<{ id: string }>()
+  const id = params?.id
+  if (!id) return null
+  return <SongDetail clipId={id} />
+}

--- a/web/components/song/RelatedSongs.tsx
+++ b/web/components/song/RelatedSongs.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { ClipCard } from "@/components/workspace/ClipCard"
+import { useSimilarClips } from "@/hooks/use-similar-clips"
+
+// Song-detail "Related songs" panel (US-17.1). Pulls similar clips from the
+// /similar endpoint and renders them with the shared ClipCard. Loading shows
+// skeletons; an empty/failed result hides the panel rather than showing a dead
+// "no results" block — related songs are supplementary.
+
+export function RelatedSongs({ clipId }: { clipId: string }) {
+  const { clips, loading } = useSimilarClips(clipId)
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="related-loading">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+    )
+  }
+
+  if (clips.length === 0) return null
+
+  return (
+    <section aria-label="Related songs" className="flex flex-col gap-3">
+      <h2 className="text-sm font-semibold">Related songs</h2>
+      <div className="flex flex-col gap-2">
+        {clips.map((clip) => (
+          <ClipCard key={clip.id} clip={clip} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -65,7 +65,10 @@ function renderDetail(clipId = "c1") {
   )
 }
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 describe("SongDetail", () => {
   it("loads and renders the song's data", async () => {

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -125,6 +125,43 @@ describe("SongDetail", () => {
     expect(await screen.findByText("Related One")).toBeInTheDocument()
   })
 
+  it("does not show the previous song when the id changes mid-fetch", async () => {
+    // First clip resolves; the second id's fetch never resolves, so the page
+    // must fall back to loading rather than keep rendering the first song.
+    const fetchMock = vi.fn((input: string) => {
+      const url = String(input)
+      if (url.includes("/similar")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ clips: [] }), { status: 200 })
+        )
+      }
+      if (url.includes("/c1")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(clip()), { status: 200 })
+        )
+      }
+      return new Promise<Response>(() => {}) // c2 hangs
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { rerender } = render(
+      <PlayerProvider>
+        <SongDetail clipId="c1" />
+      </PlayerProvider>
+    )
+    await screen.findByText("Midnight Drive")
+
+    rerender(
+      <PlayerProvider>
+        <SongDetail clipId="c2" />
+      </PlayerProvider>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("song-loading")).toBeInTheDocument()
+    )
+    expect(screen.queryByText("Midnight Drive")).not.toBeInTheDocument()
+  })
+
   it("shows a not-found state for a 404", async () => {
     stubFetch({ clip: clip(), clipStatus: 404 })
     renderDetail()

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SongDetail } from "@/components/song/SongDetail"
+import { PlayerProvider } from "@/contexts/player-context"
+import type { Clip } from "@/lib/workspace-clips"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    accessToken: "tok",
+    isLoading: false,
+    isAuthenticated: true,
+  }),
+}))
+
+function clip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "c1",
+    workspace_id: "w1",
+    title: "Midnight Drive",
+    format: "wav",
+    duration: 95,
+    bpm: 120,
+    key: "C minor",
+    style_tags: ["lofi", "chill"],
+    lyrics: "[Verse 1]\nDriving through the night\n[Chorus]\nNeon lights",
+    vocal_language: "en",
+    model: "ace-step-v1",
+    seed: 7,
+    inference_steps: 30,
+    parent_clip_ids: [],
+    generation_mode: "generate",
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+/** Stub fetch so the clip endpoint and the similar endpoint each respond. */
+function stubFetch(opts: { clip?: Clip; clipStatus?: number; similar?: Clip[] }) {
+  const fetchMock = vi.fn((input: string) => {
+    const url = String(input)
+    if (url.includes("/similar")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ clips: opts.similar ?? [], total: 0, limit: 6 }),
+          { status: 200 }
+        )
+      )
+    }
+    const status = opts.clipStatus ?? 200
+    return Promise.resolve(
+      new Response(JSON.stringify(opts.clip ?? {}), { status })
+    )
+  })
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+function renderDetail(clipId = "c1") {
+  return render(
+    <PlayerProvider>
+      <SongDetail clipId={clipId} />
+    </PlayerProvider>
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("SongDetail", () => {
+  it("loads and renders the song's data", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    expect(await screen.findByText("Midnight Drive")).toBeInTheDocument()
+  })
+
+  it("renders the metadata fields", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await screen.findByText("Midnight Drive")
+    expect(screen.getByText("BPM")).toBeInTheDocument()
+    expect(screen.getByText("120")).toBeInTheDocument()
+    expect(screen.getByText("C minor")).toBeInTheDocument()
+    // "1:35" (95s) shows in both the player time readout and the metadata.
+    expect(screen.getAllByText("1:35").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText("Private")).toBeInTheDocument()
+  })
+
+  it("renders the waveform player with click-to-seek support", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await screen.findByText("Midnight Drive")
+    expect(screen.getByRole("img", { name: "Waveform" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument()
+  })
+
+  it("renders lyrics with structure tags formatted", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await screen.findByText("Midnight Drive")
+    expect(screen.getByText("[Verse 1]")).toBeInTheDocument()
+    expect(screen.getByText("[Chorus]")).toBeInTheDocument()
+    expect(screen.getByText("Driving through the night")).toBeInTheDocument()
+  })
+
+  it("exposes inline like/dislike/share/publish actions", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await screen.findByText("Midnight Drive")
+    expect(screen.getByRole("button", { name: "Like" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Dislike" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Publish (make public)" })
+    ).toBeInTheDocument()
+  })
+
+  it("shows related songs when the similar endpoint returns clips", async () => {
+    stubFetch({
+      clip: clip(),
+      similar: [clip({ id: "c2", title: "Related One" })],
+    })
+    renderDetail()
+    await screen.findByText("Midnight Drive")
+    expect(await screen.findByText("Related One")).toBeInTheDocument()
+  })
+
+  it("shows a not-found state for a 404", async () => {
+    stubFetch({ clip: clip(), clipStatus: 404 })
+    renderDetail()
+    await waitFor(() =>
+      expect(screen.getByTestId("song-not-found")).toBeInTheDocument()
+    )
+  })
+})

--- a/web/components/song/SongDetail.tsx
+++ b/web/components/song/SongDetail.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { RelatedSongs } from "@/components/song/RelatedSongs"
+import { SongHeader } from "@/components/song/SongHeader"
+import { SongLyrics } from "@/components/song/SongLyrics"
+import { SongMetadata } from "@/components/song/SongMetadata"
+import { SongPlayer } from "@/components/song/SongPlayer"
+import { useClip } from "@/hooks/use-clip"
+import { useRequireAuth } from "@/hooks/use-require-auth"
+
+// Song-detail view (US-17.1). Holds all the data/auth logic so the App Router
+// page (app/song/[id]/page.tsx) stays a thin params→component shim that's hard
+// to break and easy to test (this takes a plain clipId).
+
+export function SongDetail({ clipId }: { clipId: string }) {
+  const { isLoading: authLoading, isAuthenticated } = useRequireAuth()
+  const { clip, loading, error, notFound } = useClip(clipId)
+
+  // Render nothing until authed — useRequireAuth redirects otherwise, and this
+  // avoids flashing protected content during the check (matches CreatePage).
+  if (authLoading || !isAuthenticated) return null
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-4 p-8" data-testid="song-loading">
+        <div className="h-8 w-64 animate-pulse rounded bg-muted" />
+        <div className="h-24 animate-pulse rounded-lg bg-muted" />
+        <div className="h-40 animate-pulse rounded-lg bg-muted" />
+      </div>
+    )
+  }
+
+  if (notFound) {
+    return (
+      <div className="mx-auto max-w-5xl p-8" data-testid="song-not-found">
+        <h1 className="text-xl font-semibold">Song not found</h1>
+        <p className="text-sm text-muted-foreground">
+          This song doesn&apos;t exist or you don&apos;t have access to it.
+        </p>
+      </div>
+    )
+  }
+
+  if (error || !clip) {
+    return (
+      <div className="mx-auto max-w-5xl p-8" data-testid="song-error">
+        <h1 className="text-xl font-semibold">Couldn&apos;t load this song</h1>
+        <p className="text-sm text-muted-foreground">
+          Something went wrong. Please try again.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-8 p-8 lg:flex-row">
+      <main className="flex min-w-0 flex-1 flex-col gap-6">
+        <SongHeader clip={clip} />
+        <SongPlayer clip={clip} />
+        <section aria-label="Details" className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold">Details</h2>
+          <SongMetadata clip={clip} />
+        </section>
+        <section aria-label="Lyrics" className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold">Lyrics</h2>
+          <SongLyrics lyrics={clip.lyrics} />
+        </section>
+      </main>
+      <aside className="w-full shrink-0 lg:w-80">
+        <RelatedSongs clipId={clip.id} />
+      </aside>
+    </div>
+  )
+}

--- a/web/components/song/SongDetail.tsx
+++ b/web/components/song/SongDetail.tsx
@@ -53,7 +53,12 @@ export function SongDetail({ clipId }: { clipId: string }) {
   }
 
   return (
-    <div className="mx-auto flex max-w-6xl flex-col gap-8 p-8 lg:flex-row">
+    // key by clip id so per-song local state (e.g. SongHeader's optimistic
+    // like/publish) resets cleanly when navigating between songs.
+    <div
+      key={clip.id}
+      className="mx-auto flex max-w-6xl flex-col gap-8 p-8 lg:flex-row"
+    >
       <main className="flex min-w-0 flex-1 flex-col gap-6">
         <SongHeader clip={clip} />
         <SongPlayer clip={clip} />

--- a/web/components/song/SongHeader.test.tsx
+++ b/web/components/song/SongHeader.test.tsx
@@ -71,6 +71,17 @@ describe("SongHeader", () => {
     ).toBeInTheDocument()
   })
 
+  it("toggles publish inline even without a callback (no persisting parent)", async () => {
+    const user = userEvent.setup()
+    renderHeader()
+    await user.click(
+      screen.getByRole("button", { name: "Publish (make public)" })
+    )
+    expect(
+      screen.getByRole("button", { name: "Unpublish (make private)" })
+    ).toHaveAttribute("aria-pressed", "true")
+  })
+
   it("emits dislike and share callbacks", async () => {
     const user = userEvent.setup()
     const onDislike = vi.fn()

--- a/web/components/song/SongHeader.test.tsx
+++ b/web/components/song/SongHeader.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { SongHeader, type SongHeaderProps } from "@/components/song/SongHeader"
+import { PlayerProvider } from "@/contexts/player-context"
+import type { Clip } from "@/lib/workspace-clips"
+
+function clip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "c1",
+    workspace_id: "w1",
+    title: "Midnight",
+    format: "wav",
+    duration: 95,
+    bpm: 120,
+    key: "C",
+    style_tags: ["lofi", "chill"],
+    lyrics: null,
+    vocal_language: null,
+    model: "ace-step-v1",
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: "remix",
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function renderHeader(props: Partial<SongHeaderProps> = {}) {
+  return render(
+    <PlayerProvider>
+      <SongHeader clip={clip()} {...props} />
+    </PlayerProvider>
+  )
+}
+
+describe("SongHeader", () => {
+  it("renders title, artist placeholder, and style/mode badges", () => {
+    renderHeader()
+    expect(screen.getByRole("heading", { name: "Midnight" })).toBeInTheDocument()
+    expect(screen.getByText("Unknown artist")).toBeInTheDocument()
+    expect(screen.getByText("Remix")).toBeInTheDocument() // mode
+    expect(screen.getByText("XL")).toBeInTheDocument() // version
+    expect(screen.getByText("lofi")).toBeInTheDocument()
+  })
+
+  it("toggles like state via the player store", async () => {
+    const user = userEvent.setup()
+    renderHeader()
+    const like = screen.getByRole("button", { name: "Like" })
+    expect(like).toHaveAttribute("aria-pressed", "false")
+    await user.click(like)
+    expect(
+      screen.getByRole("button", { name: "Unlike" })
+    ).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("optimistically toggles publish and emits the callback", async () => {
+    const user = userEvent.setup()
+    const onPublishToggle = vi.fn()
+    renderHeader({ onPublishToggle })
+    await user.click(
+      screen.getByRole("button", { name: "Publish (make public)" })
+    )
+    expect(onPublishToggle).toHaveBeenCalledWith("c1", true)
+    expect(
+      screen.getByRole("button", { name: "Unpublish (make private)" })
+    ).toBeInTheDocument()
+  })
+
+  it("emits dislike and share callbacks", async () => {
+    const user = userEvent.setup()
+    const onDislike = vi.fn()
+    const onShare = vi.fn()
+    renderHeader({ onDislike, onShare })
+    await user.click(screen.getByRole("button", { name: "Dislike" }))
+    await user.click(screen.getByRole("button", { name: "Share" }))
+    expect(onDislike).toHaveBeenCalledWith("c1")
+    expect(onShare).toHaveBeenCalledWith("c1")
+  })
+})

--- a/web/components/song/SongHeader.tsx
+++ b/web/components/song/SongHeader.tsx
@@ -54,7 +54,10 @@ export function SongHeader({
   function togglePublish() {
     const next = !isPublic
     onPublishToggle?.(clip.id, next)
-    if (onPublishToggle) setOptimisticPublic(next)
+    // Reflect locally so the inline control visibly works on the detail page
+    // (which has no persisting parent yet); a real resync lands when the publish
+    // route exists (US-17.6). Mirrors the local dislike toggle above.
+    setOptimisticPublic(next)
   }
 
   return (

--- a/web/components/song/SongHeader.tsx
+++ b/web/components/song/SongHeader.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  FavouriteIcon,
+  GlobeIcon,
+  Share01Icon,
+  ThumbsDownIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { usePlayer } from "@/contexts/player-context"
+import { modeLabel, versionLabel } from "@/lib/clip-labels"
+import { cn } from "@/lib/utils"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Song-detail header (US-17.1): title, artist, style/version/mode badges, and
+// the inline Like / Dislike / Share / Publish controls. Like is wired to the
+// global player store (the one backend-free action with a real home, as in
+// ClipCard); dislike/share/publish have no backend yet, so they give local
+// optimistic feedback and emit callbacks the parent wires when routes land
+// (US-17.6). Matches ClipCard's behavior so actions read the same app-wide.
+
+export type SongHeaderProps = {
+  clip: Clip
+  onDislike?: (id: string) => void
+  onShare?: (id: string) => void
+  onPublishToggle?: (id: string, next: boolean) => void
+}
+
+export function SongHeader({
+  clip,
+  onDislike,
+  onShare,
+  onPublishToggle,
+}: SongHeaderProps) {
+  const { state, dispatch } = usePlayer()
+  const likedSet = useMemo(() => new Set(state.likedIds), [state.likedIds])
+  const liked = likedSet.has(clip.id)
+  const [disliked, setDisliked] = useState(false)
+  const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
+  const isPublic = optimisticPublic ?? clip.is_public
+
+  const version = versionLabel(clip.model)
+  const mode = modeLabel(clip.generation_mode)
+
+  function dislike() {
+    setDisliked((d) => !d)
+    onDislike?.(clip.id)
+  }
+
+  function togglePublish() {
+    const next = !isPublic
+    onPublishToggle?.(clip.id, next)
+    if (onPublishToggle) setOptimisticPublic(next)
+  }
+
+  return (
+    <header className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-bold tracking-tight">
+          {clip.title ?? "Untitled clip"}
+        </h1>
+        {/* Backend ClipResponse has no artist column yet — placeholder. */}
+        <p className="text-sm text-muted-foreground">Unknown artist</p>
+      </div>
+
+      {(version || mode || clip.style_tags.length > 0) && (
+        <div className="flex flex-wrap items-center gap-1">
+          {version && <Badge variant="secondary">{version}</Badge>}
+          {mode && <Badge variant="outline">{mode}</Badge>}
+          {clip.style_tags.map((tag) => (
+            <Badge key={tag} variant="outline">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={liked ? "Unlike" : "Like"}
+          aria-pressed={liked}
+          onClick={() => dispatch({ type: "like/toggle", id: clip.id })}
+          className={cn(liked && "text-primary")}
+        >
+          <HugeiconsIcon
+            icon={FavouriteIcon}
+            size={18}
+            className={cn(liked && "fill-current")}
+          />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Dislike"
+          aria-pressed={disliked}
+          onClick={dislike}
+          className={cn(disliked && "text-primary")}
+        >
+          <HugeiconsIcon icon={ThumbsDownIcon} size={18} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Share"
+          onClick={() => onShare?.(clip.id)}
+        >
+          <HugeiconsIcon icon={Share01Icon} size={18} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={isPublic ? "Unpublish (make private)" : "Publish (make public)"}
+          aria-pressed={isPublic}
+          onClick={togglePublish}
+          className={cn(isPublic && "text-primary")}
+        >
+          <HugeiconsIcon icon={GlobeIcon} size={18} />
+        </Button>
+      </div>
+    </header>
+  )
+}

--- a/web/components/song/SongLyrics.test.tsx
+++ b/web/components/song/SongLyrics.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { SongLyrics } from "@/components/song/SongLyrics"
+
+describe("SongLyrics", () => {
+  it("shows an empty state when there are no lyrics", () => {
+    render(<SongLyrics lyrics={null} />)
+    expect(screen.getByTestId("lyrics-empty")).toBeInTheDocument()
+  })
+
+  it("treats whitespace-only lyrics as empty", () => {
+    render(<SongLyrics lyrics={"   \n  "} />)
+    expect(screen.getByTestId("lyrics-empty")).toBeInTheDocument()
+  })
+
+  it("renders structure tags as labels and the rest as lyric lines", () => {
+    render(<SongLyrics lyrics={"[Verse 1]\nHello world\n[Chorus]\nLa la"} />)
+    const tags = screen.getAllByTestId("lyrics-tag")
+    expect(tags.map((t) => t.textContent)).toEqual(["[Verse 1]", "[Chorus]"])
+    expect(screen.getByText("Hello world")).toBeInTheDocument()
+    expect(screen.getByText("La la")).toBeInTheDocument()
+  })
+})

--- a/web/components/song/SongLyrics.tsx
+++ b/web/components/song/SongLyrics.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+// Song-detail lyrics panel (US-17.1). Renders lyrics line by line; structure
+// tags on their own line (e.g. "[Verse 1]", "[Chorus]") are styled as section
+// labels, everything else as lyric text. Scrolls when long.
+//
+// ponytail: line-based parse is enough — ACE-Step lyrics use bracketed tags on
+// their own lines. No need for a full lyric grammar.
+
+const TAG_LINE = /^\s*\[.+\]\s*$/
+
+export function SongLyrics({ lyrics }: { lyrics: string | null }) {
+  const text = lyrics?.trim()
+  if (!text) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="lyrics-empty">
+        No lyrics for this song.
+      </p>
+    )
+  }
+
+  const lines = text.split("\n")
+  return (
+    <div className="max-h-96 overflow-y-auto" data-testid="lyrics">
+      {lines.map((line, i) =>
+        TAG_LINE.test(line) ? (
+          <p
+            key={i}
+            data-testid="lyrics-tag"
+            className="mt-3 text-xs font-semibold tracking-wide text-primary uppercase first:mt-0"
+          >
+            {line.trim()}
+          </p>
+        ) : line.trim() === "" ? (
+          <div key={i} className="h-2" aria-hidden />
+        ) : (
+          <p key={i} className="text-sm whitespace-pre-wrap">
+            {line}
+          </p>
+        )
+      )}
+    </div>
+  )
+}

--- a/web/components/song/SongMetadata.test.tsx
+++ b/web/components/song/SongMetadata.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { SongMetadata } from "@/components/song/SongMetadata"
+import type { Clip } from "@/lib/workspace-clips"
+
+function clip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "c1",
+    workspace_id: "w1",
+    title: "Song",
+    format: "wav",
+    duration: 95,
+    bpm: 120,
+    key: "C",
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: "ace-step-v1",
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: "generate",
+    is_public: true,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("SongMetadata", () => {
+  it("maps the model id to its version label", () => {
+    render(<SongMetadata clip={clip()} />)
+    expect(screen.getByText("Model")).toBeInTheDocument()
+    expect(screen.getByText("XL")).toBeInTheDocument()
+  })
+
+  it("shows BPM, key, and duration", () => {
+    render(<SongMetadata clip={clip()} />)
+    expect(screen.getByText("120")).toBeInTheDocument()
+    expect(screen.getByText("C")).toBeInTheDocument()
+    expect(screen.getByText("1:35")).toBeInTheDocument()
+  })
+
+  it("reflects visibility from is_public", () => {
+    render(<SongMetadata clip={clip({ is_public: true })} />)
+    expect(screen.getByText("Public")).toBeInTheDocument()
+  })
+
+  it("omits null fields instead of rendering blanks", () => {
+    render(<SongMetadata clip={clip({ bpm: null, key: null, model: null })} />)
+    expect(screen.queryByText("BPM")).not.toBeInTheDocument()
+    expect(screen.queryByText("Key")).not.toBeInTheDocument()
+    expect(screen.queryByText("Model")).not.toBeInTheDocument()
+    // Always-present fields remain.
+    expect(screen.getByText("Created")).toBeInTheDocument()
+  })
+})

--- a/web/components/song/SongMetadata.tsx
+++ b/web/components/song/SongMetadata.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { versionLabel } from "@/lib/clip-labels"
+import { formatTime } from "@/lib/clips"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Song-detail metadata panel (US-17.1): the clip's display fields. Only fields
+// the backend ClipResponse actually carries are shown; null values are skipped
+// so the panel never renders an empty "—".
+//
+// ponytail: mastering & distribution status are intentionally absent — they are
+// not on ClipResponse and there is no clip→job/release lookup endpoint yet.
+// Add those rows when such an endpoint lands (US-21.x mastering/distribution).
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+export function SongMetadata({ clip }: { clip: Clip }) {
+  const rows: { label: string; value: string }[] = []
+  const model = versionLabel(clip.model)
+  if (model) rows.push({ label: "Model", value: model })
+  if (clip.bpm != null) rows.push({ label: "BPM", value: String(clip.bpm) })
+  if (clip.key) rows.push({ label: "Key", value: clip.key })
+  if (clip.duration != null)
+    rows.push({ label: "Duration", value: formatTime(clip.duration) })
+  rows.push({ label: "Created", value: formatDate(clip.created_at) })
+  rows.push({ label: "Visibility", value: clip.is_public ? "Public" : "Private" })
+
+  return (
+    <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">
+      {rows.map((row) => (
+        <div key={row.label} className="flex flex-col">
+          <dt className="text-xs text-muted-foreground">{row.label}</dt>
+          <dd className="font-medium tabular-nums">{row.value}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/web/components/song/SongPlayer.tsx
+++ b/web/components/song/SongPlayer.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { PauseIcon, PlayIcon } from "@hugeicons/core-free-icons"
+
+import { SongWaveform } from "@/components/song/SongWaveform"
+import { Button } from "@/components/ui/button"
+import { usePlayer } from "@/contexts/player-context"
+import { formatTime, trackFromClip } from "@/lib/clips"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Song-detail player (US-17.1): a large play/pause control wired to the global
+// player store, the seekable SongWaveform, and a time readout. Reusing the
+// global player means the persistent Playbar, queue, and keyboard shortcuts all
+// keep working — this is just a bigger remote for the same engine.
+
+export function SongPlayer({ clip }: { clip: Clip }) {
+  const { state, dispatch } = usePlayer()
+  const isCurrent = state.current?.id === clip.id
+  const isPlaying = isCurrent && state.isPlaying
+
+  function toggle() {
+    if (isCurrent) {
+      dispatch({ type: "toggle" })
+    } else {
+      dispatch({ type: "play/track", track: trackFromClip(clip) })
+    }
+  }
+
+  // Before this clip is the active track, show its own stored duration; once
+  // playing, the audio engine's live duration takes over.
+  const duration = isCurrent ? state.duration : (clip.duration ?? 0)
+  const currentTime = isCurrent ? state.currentTime : 0
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center gap-4">
+        <Button
+          size="icon"
+          aria-label={isPlaying ? "Pause" : "Play"}
+          aria-pressed={isPlaying}
+          onClick={toggle}
+          className="size-12 shrink-0 rounded-full"
+        >
+          <HugeiconsIcon
+            icon={isPlaying ? PauseIcon : PlayIcon}
+            size={24}
+            className="fill-current"
+          />
+        </Button>
+        <div className="min-w-0 flex-1">
+          <SongWaveform clipId={clip.id} />
+        </div>
+      </div>
+      <div className="flex justify-between text-xs tabular-nums text-muted-foreground">
+        <span>{formatTime(currentTime)}</span>
+        <span>{formatTime(duration)}</span>
+      </div>
+    </div>
+  )
+}

--- a/web/components/song/SongWaveform.tsx
+++ b/web/components/song/SongWaveform.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 
 import { usePlayer } from "@/contexts/player-context"
 import { WAVEFORM_BARS as BARS, barHeights } from "@/lib/waveform"
@@ -17,6 +17,9 @@ export function SongWaveform({ clipId }: { clipId: string }) {
   const isCurrent = state.current?.id === clipId
   const progress =
     isCurrent && state.duration > 0 ? state.currentTime / state.duration : 0
+  // Pure function of clipId — memoize so it isn't recomputed on every audio
+  // tick (progress changes ~4Hz during playback, but the bars never do).
+  const heights = useMemo(() => barHeights(clipId), [clipId])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -36,7 +39,6 @@ export function SongWaveform({ clipId }: { clipId: string }) {
     const unplayed =
       styles.getPropertyValue("--muted-foreground").trim() || "#ccc"
 
-    const heights = barHeights(clipId)
     const gap = 2
     const barW = (w - gap * (BARS - 1)) / BARS
     for (let i = 0; i < BARS; i++) {
@@ -45,7 +47,7 @@ export function SongWaveform({ clipId }: { clipId: string }) {
       ctx.globalAlpha = i / BARS < progress ? 0.9 : 0.4
       ctx.fillRect(i * (barW + gap), (hgt - bh) / 2, barW, bh)
     }
-  }, [clipId, progress])
+  }, [heights, progress])
 
   function seekFromClick(e: React.MouseEvent<HTMLCanvasElement>) {
     if (!isCurrent || state.duration <= 0) return

--- a/web/components/song/SongWaveform.tsx
+++ b/web/components/song/SongWaveform.tsx
@@ -5,12 +5,18 @@ import { useEffect, useRef } from "react"
 import { usePlayer } from "@/contexts/player-context"
 import { WAVEFORM_BARS as BARS, barHeights } from "@/lib/waveform"
 
-/** Canvas mini-waveform with click-to-seek; played bars use the accent color. */
-export function MiniWaveform() {
+// Detail-page waveform (US-17.1). Unlike the player's MiniWaveform — which is
+// always bound to the *current* track — this is seeded by an explicit `clipId`
+// so it renders the right shape for the song on the page even before playback
+// starts. Click-to-seek only acts when this clip is the one playing (otherwise
+// there is no playhead to move).
+
+export function SongWaveform({ clipId }: { clipId: string }) {
   const { state, dispatch } = usePlayer()
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const trackId = state.current?.id ?? ""
-  const progress = state.duration > 0 ? state.currentTime / state.duration : 0
+  const isCurrent = state.current?.id === clipId
+  const progress =
+    isCurrent && state.duration > 0 ? state.currentTime / state.duration : 0
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -25,14 +31,12 @@ export function MiniWaveform() {
     ctx.scale(dpr, dpr)
     ctx.clearRect(0, 0, w, hgt)
 
-    // These resolve to complete color strings (e.g. "oklch(0.205 0 0)"), so
-    // use them directly — don't re-wrap in oklch().
     const styles = getComputedStyle(canvas)
     const played = styles.getPropertyValue("--primary").trim() || "#888"
     const unplayed =
       styles.getPropertyValue("--muted-foreground").trim() || "#ccc"
 
-    const heights = trackId ? barHeights(trackId) : new Array(BARS).fill(0.2)
+    const heights = barHeights(clipId)
     const gap = 2
     const barW = (w - gap * (BARS - 1)) / BARS
     for (let i = 0; i < BARS; i++) {
@@ -41,10 +45,10 @@ export function MiniWaveform() {
       ctx.globalAlpha = i / BARS < progress ? 0.9 : 0.4
       ctx.fillRect(i * (barW + gap), (hgt - bh) / 2, barW, bh)
     }
-  }, [trackId, progress])
+  }, [clipId, progress])
 
   function seekFromClick(e: React.MouseEvent<HTMLCanvasElement>) {
-    if (!state.current || state.duration <= 0) return
+    if (!isCurrent || state.duration <= 0) return
     const rect = e.currentTarget.getBoundingClientRect()
     const ratio = (e.clientX - rect.left) / rect.width
     dispatch({ type: "seek/request", time: ratio * state.duration })
@@ -56,7 +60,7 @@ export function MiniWaveform() {
       role="img"
       aria-label="Waveform"
       onClick={seekFromClick}
-      className="h-9 w-full cursor-pointer"
+      className="h-16 w-full cursor-pointer"
     />
   )
 }

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -29,7 +29,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { usePlayer } from "@/contexts/player-context"
-import { clipArtworkUrl, clipAudioUrl, formatTime, type Track } from "@/lib/clips"
+import { modeLabel, versionLabel } from "@/lib/clip-labels"
+import { formatTime, trackFromClip } from "@/lib/clips"
 import { cn } from "@/lib/utils"
 import type { Clip } from "@/lib/workspace-clips"
 
@@ -73,25 +74,6 @@ export type ClipCardProps = {
 
 const FULL_SONG_MAX_SECONDS = 60
 
-/** Model id → short version badge label. Unmapped models show their raw id. */
-const VERSION_LABELS: Record<string, string> = {
-  "ace-step-v1": "XL",
-  "ace-step-v1-turbo": "XL Turbo",
-}
-
-/** generation_mode → metadata badge label. Plain "generate"/null show nothing. */
-const MODE_LABELS: Record<string, string> = {
-  cover: "Cover",
-  extend: "Extend",
-  remix: "Remix",
-  mashup: "Mashup",
-  sample: "Sample",
-  upload: "Upload",
-  studio: "Studio",
-  mastered: "Mastered",
-  full_song: "Full Song",
-}
-
 /** Remix/Edit sub-options, shared by the primary CTA and the ⋯ submenu. */
 const REMIX_ITEMS: { action: ClipMenuAction; label: string; pro?: boolean }[] = [
   { action: "open-studio", label: "Open in Studio" },
@@ -108,18 +90,6 @@ const DOWNLOAD_ITEMS: { action: ClipMenuAction; label: string }[] = [
   { action: "download-flac", label: "FLAC" },
   { action: "download-stems", label: "Stems" },
 ]
-
-/** Build a playable Track from a clip (artist/artwork are placeholders today). */
-function trackFromClip(clip: Clip): Track {
-  return {
-    id: clip.id,
-    title: clip.title ?? "Untitled clip",
-    artist: "Unknown artist",
-    audioUrl: clipAudioUrl(clip.id),
-    artworkUrl: clipArtworkUrl(clip.id),
-    duration: clip.duration ?? undefined,
-  }
-}
 
 /** Full clip card: metadata, playback, inline rename, and action menus. */
 export function ClipCard({
@@ -148,12 +118,8 @@ export function ClipCard({
   const title = optimisticTitle ?? clip.title
   const isPublic = optimisticPublic ?? clip.is_public
 
-  const versionLabel = clip.model
-    ? (VERSION_LABELS[clip.model] ?? clip.model)
-    : null
-  const metadataLabel = clip.generation_mode
-    ? MODE_LABELS[clip.generation_mode]
-    : null
+  const version = versionLabel(clip.model)
+  const metadataLabel = modeLabel(clip.generation_mode)
   const styleText = clip.style_tags.join(", ")
   const showFullSong =
     clip.duration != null && clip.duration < FULL_SONG_MAX_SECONDS
@@ -264,11 +230,11 @@ export function ClipCard({
         )}
 
         {/* Badges. */}
-        {(versionLabel || metadataLabel) && (
+        {(version || metadataLabel) && (
           <div className="flex flex-wrap items-center gap-1">
-            {versionLabel && (
+            {version && (
               <Badge variant="secondary" className="text-[10px]">
-                {versionLabel}
+                {version}
               </Badge>
             )}
             {metadataLabel && (

--- a/web/hooks/use-clip.ts
+++ b/web/hooks/use-clip.ts
@@ -1,0 +1,59 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import type { Clip } from "@/lib/workspace-clips"
+
+/**
+ * Fetch a single clip from the same-origin BFF (/api/clips/{id}) with the
+ * in-memory access token. Used by the song-detail page (US-17.1). Refetches when
+ * `id` changes. A 404 surfaces as `notFound` (distinct from a transient `error`)
+ * so the page can show a "song not found" state instead of a generic failure.
+ * Use behind an auth guard (e.g. useRequireAuth).
+ */
+export function useClip(id: string | undefined) {
+  const { accessToken, isLoading: authLoading } = useAuth()
+  const [clip, setClip] = useState<Clip | null>(null)
+  const [error, setError] = useState(false)
+  const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    if (authLoading || !accessToken || !id) return
+    let active = true
+    fetch(`/api/clips/${encodeURIComponent(id)}`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+      .then(async (res) => {
+        if (res.status === 404) {
+          // Reset in the async callback, not the effect body (lint:
+          // react-hooks/set-state-in-effect).
+          if (active) {
+            setNotFound(true)
+            setError(false)
+          }
+          return null
+        }
+        if (!res.ok) throw new Error("fetch failed")
+        return (await res.json()) as Clip
+      })
+      .then((next) => {
+        if (active && next) {
+          setClip(next)
+          setError(false)
+          setNotFound(false)
+        }
+      })
+      .catch(() => {
+        if (active) setError(true)
+      })
+    return () => {
+      active = false
+    }
+  }, [id, accessToken, authLoading])
+
+  const loading =
+    authLoading || (!!accessToken && !!id && clip === null && !error && !notFound)
+
+  return { clip, loading, error, notFound }
+}

--- a/web/hooks/use-clip.ts
+++ b/web/hooks/use-clip.ts
@@ -5,18 +5,27 @@ import { useEffect, useState } from "react"
 import { useAuth } from "@/hooks/use-auth"
 import type { Clip } from "@/lib/workspace-clips"
 
+type Outcome =
+  | { id: string; kind: "ok"; clip: Clip }
+  | { id: string; kind: "error" }
+  | { id: string; kind: "notFound" }
+
 /**
  * Fetch a single clip from the same-origin BFF (/api/clips/{id}) with the
  * in-memory access token. Used by the song-detail page (US-17.1). Refetches when
  * `id` changes. A 404 surfaces as `notFound` (distinct from a transient `error`)
  * so the page can show a "song not found" state instead of a generic failure.
  * Use behind an auth guard (e.g. useRequireAuth).
+ *
+ * The fetch outcome is tagged with the id it belongs to. The page component
+ * stays mounted across /song/:id navigations, so an outcome whose id no longer
+ * matches the requested one is treated as "not loaded yet" — this keeps the page
+ * from showing the previous song under the new URL while the new fetch is in
+ * flight (it falls back to the loading state instead of stale data).
  */
 export function useClip(id: string | undefined) {
   const { accessToken, isLoading: authLoading } = useAuth()
-  const [clip, setClip] = useState<Clip | null>(null)
-  const [error, setError] = useState(false)
-  const [notFound, setNotFound] = useState(false)
+  const [outcome, setOutcome] = useState<Outcome | null>(null)
 
   useEffect(() => {
     if (authLoading || !accessToken || !id) return
@@ -26,34 +35,27 @@ export function useClip(id: string | undefined) {
     })
       .then(async (res) => {
         if (res.status === 404) {
-          // Reset in the async callback, not the effect body (lint:
-          // react-hooks/set-state-in-effect).
-          if (active) {
-            setNotFound(true)
-            setError(false)
-          }
-          return null
+          if (active) setOutcome({ id, kind: "notFound" })
+          return
         }
         if (!res.ok) throw new Error("fetch failed")
-        return (await res.json()) as Clip
-      })
-      .then((next) => {
-        if (active && next) {
-          setClip(next)
-          setError(false)
-          setNotFound(false)
-        }
+        const clip = (await res.json()) as Clip
+        if (active) setOutcome({ id, kind: "ok", clip })
       })
       .catch(() => {
-        if (active) setError(true)
+        if (active) setOutcome({ id, kind: "error" })
       })
     return () => {
       active = false
     }
   }, [id, accessToken, authLoading])
 
+  const current = outcome?.id === id ? outcome : null
+  const clip = current?.kind === "ok" ? current.clip : null
+  const error = current?.kind === "error"
+  const notFound = current?.kind === "notFound"
   const loading =
-    authLoading || (!!accessToken && !!id && clip === null && !error && !notFound)
+    authLoading || (!!accessToken && !!id && current === null)
 
   return { clip, loading, error, notFound }
 }

--- a/web/hooks/use-similar-clips.ts
+++ b/web/hooks/use-similar-clips.ts
@@ -19,12 +19,13 @@ type SimilarClipsResponse = {
  * mounted across /song/:id navigations, the previous song's suggestions aren't
  * shown under the new clip while its fetch is in flight.
  */
+type Result = { id: string; clips: Clip[]; error: boolean }
+
 export function useSimilarClips(id: string | undefined, limit = 6) {
   const { accessToken, isLoading: authLoading } = useAuth()
-  const [result, setResult] = useState<{ id: string; clips: Clip[] } | null>(
-    null
-  )
-  const [errorId, setErrorId] = useState<string | null>(null)
+  // Error folded into the result (not a separate errorId) so a successful
+  // retry for the same id can't leave a stale error flag set.
+  const [result, setResult] = useState<Result | null>(null)
 
   useEffect(() => {
     if (authLoading || !accessToken || !id) return
@@ -37,13 +38,10 @@ export function useSimilarClips(id: string | undefined, limit = 6) {
         return (await res.json()) as SimilarClipsResponse
       })
       .then((next) => {
-        if (active) setResult({ id, clips: next.clips ?? [] })
+        if (active) setResult({ id, clips: next.clips ?? [], error: false })
       })
       .catch(() => {
-        if (active) {
-          setErrorId(id)
-          setResult({ id, clips: [] })
-        }
+        if (active) setResult({ id, clips: [], error: true })
       })
     return () => {
       active = false
@@ -52,7 +50,7 @@ export function useSimilarClips(id: string | undefined, limit = 6) {
 
   const matches = result !== null && result.id === id
   const clips = matches ? result.clips : []
-  const error = errorId === id
+  const error = matches && result.error
   const loading = authLoading || (!!accessToken && !!id && !matches)
 
   return { clips, loading, error }

--- a/web/hooks/use-similar-clips.ts
+++ b/web/hooks/use-similar-clips.ts
@@ -1,0 +1,59 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import type { Clip } from "@/lib/workspace-clips"
+
+type SimilarClipsResponse = {
+  clips: Clip[]
+  total: number
+  limit: number
+}
+
+/**
+ * Fetch clips similar to `id` from the same-origin BFF
+ * (/api/clips/{id}/similar) for the song-detail "Related songs" panel
+ * (US-17.1). Empty/error both resolve to an empty list — related songs are a
+ * nice-to-have, so the panel degrades quietly rather than blocking the page.
+ */
+export function useSimilarClips(id: string | undefined, limit = 6) {
+  const { accessToken, isLoading: authLoading } = useAuth()
+  const [clips, setClips] = useState<Clip[]>([])
+  const [error, setError] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    if (authLoading || !accessToken || !id) return
+    let active = true
+    fetch(`/api/clips/${encodeURIComponent(id)}/similar?limit=${limit}`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("fetch failed")
+        return (await res.json()) as SimilarClipsResponse
+      })
+      .then((next) => {
+        if (active) {
+          // Reset in the async callback, not the effect body (lint:
+          // react-hooks/set-state-in-effect).
+          setError(false)
+          setClips(next.clips ?? [])
+          setLoaded(true)
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setError(true)
+          setLoaded(true)
+        }
+      })
+    return () => {
+      active = false
+    }
+  }, [id, accessToken, authLoading, limit])
+
+  const loading = authLoading || (!!accessToken && !!id && !loaded)
+
+  return { clips, loading, error }
+}

--- a/web/hooks/use-similar-clips.ts
+++ b/web/hooks/use-similar-clips.ts
@@ -7,8 +7,6 @@ import type { Clip } from "@/lib/workspace-clips"
 
 type SimilarClipsResponse = {
   clips: Clip[]
-  total: number
-  limit: number
 }
 
 /**

--- a/web/hooks/use-similar-clips.ts
+++ b/web/hooks/use-similar-clips.ts
@@ -14,12 +14,17 @@ type SimilarClipsResponse = {
  * (/api/clips/{id}/similar) for the song-detail "Related songs" panel
  * (US-17.1). Empty/error both resolve to an empty list — related songs are a
  * nice-to-have, so the panel degrades quietly rather than blocking the page.
+ *
+ * The result is tagged with the id it belongs to so that, when the page stays
+ * mounted across /song/:id navigations, the previous song's suggestions aren't
+ * shown under the new clip while its fetch is in flight.
  */
 export function useSimilarClips(id: string | undefined, limit = 6) {
   const { accessToken, isLoading: authLoading } = useAuth()
-  const [clips, setClips] = useState<Clip[]>([])
-  const [error, setError] = useState(false)
-  const [loaded, setLoaded] = useState(false)
+  const [result, setResult] = useState<{ id: string; clips: Clip[] } | null>(
+    null
+  )
+  const [errorId, setErrorId] = useState<string | null>(null)
 
   useEffect(() => {
     if (authLoading || !accessToken || !id) return
@@ -32,18 +37,12 @@ export function useSimilarClips(id: string | undefined, limit = 6) {
         return (await res.json()) as SimilarClipsResponse
       })
       .then((next) => {
-        if (active) {
-          // Reset in the async callback, not the effect body (lint:
-          // react-hooks/set-state-in-effect).
-          setError(false)
-          setClips(next.clips ?? [])
-          setLoaded(true)
-        }
+        if (active) setResult({ id, clips: next.clips ?? [] })
       })
       .catch(() => {
         if (active) {
-          setError(true)
-          setLoaded(true)
+          setErrorId(id)
+          setResult({ id, clips: [] })
         }
       })
     return () => {
@@ -51,7 +50,10 @@ export function useSimilarClips(id: string | undefined, limit = 6) {
     }
   }, [id, accessToken, authLoading, limit])
 
-  const loading = authLoading || (!!accessToken && !!id && !loaded)
+  const matches = result !== null && result.id === id
+  const clips = matches ? result.clips : []
+  const error = errorId === id
+  const loading = authLoading || (!!accessToken && !!id && !matches)
 
   return { clips, loading, error }
 }

--- a/web/lib/clip-labels.ts
+++ b/web/lib/clip-labels.ts
@@ -2,13 +2,13 @@
 // header (US-17.1) so a clip's model/mode reads the same everywhere.
 
 /** Model id → short version badge label. Unmapped models show their raw id. */
-export const VERSION_LABELS: Record<string, string> = {
+const VERSION_LABELS: Record<string, string> = {
   "ace-step-v1": "XL",
   "ace-step-v1-turbo": "XL Turbo",
 }
 
 /** generation_mode → badge label. Plain "generate"/null show nothing. */
-export const MODE_LABELS: Record<string, string> = {
+const MODE_LABELS: Record<string, string> = {
   cover: "Cover",
   extend: "Extend",
   remix: "Remix",

--- a/web/lib/clip-labels.ts
+++ b/web/lib/clip-labels.ts
@@ -1,0 +1,33 @@
+// Display-label maps shared by the clip card (US-16.6) and the song-detail
+// header (US-17.1) so a clip's model/mode reads the same everywhere.
+
+/** Model id → short version badge label. Unmapped models show their raw id. */
+export const VERSION_LABELS: Record<string, string> = {
+  "ace-step-v1": "XL",
+  "ace-step-v1-turbo": "XL Turbo",
+}
+
+/** generation_mode → badge label. Plain "generate"/null show nothing. */
+export const MODE_LABELS: Record<string, string> = {
+  cover: "Cover",
+  extend: "Extend",
+  remix: "Remix",
+  mashup: "Mashup",
+  sample: "Sample",
+  upload: "Upload",
+  studio: "Studio",
+  mastered: "Mastered",
+  full_song: "Full Song",
+}
+
+/** Short version badge label for a model id, or null when unset. */
+export function versionLabel(model: string | null): string | null {
+  if (!model) return null
+  return VERSION_LABELS[model] ?? model
+}
+
+/** Badge label for a generation_mode, or null when it has no badge. */
+export function modeLabel(mode: string | null): string | null {
+  if (!mode) return null
+  return MODE_LABELS[mode] ?? null
+}

--- a/web/lib/clips.ts
+++ b/web/lib/clips.ts
@@ -21,6 +21,22 @@ export type Track = {
   duration?: number
 }
 
+/** Build a playable Track from a clip (artist/artwork are placeholders today). */
+export function trackFromClip(clip: {
+  id: string
+  title: string | null
+  duration: number | null
+}): Track {
+  return {
+    id: clip.id,
+    title: clip.title ?? "Untitled clip",
+    artist: "Unknown artist",
+    audioUrl: clipAudioUrl(clip.id),
+    artworkUrl: clipArtworkUrl(clip.id),
+    duration: clip.duration ?? undefined,
+  }
+}
+
 /** Backend audio stream path for a clip. */
 export function clipAudioUrl(id: string): string {
   return `/api/v1/clips/${encodeURIComponent(id)}/audio`

--- a/web/lib/proxy-fetch.ts
+++ b/web/lib/proxy-fetch.ts
@@ -1,0 +1,17 @@
+// Shared fetch wrapper for the same-origin BFF proxies. Adds an abort-based
+// timeout so a stalled upstream fails closed (the caller's catch returns 502)
+// instead of hanging the request indefinitely.
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  ms = 10_000
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), ms)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/web/lib/waveform.test.ts
+++ b/web/lib/waveform.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { WAVEFORM_BARS, barHeights } from "@/lib/waveform"
+
+describe("barHeights", () => {
+  it("returns WAVEFORM_BARS heights by default", () => {
+    expect(barHeights("c1")).toHaveLength(WAVEFORM_BARS)
+  })
+
+  it("is deterministic for a given seed", () => {
+    expect(barHeights("c1")).toEqual(barHeights("c1"))
+  })
+
+  it("varies by seed", () => {
+    expect(barHeights("c1")).not.toEqual(barHeights("c2"))
+  })
+
+  it("keeps every height within the ~0.25..0.96 band", () => {
+    for (const h of barHeights("some-clip-id")) {
+      expect(h).toBeGreaterThanOrEqual(0.25)
+      expect(h).toBeLessThanOrEqual(0.965)
+    }
+  })
+})

--- a/web/lib/waveform.ts
+++ b/web/lib/waveform.ts
@@ -9,15 +9,15 @@
 
 export const WAVEFORM_BARS = 64
 
-/** `count` bar heights in 0.25..0.96, deterministic for a given `seed`. */
-export function barHeights(seed: string, count: number = WAVEFORM_BARS): number[] {
+/** WAVEFORM_BARS bar heights in ~0.25..0.96, deterministic for a given `seed`. */
+export function barHeights(seed: string): number[] {
   let h = 2166136261
   for (let i = 0; i < seed.length; i++) {
     h ^= seed.charCodeAt(i)
     h = Math.imul(h, 16777619)
   }
   const out: number[] = []
-  for (let i = 0; i < count; i++) {
+  for (let i = 0; i < WAVEFORM_BARS; i++) {
     h ^= h << 13
     h ^= h >>> 17
     h ^= h << 5

--- a/web/lib/waveform.ts
+++ b/web/lib/waveform.ts
@@ -1,0 +1,27 @@
+// Deterministic pseudo-waveform bar heights, seeded by a stable string (a clip
+// id). Shared by the player MiniWaveform and the song-detail SongWaveform so a
+// clip looks the same wherever its waveform is drawn.
+//
+// ponytail: this is a seeded PRNG, not real audio peaks — it looks like a
+// waveform and shows played/unplayed progress without downloading and decoding
+// the file. Swap for AudioContext.decodeAudioData only if true amplitude
+// rendering is ever required.
+
+export const WAVEFORM_BARS = 64
+
+/** `count` bar heights in 0.25..0.96, deterministic for a given `seed`. */
+export function barHeights(seed: string, count: number = WAVEFORM_BARS): number[] {
+  let h = 2166136261
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  const out: number[] = []
+  for (let i = 0; i < count; i++) {
+    h ^= h << 13
+    h ^= h >>> 17
+    h ^= h << 5
+    out.push(0.25 + (Math.abs(h) % 1000) / 1000 / 1.4) // 0.25..0.96
+  }
+  return out
+}


### PR DESCRIPTION
## Summary

Implements **US-17.1 — Song Detail Page** (#195): a dedicated `/song/[id]`
route showing a song's waveform player, metadata, lyrics, inline actions, and a
related-songs panel.

Reuses the existing app infrastructure rather than adding new dependencies:
the global `PlayerProvider` drives playback and a seeded canvas waveform
(no wavesurfer.js), and the shared `ClipCard` renders related songs.

## What's included

- **Route** `app/song/[id]/page.tsx` — thin params→component shim → `SongDetail`
- **BFF proxies** `GET /api/clips/[id]` and `/api/clips/[id]/similar` (mirror the
  existing `/api/clips` proxy: forward the Bearer token, pass status/body through)
- **Hooks** `use-clip`, `use-similar-clips` (native fetch, mirror `use-clips`);
  both tag results by id so navigating between songs never shows stale data
- **`components/song/`**: `SongDetail`, `SongHeader` (title/badges + inline
  like/dislike/share/publish), `SongPlayer` + `SongWaveform` (click-to-seek),
  `SongMetadata`, `SongLyrics` (structure-tag formatting), `RelatedSongs`
- Small shared extractions: `lib/waveform` (`barHeights`), `trackFromClip` and
  the model/mode label maps into `lib/clips` / `lib/clip-labels`

## Acceptance criteria

- [x] Song detail page loads at `/song/:id` with correct song data
- [x] Waveform player renders and supports click-to-seek
- [x] All metadata fields display correctly
- [x] Lyrics section renders with structure tags formatted
- [x] Like/dislike/share/publish actions work inline
- [x] Related songs panel shows relevant suggestions

## Known limitations / deferred (out of this story's acceptance criteria)

- **Mastering & distribution status** are not shown — `ClipResponse` carries no
  such fields and there is no clip→job/release lookup endpoint yet. Visibility
  (public/private) is shown from `is_public`.
- **Full action menu** → US-17.2; **generation-lineage visualization** → US-17.7;
  **comments** have no backend. Not built here.
- Like → global player store; dislike/share/publish are local optimistic UI
  (no backend routes yet), matching `ClipCard`'s existing behavior. Persistence
  lands with US-17.6.
- Artist shows the app-wide "Unknown artist" placeholder (no artist column on
  `ClipResponse`), consistent with the player bar.

## Testing

- `npm test` — 339 passing (Vitest + RTL), incl. BFF route tests, the
  `SongDetail` integration covering every acceptance criterion, and the
  id-change staleness guard.
- `npm run typecheck`, `npm run lint`, `npm run build` all green.
- Cross-family review: `codex review` (3 P2 findings addressed); deslop scan
  applied.

Closes #195


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new song detail experience with playback controls, metadata, lyrics, and a “Related songs” panel.
  * Introduced a deterministic waveform with click-to-seek.
  * Added Like/Dislike/Share and Publish/Unpublish controls in the song header.
* **Bug Fixes**
  * Improved handling for missing/failed clip data with clear loading, not-found, and unavailable states.
  * Related-songs requests now enforce auth and safely forward only allowed query options (including capped `limit`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->