### PR TITLE
feat(web): Full Action Menu (US-17.2)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -61,8 +61,8 @@ The `/song/[id]` route renders a full-page view of a single clip.
   navigations.
 - `hooks/use-similar-clips.ts` — fetches similar clips from the BFF.
 - `app/api/clips/[id]/route.ts` — same-origin BFF proxy for
-  `GET /api/v1/clips/{id}`; forwards the Bearer token, keeps the backend URL
-  server-side.
+  `GET`/`DELETE /api/v1/clips/{id}`; forwards the Bearer token, keeps the
+  backend URL server-side.
 - `app/api/clips/[id]/similar/route.ts` — same-origin BFF proxy for
   `GET /api/v1/clips/{id}/similar`; whitelists and bounds `scope`/`limit`
   before forwarding.
@@ -70,6 +70,35 @@ The `/song/[id]` route renders a full-page view of a single clip.
   with the player `MiniWaveform`).
 - `lib/clip-labels.ts` — display-label maps for clip model/generation_mode.
 - `lib/proxy-fetch.ts` — `fetchWithTimeout` used by BFF routes.
+
+## Full Action Menu (US-17.2)
+
+The song detail page's primary action button opens the full action menu — every
+edit, remix, audio, export, and manage operation on a song in one place.
+
+- `lib/song-actions.ts` — the shared action registry: grouped definitions
+  (label, icon, workflow, Pro-gating) that both `SongActionsMenu` and
+  `ClipCard`'s menus draw from, so the two surfaces can't drift apart.
+- `hooks/use-song-actions.ts` — dispatches a selected action to its workflow:
+  navigation (studio today; editor when US-18 ships), a workflow modal, a file
+  download, or an inline operation (optimistic publish toggle, delete with
+  confirmation).
+- `hooks/use-subscription-tier.ts` — lightweight subscription-tier lookup used
+  to lock Pro-only menu items for free-tier users, without mounting the full
+  model-selection context.
+- `components/song/SongActionsMenu.tsx` — the grouped dropdown menu, purely
+  presentational; renders the registry and emits the chosen action id.
+- `components/song/SongActionModal.tsx` — placeholder container for
+  modal-workflow actions; each item already opens a modal, with real workflow
+  content landing story by story in US-17.3+.
+- `components/song/DeleteSongDialog.tsx` — delete confirmation; keeps the
+  dialog open with an error on failure so the user can retry or cancel.
+- `app/api/clips/[id]/audio/route.ts` — same-origin BFF proxy for
+  `GET /api/v1/clips/{id}/audio`; forwards the Bearer token and an optional
+  `format` query (mp3/wav/flac) for the menu's Download items.
+- `lib/clips.ts` — `downloadClipAudio` fetches the audio proxy with the
+  in-memory token and hands the blob to the browser via a temporary
+  object-URL anchor.
 
 ## Adding components
 

--- a/web/app/api/clips/[id]/audio/route.test.ts
+++ b/web/app/api/clips/[id]/audio/route.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { GET } from "@/app/api/clips/[id]/audio/route"
+
+function req(url: string, init: RequestInit = {}): NextRequest {
+  return new Request(url, init) as unknown as NextRequest
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("GET /api/clips/[id]/audio", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await GET(req("http://localhost/api/clips/c1/audio"), ctx("c1"))
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the token and format query, passing audio bytes through", async () => {
+    const bytes = new Uint8Array([1, 2, 3])
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(bytes, {
+        status: 200,
+        headers: { "content-type": "audio/mpeg" },
+      })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await GET(
+      req("http://localhost/api/clips/c1/audio?format=mp3", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("audio/mpeg")
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(bytes)
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips/c1/audio")
+    expect(url).toContain("format=mp3")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+  })
+
+  it("omits the format query when none is requested", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: { "content-type": "audio/wav" },
+      })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await GET(
+      req("http://localhost/api/clips/c1/audio", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).not.toContain("format=")
+  })
+
+  it("passes backend errors through as JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        })
+      )
+    )
+    const res = await GET(
+      req("http://localhost/api/clips/missing/audio", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("missing")
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 502 when the backend is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+    )
+    const res = await GET(
+      req("http://localhost/api/clips/c1/audio", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(502)
+  })
+})

--- a/web/app/api/clips/[id]/audio/route.ts
+++ b/web/app/api/clips/[id]/audio/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+import { fetchWithTimeout } from "@/lib/proxy-fetch"
+
+// Same-origin proxy for GET /api/v1/clips/{clip_id}/audio (US-17.2). The full
+// action menu's Download items fetch through here with the in-memory Bearer
+// token (a plain <a href> can't attach one). The optional `format` query is
+// forwarded so the backend converts (mp3/wav/flac); audio bytes and
+// content-type pass through, errors pass through as JSON.
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { id } = await ctx.params
+  const format = new URL(request.url).searchParams.get("format")
+  const query = format ? `?format=${encodeURIComponent(format)}` : ""
+
+  let res: Response
+  try {
+    res = await fetchWithTimeout(
+      `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}/audio${query}`,
+      { headers: { authorization: auth } }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Clip service is unavailable." },
+      { status: 502 }
+    )
+  }
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    return NextResponse.json(body, { status: res.status })
+  }
+
+  const headers = new Headers()
+  for (const name of ["content-type", "content-length"]) {
+    const value = res.headers.get(name)
+    if (value) headers.set(name, value)
+  }
+  return new NextResponse(res.body, { status: res.status, headers })
+}

--- a/web/app/api/clips/[id]/route.test.ts
+++ b/web/app/api/clips/[id]/route.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { NextRequest } from "next/server"
 
-import { GET } from "@/app/api/clips/[id]/route"
+import { DELETE, GET } from "@/app/api/clips/[id]/route"
 
 function req(url: string, init: RequestInit = {}): NextRequest {
   return new Request(url, init) as unknown as NextRequest
@@ -66,6 +66,71 @@ describe("GET /api/clips/[id]", () => {
     )
     const res = await GET(
       req("http://localhost/api/clips/c1", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(502)
+  })
+})
+
+describe("DELETE /api/clips/[id]", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await DELETE(
+      req("http://localhost/api/clips/c1", { method: "DELETE" }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the delete to the backend and passes 204 through", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await DELETE(
+      req("http://localhost/api/clips/c1", {
+        method: "DELETE",
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(204)
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips/c1")
+    expect(opts.method).toBe("DELETE")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+  })
+
+  it("passes a 404 through for an unknown clip", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "not found" }), { status: 404 })
+      )
+    )
+    const res = await DELETE(
+      req("http://localhost/api/clips/missing", {
+        method: "DELETE",
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("missing")
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 502 when the backend is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+    )
+    const res = await DELETE(
+      req("http://localhost/api/clips/c1", {
+        method: "DELETE",
         headers: { authorization: "Bearer tok" },
       }),
       ctx("c1")

--- a/web/app/api/clips/[id]/route.ts
+++ b/web/app/api/clips/[id]/route.ts
@@ -3,11 +3,12 @@ import { NextResponse, type NextRequest } from "next/server"
 import { BACKEND_URL } from "@/lib/auth-server"
 import { fetchWithTimeout } from "@/lib/proxy-fetch"
 
-// Same-origin proxy for GET /api/v1/clips/{clip_id} (US-17.1). The client holds
-// the access token in memory and sends it as a Bearer header; this route
-// forwards it so the backend URL stays server-side. The song-detail page fetches
-// a single clip through here. Status/body pass through verbatim (200 with the
-// clip, 401, 404 when the clip is unknown or not owned).
+// Same-origin proxy for /api/v1/clips/{clip_id} (GET US-17.1, DELETE US-17.2).
+// The client holds the access token in memory and sends it as a Bearer header;
+// this route forwards it so the backend URL stays server-side. The song-detail
+// page fetches a single clip through here, and the full action menu deletes
+// through here. Status/body pass through verbatim (200 with the clip, 204 on
+// delete, 401, 404 when the clip is unknown or not owned).
 
 export async function GET(
   request: NextRequest,
@@ -31,6 +32,37 @@ export async function GET(
       { status: 502 }
     )
   }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}
+
+export async function DELETE(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { id } = await ctx.params
+  let res: Response
+  try {
+    res = await fetchWithTimeout(
+      `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}`,
+      {
+        method: "DELETE",
+        headers: { authorization: auth, accept: "application/json" },
+      }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Clip service is unavailable." },
+      { status: 502 }
+    )
+  }
+  // Success is a bodyless 204; error statuses carry a JSON detail.
+  if (res.status === 204) return new NextResponse(null, { status: 204 })
   const body = await res.json().catch(() => ({}))
   return NextResponse.json(body, { status: res.status })
 }

--- a/web/components/song/DeleteSongDialog.tsx
+++ b/web/components/song/DeleteSongDialog.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+// US-17.2: confirmation for the action menu's Delete. Built on Dialog (the
+// repo has no alert-dialog primitive). A failed delete keeps the dialog open
+// with the error so the user can retry or cancel.
+
+export type DeleteSongDialogProps = {
+  open: boolean
+  title: string | null
+  deleting: boolean
+  error: string | null
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+export function DeleteSongDialog({
+  open,
+  title,
+  deleting,
+  error,
+  onCancel,
+  onConfirm,
+}: DeleteSongDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel()
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete this song?</DialogTitle>
+          <DialogDescription>
+            &ldquo;{title ?? "Untitled clip"}&rdquo; and its audio will be
+            permanently deleted. This can&apos;t be undone.
+          </DialogDescription>
+        </DialogHeader>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm} disabled={deleting}>
+            {deleting ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/song/SongActionModal.tsx
+++ b/web/components/song/SongActionModal.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { findSongAction, type SongActionId } from "@/lib/song-actions"
+
+// US-17.2: placeholder container for the modal-workflow actions. The action
+// menu dispatches into here so every menu item already opens its own modal;
+// the real workflow content (prompts, options, submission) lands with
+// US-17.3+ story by story.
+
+export type SongActionModalProps = {
+  /** The modal-workflow action to show, or null when closed. */
+  action: SongActionId | null
+  onClose: () => void
+}
+
+export function SongActionModal({ action, onClose }: SongActionModalProps) {
+  const definition = action ? findSongAction(action) : null
+
+  return (
+    <Dialog
+      open={definition != null}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{definition?.label}</DialogTitle>
+          <DialogDescription>
+            This workflow isn&apos;t available yet — it arrives with an upcoming
+            update.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/song/SongActionsMenu.test.tsx
+++ b/web/components/song/SongActionsMenu.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { SongActionsMenu } from "@/components/song/SongActionsMenu"
+
+function renderMenu(
+  props: Partial<React.ComponentProps<typeof SongActionsMenu>> = {}
+) {
+  const onAction = vi.fn()
+  render(
+    <SongActionsMenu
+      isPublic={false}
+      isFreeTier={false}
+      onAction={onAction}
+      {...props}
+    />
+  )
+  return { onAction }
+}
+
+async function openMenu() {
+  await userEvent.click(
+    screen.getByRole("button", { name: /song actions menu/i })
+  )
+  return screen.getByRole("menu")
+}
+
+describe("SongActionsMenu", () => {
+  it("renders every operation grouped under its category header", async () => {
+    renderMenu()
+    await openMenu()
+
+    for (const category of ["Edit", "Create", "Audio", "Export", "Manage"]) {
+      expect(screen.getByText(category)).toBeInTheDocument()
+    }
+    for (const label of [
+      "Remix",
+      "Edit (Repaint)",
+      "Open in Editor",
+      "Open in Studio",
+      "Cover",
+      "Extend",
+      "Mashup",
+      "Sample from Song",
+      "Use as Inspiration",
+      "Add Vocal",
+      "Remaster",
+      "Replace Section",
+      "Crop",
+      "Adjust Speed",
+      "Send to Mastering",
+      "Export to DAW",
+      "Create Music Video",
+      "Download",
+      "Publish",
+      "Delete",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+  })
+
+  it("emits the action id when an item is selected", async () => {
+    const { onAction } = renderMenu()
+    await openMenu()
+
+    await userEvent.click(screen.getByRole("menuitem", { name: /remaster/i }))
+    expect(onAction).toHaveBeenCalledWith("remaster")
+  })
+
+  it("offers download formats in a submenu and emits their ids", async () => {
+    const { onAction } = renderMenu()
+    await openMenu()
+
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download" }))
+    for (const label of ["MP3", "WAV", "FLAC", "Stems"]) {
+      expect(screen.getByRole("menuitem", { name: new RegExp(label) })).toBeInTheDocument()
+    }
+    await userEvent.click(screen.getByRole("menuitem", { name: /WAV/ }))
+    expect(onAction).toHaveBeenCalledWith("download-wav")
+  })
+
+  it("labels the publish item from the current visibility", async () => {
+    renderMenu({ isPublic: true })
+    await openMenu()
+    expect(screen.getByText("Unpublish")).toBeInTheDocument()
+    expect(screen.queryByText(/^Publish$/)).not.toBeInTheDocument()
+  })
+
+  it("locks Pro-only actions for free-tier users", async () => {
+    const { onAction } = renderMenu({ isFreeTier: true })
+    await openMenu()
+
+    const editor = screen.getByRole("menuitem", { name: /open in editor/i })
+    expect(editor).toHaveAttribute("aria-disabled", "true")
+    // Pro badge is visible on gated items.
+    expect(screen.getAllByText("Pro").length).toBeGreaterThanOrEqual(4)
+
+    await userEvent.click(editor)
+    expect(onAction).not.toHaveBeenCalled()
+  })
+
+  it("keeps Pro badges but no lock for pro users", async () => {
+    renderMenu({ isFreeTier: false })
+    await openMenu()
+
+    const editor = screen.getByRole("menuitem", { name: /open in editor/i })
+    expect(editor).not.toHaveAttribute("aria-disabled", "true")
+    expect(screen.getAllByText("Pro").length).toBeGreaterThanOrEqual(4)
+  })
+
+  it("supports keyboard navigation: arrows move focus, Escape closes", async () => {
+    renderMenu()
+    const trigger = screen.getByRole("button", { name: /song actions menu/i })
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    // Keyboard open focuses the first item; ArrowDown moves to the next.
+    expect(screen.getByRole("menuitem", { name: "Remix" })).toHaveFocus()
+    await userEvent.keyboard("{ArrowDown}")
+    expect(
+      screen.getByRole("menuitem", { name: "Edit (Repaint)" })
+    ).toHaveFocus()
+
+    await userEvent.keyboard("{Escape}")
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+  })
+})

--- a/web/components/song/SongActionsMenu.tsx
+++ b/web/components/song/SongActionsMenu.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  ArrowDown01Icon,
+  Download01Icon,
+  LockIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  SONG_ACTION_GROUPS,
+  SONG_DOWNLOAD_ITEMS,
+  type SongActionDefinition,
+  type SongActionId,
+} from "@/lib/song-actions"
+
+// US-17.2: the song-detail full action menu — the hub for every edit, remix,
+// audio, export, and manage operation on a song. Purely presentational: it
+// renders the shared registry (lib/song-actions) and emits the selected action
+// id; the parent (SongDetail via useSongActions) decides whether that means a
+// modal, navigation, an inline call, or a download. Keyboard behavior (arrows,
+// Escape, type-ahead) comes from the Radix DropdownMenu primitives.
+
+export type SongActionsMenuProps = {
+  /** Current visibility; flips the Publish/Unpublish label. */
+  isPublic: boolean
+  /** Free-tier users see Pro-only actions locked (badge + lock, disabled). */
+  isFreeTier: boolean
+  onAction: (action: SongActionId) => void
+}
+
+export function SongActionsMenu({
+  isPublic,
+  isFreeTier,
+  onAction,
+}: SongActionsMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="sm" aria-label="Song actions menu">
+          Actions
+          <HugeiconsIcon icon={ArrowDown01Icon} data-icon="inline-end" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        {SONG_ACTION_GROUPS.map((group, groupIndex) => (
+          <DropdownMenuGroup key={group.category} aria-label={group.label}>
+            {groupIndex > 0 && <DropdownMenuSeparator />}
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {group.label}
+            </DropdownMenuLabel>
+            {group.actions.map((action) => (
+              <ActionItem
+                key={action.id}
+                action={action}
+                isPublic={isPublic}
+                isFreeTier={isFreeTier}
+                onAction={onAction}
+              />
+            ))}
+            {group.category === "export" && (
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <HugeiconsIcon
+                    icon={Download01Icon}
+                    size={16}
+                    className="text-muted-foreground"
+                  />
+                  Download
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  {SONG_DOWNLOAD_ITEMS.map((action) => (
+                    <ActionItem
+                      key={action.id}
+                      action={action}
+                      isPublic={isPublic}
+                      isFreeTier={isFreeTier}
+                      onAction={onAction}
+                      hideIcon
+                    />
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            )}
+          </DropdownMenuGroup>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function ActionItem({
+  action,
+  isPublic,
+  isFreeTier,
+  onAction,
+  hideIcon = false,
+}: {
+  action: SongActionDefinition
+  isPublic: boolean
+  isFreeTier: boolean
+  onAction: (action: SongActionId) => void
+  hideIcon?: boolean
+}) {
+  const locked = !!action.proOnly && isFreeTier
+  const label =
+    action.id === "publish-toggle"
+      ? isPublic
+        ? "Unpublish"
+        : "Publish"
+      : action.label
+
+  return (
+    <DropdownMenuItem
+      variant={action.destructive ? "destructive" : "default"}
+      disabled={locked}
+      onSelect={() => onAction(action.id)}
+    >
+      {!hideIcon && (
+        <HugeiconsIcon
+          icon={action.icon}
+          size={16}
+          className="text-muted-foreground"
+        />
+      )}
+      {label}
+      {action.proOnly && (
+        <Badge variant="outline" className="ml-auto text-[10px]">
+          {locked && <HugeiconsIcon icon={LockIcon} data-icon="inline-start" />}
+          Pro
+        </Badge>
+      )}
+    </DropdownMenuItem>
+  )
+}

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -228,14 +228,28 @@ describe("SongDetail full action menu (US-17.2)", () => {
     expect(dialog).toHaveTextContent(/isn't available yet/i)
   })
 
-  it("navigates to the editor for a pro user", async () => {
+  it("navigates to the studio from the menu", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await openActions()
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: /open in studio/i })
+    )
+    expect(push).toHaveBeenCalledWith("/studio?song=c1")
+  })
+
+  it("shows the placeholder modal for Open in Editor (pro user) until US-18", async () => {
     stubFetch({ clip: clip(), tier: "pro" })
     renderDetail()
     await openActions()
     await userEvent.click(
       screen.getByRole("menuitem", { name: /open in editor/i })
     )
-    expect(push).toHaveBeenCalledWith("/editor/c1")
+    // No /editor route exists yet — navigating would 404.
+    expect(push).not.toHaveBeenCalledWith("/editor/c1")
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "Open in Editor"
+    )
   })
 
   it("locks Pro-only actions for a free user", async () => {

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -256,6 +256,42 @@ describe("SongDetail full action menu (US-17.2)", () => {
     expect(
       screen.getByRole("button", { name: "Unpublish (make private)" })
     ).toBeInTheDocument()
+
+    // And the other direction: the header button updates the menu label.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Unpublish (make private)" })
+    )
+    await openActions()
+    expect(screen.getByRole("menuitem", { name: /^publish$/i })).toBeInTheDocument()
+  })
+
+  it("closes the workflow modal with Escape", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await openActions()
+    await userEvent.click(screen.getByRole("menuitem", { name: /remaster/i }))
+    await screen.findByRole("dialog")
+
+    await userEvent.keyboard("{Escape}")
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+  })
+
+  it("cancels delete without calling the backend", async () => {
+    const fetchMock = stubFetch({ clip: clip() })
+    renderDetail()
+    await openActions()
+    await userEvent.click(screen.getByRole("menuitem", { name: /delete/i }))
+    await screen.findByRole("dialog")
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE")
+    ).toHaveLength(0)
   })
 
   it("deletes the song after confirmation and navigates home", async () => {

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { SongDetail } from "@/components/song/SongDetail"
@@ -11,6 +12,12 @@ vi.mock("@/hooks/use-auth", () => ({
     isLoading: false,
     isAuthenticated: true,
   }),
+}))
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace: vi.fn() }),
+  usePathname: () => "/song/c1",
 }))
 
 function clip(overrides: Partial<Clip> = {}): Clip {
@@ -36,9 +43,15 @@ function clip(overrides: Partial<Clip> = {}): Clip {
   }
 }
 
-/** Stub fetch so the clip endpoint and the similar endpoint each respond. */
-function stubFetch(opts: { clip?: Clip; clipStatus?: number; similar?: Clip[] }) {
-  const fetchMock = vi.fn((input: string) => {
+/** Stub fetch so the clip, similar, profile, and delete endpoints respond. */
+function stubFetch(opts: {
+  clip?: Clip
+  clipStatus?: number
+  similar?: Clip[]
+  tier?: string
+  deleteStatus?: number
+}) {
+  const fetchMock = vi.fn((input: string, init?: RequestInit) => {
     const url = String(input)
     if (url.includes("/similar")) {
       return Promise.resolve(
@@ -46,6 +59,19 @@ function stubFetch(opts: { clip?: Clip; clipStatus?: number; similar?: Clip[] })
           JSON.stringify({ clips: opts.similar ?? [], total: 0, limit: 6 }),
           { status: 200 }
         )
+      )
+    }
+    if (url.includes("/users/me")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ subscription_tier: opts.tier ?? "free" }),
+          { status: 200 }
+        )
+      )
+    }
+    if (init?.method === "DELETE") {
+      return Promise.resolve(
+        new Response(null, { status: opts.deleteStatus ?? 204 })
       )
     }
     const status = opts.clipStatus ?? 200
@@ -171,5 +197,100 @@ describe("SongDetail", () => {
     await waitFor(() =>
       expect(screen.getByTestId("song-not-found")).toBeInTheDocument()
     )
+  })
+})
+
+describe("SongDetail full action menu (US-17.2)", () => {
+  async function openActions() {
+    await screen.findByText("Midnight Drive")
+    await userEvent.click(
+      screen.getByRole("button", { name: /song actions menu/i })
+    )
+  }
+
+  it("renders every category group from the action menu", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await openActions()
+    for (const category of ["Edit", "Create", "Audio", "Export", "Manage"]) {
+      expect(screen.getByText(category)).toBeInTheDocument()
+    }
+  })
+
+  it("opens the workflow modal for a modal action", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await openActions()
+    await userEvent.click(screen.getByRole("menuitem", { name: /remaster/i }))
+
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveTextContent("Remaster")
+    expect(dialog).toHaveTextContent(/isn't available yet/i)
+  })
+
+  it("navigates to the editor for a pro user", async () => {
+    stubFetch({ clip: clip(), tier: "pro" })
+    renderDetail()
+    await openActions()
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: /open in editor/i })
+    )
+    expect(push).toHaveBeenCalledWith("/editor/c1")
+  })
+
+  it("locks Pro-only actions for a free user", async () => {
+    stubFetch({ clip: clip(), tier: "free" })
+    renderDetail()
+    await openActions()
+    expect(
+      screen.getByRole("menuitem", { name: /open in editor/i })
+    ).toHaveAttribute("aria-disabled", "true")
+  })
+
+  it("shares publish state between the menu and the header button", async () => {
+    stubFetch({ clip: clip() })
+    renderDetail()
+    await openActions()
+    await userEvent.click(screen.getByRole("menuitem", { name: /publish/i }))
+
+    expect(
+      screen.getByRole("button", { name: "Unpublish (make private)" })
+    ).toBeInTheDocument()
+  })
+
+  it("deletes the song after confirmation and navigates home", async () => {
+    const fetchMock = stubFetch({ clip: clip() })
+    renderDetail()
+    await openActions()
+    await userEvent.click(screen.getByRole("menuitem", { name: /delete/i }))
+
+    // Nothing deleted until confirmed.
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveTextContent(/permanently deleted/i)
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "DELETE")
+    ).toHaveLength(0)
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/"))
+    const deletes = fetchMock.mock.calls.filter(
+      ([, init]) => init?.method === "DELETE"
+    )
+    expect(deletes).toHaveLength(1)
+    expect(String(deletes[0][0])).toBe("/api/clips/c1")
+  })
+
+  it("keeps the confirmation open with an error when delete fails", async () => {
+    stubFetch({ clip: clip(), deleteStatus: 500 })
+    renderDetail()
+    await openActions()
+    await userEvent.click(screen.getByRole("menuitem", { name: /delete/i }))
+    await screen.findByRole("dialog")
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/delete/i)
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(push).not.toHaveBeenCalledWith("/")
   })
 })

--- a/web/components/song/SongDetail.tsx
+++ b/web/components/song/SongDetail.tsx
@@ -1,16 +1,25 @@
 "use client"
 
+import { DeleteSongDialog } from "@/components/song/DeleteSongDialog"
 import { RelatedSongs } from "@/components/song/RelatedSongs"
+import { SongActionModal } from "@/components/song/SongActionModal"
+import { SongActionsMenu } from "@/components/song/SongActionsMenu"
 import { SongHeader } from "@/components/song/SongHeader"
 import { SongLyrics } from "@/components/song/SongLyrics"
 import { SongMetadata } from "@/components/song/SongMetadata"
 import { SongPlayer } from "@/components/song/SongPlayer"
 import { useClip } from "@/hooks/use-clip"
 import { useRequireAuth } from "@/hooks/use-require-auth"
+import { useSongActions } from "@/hooks/use-song-actions"
+import { useSubscriptionTier } from "@/hooks/use-subscription-tier"
+import type { Clip } from "@/lib/workspace-clips"
 
 // Song-detail view (US-17.1). Holds all the data/auth logic so the App Router
 // page (app/song/[id]/page.tsx) stays a thin params→component shim that's hard
-// to break and easy to test (this takes a plain clipId).
+// to break and easy to test (this takes a plain clipId). The full action menu
+// (US-17.2) dispatches through useSongActions: modal workflows open the
+// placeholder container, editor/studio navigate, downloads fetch audio, and
+// delete confirms first.
 
 export function SongDetail({ clipId }: { clipId: string }) {
   const { isLoading: authLoading, isAuthenticated } = useRequireAuth()
@@ -52,15 +61,36 @@ export function SongDetail({ clipId }: { clipId: string }) {
     )
   }
 
+  // key by clip id so per-song local state (SongHeader's optimistic like,
+  // useSongActions' publish/modal state) resets cleanly between songs.
+  return <SongDetailContent key={clip.id} clip={clip} />
+}
+
+function SongDetailContent({ clip }: { clip: Clip }) {
+  const { isFreeTier } = useSubscriptionTier()
+  const actions = useSongActions(clip)
+
   return (
-    // key by clip id so per-song local state (e.g. SongHeader's optimistic
-    // like/publish) resets cleanly when navigating between songs.
-    <div
-      key={clip.id}
-      className="mx-auto flex max-w-6xl flex-col gap-8 p-8 lg:flex-row"
-    >
+    <div className="mx-auto flex max-w-6xl flex-col gap-8 p-8 lg:flex-row">
       <main className="flex min-w-0 flex-1 flex-col gap-6">
-        <SongHeader clip={clip} />
+        <SongHeader
+          clip={clip}
+          isPublic={actions.isPublic}
+          onPublishToggle={actions.togglePublish}
+          actions={
+            <SongActionsMenu
+              isPublic={actions.isPublic}
+              isFreeTier={isFreeTier}
+              onAction={actions.handleAction}
+            />
+          }
+        />
+        {/* Download errors surface here; delete errors show in their dialog. */}
+        {actions.actionError && !actions.confirmingDelete && (
+          <p role="alert" className="text-sm text-destructive">
+            {actions.actionError}
+          </p>
+        )}
         <SongPlayer clip={clip} />
         <section aria-label="Details" className="flex flex-col gap-3">
           <h2 className="text-sm font-semibold">Details</h2>
@@ -74,6 +104,18 @@ export function SongDetail({ clipId }: { clipId: string }) {
       <aside className="w-full shrink-0 lg:w-80">
         <RelatedSongs clipId={clip.id} />
       </aside>
+      <SongActionModal
+        action={actions.activeModal}
+        onClose={actions.closeModal}
+      />
+      <DeleteSongDialog
+        open={actions.confirmingDelete}
+        title={clip.title}
+        deleting={actions.deleting}
+        error={actions.actionError}
+        onCancel={actions.cancelDelete}
+        onConfirm={actions.confirmDelete}
+      />
     </div>
   )
 }

--- a/web/components/song/SongHeader.tsx
+++ b/web/components/song/SongHeader.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useMemo, useState, type ReactNode } from "react"
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
   FavouriteIcon,
@@ -28,6 +28,13 @@ export type SongHeaderProps = {
   onDislike?: (id: string) => void
   onShare?: (id: string) => void
   onPublishToggle?: (id: string, next: boolean) => void
+  /**
+   * Controlled visibility. When the parent owns publish state (US-17.2's
+   * action menu shares it), this wins over the local optimistic toggle.
+   */
+  isPublic?: boolean
+  /** Extra controls rendered at the end of the action row (e.g. the menu). */
+  actions?: ReactNode
 }
 
 export function SongHeader({
@@ -35,13 +42,15 @@ export function SongHeader({
   onDislike,
   onShare,
   onPublishToggle,
+  isPublic: isPublicProp,
+  actions,
 }: SongHeaderProps) {
   const { state, dispatch } = usePlayer()
   const likedSet = useMemo(() => new Set(state.likedIds), [state.likedIds])
   const liked = likedSet.has(clip.id)
   const [disliked, setDisliked] = useState(false)
   const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
-  const isPublic = optimisticPublic ?? clip.is_public
+  const isPublic = isPublicProp ?? optimisticPublic ?? clip.is_public
 
   const version = versionLabel(clip.model)
   const mode = modeLabel(clip.generation_mode)
@@ -125,6 +134,7 @@ export function SongHeader({
         >
           <HugeiconsIcon icon={GlobeIcon} size={18} />
         </Button>
+        {actions && <div className="ml-auto">{actions}</div>}
       </div>
     </header>
   )

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -39,25 +39,11 @@ import type { Clip } from "@/lib/workspace-clips"
 // LikeButton). Everything else is exposed as a callback prop because the backend
 // has no like/dislike/share/publish/title/menu endpoints proxied in web/ yet;
 // the parent (or a future hook) wires those when the routes land.
+// The action vocabulary lives in lib/song-actions (US-17.2) and is re-exported
+// here so existing imports keep working.
 
-/** Every action reachable from the clip card menus (spec §9.2). */
-export type ClipMenuAction =
-  | "remix-edit"
-  | "open-studio"
-  | "open-editor"
-  | "cover"
-  | "extend"
-  | "mashup"
-  | "sample"
-  | "use-inspiration"
-  | "send-mastering"
-  | "export-daw"
-  | "create-video"
-  | "download-mp3"
-  | "download-wav"
-  | "download-flac"
-  | "download-stems"
-  | "delete"
+export type { ClipMenuAction } from "@/lib/song-actions"
+import type { ClipMenuAction } from "@/lib/song-actions"
 
 export type ClipCardProps = {
   clip: Clip

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -59,13 +59,17 @@ afterEach(() => {
 })
 
 describe("useSongActions", () => {
-  it("routes navigation actions to the editor and studio pages", () => {
+  it("routes open-studio to the studio page", () => {
     const { result } = setup()
-    act(() => result.current.handleAction("open-editor"))
-    expect(push).toHaveBeenCalledWith("/editor/c1")
-
     act(() => result.current.handleAction("open-studio"))
     expect(push).toHaveBeenCalledWith("/studio?song=c1")
+  })
+
+  it("keeps open-editor on the placeholder modal until the editor ships", () => {
+    const { result } = setup()
+    act(() => result.current.handleAction("open-editor"))
+    expect(push).not.toHaveBeenCalled()
+    expect(result.current.activeModal).toBe("open-editor")
   })
 
   it("opens and closes the workflow modal for modal actions", () => {

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -1,0 +1,168 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+import { useSongActions } from "@/hooks/use-song-actions"
+import type { Clip } from "@/lib/workspace-clips"
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+  )
+}
+
+function clip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "c1",
+    workspace_id: "w1",
+    title: "My Song",
+    format: "mp3",
+    duration: 30,
+    bpm: null,
+    key: null,
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    generation_mode: null,
+    parent_clip_ids: [],
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function setup(c: Clip = clip()) {
+  return renderHook(() => useSongActions(c), { wrapper })
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("useSongActions", () => {
+  it("routes navigation actions to the editor and studio pages", () => {
+    const { result } = setup()
+    act(() => result.current.handleAction("open-editor"))
+    expect(push).toHaveBeenCalledWith("/editor/c1")
+
+    act(() => result.current.handleAction("open-studio"))
+    expect(push).toHaveBeenCalledWith("/studio?song=c1")
+  })
+
+  it("opens and closes the workflow modal for modal actions", () => {
+    const { result } = setup()
+    act(() => result.current.handleAction("remaster"))
+    expect(result.current.activeModal).toBe("remaster")
+
+    act(() => result.current.closeModal())
+    expect(result.current.activeModal).toBeNull()
+  })
+
+  it("toggles publish state optimistically", () => {
+    const { result } = setup()
+    expect(result.current.isPublic).toBe(false)
+
+    act(() => result.current.handleAction("publish-toggle"))
+    expect(result.current.isPublic).toBe(true)
+
+    act(() => result.current.handleAction("publish-toggle"))
+    expect(result.current.isPublic).toBe(false)
+  })
+
+  it("asks for confirmation before deleting, then deletes and leaves", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = setup()
+    act(() => result.current.handleAction("delete"))
+    expect(result.current.confirmingDelete).toBe(true)
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    await act(() => result.current.confirmDelete())
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/clips/c1")
+    expect(opts.method).toBe("DELETE")
+    expect(
+      (opts.headers as Record<string, string>).authorization
+    ).toBe("Bearer tok")
+    expect(push).toHaveBeenCalledWith("/")
+  })
+
+  it("surfaces a delete failure and stays on the page", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 500 }))
+    )
+
+    const { result } = setup()
+    act(() => result.current.handleAction("delete"))
+    await act(() => result.current.confirmDelete())
+
+    expect(push).not.toHaveBeenCalled()
+    expect(result.current.actionError).toMatch(/delete/i)
+    expect(result.current.deleting).toBe(false)
+    // The dialog stays open so the user can retry or cancel.
+    expect(result.current.confirmingDelete).toBe(true)
+
+    act(() => result.current.cancelDelete())
+    expect(result.current.confirmingDelete).toBe(false)
+  })
+
+  it("downloads audio in the requested format", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+    URL.createObjectURL = vi.fn().mockReturnValue("blob:x")
+    URL.revokeObjectURL = vi.fn()
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {})
+
+    const { result } = setup()
+    act(() => result.current.handleAction("download-flac"))
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/clips/c1/audio?format=flac",
+        expect.anything()
+      )
+    )
+    expect(result.current.actionError).toBeNull()
+  })
+
+  it("surfaces a failed download", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 404 }))
+    )
+
+    const { result } = setup()
+    act(() => result.current.handleAction("download-mp3"))
+
+    await waitFor(() => expect(result.current.actionError).toMatch(/download/i))
+
+    act(() => result.current.clearActionError())
+    expect(result.current.actionError).toBeNull()
+  })
+})

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -1,0 +1,100 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { useAuth } from "@/hooks/use-auth"
+import { downloadClipAudio, type DownloadFormat } from "@/lib/clips"
+import { findSongAction, type SongActionId } from "@/lib/song-actions"
+import type { Clip } from "@/lib/workspace-clips"
+
+// US-17.2: dispatch for the full action menu. Routes a selected action to its
+// workflow: navigation (editor/studio), a workflow modal (content lands in
+// US-17.3+), a file download, or an inline operation (optimistic publish
+// toggle — persistence lands with US-17.6 — and delete-with-confirmation).
+
+const DOWNLOAD_FORMAT: Partial<Record<SongActionId, DownloadFormat>> = {
+  "download-mp3": "mp3",
+  "download-wav": "wav",
+  "download-flac": "flac",
+}
+
+export function useSongActions(clip: Clip) {
+  const router = useRouter()
+  const { accessToken } = useAuth()
+  const [activeModal, setActiveModal] = useState<SongActionId | null>(null)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
+
+  const isPublic = optimisticPublic ?? clip.is_public
+
+  function handleAction(action: SongActionId) {
+    const workflow = findSongAction(action)?.workflow
+    if (workflow === "navigation") {
+      router.push(
+        action === "open-editor"
+          ? `/editor/${encodeURIComponent(clip.id)}`
+          : `/studio?song=${encodeURIComponent(clip.id)}`
+      )
+      return
+    }
+    if (workflow === "modal") {
+      setActiveModal(action)
+      return
+    }
+    if (workflow === "download") {
+      const format = DOWNLOAD_FORMAT[action]
+      if (!format || !accessToken) return
+      void downloadClipAudio(clip.id, format, accessToken, clip.title).then(
+        (ok) => {
+          if (!ok) setActionError("Couldn't download this song. Please try again.")
+        }
+      )
+      return
+    }
+    // Inline actions.
+    if (action === "publish-toggle") {
+      // Optimistic, like SongHeader/ClipCard — the publish route lands in
+      // US-17.6; until then the toggle is local feedback only.
+      setOptimisticPublic(!isPublic)
+    } else if (action === "delete") {
+      setConfirmingDelete(true)
+    }
+  }
+
+  async function confirmDelete() {
+    if (!accessToken) return
+    setDeleting(true)
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/clips/${encodeURIComponent(clip.id)}`, {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${accessToken}` },
+      })
+      if (res.status !== 204) throw new Error(`delete failed (${res.status})`)
+      router.push("/")
+    } catch {
+      // Keep the dialog open so the user can retry or cancel.
+      setActionError("Couldn't delete this song. Please try again.")
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return {
+    isPublic,
+    activeModal,
+    closeModal: () => setActiveModal(null),
+    confirmingDelete,
+    cancelDelete: () => setConfirmingDelete(false),
+    confirmDelete,
+    deleting,
+    actionError,
+    clearActionError: () => setActionError(null),
+    handleAction,
+    /** SongHeader-compatible publish callback (id, next). */
+    togglePublish: (_id: string, next: boolean) => setOptimisticPublic(next),
+  }
+}

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -33,11 +33,9 @@ export function useSongActions(clip: Clip) {
   function handleAction(action: SongActionId) {
     const workflow = findSongAction(action)?.workflow
     if (workflow === "navigation") {
-      router.push(
-        action === "open-editor"
-          ? `/editor/${encodeURIComponent(clip.id)}`
-          : `/studio?song=${encodeURIComponent(clip.id)}`
-      )
+      // Only open-studio navigates today; open-editor joins when the editor
+      // page ships (US-18) and its registry entry flips back to navigation.
+      router.push(`/studio?song=${encodeURIComponent(clip.id)}`)
       return
     }
     if (workflow === "modal") {

--- a/web/hooks/use-subscription-tier.test.tsx
+++ b/web/hooks/use-subscription-tier.test.tsx
@@ -55,6 +55,8 @@ describe("useSubscriptionTier", () => {
     expect(
       (opts.headers as Record<string, string>).authorization
     ).toBe("Bearer tok")
+    // Bounded fetch: a hung profile request must not lock Pro items forever.
+    expect(opts.signal).toBeInstanceOf(AbortSignal)
   })
 
   it("reports free tier for a free profile", async () => {

--- a/web/hooks/use-subscription-tier.test.tsx
+++ b/web/hooks/use-subscription-tier.test.tsx
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+import { useSubscriptionTier } from "@/hooks/use-subscription-tier"
+
+function makeAuthValue(overrides: Partial<{ accessToken: string | null }> = {}) {
+  return {
+    user: { id: "u1", email: "a@b.co" },
+    accessToken: "tok" as string | null,
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn(),
+    completeLogin: vi.fn(),
+    logout: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeWrapper(authValue = makeAuthValue()) {
+  return function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+    )
+  }
+}
+
+function profileRes(tier: string) {
+  return new Response(JSON.stringify({ subscription_tier: tier }), {
+    status: 200,
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("useSubscriptionTier", () => {
+  it("fetches /api/users/me with the Bearer token and reports a pro tier", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(profileRes("pro"))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(() => useSubscriptionTier(), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.tier).toBe("pro")
+    expect(result.current.isFreeTier).toBe(false)
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/users/me")
+    expect(
+      (opts.headers as Record<string, string>).authorization
+    ).toBe("Bearer tok")
+  })
+
+  it("reports free tier for a free profile", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(profileRes("free")))
+
+    const { result } = renderHook(() => useSubscriptionTier(), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.tier).toBe("free")
+    expect(result.current.isFreeTier).toBe(true)
+  })
+
+  it("defaults to free when the profile fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")))
+
+    const { result } = renderHook(() => useSubscriptionTier(), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.isFreeTier).toBe(true)
+  })
+
+  it("defaults to free without fetching when unauthenticated", () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { result } = renderHook(() => useSubscriptionTier(), {
+      wrapper: makeWrapper(makeAuthValue({ accessToken: null })),
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.isFreeTier).toBe(true)
+  })
+})

--- a/web/hooks/use-subscription-tier.ts
+++ b/web/hooks/use-subscription-tier.ts
@@ -1,0 +1,43 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+
+// Reusable subscription-tier lookup (US-17.2). ModelSelectionProvider fetches
+// the same profile but is mounted only on the Create page; pages that just need
+// the tier (e.g. song detail's Pro-gated actions) use this instead of mounting
+// the whole model-selection context. Defaults to "free" until proven otherwise,
+// mirroring the provider — a fetch failure must never unlock Pro features.
+
+export function useSubscriptionTier() {
+  const { accessToken, isLoading: authLoading } = useAuth()
+  const [tier, setTier] = useState("free")
+  const [fetched, setFetched] = useState(false)
+
+  useEffect(() => {
+    if (authLoading || !accessToken) return
+    let active = true
+    fetch("/api/users/me", {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("profile fetch failed")
+        const profile = (await res.json()) as { subscription_tier?: string }
+        if (active && profile.subscription_tier) setTier(profile.subscription_tier)
+      })
+      .catch(() => {
+        // Keep the free default.
+      })
+      .finally(() => {
+        if (active) setFetched(true)
+      })
+    return () => {
+      active = false
+    }
+  }, [accessToken, authLoading])
+
+  const isLoading = !!accessToken && !authLoading && !fetched
+  // Same rule as ModelSelector: anything that isn't exactly "pro" is free.
+  return { tier, isFreeTier: tier !== "pro", isLoading }
+}

--- a/web/hooks/use-subscription-tier.ts
+++ b/web/hooks/use-subscription-tier.ts
@@ -18,8 +18,12 @@ export function useSubscriptionTier() {
   useEffect(() => {
     if (authLoading || !accessToken) return
     let active = true
+    // Bound the fetch like the model-selection provider does — a hung profile
+    // request must not leave Pro menu items locked indefinitely; on timeout the
+    // catch keeps the free default and finally resolves the loading state.
     fetch("/api/users/me", {
       headers: { authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(5000),
     })
       .then(async (res) => {
         if (!res.ok) throw new Error("profile fetch failed")

--- a/web/lib/clips.test.ts
+++ b/web/lib/clips.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { clipAudioUrl, clipArtworkUrl, formatTime } from "@/lib/clips"
+import {
+  clipAudioUrl,
+  clipArtworkUrl,
+  downloadClipAudio,
+  formatTime,
+} from "@/lib/clips"
 
 describe("clip url builders", () => {
   it("builds the audio + artwork backend paths", () => {
@@ -25,5 +30,81 @@ describe("formatTime", () => {
     expect(formatTime(9.9)).toBe("0:09")
     expect(formatTime(-3)).toBe("0:00")
     expect(formatTime(NaN)).toBe("0:00")
+  })
+})
+
+describe("downloadClipAudio", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  function stubDownloadEnv(status = 200) {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1, 2]), { status }))
+    vi.stubGlobal("fetch", fetchMock)
+    // jsdom has no createObjectURL; give it one so the anchor gets a real href.
+    const createUrl = vi.fn().mockReturnValue("blob:test")
+    const revokeUrl = vi.fn()
+    vi.stubGlobal("URL", Object.assign(URL, {}))
+    URL.createObjectURL = createUrl
+    URL.revokeObjectURL = revokeUrl
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {})
+    return { fetchMock, createUrl, revokeUrl, click }
+  }
+
+  it("fetches the BFF audio route with the token and clicks a named anchor", async () => {
+    const { fetchMock, click, revokeUrl } = stubDownloadEnv()
+    const anchors: HTMLAnchorElement[] = []
+    const origCreate = document.createElement.bind(document)
+    vi.spyOn(document, "createElement").mockImplementation((tag) => {
+      const el = origCreate(tag)
+      if (tag === "a") anchors.push(el as HTMLAnchorElement)
+      return el
+    })
+
+    const ok = await downloadClipAudio("c1", "mp3", "tok", "My Song")
+    expect(ok).toBe(true)
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/clips/c1/audio?format=mp3")
+    expect(
+      (opts.headers as Record<string, string>).authorization
+    ).toBe("Bearer tok")
+
+    expect(anchors).toHaveLength(1)
+    expect(anchors[0].download).toBe("My Song.mp3")
+    expect(click).toHaveBeenCalledOnce()
+    expect(revokeUrl).toHaveBeenCalledWith("blob:test")
+  })
+
+  it("falls back to the clip id for an untitled clip", async () => {
+    stubDownloadEnv()
+    const anchors: HTMLAnchorElement[] = []
+    const origCreate = document.createElement.bind(document)
+    vi.spyOn(document, "createElement").mockImplementation((tag) => {
+      const el = origCreate(tag)
+      if (tag === "a") anchors.push(el as HTMLAnchorElement)
+      return el
+    })
+
+    await downloadClipAudio("c1", "wav", "tok", null)
+    expect(anchors[0].download).toBe("c1.wav")
+  })
+
+  it("returns false without downloading when the fetch fails", async () => {
+    const { click } = stubDownloadEnv(404)
+    const ok = await downloadClipAudio("c1", "mp3", "tok", "x")
+    expect(ok).toBe(false)
+    expect(click).not.toHaveBeenCalled()
+  })
+
+  it("returns false when the request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("net down")))
+    const ok = await downloadClipAudio("c1", "mp3", "tok", "x")
+    expect(ok).toBe(false)
   })
 })

--- a/web/lib/clips.ts
+++ b/web/lib/clips.ts
@@ -47,6 +47,46 @@ export function clipArtworkUrl(id: string): string {
   return `/api/v1/clips/${encodeURIComponent(id)}/artwork`
 }
 
+/** Formats the same-origin audio proxy can convert to (US-17.2 downloads). */
+export type DownloadFormat = "mp3" | "wav" | "flac"
+
+/**
+ * Download a clip's audio as a file via the same-origin proxy
+ * (/api/clips/{id}/audio). Fetches with the in-memory Bearer token — a plain
+ * <a href> can't attach one — then hands the bytes to the browser through a
+ * temporary object-URL anchor. Returns false when the fetch fails so the
+ * caller can surface an error state.
+ */
+export async function downloadClipAudio(
+  id: string,
+  format: DownloadFormat,
+  accessToken: string,
+  title: string | null
+): Promise<boolean> {
+  let blob: Blob
+  try {
+    const res = await fetch(
+      `/api/clips/${encodeURIComponent(id)}/audio?format=${format}`,
+      { headers: { authorization: `Bearer ${accessToken}` } }
+    )
+    if (!res.ok) return false
+    blob = await res.blob()
+  } catch {
+    return false
+  }
+
+  const url = URL.createObjectURL(blob)
+  try {
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = `${title || id}.${format}`
+    anchor.click()
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+  return true
+}
+
 /** Format a number of seconds as `m:ss` (negative/NaN → `0:00`). */
 export function formatTime(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds < 0) seconds = 0

--- a/web/lib/song-actions.test.ts
+++ b/web/lib/song-actions.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  SONG_ACTION_GROUPS,
+  SONG_DOWNLOAD_ITEMS,
+  findSongAction,
+  type SongActionDefinition,
+} from "@/lib/song-actions"
+
+const allActions: SongActionDefinition[] = [
+  ...SONG_ACTION_GROUPS.flatMap((g) => g.actions),
+  ...SONG_DOWNLOAD_ITEMS,
+]
+
+describe("SONG_ACTION_GROUPS", () => {
+  it("has the five categories in spec order", () => {
+    expect(SONG_ACTION_GROUPS.map((g) => g.category)).toEqual([
+      "edit",
+      "create",
+      "audio",
+      "export",
+      "manage",
+    ])
+    expect(SONG_ACTION_GROUPS.map((g) => g.label)).toEqual([
+      "Edit",
+      "Create",
+      "Audio",
+      "Export",
+      "Manage",
+    ])
+  })
+
+  it("lists every operation from US-17.2 in its category", () => {
+    const ids = Object.fromEntries(
+      SONG_ACTION_GROUPS.map((g) => [g.category, g.actions.map((a) => a.id)])
+    )
+    expect(ids.edit).toEqual(["remix", "repaint", "open-editor", "open-studio"])
+    expect(ids.create).toEqual([
+      "cover",
+      "extend",
+      "mashup",
+      "sample",
+      "use-inspiration",
+    ])
+    expect(ids.audio).toEqual([
+      "add-vocal",
+      "remaster",
+      "replace-section",
+      "crop",
+      "adjust-speed",
+    ])
+    // Download is a submenu (SONG_DOWNLOAD_ITEMS), not a flat export action.
+    expect(ids.export).toEqual(["send-mastering", "export-daw", "create-video"])
+    expect(ids.manage).toEqual(["publish-toggle", "delete"])
+  })
+
+  it("gives every action a label and an icon", () => {
+    for (const action of allActions) {
+      expect(action.label).toBeTruthy()
+      expect(action.icon).toBeTruthy()
+    }
+  })
+
+  it("marks exactly the Pro-gated actions as proOnly", () => {
+    const pro = allActions.filter((a) => a.proOnly).map((a) => a.id)
+    expect(pro.sort()).toEqual(
+      [
+        "create-video",
+        "download-stems",
+        "export-daw",
+        "open-editor",
+        "send-mastering",
+      ].sort()
+    )
+  })
+
+  it("routes editor/studio to navigation and publish/delete inline", () => {
+    expect(findSongAction("open-editor")?.workflow).toBe("navigation")
+    expect(findSongAction("open-studio")?.workflow).toBe("navigation")
+    expect(findSongAction("publish-toggle")?.workflow).toBe("inline")
+    expect(findSongAction("delete")?.workflow).toBe("inline")
+  })
+
+  it("routes generation and audio operations to modals", () => {
+    for (const id of [
+      "remix",
+      "repaint",
+      "cover",
+      "extend",
+      "mashup",
+      "sample",
+      "use-inspiration",
+      "add-vocal",
+      "remaster",
+      "replace-section",
+      "crop",
+      "adjust-speed",
+      "send-mastering",
+      "export-daw",
+      "create-video",
+    ] as const) {
+      expect(findSongAction(id)?.workflow).toBe("modal")
+    }
+  })
+
+  it("marks only Delete as destructive", () => {
+    const destructive = allActions.filter((a) => a.destructive).map((a) => a.id)
+    expect(destructive).toEqual(["delete"])
+  })
+})
+
+describe("SONG_DOWNLOAD_ITEMS", () => {
+  it("offers MP3/WAV/FLAC as direct downloads and Stems as a Pro modal", () => {
+    expect(SONG_DOWNLOAD_ITEMS.map((a) => a.id)).toEqual([
+      "download-mp3",
+      "download-wav",
+      "download-flac",
+      "download-stems",
+    ])
+    for (const id of ["download-mp3", "download-wav", "download-flac"] as const) {
+      const item = findSongAction(id)
+      expect(item?.workflow).toBe("download")
+      expect(item?.proOnly).toBeFalsy()
+    }
+    // Stem separation is a backend job (POST /clips/{id}/stems), not a file
+    // fetch — it goes through the modal workflow like other generation actions.
+    expect(findSongAction("download-stems")?.workflow).toBe("modal")
+  })
+})
+
+describe("findSongAction", () => {
+  it("resolves any id, including download submenu items", () => {
+    expect(findSongAction("remix")?.label).toBe("Remix")
+    expect(findSongAction("download-wav")?.label).toBe("WAV")
+  })
+})

--- a/web/lib/song-actions.test.ts
+++ b/web/lib/song-actions.test.ts
@@ -74,17 +74,18 @@ describe("SONG_ACTION_GROUPS", () => {
     )
   })
 
-  it("routes editor/studio to navigation and publish/delete inline", () => {
-    expect(findSongAction("open-editor")?.workflow).toBe("navigation")
+  it("routes studio to navigation and publish/delete inline", () => {
     expect(findSongAction("open-studio")?.workflow).toBe("navigation")
     expect(findSongAction("publish-toggle")?.workflow).toBe("inline")
     expect(findSongAction("delete")?.workflow).toBe("inline")
   })
 
-  it("routes generation and audio operations to modals", () => {
+  it("routes unbuilt destinations and generation/audio operations to modals", () => {
     for (const id of [
       "remix",
       "repaint",
+      // open-editor flips to navigation when the editor page ships (US-18).
+      "open-editor",
       "cover",
       "extend",
       "mashup",

--- a/web/lib/song-actions.ts
+++ b/web/lib/song-actions.ts
@@ -103,10 +103,12 @@ export const SONG_ACTION_GROUPS: SongActionGroup[] = [
         workflow: "modal",
       },
       {
+        // Becomes "navigation" to /editor/{id} when the editor page ships
+        // (US-18); until then the placeholder modal keeps users off a 404.
         id: "open-editor",
         label: "Open in Editor",
         icon: PencilEdit02Icon,
-        workflow: "navigation",
+        workflow: "modal",
         proOnly: true,
       },
       {

--- a/web/lib/song-actions.ts
+++ b/web/lib/song-actions.ts
@@ -1,0 +1,253 @@
+import type { IconSvgElement } from "@hugeicons/react"
+import {
+  ArrowExpand01Icon,
+  AudioWave01Icon,
+  CropIcon,
+  DashboardSpeed02Icon,
+  Delete02Icon,
+  Exchange01Icon,
+  FileExportIcon,
+  GitMergeIcon,
+  GlobeIcon,
+  Idea01Icon,
+  Layers01Icon,
+  MagicWand01Icon,
+  MusicNote01Icon,
+  PaintBrush01Icon,
+  PencilEdit02Icon,
+  RepeatIcon,
+  Rocket01Icon,
+  SlidersHorizontalIcon,
+  Video01Icon,
+  VoiceIcon,
+} from "@hugeicons/core-free-icons"
+
+// Shared action vocabulary for song/clip operations (US-17.2). The song-detail
+// full action menu renders from this registry; ClipCard's menus predate it and
+// keep their own item arrays, but their `ClipMenuAction` type now derives from
+// the ids here so the two surfaces can't drift apart.
+
+/** Formats offered in a Download submenu (song menu and clip card). */
+export type DownloadAction =
+  | "download-mp3"
+  | "download-wav"
+  | "download-flac"
+  | "download-stems"
+
+/** Every action reachable from the clip card menus (spec §9.2). */
+export type ClipMenuAction =
+  | "remix-edit"
+  | "open-studio"
+  | "open-editor"
+  | "cover"
+  | "extend"
+  | "mashup"
+  | "sample"
+  | "use-inspiration"
+  | "send-mastering"
+  | "export-daw"
+  | "create-video"
+  | DownloadAction
+  | "delete"
+
+/** Every action reachable from the song-detail full action menu (US-17.2). */
+export type SongActionId =
+  | Exclude<ClipMenuAction, "remix-edit">
+  | "remix"
+  | "repaint"
+  | "add-vocal"
+  | "remaster"
+  | "replace-section"
+  | "crop"
+  | "adjust-speed"
+  | "publish-toggle"
+
+export type SongActionCategory = "edit" | "create" | "audio" | "export" | "manage"
+
+/**
+ * How an action is carried out when selected:
+ * - `modal`      — opens a workflow modal (content lands in US-17.3+)
+ * - `navigation` — routes to another page (editor/studio)
+ * - `inline`     — acts in place (publish toggle, delete confirmation)
+ * - `download`   — fetches the clip's audio as a file
+ */
+export type SongActionWorkflow = "modal" | "navigation" | "inline" | "download"
+
+export type SongActionDefinition = {
+  id: SongActionId
+  label: string
+  icon: IconSvgElement
+  workflow: SongActionWorkflow
+  /** Gated behind the Pro tier; free-tier users see a locked item. */
+  proOnly?: boolean
+  destructive?: boolean
+}
+
+export type SongActionGroup = {
+  category: SongActionCategory
+  label: string
+  actions: SongActionDefinition[]
+}
+
+/** The grouped menu body. Download renders separately as a submenu. */
+export const SONG_ACTION_GROUPS: SongActionGroup[] = [
+  {
+    category: "edit",
+    label: "Edit",
+    actions: [
+      { id: "remix", label: "Remix", icon: RepeatIcon, workflow: "modal" },
+      {
+        id: "repaint",
+        label: "Edit (Repaint)",
+        icon: PaintBrush01Icon,
+        workflow: "modal",
+      },
+      {
+        id: "open-editor",
+        label: "Open in Editor",
+        icon: PencilEdit02Icon,
+        workflow: "navigation",
+        proOnly: true,
+      },
+      {
+        id: "open-studio",
+        label: "Open in Studio",
+        icon: SlidersHorizontalIcon,
+        workflow: "navigation",
+      },
+    ],
+  },
+  {
+    category: "create",
+    label: "Create",
+    actions: [
+      { id: "cover", label: "Cover", icon: MusicNote01Icon, workflow: "modal" },
+      {
+        id: "extend",
+        label: "Extend",
+        icon: ArrowExpand01Icon,
+        workflow: "modal",
+      },
+      { id: "mashup", label: "Mashup", icon: GitMergeIcon, workflow: "modal" },
+      {
+        id: "sample",
+        label: "Sample from Song",
+        icon: AudioWave01Icon,
+        workflow: "modal",
+      },
+      {
+        id: "use-inspiration",
+        label: "Use as Inspiration",
+        icon: Idea01Icon,
+        workflow: "modal",
+      },
+    ],
+  },
+  {
+    category: "audio",
+    label: "Audio",
+    actions: [
+      { id: "add-vocal", label: "Add Vocal", icon: VoiceIcon, workflow: "modal" },
+      {
+        id: "remaster",
+        label: "Remaster",
+        icon: MagicWand01Icon,
+        workflow: "modal",
+      },
+      {
+        id: "replace-section",
+        label: "Replace Section",
+        icon: Exchange01Icon,
+        workflow: "modal",
+      },
+      { id: "crop", label: "Crop", icon: CropIcon, workflow: "modal" },
+      {
+        id: "adjust-speed",
+        label: "Adjust Speed",
+        icon: DashboardSpeed02Icon,
+        workflow: "modal",
+      },
+    ],
+  },
+  {
+    category: "export",
+    label: "Export",
+    actions: [
+      {
+        id: "send-mastering",
+        label: "Send to Mastering",
+        icon: Rocket01Icon,
+        workflow: "modal",
+        proOnly: true,
+      },
+      {
+        id: "export-daw",
+        label: "Export to DAW",
+        icon: FileExportIcon,
+        workflow: "modal",
+        proOnly: true,
+      },
+      {
+        id: "create-video",
+        label: "Create Music Video",
+        icon: Video01Icon,
+        workflow: "modal",
+        proOnly: true,
+      },
+    ],
+  },
+  {
+    category: "manage",
+    label: "Manage",
+    actions: [
+      {
+        // Label is static here; the menu shows Publish/Unpublish by state.
+        id: "publish-toggle",
+        label: "Publish",
+        icon: GlobeIcon,
+        workflow: "inline",
+      },
+      {
+        id: "delete",
+        label: "Delete",
+        icon: Delete02Icon,
+        workflow: "inline",
+        destructive: true,
+      },
+    ],
+  },
+]
+
+/**
+ * Download submenu items (rendered inside the Export group). MP3/WAV/FLAC hit
+ * the audio endpoint directly; stem separation is a backend job, so Stems goes
+ * through the modal workflow and is Pro-gated.
+ */
+export const SONG_DOWNLOAD_ITEMS: SongActionDefinition[] = [
+  { id: "download-mp3", label: "MP3", icon: AudioWave01Icon, workflow: "download" },
+  { id: "download-wav", label: "WAV", icon: AudioWave01Icon, workflow: "download" },
+  {
+    id: "download-flac",
+    label: "FLAC",
+    icon: AudioWave01Icon,
+    workflow: "download",
+  },
+  {
+    id: "download-stems",
+    label: "Stems",
+    icon: Layers01Icon,
+    workflow: "modal",
+    proOnly: true,
+  },
+]
+
+const ACTION_INDEX = new Map<SongActionId, SongActionDefinition>(
+  [...SONG_ACTION_GROUPS.flatMap((g) => g.actions), ...SONG_DOWNLOAD_ITEMS].map(
+    (a) => [a.id, a]
+  )
+)
+
+/** Look up an action definition by id (download items included). */
+export function findSongAction(id: SongActionId): SongActionDefinition | undefined {
+  return ACTION_INDEX.get(id)
+}


### PR DESCRIPTION
## Summary
Implements #196: US-17.2 Full Action Menu — the central hub for all edit, remix, audio, export, and manage operations on the song detail page.

- **Shared action registry** (`web/lib/song-actions.ts`): typed ids, five categorized groups (Edit/Create/Audio/Export/Manage), Pro flags, and workflow kinds; `ClipMenuAction` (ClipCard) now derives from the shared ids so the two menu surfaces can't drift.
- **`SongActionsMenu`** — Radix/shadcn dropdown with category headers, a Download submenu (MP3/WAV/FLAC/Stems), Pro badge + lock + disabled state on the free tier, destructive Delete, and built-in keyboard navigation.
- **`useSongActions` dispatch hook** — routes selections: navigation (`/studio?song={id}`), placeholder workflow modals, Bearer-token file downloads, optimistic publish toggle (shared with the header button), and delete behind a confirmation dialog.
- **`useSubscriptionTier` hook** — reusable `/api/users/me` tier lookup with a 5s abort timeout; free by default so a fetch failure never unlocks Pro features.
- **BFF proxies** — `DELETE /api/clips/[id]` and `GET /api/clips/[id]/audio?format=` (the audio proxy also unblocks future player streaming).

## Acceptance Criteria
- [x] Action menu renders all operations grouped by category (20 actions, 5 groups + Download submenu)
- [x] Each action triggers the correct workflow (modal / navigation / inline / download)
- [x] Pro-only actions are visually distinguished for free-tier users (badge + lock, disabled)
- [x] Menu is keyboard navigable and accessible (Radix: arrows, Escape, type-ahead; aria-label on trigger; asserted in tests)

## Test Plan
- [x] Unit tests written (TDD approach) — 51 new tests across registry, hooks, routes, menu, and page integration
- [x] All tests passing (392 total, 60 files)
- [x] Diff coverage ≥85% on changed lines — measured 95% (diff-cover vs origin/main)
- [x] Linting + typecheck + production build clean
- [x] Internal code review (advisory) completed — 1 Major fixed (editor 404), 1 suggestion rebutted (WCAG 2.5.3 substring rule already satisfied)
- [x] Cross-family review pass: codex — 1 Major fixed (unbounded tier fetch)
- [x] Test mutation sanity check completed — 4/4 mutations killed

## Known Limitations / Intentionally Deferred
- **Modal content is placeholder-only** — every modal-workflow action opens a "coming soon" dialog; real workflow modals land with US-17.3+ (#197+), per the issue's approved plan (Design Choice 2).
- **"Open in Editor" opens the placeholder modal instead of navigating** — no `/editor` page exists until Stage 18; the registry entry flips back to `navigation` when it ships.
- **Publish/Unpublish is an optimistic local toggle** — persistence lands with US-17.6 (#200); matches the existing SongHeader/ClipCard pattern.
- **Stems download is Pro-gated placeholder** — stem separation is a backend job (`POST /clips/{id}/stems`), not a file fetch; the real flow is a later story.
- **No tier guard inside `useSongActions`** — Pro gating lives in the menu's disabled state; add a hook-level guard if the hook gains a second consumer.
- Web vitest suite is not run in CI (CI is Python-only) — all gates above were run locally.

## Implementation Notes
- The CodeRabbit plan on the issue predates Stage 16/17.1 landing; paths (`web/src/…`), jest, and the `isPublished` field were adapted to the real codebase (`web/…`, Vitest, `is_public`).
- Tier lookup is a standalone hook rather than mounting `ModelSelectionProvider` app-wide.

Closes #196