### PR TITLE
feat(web): Editing Workflow Modals (US-17.3)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -100,6 +100,39 @@ edit, remix, audio, export, and manage operation on a song in one place.
   in-memory token and hands the blob to the browser via a temporary
   object-URL anchor.
 
+## Editing Workflow Modals (US-17.3)
+
+Modal-based UIs for every editing/iterative operation reachable from the full
+action menu, plus a one-click inline remaster.
+
+- `lib/editing.ts` — typed client: one `submit*` function per operation
+  (crop, speed, remaster, extend, cover, remix, repaint, sample, add-vocal,
+  mashup), each posting a payload to its BFF route and classifying the
+  response into an `EditSubmitResult` (accepted/unauthorized/invalid/
+  insufficient-credits/error).
+- `hooks/use-clip-edit.ts` — `useClipEdit`, a self-contained state machine
+  (idle → submitting → polling → success/error) any modal can drop in; polls
+  the job-status endpoint after a 202 and exposes the resulting clip ids.
+- `components/song/SongActionModal.tsx` — dispatches the selected action id
+  to its modal (`repaint` and `replace-section` both open Replace Section);
+  actions whose workflows land in later stories still show the "not
+  available yet" placeholder.
+- `components/song/modals/` — one modal per operation (`CropModal`,
+  `SpeedModal`, `ExtendModal`, `CoverModal`, `RemixModal`,
+  `ReplaceSectionModal`, `SampleModal`, `AddVocalModal`, `MashupModal`), built
+  on shared pieces: `EditModalShell` (phase-driven chrome: form → spinner →
+  success-with-link → error-with-retry), `RangeSelector` (waveform range
+  picker), `TimeDurationInput`, `StyleTextarea`, and `ClipMultiSelector`
+  (mashup's 2+ clip picker).
+- `components/song/RemasterStatus.tsx` — inline progress/success/error for
+  the one-click Remaster action, which has no modal of its own.
+- `lib/editing-validation.ts` / `lib/constants/editing.ts` — per-modal form
+  validation and shared option lists (blend modes, sample roles).
+- `lib/edit-proxy.ts` — `forwardEdit` / `clipEditRoute`, the shared same-origin
+  proxy powering `app/api/clips/[id]/{crop,speed,remaster,extend,cover,remix,
+  repaint,sample,add-vocal}/route.ts` and `app/api/mashup/route.ts`; forwards
+  the Bearer token and passes backend status/body through unchanged.
+
 ## Adding components
 
 To add components to your app, run the following command:

--- a/web/app/api/clips/[id]/add-vocal/route.ts
+++ b/web/app/api/clips/[id]/add-vocal/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/add-vocal (US-17.3).
+export const POST = clipEditRoute("add-vocal")

--- a/web/app/api/clips/[id]/cover/route.ts
+++ b/web/app/api/clips/[id]/cover/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/cover (US-17.3).
+export const POST = clipEditRoute("cover")

--- a/web/app/api/clips/[id]/crop/route.ts
+++ b/web/app/api/clips/[id]/crop/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/crop (US-17.3).
+export const POST = clipEditRoute("crop")

--- a/web/app/api/clips/[id]/extend/route.ts
+++ b/web/app/api/clips/[id]/extend/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/extend (US-17.3).
+export const POST = clipEditRoute("extend")

--- a/web/app/api/clips/[id]/remaster/route.ts
+++ b/web/app/api/clips/[id]/remaster/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/remaster (US-17.3).
+export const POST = clipEditRoute("remaster")

--- a/web/app/api/clips/[id]/remix/route.ts
+++ b/web/app/api/clips/[id]/remix/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/remix (US-17.3).
+export const POST = clipEditRoute("remix")

--- a/web/app/api/clips/[id]/repaint/route.ts
+++ b/web/app/api/clips/[id]/repaint/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/repaint (US-17.3).
+export const POST = clipEditRoute("repaint")

--- a/web/app/api/clips/[id]/sample/route.ts
+++ b/web/app/api/clips/[id]/sample/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/sample (US-17.3).
+export const POST = clipEditRoute("sample")

--- a/web/app/api/clips/[id]/speed/route.ts
+++ b/web/app/api/clips/[id]/speed/route.ts
@@ -1,0 +1,4 @@
+import { clipEditRoute } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/speed (US-17.3).
+export const POST = clipEditRoute("speed")

--- a/web/app/api/mashup/route.ts
+++ b/web/app/api/mashup/route.ts
@@ -1,0 +1,9 @@
+import { type NextRequest, type NextResponse } from "next/server"
+
+import { forwardEdit } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/mashup (US-17.3). Not clip-scoped: the
+// clip ids travel in the request body, so this forwards straight to the backend.
+export function POST(request: NextRequest): Promise<NextResponse> {
+  return forwardEdit(request, "/api/v1/mashup")
+}

--- a/web/components/song/RemasterStatus.tsx
+++ b/web/components/song/RemasterStatus.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import type { ClipEditState } from "@/hooks/use-clip-edit"
+
+// Inline status for the one-click Remaster action (US-17.3). Remaster has no
+// modal, so its progress/success/error surface here on the song page: a spinner
+// while it runs, a "View" link to the remastered clip on success, and a
+// dismissible error otherwise.
+
+export function RemasterStatus({
+  state,
+  onDismiss,
+}: {
+  state: ClipEditState
+  onDismiss: () => void
+}) {
+  const router = useRouter()
+
+  if (state.phase === "submitting" || state.phase === "polling") {
+    return (
+      <p role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
+        <HugeiconsIcon icon={Loading03Icon} className="animate-spin" data-icon="inline-start" />
+        Remastering…
+      </p>
+    )
+  }
+
+  if (state.phase === "success") {
+    const newClipId = state.clipIds[0]
+    return (
+      <div role="status" className="flex items-center gap-3 text-sm">
+        <span>Remaster ready.</span>
+        {newClipId && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => router.push(`/song/${encodeURIComponent(newClipId)}`)}
+          >
+            View
+          </Button>
+        )}
+        <Button size="sm" variant="ghost" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    )
+  }
+
+  if (state.phase === "error") {
+    return (
+      <div role="alert" className="flex items-center gap-3 text-sm text-destructive">
+        <span>{state.message}</span>
+        <Button size="sm" variant="ghost" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/web/components/song/SongActionModal.test.tsx
+++ b/web/components/song/SongActionModal.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { SongActionModal } from "@/components/song/SongActionModal"
+import { makeClip } from "@/test/clip-factory"
+
+// Each editing modal is exercised in its own test; here we only verify the
+// dispatch maps an action id to the right modal (or the placeholder), so the
+// modals are stubbed to lightweight markers.
+vi.mock("@/components/song/modals/CropModal", () => ({
+  CropModal: () => <div data-testid="crop-modal" />,
+}))
+vi.mock("@/components/song/modals/SpeedModal", () => ({
+  SpeedModal: () => <div data-testid="speed-modal" />,
+}))
+vi.mock("@/components/song/modals/ExtendModal", () => ({
+  ExtendModal: () => <div data-testid="extend-modal" />,
+}))
+vi.mock("@/components/song/modals/CoverModal", () => ({
+  CoverModal: () => <div data-testid="cover-modal" />,
+}))
+vi.mock("@/components/song/modals/RemixModal", () => ({
+  RemixModal: () => <div data-testid="remix-modal" />,
+}))
+vi.mock("@/components/song/modals/ReplaceSectionModal", () => ({
+  ReplaceSectionModal: () => <div data-testid="replace-modal" />,
+}))
+vi.mock("@/components/song/modals/SampleModal", () => ({
+  SampleModal: () => <div data-testid="sample-modal" />,
+}))
+vi.mock("@/components/song/modals/AddVocalModal", () => ({
+  AddVocalModal: () => <div data-testid="add-vocal-modal" />,
+}))
+vi.mock("@/components/song/modals/MashupModal", () => ({
+  MashupModal: () => <div data-testid="mashup-modal" />,
+}))
+
+const clip = makeClip()
+
+describe("SongActionModal dispatch", () => {
+  it("renders nothing when no action is active", () => {
+    const { container } = render(
+      <SongActionModal clip={clip} action={null} onClose={vi.fn()} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it.each([
+    ["crop", "crop-modal"],
+    ["adjust-speed", "speed-modal"],
+    ["extend", "extend-modal"],
+    ["cover", "cover-modal"],
+    ["remix", "remix-modal"],
+    ["replace-section", "replace-modal"],
+    ["repaint", "replace-modal"],
+    ["sample", "sample-modal"],
+    ["add-vocal", "add-vocal-modal"],
+    ["mashup", "mashup-modal"],
+  ] as const)("routes %s to its modal", (action, testId) => {
+    render(<SongActionModal clip={clip} action={action} onClose={vi.fn()} />)
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
+  })
+
+  it("shows the not-available placeholder for a not-yet-built modal action", () => {
+    render(<SongActionModal clip={clip} action="export-daw" onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent(/isn't available yet/i)
+  })
+})

--- a/web/components/song/SongActionModal.tsx
+++ b/web/components/song/SongActionModal.tsx
@@ -7,29 +7,72 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { AddVocalModal } from "@/components/song/modals/AddVocalModal"
+import { CoverModal } from "@/components/song/modals/CoverModal"
+import { CropModal } from "@/components/song/modals/CropModal"
+import { ExtendModal } from "@/components/song/modals/ExtendModal"
+import { MashupModal } from "@/components/song/modals/MashupModal"
+import { RemixModal } from "@/components/song/modals/RemixModal"
+import { ReplaceSectionModal } from "@/components/song/modals/ReplaceSectionModal"
+import { SampleModal } from "@/components/song/modals/SampleModal"
+import { SpeedModal } from "@/components/song/modals/SpeedModal"
 import { findSongAction, type SongActionId } from "@/lib/song-actions"
+import type { Clip } from "@/lib/workspace-clips"
 
-// US-17.2: placeholder container for the modal-workflow actions. The action
-// menu dispatches into here so every menu item already opens its own modal;
-// the real workflow content (prompts, options, submission) lands with
-// US-17.3+ story by story.
+// US-17.3: dispatch for the modal-workflow actions. useSongActions opens this
+// with the selected action id; each editing action routes to its own modal
+// (crop/speed/extend/cover/remix/replace-section/sample/add-vocal/mashup).
+// `repaint` and `replace-section` are the same regenerate-a-range operation, so
+// both open the Replace Section modal. Actions whose modals ship in later
+// stories (open-editor, use-inspiration, export/mastering/video, stems) keep the
+// "not available yet" placeholder so a menu click never dead-ends.
 
 export type SongActionModalProps = {
+  clip: Clip
   /** The modal-workflow action to show, or null when closed. */
   action: SongActionId | null
   onClose: () => void
 }
 
-export function SongActionModal({ action, onClose }: SongActionModalProps) {
-  const definition = action ? findSongAction(action) : null
+export function SongActionModal({ clip, action, onClose }: SongActionModalProps) {
+  switch (action) {
+    case "crop":
+      return <CropModal clip={clip} open onClose={onClose} />
+    case "adjust-speed":
+      return <SpeedModal clip={clip} open onClose={onClose} />
+    case "extend":
+      return <ExtendModal clip={clip} open onClose={onClose} />
+    case "cover":
+      return <CoverModal clip={clip} open onClose={onClose} />
+    case "remix":
+      return <RemixModal clip={clip} open onClose={onClose} />
+    case "repaint":
+    case "replace-section":
+      return <ReplaceSectionModal clip={clip} open onClose={onClose} />
+    case "sample":
+      return <SampleModal clip={clip} open onClose={onClose} />
+    case "add-vocal":
+      return <AddVocalModal clip={clip} open onClose={onClose} />
+    case "mashup":
+      return <MashupModal clip={clip} open onClose={onClose} />
+    case null:
+      return null
+    default:
+      return <PlaceholderModal action={action} onClose={onClose} />
+  }
+}
 
+/** Fallback for modal actions whose workflow lands in a later story. */
+function PlaceholderModal({
+  action,
+  onClose,
+}: {
+  action: SongActionId
+  onClose: () => void
+}) {
+  const definition = findSongAction(action)
   return (
-    <Dialog
-      open={definition != null}
-      onOpenChange={(open) => {
-        if (!open) onClose()
-      }}
-    >
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{definition?.label}</DialogTitle>

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -221,11 +221,12 @@ describe("SongDetail full action menu (US-17.2)", () => {
     stubFetch({ clip: clip() })
     renderDetail()
     await openActions()
-    await userEvent.click(screen.getByRole("menuitem", { name: /remaster/i }))
+    await userEvent.click(screen.getByRole("menuitem", { name: /^crop$/i }))
 
     const dialog = await screen.findByRole("dialog")
-    expect(dialog).toHaveTextContent("Remaster")
-    expect(dialog).toHaveTextContent(/isn't available yet/i)
+    expect(dialog).toHaveTextContent("Crop")
+    expect(within(dialog).getByLabelText("Start")).toBeInTheDocument()
+    expect(within(dialog).getByLabelText("End")).toBeInTheDocument()
   })
 
   it("navigates to the studio from the menu", async () => {
@@ -283,7 +284,7 @@ describe("SongDetail full action menu (US-17.2)", () => {
     stubFetch({ clip: clip() })
     renderDetail()
     await openActions()
-    await userEvent.click(screen.getByRole("menuitem", { name: /remaster/i }))
+    await userEvent.click(screen.getByRole("menuitem", { name: /^cover$/i }))
     await screen.findByRole("dialog")
 
     await userEvent.keyboard("{Escape}")

--- a/web/components/song/SongDetail.tsx
+++ b/web/components/song/SongDetail.tsx
@@ -4,6 +4,7 @@ import { DeleteSongDialog } from "@/components/song/DeleteSongDialog"
 import { RelatedSongs } from "@/components/song/RelatedSongs"
 import { SongActionModal } from "@/components/song/SongActionModal"
 import { SongActionsMenu } from "@/components/song/SongActionsMenu"
+import { RemasterStatus } from "@/components/song/RemasterStatus"
 import { SongHeader } from "@/components/song/SongHeader"
 import { SongLyrics } from "@/components/song/SongLyrics"
 import { SongMetadata } from "@/components/song/SongMetadata"
@@ -91,6 +92,10 @@ function SongDetailContent({ clip }: { clip: Clip }) {
             {actions.actionError}
           </p>
         )}
+        <RemasterStatus
+          state={actions.remasterState}
+          onDismiss={actions.dismissRemaster}
+        />
         <SongPlayer clip={clip} />
         <section aria-label="Details" className="flex flex-col gap-3">
           <h2 className="text-sm font-semibold">Details</h2>
@@ -105,6 +110,7 @@ function SongDetailContent({ clip }: { clip: Clip }) {
         <RelatedSongs clipId={clip.id} />
       </aside>
       <SongActionModal
+        clip={clip}
         action={actions.activeModal}
         onClose={actions.closeModal}
       />

--- a/web/components/song/modals/AddVocalModal.test.tsx
+++ b/web/components/song/modals/AddVocalModal.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { AddVocalModal } from "@/components/song/modals/AddVocalModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitAddVocal = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitAddVocal: (...args: unknown[]) => submitAddVocal(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+describe("AddVocalModal", () => {
+  it("opens with lyrics + vocal-style controls", () => {
+    render(<AddVocalModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent("Add vocal")
+    expect(screen.getByLabelText(/Lyrics/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Vocal style/)).toBeInTheDocument()
+  })
+
+  it("disables submit until lyrics are provided", async () => {
+    render(<AddVocalModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("button", { name: "Add vocal" })).toBeDisabled()
+    await userEvent.type(screen.getByLabelText(/Lyrics/), "la la la")
+    expect(screen.getByRole("button", { name: "Add vocal" })).toBeEnabled()
+  })
+
+  it("submits the add-vocal payload to the add-vocal endpoint and reaches success", async () => {
+    submitAddVocal.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["voiced-1"] })
+
+    render(<AddVocalModal clip={makeClip()} open onClose={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText(/Lyrics/), "la la la")
+    await userEvent.click(screen.getByRole("button", { name: "Add vocal" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitAddVocal).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({ lyrics: "la la la" }),
+      "tok"
+    )
+  })
+})

--- a/web/components/song/modals/AddVocalModal.tsx
+++ b/web/components/song/modals/AddVocalModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { useAuth } from "@/hooks/use-auth"
 import { useClipEdit } from "@/hooks/use-clip-edit"
@@ -30,7 +30,7 @@ export function AddVocalModal({
   const [vocalStyle, setVocalStyle] = useState("")
 
   const error = lyrics.trim() ? null : "Lyrics are required."
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/AddVocalModal.tsx
+++ b/web/components/song/modals/AddVocalModal.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { submitAddVocal } from "@/lib/editing"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { EditModalShell } from "./EditModalShell"
+import { StyleTextarea } from "./StyleTextarea"
+
+// Add-vocal modal (US-17.3): layer sung lyrics over a clip
+// (POST /clips/{id}/add-vocal). Consumes a credit. A required lyrics field plus
+// an optional vocal-style hint.
+
+export function AddVocalModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+
+  const [lyrics, setLyrics] = useState("")
+  const [vocalStyle, setVocalStyle] = useState("")
+
+  const error = lyrics.trim() ? null : "Lyrics are required."
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    void edit.submit(
+      () =>
+        submitAddVocal(clip.id, { lyrics, vocal_style: vocalStyle }, accessToken),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Add vocal"
+      description="Layer sung lyrics over this clip."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Add vocal"
+      creditHint="Uses 1 credit"
+      onRetry={edit.retry}
+    >
+      <StyleTextarea
+        label="Lyrics"
+        value={lyrics}
+        onChange={setLyrics}
+        maxLength={5000}
+        required
+        rows={4}
+      />
+      <StyleTextarea
+        label="Vocal style"
+        value={vocalStyle}
+        onChange={setVocalStyle}
+        maxLength={1000}
+      />
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/AddVocalModal.tsx
+++ b/web/components/song/modals/AddVocalModal.tsx
@@ -59,7 +59,7 @@ export function AddVocalModal({
       canSubmit={canSubmit}
       submitLabel="Add vocal"
       creditHint="Uses 1 credit"
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <StyleTextarea
         label="Lyrics"

--- a/web/components/song/modals/ClipMultiSelector.test.tsx
+++ b/web/components/song/modals/ClipMultiSelector.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ClipMultiSelector } from "@/components/song/modals/ClipMultiSelector"
+import { MASHUP_CLIPS_MAX } from "@/lib/constants/editing"
+import { makeClip } from "@/test/clip-factory"
+
+const useClips = vi.fn()
+vi.mock("@/hooks/use-clips", () => ({
+  useClips: (...args: unknown[]) => useClips(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+function mockClips(clips: ReturnType<typeof makeClip>[]) {
+  useClips.mockReturnValue({ data: { clips }, loading: false, error: false })
+}
+
+describe("ClipMultiSelector", () => {
+  it("hides clips that are not WAV with duration", () => {
+    mockClips([
+      makeClip({ id: "wav-1", title: "Keeper" }),
+      makeClip({ id: "mp3-1", title: "Wrong format", format: "mp3" }),
+      makeClip({ id: "no-dur", title: "No duration", duration: null }),
+    ])
+    render(<ClipMultiSelector workspaceId="ws-1" selected={[]} onChange={vi.fn()} />)
+
+    expect(screen.getByText("Keeper")).toBeInTheDocument()
+    expect(screen.queryByText("Wrong format")).not.toBeInTheDocument()
+    expect(screen.queryByText("No duration")).not.toBeInTheDocument()
+  })
+
+  it("shows a loading state while fetching", () => {
+    useClips.mockReturnValue({ data: null, loading: true, error: false })
+    render(<ClipMultiSelector workspaceId="ws-1" selected={[]} onChange={vi.fn()} />)
+    expect(screen.getByText("Loading clips…")).toBeInTheDocument()
+  })
+
+  it("shows an empty state when no clips are eligible", () => {
+    mockClips([makeClip({ id: "mp3-1", format: "mp3" })])
+    render(<ClipMultiSelector workspaceId="ws-1" selected={[]} onChange={vi.fn()} />)
+    expect(screen.getByText("No eligible clips to mash up.")).toBeInTheDocument()
+  })
+
+  it("toggles a clip's id through onChange, preserving order", async () => {
+    const onChange = vi.fn()
+    mockClips([
+      makeClip({ id: "a", title: "Alpha" }),
+      makeClip({ id: "b", title: "Beta" }),
+    ])
+    render(<ClipMultiSelector workspaceId="ws-1" selected={["a"]} onChange={onChange} />)
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /Beta/ }))
+    expect(onChange).toHaveBeenCalledWith(["a", "b"])
+  })
+
+  it("removes a clip's id when unchecked", async () => {
+    const onChange = vi.fn()
+    mockClips([makeClip({ id: "a", title: "Alpha" })])
+    render(<ClipMultiSelector workspaceId="ws-1" selected={["a"]} onChange={onChange} />)
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /Alpha/ }))
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it("disables unselected clips once the max is reached", () => {
+    const clips = Array.from({ length: MASHUP_CLIPS_MAX + 1 }, (_, i) =>
+      makeClip({ id: `c${i}`, title: `Clip ${i}` })
+    )
+    mockClips(clips)
+    const selected = clips.slice(0, MASHUP_CLIPS_MAX).map((c) => c.id)
+    render(<ClipMultiSelector workspaceId="ws-1" selected={selected} onChange={vi.fn()} />)
+
+    // The one clip past the cap that is not selected must be disabled.
+    const overflow = screen.getByRole("checkbox", { name: /Clip 8/ })
+    expect(overflow).toBeDisabled()
+    // Selected ones stay enabled so they can be removed.
+    expect(screen.getByRole("checkbox", { name: /Clip 0/ })).toBeEnabled()
+  })
+})

--- a/web/components/song/modals/ClipMultiSelector.test.tsx
+++ b/web/components/song/modals/ClipMultiSelector.test.tsx
@@ -64,6 +64,21 @@ describe("ClipMultiSelector", () => {
     expect(onChange).toHaveBeenCalledWith([])
   })
 
+  it("prunes a pre-seeded selection id that is not eligible", async () => {
+    const onChange = vi.fn()
+    // "a" is eligible; the seeded "ghost" clip is not in the eligible list.
+    mockClips([makeClip({ id: "a", title: "Alpha" })])
+    render(
+      <ClipMultiSelector
+        workspaceId="ws-1"
+        selected={["ghost", "a"]}
+        onChange={onChange}
+      />
+    )
+    // The ineligible id is dropped so it can't be submitted invisibly.
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith(["a"]))
+  })
+
   it("disables unselected clips once the max is reached", () => {
     const clips = Array.from({ length: MASHUP_CLIPS_MAX + 1 }, (_, i) =>
       makeClip({ id: `c${i}`, title: `Clip ${i}` })

--- a/web/components/song/modals/ClipMultiSelector.tsx
+++ b/web/components/song/modals/ClipMultiSelector.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useClips } from "@/hooks/use-clips"
+import { MASHUP_CLIPS_MAX, MASHUP_CLIPS_MIN } from "@/lib/constants/editing"
+
+// Multi-clip picker for the Mashup modal (US-17.3). Lists the workspace's clips
+// and lets the user pick which ones to combine, keeping selection *order* (the
+// first pick is the mashup's primary). The backend mashup needs WAV sources that
+// carry duration metadata, so ineligible clips are filtered out entirely rather
+// than shown-but-disabled. Selection is capped at MASHUP_CLIPS_MAX: once the cap
+// is reached the remaining checkboxes go disabled instead of silently no-oping.
+
+export function ClipMultiSelector({
+  workspaceId,
+  selected,
+  onChange,
+}: {
+  workspaceId: string
+  selected: string[]
+  onChange: (ids: string[]) => void
+}) {
+  const { data, loading } = useClips(
+    { workspace_id: workspaceId, per_page: 50 },
+    { enabled: true }
+  )
+
+  const eligible = (data?.clips ?? []).filter(
+    (clip) => clip.format === "wav" && clip.duration != null
+  )
+
+  function toggle(id: string) {
+    if (selected.includes(id)) {
+      onChange(selected.filter((s) => s !== id))
+    } else {
+      onChange([...selected, id])
+    }
+  }
+
+  const atMax = selected.length >= MASHUP_CLIPS_MAX
+
+  return (
+    <div className="flex flex-col gap-2">
+      {loading ? (
+        <p className="py-4 text-sm text-muted-foreground">Loading clips…</p>
+      ) : eligible.length === 0 ? (
+        <p className="py-4 text-sm text-muted-foreground">
+          No eligible clips to mash up.
+        </p>
+      ) : (
+        <ul className="flex max-h-56 flex-col gap-1 overflow-y-auto">
+          {eligible.map((clip) => {
+            const checked = selected.includes(clip.id)
+            return (
+              <li key={clip.id}>
+                <label className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={!checked && atMax}
+                    onChange={() => toggle(clip.id)}
+                    className="size-4 shrink-0"
+                  />
+                  <span className="truncate">{clip.title || "Untitled"}</span>
+                  <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                    {clip.duration}s
+                    {clip.bpm != null && ` · ${clip.bpm} BPM`}
+                  </span>
+                </label>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>{selected.length} selected</span>
+        {selected.length < MASHUP_CLIPS_MIN && (
+          <span>Select at least {MASHUP_CLIPS_MIN} clips.</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/components/song/modals/ClipMultiSelector.tsx
+++ b/web/components/song/modals/ClipMultiSelector.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useEffect } from "react"
+
 import { useClips } from "@/hooks/use-clips"
 import { MASHUP_CLIPS_MAX, MASHUP_CLIPS_MIN } from "@/lib/constants/editing"
 
@@ -27,6 +29,17 @@ export function ClipMultiSelector({
   const eligible = (data?.clips ?? []).filter(
     (clip) => clip.format === "wav" && clip.duration != null
   )
+
+  // Once clips load, drop any pre-seeded selection (e.g. the opening clip) that
+  // isn't eligible — otherwise an id with no rendered checkbox would still count
+  // toward the min/max and get submitted in clip_ids, guaranteeing a backend 422.
+  const eligibleKey = eligible.map((c) => c.id).join(",")
+  useEffect(() => {
+    if (loading) return
+    const eligibleIds = new Set(eligibleKey ? eligibleKey.split(",") : [])
+    const pruned = selected.filter((id) => eligibleIds.has(id))
+    if (pruned.length !== selected.length) onChange(pruned)
+  }, [loading, eligibleKey, selected, onChange])
 
   function toggle(id: string) {
     if (selected.includes(id)) {

--- a/web/components/song/modals/CoverModal.test.tsx
+++ b/web/components/song/modals/CoverModal.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { CoverModal } from "@/components/song/modals/CoverModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitCover = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitCover: (...args: unknown[]) => submitCover(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+describe("CoverModal", () => {
+  it("opens with target-style and optional lyrics fields", () => {
+    render(<CoverModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent("Cover")
+    expect(screen.getByLabelText(/Target style/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Lyrics override/)).toBeInTheDocument()
+  })
+
+  it("disables submit until a target style is entered", () => {
+    render(<CoverModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("button", { name: "Create cover" })).toBeDisabled()
+  })
+
+  it("submits the cover payload and reaches success", async () => {
+    submitCover.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["cover-1"] })
+
+    render(<CoverModal clip={makeClip()} open onClose={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText(/Target style/), "acoustic ballad")
+    await userEvent.click(screen.getByRole("button", { name: "Create cover" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitCover).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({ style: "acoustic ballad" }),
+      "tok"
+    )
+  })
+})

--- a/web/components/song/modals/CoverModal.tsx
+++ b/web/components/song/modals/CoverModal.tsx
@@ -63,7 +63,7 @@ export function CoverModal({
       canSubmit={canSubmit}
       submitLabel="Create cover"
       creditHint="Uses 1 credit"
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <StyleTextarea
         label="Target style"

--- a/web/components/song/modals/CoverModal.tsx
+++ b/web/components/song/modals/CoverModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { useAuth } from "@/hooks/use-auth"
 import { useClipEdit } from "@/hooks/use-clip-edit"
@@ -30,7 +30,7 @@ export function CoverModal({
   const [lyricsOverride, setLyricsOverride] = useState("")
 
   const error = !style.trim() ? "Target style is required." : null
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/CoverModal.tsx
+++ b/web/components/song/modals/CoverModal.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { submitCover } from "@/lib/editing"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { EditModalShell } from "./EditModalShell"
+import { StyleTextarea } from "./StyleTextarea"
+
+// Cover modal (US-17.3): re-record a clip in a new target style, optionally
+// swapping in fresh lyrics. Iterative (POST /clips/{id}/cover) so it consumes a
+// credit.
+
+export function CoverModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+
+  const [style, setStyle] = useState("")
+  const [lyricsOverride, setLyricsOverride] = useState("")
+
+  const error = !style.trim() ? "Target style is required." : null
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    void edit.submit(
+      () =>
+        submitCover(
+          clip.id,
+          { style, lyrics_override: lyricsOverride },
+          accessToken
+        ),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Cover"
+      description="Re-record this clip in a new style."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Create cover"
+      creditHint="Uses 1 credit"
+      onRetry={edit.retry}
+    >
+      <StyleTextarea
+        label="Target style"
+        value={style}
+        onChange={setStyle}
+        placeholder="e.g. acoustic ballad, synthwave, jazz trio"
+        required
+      />
+      <StyleTextarea
+        label="Lyrics override"
+        value={lyricsOverride}
+        onChange={setLyricsOverride}
+        placeholder="Optional — replace the lyrics for the cover"
+        maxLength={5000}
+      />
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/CoverModal.tsx
+++ b/web/components/song/modals/CoverModal.tsx
@@ -38,7 +38,7 @@ export function CoverModal({
       () =>
         submitCover(
           clip.id,
-          { style, lyrics_override: lyricsOverride },
+          { style: style.trim(), lyrics_override: lyricsOverride },
           accessToken
         ),
       accessToken

--- a/web/components/song/modals/CropModal.test.tsx
+++ b/web/components/song/modals/CropModal.test.tsx
@@ -63,4 +63,41 @@ describe("CropModal", () => {
       "tok"
     )
   })
+
+  it("retry resubmits with corrected field values, not the stale payload", async () => {
+    // First attempt fails at the backend; the user then fixes the range and
+    // retries. Try again must send the current values, not the original ones.
+    submitCrop.mockResolvedValue({ status: "invalid", detail: "bad range" })
+
+    render(<CropModal clip={makeClip({ duration: 60 })} open onClose={vi.fn()} />)
+    const end = screen.getByLabelText("End")
+    await userEvent.clear(end)
+    await userEvent.type(end, "20s")
+    await userEvent.click(screen.getByRole("button", { name: "Crop" }))
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("bad range"))
+    expect(submitCrop).toHaveBeenLastCalledWith(
+      "clip-1",
+      expect.objectContaining({ end: "20s" }),
+      "tok"
+    )
+
+    // Correct the field, then retry — the resubmission carries the new value.
+    // Re-query: the form remounts after the spinner, so the earlier node is stale.
+    submitCrop.mockResolvedValue({ status: "accepted", jobId: "j2", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["cropped-2"] })
+    const endAfterError = screen.getByLabelText("End")
+    await userEvent.clear(endAfterError)
+    await userEvent.type(endAfterError, "45s")
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitCrop).toHaveBeenLastCalledWith(
+      "clip-1",
+      expect.objectContaining({ end: "45s" }),
+      "tok"
+    )
+  })
 })

--- a/web/components/song/modals/CropModal.test.tsx
+++ b/web/components/song/modals/CropModal.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { CropModal } from "@/components/song/modals/CropModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitCrop = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitCrop: (...args: unknown[]) => submitCrop(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+describe("CropModal", () => {
+  it("opens with range + fade controls and a beat-snap toggle", () => {
+    render(<CropModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent("Crop")
+    expect(screen.getByLabelText("Start")).toBeInTheDocument()
+    expect(screen.getByLabelText("End")).toBeInTheDocument()
+    expect(screen.getByLabelText("Fade in")).toBeInTheDocument()
+    expect(screen.getByLabelText(/Snap to beat/)).toBeEnabled()
+  })
+
+  it("disables the snap toggle when the clip has no BPM", () => {
+    render(<CropModal clip={makeClip({ bpm: null })} open onClose={vi.fn()} />)
+    expect(screen.getByLabelText(/Snap to beat/)).toBeDisabled()
+  })
+
+  it("blocks submit when start is not before end", async () => {
+    render(<CropModal clip={makeClip({ duration: 60 })} open onClose={vi.fn()} />)
+    const start = screen.getByLabelText("Start")
+    await userEvent.clear(start)
+    await userEvent.type(start, "90s")
+    expect(screen.getByRole("button", { name: "Crop" })).toBeDisabled()
+  })
+
+  it("submits the crop payload to the crop endpoint and reaches success", async () => {
+    submitCrop.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["cropped-1"] })
+
+    render(<CropModal clip={makeClip({ duration: 60 })} open onClose={vi.fn()} />)
+    const end = screen.getByLabelText("End")
+    await userEvent.clear(end)
+    await userEvent.type(end, "30s")
+    await userEvent.click(screen.getByRole("button", { name: "Crop" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitCrop).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({ start: "0s", end: "30s", snap_to_beat: false }),
+      "tok"
+    )
+  })
+})

--- a/web/components/song/modals/CropModal.tsx
+++ b/web/components/song/modals/CropModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
@@ -41,7 +41,7 @@ export function CropModal({
   const fadeInError = validateTimeField(fadeIn, "Fade in")
   const fadeOutError = validateTimeField(fadeOut, "Fade out")
   const error = rangeError || fadeInError || fadeOutError
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/CropModal.tsx
+++ b/web/components/song/modals/CropModal.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { submitCrop } from "@/lib/editing"
+import { validateRange, validateTimeField } from "@/lib/editing-validation"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { EditModalShell } from "./EditModalShell"
+import { RangeSelector } from "./RangeSelector"
+import { TimeDurationInput } from "./TimeDurationInput"
+
+// Crop modal (US-17.3): trim a clip to a [start, end] range with optional fades
+// and beat snapping. Local, credit-free (POST /clips/{id}/crop). Snap-to-beat is
+// only offered when the clip carries BPM metadata (the backend needs it).
+
+export function CropModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+  const durationMs = clip.duration != null ? Math.round(clip.duration * 1000) : 0
+
+  const [start, setStart] = useState("0s")
+  const [end, setEnd] = useState(clip.duration != null ? `${clip.duration}s` : "")
+  const [fadeIn, setFadeIn] = useState("0s")
+  const [fadeOut, setFadeOut] = useState("0s")
+  const [snapToBeat, setSnapToBeat] = useState(false)
+
+  const rangeError = validateRange(start, end, durationMs || null)
+  const fadeInError = validateTimeField(fadeIn, "Fade in")
+  const fadeOutError = validateTimeField(fadeOut, "Fade out")
+  const error = rangeError || fadeInError || fadeOutError
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    void edit.submit(
+      () =>
+        submitCrop(
+          clip.id,
+          { start, end, fade_in: fadeIn, fade_out: fadeOut, snap_to_beat: snapToBeat },
+          accessToken
+        ),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Crop"
+      description="Trim this clip to a section."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Crop"
+      onRetry={edit.retry}
+    >
+      <RangeSelector
+        clipId={clip.id}
+        durationMs={durationMs}
+        start={start}
+        end={end}
+        onChange={({ start: s, end: e }) => {
+          setStart(s)
+          setEnd(e)
+        }}
+        snapToBeat={snapToBeat}
+        bpm={clip.bpm}
+      />
+      <div className="grid grid-cols-2 gap-3">
+        <TimeDurationInput
+          label="Fade in"
+          value={fadeIn}
+          onChange={setFadeIn}
+          placeholder="0s"
+          error={fadeInError}
+        />
+        <TimeDurationInput
+          label="Fade out"
+          value={fadeOut}
+          onChange={setFadeOut}
+          placeholder="0s"
+          error={fadeOutError}
+        />
+      </div>
+      <div className="flex items-center justify-between">
+        <Label htmlFor="crop-snap">
+          Snap to beat
+          {clip.bpm == null && (
+            <span className="text-xs font-normal text-muted-foreground">
+              {" "}
+              (needs BPM)
+            </span>
+          )}
+        </Label>
+        <Switch
+          id="crop-snap"
+          checked={snapToBeat}
+          onCheckedChange={setSnapToBeat}
+          disabled={clip.bpm == null}
+        />
+      </div>
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/CropModal.tsx
+++ b/web/components/song/modals/CropModal.tsx
@@ -73,7 +73,7 @@ export function CropModal({
       onSubmit={handleSubmit}
       canSubmit={canSubmit}
       submitLabel="Crop"
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <RangeSelector
         clipId={clip.id}

--- a/web/components/song/modals/EditModalShell.tsx
+++ b/web/components/song/modals/EditModalShell.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { useRouter } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import type { ClipEditState } from "@/hooks/use-clip-edit"
+
+// Shared frame for every editing workflow modal (US-17.3). Owns the phase-driven
+// chrome — the form (idle), an in-flight spinner (submitting/polling), a success
+// state that links to the resulting clip, and an inline error with Retry — so
+// each modal only supplies its own fields and submit closure. On success it can
+// navigate to the new clip so "results appear as new clips" is reachable from
+// the song page, which has no workspace panel of its own.
+
+export function EditModalShell({
+  open,
+  onOpenChange,
+  title,
+  description,
+  state,
+  onSubmit,
+  canSubmit,
+  submitLabel = "Create",
+  creditHint,
+  onRetry,
+  children,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: string
+  state: ClipEditState
+  onSubmit: () => void
+  canSubmit: boolean
+  submitLabel?: string
+  creditHint?: string
+  onRetry: () => void
+  children: ReactNode
+}) {
+  const router = useRouter()
+  const busy = state.phase === "submitting" || state.phase === "polling"
+
+  function viewResult(clipId: string) {
+    onOpenChange(false)
+    router.push(`/song/${encodeURIComponent(clipId)}`)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+
+        {state.phase === "success" ? (
+          <div role="status" className="flex flex-col gap-3 text-sm">
+            <p>
+              {state.clipIds.length > 1
+                ? `${state.clipIds.length} new clips are ready.`
+                : "Your new clip is ready."}
+            </p>
+          </div>
+        ) : busy ? (
+          <div role="status" className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+            <HugeiconsIcon icon={Loading03Icon} className="animate-spin" data-icon="inline-start" />
+            <span>
+              Working…
+              {state.phase === "polling" && state.estimatedSeconds > 0
+                ? ` ~${state.estimatedSeconds}s`
+                : ""}
+            </span>
+            {state.phase === "polling" && state.progress && (
+              <span className="text-xs">{state.progress}</span>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">{children}</div>
+        )}
+
+        {state.phase === "error" && (
+          <p role="alert" className="text-sm text-destructive">
+            {state.message}
+          </p>
+        )}
+
+        <DialogFooter>
+          {state.phase === "success" ? (
+            <>
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+              <Button onClick={() => viewResult(state.clipIds[0])} disabled={state.clipIds.length === 0}>
+                View
+              </Button>
+            </>
+          ) : state.phase === "error" ? (
+            <>
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={onRetry}>Try again</Button>
+            </>
+          ) : (
+            <>
+              {creditHint && !busy && (
+                <span className="mr-auto self-center text-xs text-muted-foreground">
+                  {creditHint}
+                </span>
+              )}
+              <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+                Cancel
+              </Button>
+              <Button onClick={onSubmit} disabled={!canSubmit || busy}>
+                {busy ? "Working…" : submitLabel}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/song/modals/ExtendModal.test.tsx
+++ b/web/components/song/modals/ExtendModal.test.tsx
@@ -54,4 +54,14 @@ describe("ExtendModal", () => {
       "tok"
     )
   })
+
+  it("blocks an extend that would exceed the 240s generation cap", async () => {
+    // 200s clip + a 60s extension from the end = 260s > DURATION_MAX (240s).
+    render(<ExtendModal clip={makeClip({ duration: 200 })} open onClose={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText("Duration"), "60s")
+
+    expect(screen.getByText(/can't exceed 240s/)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Extend" })).toBeDisabled()
+    expect(submitExtend).not.toHaveBeenCalled()
+  })
 })

--- a/web/components/song/modals/ExtendModal.test.tsx
+++ b/web/components/song/modals/ExtendModal.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ExtendModal } from "@/components/song/modals/ExtendModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitExtend = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitExtend: (...args: unknown[]) => submitExtend(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+describe("ExtendModal", () => {
+  it("opens with an extension-point selector and duration + optional fields", () => {
+    render(<ExtendModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent("Extend")
+    expect(screen.getByLabelText("From end")).toBeInTheDocument()
+    expect(screen.getByLabelText("At timestamp")).toBeInTheDocument()
+    expect(screen.getByLabelText("Duration")).toBeInTheDocument()
+    expect(screen.getByLabelText("Style override")).toBeInTheDocument()
+    expect(screen.getByLabelText("Lyrics continuation")).toBeInTheDocument()
+  })
+
+  it("disables submit until a duration is entered", () => {
+    render(<ExtendModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("button", { name: "Extend" })).toBeDisabled()
+  })
+
+  it("submits the extend payload from the end and reaches success", async () => {
+    submitExtend.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["extended-1"] })
+
+    render(<ExtendModal clip={makeClip()} open onClose={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText("Duration"), "45s")
+    await userEvent.click(screen.getByRole("button", { name: "Extend" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitExtend).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({ duration: "45s", from_point: "end" }),
+      "tok"
+    )
+  })
+})

--- a/web/components/song/modals/ExtendModal.tsx
+++ b/web/components/song/modals/ExtendModal.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { useAuth } from "@/hooks/use-auth"
 import { useClipEdit } from "@/hooks/use-clip-edit"
+import { DURATION_MAX } from "@/lib/constants/generation"
 import { submitExtend } from "@/lib/editing"
 import { parseTimeString, validateTimeField } from "@/lib/editing-validation"
 import type { Clip } from "@/lib/workspace-clips"
@@ -52,7 +53,20 @@ export function ExtendModal({
     return null
   }, [mode, timestamp, durationMs])
 
-  const error = durationError || timestampError
+  // The backend rejects an extend whose resulting length exceeds the generation
+  // cap (iterative.py: from_point + duration > DURATION_MAX). Mirror that here so
+  // a near-limit extend fails inline instead of round-tripping a 422.
+  const capError = useMemo(() => {
+    if (durationError || timestampError) return null
+    const fromMs = mode === "timestamp" ? (parseTimeString(timestamp) ?? 0) : durationMs
+    const durMs = parseTimeString(duration) ?? 0
+    if (durMs <= 0) return null
+    return fromMs + durMs > DURATION_MAX * 1000
+      ? `The extended clip can't exceed ${DURATION_MAX}s.`
+      : null
+  }, [durationError, timestampError, mode, timestamp, duration, durationMs])
+
+  const error = durationError || timestampError || capError
   const canSubmit = !error
 
   function handleSubmit() {
@@ -128,7 +142,7 @@ export function ExtendModal({
         value={duration}
         onChange={setDuration}
         placeholder="30s"
-        error={duration ? durationError : null}
+        error={duration ? durationError || capError : null}
       />
       <StyleTextarea
         label="Style override"

--- a/web/components/song/modals/ExtendModal.tsx
+++ b/web/components/song/modals/ExtendModal.tsx
@@ -91,7 +91,7 @@ export function ExtendModal({
       canSubmit={canSubmit}
       submitLabel="Extend"
       creditHint="Uses 1 credit"
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <div className="flex flex-col gap-2">
         <Label htmlFor={fromPointId}>Extension point</Label>

--- a/web/components/song/modals/ExtendModal.tsx
+++ b/web/components/song/modals/ExtendModal.tsx
@@ -53,7 +53,7 @@ export function ExtendModal({
   }, [mode, timestamp, durationMs])
 
   const error = durationError || timestampError
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/ExtendModal.tsx
+++ b/web/components/song/modals/ExtendModal.tsx
@@ -108,9 +108,9 @@ export function ExtendModal({
       onRetry={handleSubmit}
     >
       <div className="flex flex-col gap-2">
-        <Label htmlFor={fromPointId}>Extension point</Label>
+        <Label id={fromPointId}>Extension point</Label>
         <RadioGroup
-          id={fromPointId}
+          aria-labelledby={fromPointId}
           value={mode}
           onValueChange={(v) => setMode(v as "end" | "timestamp")}
         >

--- a/web/components/song/modals/ExtendModal.tsx
+++ b/web/components/song/modals/ExtendModal.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useId, useMemo, useState } from "react"
+
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { submitExtend } from "@/lib/editing"
+import { parseTimeString, validateTimeField } from "@/lib/editing-validation"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { EditModalShell } from "./EditModalShell"
+import { StyleTextarea } from "./StyleTextarea"
+import { TimeDurationInput } from "./TimeDurationInput"
+
+// Extend modal (US-17.3): lengthen a clip from its end or from a chosen
+// timestamp, optionally steering the continuation with a style override and
+// fresh lyrics. Iterative (POST /clips/{id}/extend) so it consumes a credit.
+
+export function ExtendModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+  const durationMs = clip.duration != null ? Math.round(clip.duration * 1000) : 0
+  const fromPointId = useId()
+
+  const [duration, setDuration] = useState("")
+  const [mode, setMode] = useState<"end" | "timestamp">("end")
+  const [timestamp, setTimestamp] = useState("")
+  const [styleOverride, setStyleOverride] = useState("")
+  const [lyrics, setLyrics] = useState("")
+
+  const durationError =
+    validateTimeField(duration, "Duration") ||
+    ((parseTimeString(duration) ?? 0) <= 0 ? "Duration must be greater than 0." : null)
+
+  const timestampError = useMemo(() => {
+    if (mode !== "timestamp") return null
+    const fieldError = validateTimeField(timestamp, "Timestamp")
+    if (fieldError) return fieldError
+    const ms = parseTimeString(timestamp) as number
+    if (ms <= 0) return "Timestamp must be greater than 0."
+    if (durationMs && ms > durationMs) return "Timestamp can't exceed the clip length."
+    return null
+  }, [mode, timestamp, durationMs])
+
+  const error = durationError || timestampError
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    void edit.submit(
+      () =>
+        submitExtend(
+          clip.id,
+          {
+            duration,
+            from_point: mode === "timestamp" ? timestamp : "end",
+            style_override: styleOverride,
+            lyrics,
+          },
+          accessToken
+        ),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Extend"
+      description="Add more music to this clip."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Extend"
+      creditHint="Uses 1 credit"
+      onRetry={edit.retry}
+    >
+      <div className="flex flex-col gap-2">
+        <Label htmlFor={fromPointId}>Extension point</Label>
+        <RadioGroup
+          id={fromPointId}
+          value={mode}
+          onValueChange={(v) => setMode(v as "end" | "timestamp")}
+        >
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="end" id={`${fromPointId}-end`} />
+            <Label htmlFor={`${fromPointId}-end`} className="font-normal">
+              From end
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="timestamp" id={`${fromPointId}-timestamp`} />
+            <Label htmlFor={`${fromPointId}-timestamp`} className="font-normal">
+              At timestamp
+            </Label>
+          </div>
+        </RadioGroup>
+        {mode === "timestamp" && (
+          <TimeDurationInput
+            label="Timestamp"
+            value={timestamp}
+            onChange={setTimestamp}
+            placeholder="30s"
+            error={timestampError}
+          />
+        )}
+      </div>
+      <TimeDurationInput
+        label="Duration"
+        value={duration}
+        onChange={setDuration}
+        placeholder="30s"
+        error={duration ? durationError : null}
+      />
+      <StyleTextarea
+        label="Style override"
+        value={styleOverride}
+        onChange={setStyleOverride}
+        placeholder="Optional — steer the new section's style"
+      />
+      <StyleTextarea
+        label="Lyrics continuation"
+        value={lyrics}
+        onChange={setLyrics}
+        placeholder="Optional — lyrics for the extended section"
+        maxLength={5000}
+      />
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/MashupModal.test.tsx
+++ b/web/components/song/modals/MashupModal.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { MashupModal } from "@/components/song/modals/MashupModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitMashup = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitMashup: (...args: unknown[]) => submitMashup(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+const useClips = vi.fn()
+vi.mock("@/hooks/use-clips", () => ({
+  useClips: (...args: unknown[]) => useClips(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+const clip = makeClip({ id: "clip-1", title: "Primary", workspace_id: "ws-1" })
+
+function mockEligibleClips() {
+  useClips.mockReturnValue({
+    data: {
+      clips: [
+        clip,
+        makeClip({ id: "clip-2", title: "Second" }),
+        makeClip({ id: "clip-3", title: "Third" }),
+      ],
+    },
+    loading: false,
+    error: false,
+  })
+}
+
+describe("MashupModal", () => {
+  it("blocks submit until at least two clips are selected", () => {
+    mockEligibleClips()
+    render(<MashupModal clip={clip} open onClose={vi.fn()} />)
+    expect(screen.getByRole("button", { name: "Create mashup" })).toBeDisabled()
+  })
+
+  it("enables submit once a second eligible clip is picked", async () => {
+    mockEligibleClips()
+    render(<MashupModal clip={clip} open onClose={vi.fn()} />)
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /Second/ }))
+    expect(screen.getByRole("button", { name: "Create mashup" })).toBeEnabled()
+  })
+
+  it("submits the mashup payload and reaches success", async () => {
+    mockEligibleClips()
+    submitMashup.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["mashup-1"] })
+
+    render(<MashupModal clip={clip} open onClose={vi.fn()} />)
+    await userEvent.click(screen.getByRole("checkbox", { name: /Second/ }))
+    await userEvent.click(screen.getByRole("button", { name: "Create mashup" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitMashup).toHaveBeenCalledWith(
+      expect.objectContaining({ clip_ids: ["clip-1", "clip-2"], blend_mode: "layered" }),
+      "tok"
+    )
+    const payload = submitMashup.mock.calls[0][0]
+    expect(payload.clip_ids[0]).toBe("clip-1")
+  })
+})

--- a/web/components/song/modals/MashupModal.tsx
+++ b/web/components/song/modals/MashupModal.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { submitMashup } from "@/lib/editing"
+import {
+  BLEND_MODES,
+  MASHUP_CLIPS_MAX,
+  MASHUP_CLIPS_MIN,
+  type BlendMode,
+} from "@/lib/constants/editing"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { ClipMultiSelector } from "./ClipMultiSelector"
+import { EditModalShell } from "./EditModalShell"
+import { StyleTextarea } from "./StyleTextarea"
+
+// Mashup modal (US-17.3): combine 2–8 clips from the workspace into a new clip.
+// The current clip seeds the selection as the primary (first) source. Iterative
+// (POST /api/mashup — note: no clip id in the path), so it consumes one credit.
+
+export function MashupModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+
+  const [selected, setSelected] = useState<string[]>([clip.id])
+  const [blendMode, setBlendMode] = useState<BlendMode>("layered")
+  const [style, setStyle] = useState("")
+
+  const unique = new Set(selected).size === selected.length
+  const error =
+    selected.length < MASHUP_CLIPS_MIN
+      ? `Select at least ${MASHUP_CLIPS_MIN} clips.`
+      : selected.length > MASHUP_CLIPS_MAX
+        ? `Select at most ${MASHUP_CLIPS_MAX} clips.`
+        : !unique
+          ? "Clips must be unique."
+          : null
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    void edit.submit(
+      () =>
+        submitMashup(
+          { clip_ids: selected, blend_mode: blendMode, style },
+          accessToken
+        ),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Mashup"
+      description="Combine several clips into a new one."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Create mashup"
+      creditHint="Uses 1 credit"
+      onRetry={edit.retry}
+    >
+      <ClipMultiSelector
+        workspaceId={clip.workspace_id}
+        selected={selected}
+        onChange={setSelected}
+      />
+      <div className="flex flex-col gap-2">
+        <Label>Blend mode</Label>
+        <RadioGroup
+          value={blendMode}
+          onValueChange={(value) => setBlendMode(value as BlendMode)}
+        >
+          {BLEND_MODES.map((option) => (
+            <div key={option.value} className="flex items-center gap-2">
+              <RadioGroupItem value={option.value} id={`mashup-blend-${option.value}`} />
+              <Label htmlFor={`mashup-blend-${option.value}`} className="font-normal">
+                {option.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </div>
+      <StyleTextarea label="Style override" value={style} onChange={setStyle} />
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/MashupModal.tsx
+++ b/web/components/song/modals/MashupModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
@@ -48,7 +48,7 @@ export function MashupModal({
         : !unique
           ? "Clips must be unique."
           : null
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/MashupModal.tsx
+++ b/web/components/song/modals/MashupModal.tsx
@@ -80,7 +80,7 @@ export function MashupModal({
       canSubmit={canSubmit}
       submitLabel="Create mashup"
       creditHint="Uses 1 credit"
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <ClipMultiSelector
         workspaceId={clip.workspace_id}

--- a/web/components/song/modals/RangeSelector.tsx
+++ b/web/components/song/modals/RangeSelector.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { type PointerEvent as ReactPointerEvent, useCallback, useMemo, useRef } from "react"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { WAVEFORM_BARS as BARS, barHeights } from "@/lib/waveform"
+import { formatMs, parseTimeString } from "@/lib/editing-validation"
+
+// Range selector for the crop / replace-section / sample modals (US-17.3).
+// Instead of a heavy audio-decoding dependency, it reuses the app's decorative
+// waveform (`barHeights`, seeded from the clip id — the same bars the song page
+// shows) and overlays a draggable [start, end] region. The numeric time inputs
+// stay in sync with the handles and are the accessible, testable path; dragging
+// is the visual convenience. Emits `start`/`end` as backend time strings.
+
+function clampMs(ms: number, durationMs: number): number {
+  return Math.max(0, Math.min(ms, durationMs))
+}
+
+function snap(ms: number, bpm: number | null | undefined, enabled: boolean): number {
+  if (!enabled || !bpm || bpm <= 0) return ms
+  const beatMs = 60000 / bpm
+  return Math.round(ms / beatMs) * beatMs
+}
+
+export function RangeSelector({
+  clipId,
+  durationMs,
+  start,
+  end,
+  onChange,
+  snapToBeat = false,
+  bpm = null,
+}: {
+  clipId: string
+  durationMs: number
+  start: string
+  end: string
+  onChange: (next: { start: string; end: string }) => void
+  snapToBeat?: boolean
+  bpm?: number | null
+}) {
+  const heights = useMemo(() => barHeights(clipId), [clipId])
+  const trackRef = useRef<HTMLDivElement>(null)
+  const dragging = useRef<"start" | "end" | null>(null)
+
+  const startMs = clampMs(parseTimeString(start) ?? 0, durationMs)
+  const endMs = clampMs(parseTimeString(end) ?? durationMs, durationMs)
+  const startPct = durationMs > 0 ? (startMs / durationMs) * 100 : 0
+  const endPct = durationMs > 0 ? (endMs / durationMs) * 100 : 100
+
+  const emit = useCallback(
+    (handle: "start" | "end", ms: number) => {
+      const snapped = clampMs(snap(ms, bpm, snapToBeat), durationMs)
+      if (handle === "start") {
+        onChange({ start: formatMs(Math.min(snapped, endMs)), end })
+      } else {
+        onChange({ start, end: formatMs(Math.max(snapped, startMs)) })
+      }
+    },
+    [bpm, snapToBeat, durationMs, onChange, start, end, startMs, endMs]
+  )
+
+  // Pointer capture keeps events flowing to the grabbed handle even when the
+  // cursor leaves it, so the drag stays live across the whole track without
+  // manual window listeners (which the refs lint rightly flags).
+  const onHandleMove = (e: ReactPointerEvent<HTMLButtonElement>) => {
+    const handle = dragging.current
+    const track = trackRef.current
+    if (!handle || !track) return
+    const rect = track.getBoundingClientRect()
+    if (rect.width <= 0) return
+    const ratio = (e.clientX - rect.left) / rect.width
+    emit(handle, Math.max(0, Math.min(1, ratio)) * durationMs)
+  }
+
+  const onHandleUp = (e: ReactPointerEvent<HTMLButtonElement>) => {
+    dragging.current = null
+    e.currentTarget.releasePointerCapture(e.pointerId)
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div
+        ref={trackRef}
+        className="relative flex h-16 w-full items-center gap-[2px] overflow-hidden rounded-md bg-muted/40 px-1"
+        aria-label="Selection range"
+      >
+        {heights.map((h, i) => {
+          const barPct = ((i + 0.5) / BARS) * 100
+          const selected = barPct >= startPct && barPct <= endPct
+          return (
+            <div
+              key={i}
+              className={selected ? "flex-1 bg-primary" : "flex-1 bg-muted-foreground/40"}
+              style={{ height: `${Math.max(6, h * 100)}%` }}
+            />
+          )
+        })}
+        <div
+          className="pointer-events-none absolute inset-y-0 border-x-2 border-primary/70 bg-primary/10"
+          style={{ left: `${startPct}%`, right: `${100 - endPct}%` }}
+        />
+        <button
+          type="button"
+          aria-label="Selection start"
+          onPointerDown={(e) => {
+            dragging.current = "start"
+            e.currentTarget.setPointerCapture(e.pointerId)
+          }}
+          onPointerMove={onHandleMove}
+          onPointerUp={onHandleUp}
+          className="absolute top-0 h-full w-3 -translate-x-1/2 cursor-ew-resize rounded bg-primary"
+          style={{ left: `${startPct}%` }}
+        />
+        <button
+          type="button"
+          aria-label="Selection end"
+          onPointerDown={(e) => {
+            dragging.current = "end"
+            e.currentTarget.setPointerCapture(e.pointerId)
+          }}
+          onPointerMove={onHandleMove}
+          onPointerUp={onHandleUp}
+          className="absolute top-0 h-full w-3 -translate-x-1/2 cursor-ew-resize rounded bg-primary"
+          style={{ left: `${endPct}%` }}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={`${clipId}-range-start`}>Start</Label>
+          <Input
+            id={`${clipId}-range-start`}
+            value={start}
+            onChange={(e) => onChange({ start: e.target.value, end })}
+            placeholder="0s"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={`${clipId}-range-end`}>End</Label>
+          <Input
+            id={`${clipId}-range-end`}
+            value={end}
+            onChange={(e) => onChange({ start, end: e.target.value })}
+            placeholder={formatMs(durationMs)}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/components/song/modals/RemixModal.test.tsx
+++ b/web/components/song/modals/RemixModal.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { RemixModal } from "@/components/song/modals/RemixModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitRemix = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitRemix: (...args: unknown[]) => submitRemix(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+describe("RemixModal", () => {
+  it("opens with a required style field and a credit hint", () => {
+    render(<RemixModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent("Remix")
+    expect(screen.getByLabelText(/New style/)).toBeInTheDocument()
+    expect(screen.getByText("Uses 1 credit")).toBeInTheDocument()
+  })
+
+  it("disables submit until a non-empty style is entered", async () => {
+    render(<RemixModal clip={makeClip()} open onClose={vi.fn()} />)
+    const remix = screen.getByRole("button", { name: "Remix" })
+    expect(remix).toBeDisabled()
+
+    await userEvent.type(screen.getByLabelText(/New style/), "   ")
+    expect(remix).toBeDisabled()
+
+    await userEvent.type(screen.getByLabelText(/New style/), "synthwave")
+    expect(remix).toBeEnabled()
+  })
+
+  it("submits the style payload and reaches success", async () => {
+    submitRemix.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["remix-1"] })
+
+    render(<RemixModal clip={makeClip()} open onClose={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText(/New style/), "80s synthwave")
+    await userEvent.click(screen.getByRole("button", { name: "Remix" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitRemix).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({ style: "80s synthwave" }),
+      "tok"
+    )
+  })
+})

--- a/web/components/song/modals/RemixModal.tsx
+++ b/web/components/song/modals/RemixModal.tsx
@@ -35,7 +35,7 @@ export function RemixModal({
   function handleSubmit() {
     if (!accessToken || error) return
     void edit.submit(
-      () => submitRemix(clip.id, { style }, accessToken),
+      () => submitRemix(clip.id, { style: style.trim() }, accessToken),
       accessToken
     )
   }

--- a/web/components/song/modals/RemixModal.tsx
+++ b/web/components/song/modals/RemixModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { useAuth } from "@/hooks/use-auth"
 import { useClipEdit } from "@/hooks/use-clip-edit"
@@ -30,7 +30,7 @@ export function RemixModal({
   const [style, setStyle] = useState("")
 
   const error = style.trim() === "" ? "A new style is required." : null
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/RemixModal.tsx
+++ b/web/components/song/modals/RemixModal.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { submitRemix } from "@/lib/editing"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { EditModalShell } from "./EditModalShell"
+import { StyleTextarea } from "./StyleTextarea"
+
+// Remix modal (US-17.3): re-generate a clip in a new style while keeping its
+// musical bones. Iterative and credit-consuming (POST /clips/{id}/remix). The
+// backend's RemixRequest requires a non-empty `style`, so submit is blocked
+// until one is entered.
+
+export function RemixModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+
+  const [style, setStyle] = useState("")
+
+  const error = style.trim() === "" ? "A new style is required." : null
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    void edit.submit(
+      () => submitRemix(clip.id, { style }, accessToken),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Remix"
+      description="Re-imagine this clip in a new style."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Remix"
+      creditHint="Uses 1 credit"
+      onRetry={edit.retry}
+    >
+      <StyleTextarea
+        label="New style"
+        value={style}
+        onChange={setStyle}
+        placeholder="e.g. 80s synthwave, dreamy pads"
+        required
+      />
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/RemixModal.tsx
+++ b/web/components/song/modals/RemixModal.tsx
@@ -58,7 +58,7 @@ export function RemixModal({
       canSubmit={canSubmit}
       submitLabel="Remix"
       creditHint="Uses 1 credit"
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <StyleTextarea
         label="New style"

--- a/web/components/song/modals/ReplaceSectionModal.test.tsx
+++ b/web/components/song/modals/ReplaceSectionModal.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ReplaceSectionModal } from "@/components/song/modals/ReplaceSectionModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitRepaint = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitRepaint: (...args: unknown[]) => submitRepaint(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+describe("ReplaceSectionModal", () => {
+  it("opens with range + instruction controls", () => {
+    render(<ReplaceSectionModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent("Replace section")
+    expect(screen.getByLabelText("Start")).toBeInTheDocument()
+    expect(screen.getByLabelText("End")).toBeInTheDocument()
+    expect(screen.getByLabelText(/Replacement instructions/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Style/)).toBeInTheDocument()
+  })
+
+  it("disables submit until replacement instructions are provided", async () => {
+    render(<ReplaceSectionModal clip={makeClip({ duration: 60 })} open onClose={vi.fn()} />)
+    expect(screen.getByRole("button", { name: "Replace" })).toBeDisabled()
+    await userEvent.type(screen.getByLabelText(/Replacement instructions/), "make it jazzy")
+    expect(screen.getByRole("button", { name: "Replace" })).toBeEnabled()
+  })
+
+  it("submits the repaint payload to the repaint endpoint and reaches success", async () => {
+    submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["repainted-1"] })
+
+    render(<ReplaceSectionModal clip={makeClip({ duration: 60 })} open onClose={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText(/Replacement instructions/), "make it jazzy")
+    await userEvent.click(screen.getByRole("button", { name: "Replace" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitRepaint).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({ start: "0s", end: "60s", prompt: "make it jazzy" }),
+      "tok"
+    )
+  })
+})

--- a/web/components/song/modals/ReplaceSectionModal.tsx
+++ b/web/components/song/modals/ReplaceSectionModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { useAuth } from "@/hooks/use-auth"
 import { useClipEdit } from "@/hooks/use-clip-edit"
@@ -37,7 +37,7 @@ export function ReplaceSectionModal({
 
   const rangeError = validateRange(start, end, durationMs || null)
   const error = rangeError || (prompt.trim() ? null : "Replacement instructions are required.")
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/ReplaceSectionModal.tsx
+++ b/web/components/song/modals/ReplaceSectionModal.tsx
@@ -66,7 +66,7 @@ export function ReplaceSectionModal({
       canSubmit={canSubmit}
       submitLabel="Replace"
       creditHint="Uses 1 credit"
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <RangeSelector
         clipId={clip.id}

--- a/web/components/song/modals/ReplaceSectionModal.tsx
+++ b/web/components/song/modals/ReplaceSectionModal.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { submitRepaint } from "@/lib/editing"
+import { validateRange } from "@/lib/editing-validation"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { EditModalShell } from "./EditModalShell"
+import { RangeSelector } from "./RangeSelector"
+import { StyleTextarea } from "./StyleTextarea"
+
+// Replace-section modal (US-17.3): regenerate a [start, end] region of a clip
+// from new instructions (POST /clips/{id}/repaint). Consumes a credit. Reuses
+// RangeSelector for the region and StyleTextarea for the required replacement
+// prompt plus an optional style hint.
+
+export function ReplaceSectionModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+  const durationMs = clip.duration != null ? Math.round(clip.duration * 1000) : 0
+
+  const [start, setStart] = useState("0s")
+  const [end, setEnd] = useState(clip.duration != null ? `${clip.duration}s` : "")
+  const [prompt, setPrompt] = useState("")
+  const [style, setStyle] = useState("")
+
+  const rangeError = validateRange(start, end, durationMs || null)
+  const error = rangeError || (prompt.trim() ? null : "Replacement instructions are required.")
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    void edit.submit(
+      () =>
+        submitRepaint(clip.id, { start, end, prompt, style }, accessToken),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Replace section"
+      description="Regenerate a section of this clip from new instructions."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Replace"
+      creditHint="Uses 1 credit"
+      onRetry={edit.retry}
+    >
+      <RangeSelector
+        clipId={clip.id}
+        durationMs={durationMs}
+        start={start}
+        end={end}
+        onChange={({ start: s, end: e }) => {
+          setStart(s)
+          setEnd(e)
+        }}
+        bpm={clip.bpm}
+      />
+      <StyleTextarea
+        label="Replacement instructions"
+        value={prompt}
+        onChange={setPrompt}
+        maxLength={2000}
+        required
+      />
+      <StyleTextarea
+        label="Style"
+        value={style}
+        onChange={setStyle}
+        maxLength={1000}
+      />
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/ReplaceSectionModal.tsx
+++ b/web/components/song/modals/ReplaceSectionModal.tsx
@@ -43,7 +43,7 @@ export function ReplaceSectionModal({
     if (!accessToken || error) return
     void edit.submit(
       () =>
-        submitRepaint(clip.id, { start, end, prompt, style }, accessToken),
+        submitRepaint(clip.id, { start, end, prompt: prompt.trim(), style }, accessToken),
       accessToken
     )
   }

--- a/web/components/song/modals/SampleModal.test.tsx
+++ b/web/components/song/modals/SampleModal.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SampleModal } from "@/components/song/modals/SampleModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitSample = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitSample: (...args: unknown[]) => submitSample(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+describe("SampleModal", () => {
+  it("renders the range, role radios, prompt, and clip-count controls", () => {
+    render(<SampleModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent("Sample from song")
+    expect(screen.getByLabelText("Start")).toBeInTheDocument()
+    expect(screen.getByLabelText("End")).toBeInTheDocument()
+    expect(screen.getByLabelText("Loop bed")).toBeInTheDocument()
+    expect(screen.getByLabelText("Intro / outro")).toBeInTheDocument()
+    expect(screen.getByLabelText("Rhythmic element")).toBeInTheDocument()
+    expect(screen.getByLabelText("Melodic hook")).toBeInTheDocument()
+    expect(screen.getByLabelText(/Prompt/)).toBeInTheDocument()
+    expect(screen.getByText("Number of clips")).toBeInTheDocument()
+  })
+
+  it("disables submit while the prompt is empty", () => {
+    render(<SampleModal clip={makeClip({ duration: 60 })} open onClose={vi.fn()} />)
+    expect(screen.getByRole("button", { name: "Create sample" })).toBeDisabled()
+  })
+
+  it("updates the credit hint when the clip count changes", async () => {
+    render(<SampleModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByText("Uses 1 credit")).toBeInTheDocument()
+    await userEvent.click(screen.getByLabelText("3"))
+    expect(screen.getByText("Uses 3 credits")).toBeInTheDocument()
+  })
+
+  it("submits the sample payload and reaches success", async () => {
+    submitSample.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["sample-1", "sample-2"] })
+
+    render(<SampleModal clip={makeClip({ duration: 60 })} open onClose={vi.fn()} />)
+    await userEvent.type(screen.getByLabelText(/Prompt/), "warm vinyl loop")
+    await userEvent.click(screen.getByLabelText("Melodic hook"))
+    await userEvent.click(screen.getByLabelText("2"))
+    await userEvent.click(screen.getByRole("button", { name: "Create sample" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("2 new clips are ready.")).toBeInTheDocument()
+    )
+    expect(submitSample).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({
+        start: "0s",
+        end: "60s",
+        role: "melodic-hook",
+        prompt: "warm vinyl loop",
+        num_clips: 2,
+      }),
+      "tok"
+    )
+  })
+})

--- a/web/components/song/modals/SampleModal.tsx
+++ b/web/components/song/modals/SampleModal.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { submitSample } from "@/lib/editing"
+import { validateRange } from "@/lib/editing-validation"
+import {
+  SAMPLE_NUM_CLIPS_MAX,
+  SAMPLE_NUM_CLIPS_MIN,
+  SAMPLE_ROLES,
+  type SampleRole,
+} from "@/lib/constants/editing"
+import { PROMPT_MAX_LENGTH } from "@/lib/constants/generation"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { EditModalShell } from "./EditModalShell"
+import { RangeSelector } from "./RangeSelector"
+import { StyleTextarea } from "./StyleTextarea"
+
+// Sample modal (US-17.3): extract a musical sample (loop bed, hook, etc.) from a
+// [start, end] region of a clip, generating 1–4 new clips in the chosen role.
+// Iterative (POST /clips/{id}/sample), so it consumes one credit per output clip
+// — the footer hint tracks `num_clips` so the cost is clear before submit.
+
+export function SampleModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+  const durationMs = clip.duration != null ? Math.round(clip.duration * 1000) : 0
+
+  const [start, setStart] = useState("0s")
+  const [end, setEnd] = useState(clip.duration != null ? `${clip.duration}s` : "")
+  const [role, setRole] = useState<SampleRole>("loop-bed")
+  const [prompt, setPrompt] = useState("")
+  const [numClips, setNumClips] = useState(SAMPLE_NUM_CLIPS_MIN)
+
+  const rangeError = validateRange(start, end, durationMs || null)
+  const promptError = prompt.trim() ? null : "Prompt is required."
+  const numClipsError =
+    Number.isInteger(numClips) &&
+    numClips >= SAMPLE_NUM_CLIPS_MIN &&
+    numClips <= SAMPLE_NUM_CLIPS_MAX
+      ? null
+      : `Number of clips must be between ${SAMPLE_NUM_CLIPS_MIN} and ${SAMPLE_NUM_CLIPS_MAX}.`
+  const error = rangeError || promptError || numClipsError
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    void edit.submit(
+      () =>
+        submitSample(
+          clip.id,
+          { start, end, role, prompt, num_clips: numClips },
+          accessToken
+        ),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Sample from song"
+      description="Extract a sample from a section of this clip."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Create sample"
+      creditHint={`Uses ${numClips} credit${numClips > 1 ? "s" : ""}`}
+      onRetry={edit.retry}
+    >
+      <RangeSelector
+        clipId={clip.id}
+        durationMs={durationMs}
+        start={start}
+        end={end}
+        onChange={({ start: s, end: e }) => {
+          setStart(s)
+          setEnd(e)
+        }}
+        bpm={clip.bpm}
+      />
+      <div className="flex flex-col gap-2">
+        <Label>Role</Label>
+        <RadioGroup
+          value={role}
+          onValueChange={(value) => setRole(value as SampleRole)}
+        >
+          {SAMPLE_ROLES.map((option) => (
+            <div key={option.value} className="flex items-center gap-2">
+              <RadioGroupItem value={option.value} id={`sample-role-${option.value}`} />
+              <Label htmlFor={`sample-role-${option.value}`} className="font-normal">
+                {option.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </div>
+      <StyleTextarea
+        label="Prompt"
+        value={prompt}
+        onChange={setPrompt}
+        maxLength={PROMPT_MAX_LENGTH}
+        required
+      />
+      <div className="flex flex-col gap-2">
+        <Label>Number of clips</Label>
+        <RadioGroup
+          value={String(numClips)}
+          onValueChange={(value) => setNumClips(Number(value))}
+          className="flex gap-4"
+        >
+          {Array.from(
+            { length: SAMPLE_NUM_CLIPS_MAX - SAMPLE_NUM_CLIPS_MIN + 1 },
+            (_, i) => SAMPLE_NUM_CLIPS_MIN + i
+          ).map((count) => (
+            <div key={count} className="flex items-center gap-2">
+              <RadioGroupItem value={String(count)} id={`sample-num-${count}`} />
+              <Label htmlFor={`sample-num-${count}`} className="font-normal">
+                {count}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </div>
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/SampleModal.tsx
+++ b/web/components/song/modals/SampleModal.tsx
@@ -87,7 +87,7 @@ export function SampleModal({
       canSubmit={canSubmit}
       submitLabel="Create sample"
       creditHint={`Uses ${numClips} credit${numClips > 1 ? "s" : ""}`}
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <RangeSelector
         clipId={clip.id}

--- a/web/components/song/modals/SampleModal.tsx
+++ b/web/components/song/modals/SampleModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
@@ -54,7 +54,7 @@ export function SampleModal({
       ? null
       : `Number of clips must be between ${SAMPLE_NUM_CLIPS_MIN} and ${SAMPLE_NUM_CLIPS_MAX}.`
   const error = rangeError || promptError || numClipsError
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/SampleModal.tsx
+++ b/web/components/song/modals/SampleModal.tsx
@@ -62,7 +62,7 @@ export function SampleModal({
       () =>
         submitSample(
           clip.id,
-          { start, end, role, prompt, num_clips: numClips },
+          { start, end, role, prompt: prompt.trim(), num_clips: numClips },
           accessToken
         ),
       accessToken

--- a/web/components/song/modals/SpeedModal.test.tsx
+++ b/web/components/song/modals/SpeedModal.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SpeedModal } from "@/components/song/modals/SpeedModal"
+import { makeClip } from "@/test/clip-factory"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitSpeed = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitSpeed: (...args: unknown[]) => submitSpeed(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+describe("SpeedModal", () => {
+  it("opens with a mode toggle, multiplier slider and preserve-pitch switch", () => {
+    render(<SpeedModal clip={makeClip()} open onClose={vi.fn()} />)
+    expect(screen.getByRole("dialog")).toHaveTextContent("Adjust speed")
+    expect(screen.getByRole("radio", { name: "By multiplier" })).toBeInTheDocument()
+    expect(screen.getByRole("slider")).toBeInTheDocument()
+    expect(screen.getByLabelText("Preserve pitch")).toBeChecked()
+  })
+
+  it("disables the target-BPM mode when the clip has no BPM", () => {
+    render(<SpeedModal clip={makeClip({ bpm: null })} open onClose={vi.fn()} />)
+    expect(screen.getByRole("radio", { name: /By target BPM/ })).toBeDisabled()
+  })
+
+  it("blocks submit when the target BPM is not a positive number", async () => {
+    render(<SpeedModal clip={makeClip({ bpm: 120 })} open onClose={vi.fn()} />)
+    await userEvent.click(screen.getByRole("radio", { name: /By target BPM/ }))
+    const bpm = screen.getByLabelText("Target BPM")
+    await userEvent.clear(bpm)
+    await userEvent.type(bpm, "0")
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled()
+  })
+
+  it("submits a multiplier payload and reaches success", async () => {
+    submitSpeed.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["sped-1"] })
+
+    render(<SpeedModal clip={makeClip()} open onClose={vi.fn()} />)
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitSpeed).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({ multiplier: 1, preserve_pitch: true }),
+      "tok"
+    )
+    expect(submitSpeed.mock.calls[0][1]).not.toHaveProperty("target_bpm")
+  })
+
+  it("submits a target-BPM payload with only the bpm field", async () => {
+    submitSpeed.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["sped-1"] })
+
+    render(<SpeedModal clip={makeClip({ bpm: 120 })} open onClose={vi.fn()} />)
+    await userEvent.click(screen.getByRole("radio", { name: /By target BPM/ }))
+    const bpm = screen.getByLabelText("Target BPM")
+    await userEvent.clear(bpm)
+    await userEvent.type(bpm, "90")
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    expect(submitSpeed).toHaveBeenCalledWith(
+      "clip-1",
+      expect.objectContaining({ target_bpm: 90, preserve_pitch: true }),
+      "tok"
+    )
+    expect(submitSpeed.mock.calls[0][1]).not.toHaveProperty("multiplier")
+  })
+})

--- a/web/components/song/modals/SpeedModal.test.tsx
+++ b/web/components/song/modals/SpeedModal.test.tsx
@@ -44,6 +44,17 @@ describe("SpeedModal", () => {
     expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled()
   })
 
+  it("blocks a target BPM that would fall outside the 0.5x-2.0x rate range", async () => {
+    // clip.bpm 120 → valid target range is 60–240; 300 would need a 2.5x rate.
+    render(<SpeedModal clip={makeClip({ bpm: 120 })} open onClose={vi.fn()} />)
+    await userEvent.click(screen.getByRole("radio", { name: /By target BPM/ }))
+    const bpm = screen.getByLabelText("Target BPM")
+    await userEvent.clear(bpm)
+    await userEvent.type(bpm, "300")
+    expect(screen.getByText(/between 60 and 240/)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled()
+  })
+
   it("submits a multiplier payload and reaches success", async () => {
     submitSpeed.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
     fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["sped-1"] })

--- a/web/components/song/modals/SpeedModal.tsx
+++ b/web/components/song/modals/SpeedModal.tsx
@@ -84,7 +84,7 @@ export function SpeedModal({
       onSubmit={handleSubmit}
       canSubmit={canSubmit}
       submitLabel="Apply"
-      onRetry={edit.retry}
+      onRetry={handleSubmit}
     >
       <RadioGroup value={mode} onValueChange={(v) => setMode(v as SpeedMode)}>
         <div className="flex items-center gap-2">

--- a/web/components/song/modals/SpeedModal.tsx
+++ b/web/components/song/modals/SpeedModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -55,7 +55,7 @@ export function SpeedModal({
       ? `Speed must be between ${SPEED_MULTIPLIER_MIN}× and ${SPEED_MULTIPLIER_MAX}×.`
       : null
   const error = multiplierError || bpmError
-  const canSubmit = useMemo(() => !error, [error])
+  const canSubmit = !error
 
   function handleSubmit() {
     if (!accessToken || error) return

--- a/web/components/song/modals/SpeedModal.tsx
+++ b/web/components/song/modals/SpeedModal.tsx
@@ -43,11 +43,18 @@ export function SpeedModal({
   const [preservePitch, setPreservePitch] = useState(true)
 
   const bpmValue = Number(targetBpm)
+  // The backend resolves multiplier = target_bpm / clip.bpm and rejects a result
+  // outside 0.5×–2.0×, so bound the target to the clip's valid rate range here to
+  // catch it inline instead of via a 422.
+  const bpmMin = clip.bpm != null ? clip.bpm * SPEED_MULTIPLIER_MIN : 0
+  const bpmMax = clip.bpm != null ? clip.bpm * SPEED_MULTIPLIER_MAX : 0
   const bpmError =
     mode === "bpm"
       ? targetBpm.trim() === "" || !Number.isFinite(bpmValue) || bpmValue <= 0
         ? "Enter a target BPM greater than 0."
-        : null
+        : clip.bpm != null && (bpmValue < bpmMin || bpmValue > bpmMax)
+          ? `Target BPM must be between ${Math.ceil(bpmMin)} and ${Math.floor(bpmMax)} for this clip.`
+          : null
       : null
   const multiplierError =
     mode === "multiplier" &&

--- a/web/components/song/modals/SpeedModal.tsx
+++ b/web/components/song/modals/SpeedModal.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Slider } from "@/components/ui/slider"
+import { Switch } from "@/components/ui/switch"
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { SPEED_MULTIPLIER_MAX, SPEED_MULTIPLIER_MIN } from "@/lib/constants/editing"
+import { submitSpeed } from "@/lib/editing"
+import type { SpeedPayload } from "@/lib/editing"
+import type { Clip } from "@/lib/workspace-clips"
+
+import { EditModalShell } from "./EditModalShell"
+
+// Speed modal (US-17.3): retime a clip either by a playback multiplier or to a
+// target BPM, optionally preserving pitch. Local, credit-free (POST
+// /clips/{id}/speed). The backend's SpeedRequest accepts exactly one of
+// `multiplier` / `target_bpm`, so the mode toggle decides which single field is
+// sent. Target-BPM retiming needs the source BPM, so it is only offered when the
+// clip carries BPM metadata.
+
+type SpeedMode = "multiplier" | "bpm"
+
+export function SpeedModal({
+  clip,
+  open,
+  onClose,
+}: {
+  clip: Clip
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+
+  const [mode, setMode] = useState<SpeedMode>("multiplier")
+  const [multiplier, setMultiplier] = useState(1)
+  const [targetBpm, setTargetBpm] = useState("")
+  const [preservePitch, setPreservePitch] = useState(true)
+
+  const bpmValue = Number(targetBpm)
+  const bpmError =
+    mode === "bpm"
+      ? targetBpm.trim() === "" || !Number.isFinite(bpmValue) || bpmValue <= 0
+        ? "Enter a target BPM greater than 0."
+        : null
+      : null
+  const multiplierError =
+    mode === "multiplier" &&
+    (multiplier < SPEED_MULTIPLIER_MIN || multiplier > SPEED_MULTIPLIER_MAX)
+      ? `Speed must be between ${SPEED_MULTIPLIER_MIN}× and ${SPEED_MULTIPLIER_MAX}×.`
+      : null
+  const error = multiplierError || bpmError
+  const canSubmit = useMemo(() => !error, [error])
+
+  function handleSubmit() {
+    if (!accessToken || error) return
+    // Send only the active mode's field so the backend's exactly-one rule holds.
+    const payload: SpeedPayload =
+      mode === "multiplier"
+        ? { multiplier, preserve_pitch: preservePitch }
+        : { target_bpm: bpmValue, preserve_pitch: preservePitch }
+    void edit.submit(() => submitSpeed(clip.id, payload, accessToken), accessToken)
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Adjust speed"
+      description="Retime this clip without re-generating it."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Apply"
+      onRetry={edit.retry}
+    >
+      <RadioGroup value={mode} onValueChange={(v) => setMode(v as SpeedMode)}>
+        <div className="flex items-center gap-2">
+          <RadioGroupItem id="speed-mode-multiplier" value="multiplier" />
+          <Label htmlFor="speed-mode-multiplier">By multiplier</Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <RadioGroupItem
+            id="speed-mode-bpm"
+            value="bpm"
+            disabled={clip.bpm == null}
+          />
+          <Label htmlFor="speed-mode-bpm">
+            By target BPM
+            {clip.bpm == null && (
+              <span className="text-xs font-normal text-muted-foreground">
+                {" "}
+                (needs BPM)
+              </span>
+            )}
+          </Label>
+        </div>
+      </RadioGroup>
+
+      {mode === "multiplier" ? (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="speed-multiplier">Speed</Label>
+            <span className="text-sm tabular-nums text-muted-foreground">
+              {multiplier.toFixed(2)}×
+            </span>
+          </div>
+          <Slider
+            id="speed-multiplier"
+            min={SPEED_MULTIPLIER_MIN}
+            max={SPEED_MULTIPLIER_MAX}
+            step={0.05}
+            value={[multiplier]}
+            onValueChange={([v]) => setMultiplier(v)}
+          />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="speed-target-bpm">Target BPM</Label>
+          <Input
+            id="speed-target-bpm"
+            type="number"
+            inputMode="numeric"
+            min={1}
+            value={targetBpm}
+            onChange={(e) => setTargetBpm(e.target.value)}
+            placeholder="120"
+            aria-invalid={bpmError != null}
+          />
+          {bpmError && (
+            <p className="text-xs text-destructive">{bpmError}</p>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <Label htmlFor="speed-preserve-pitch">Preserve pitch</Label>
+        <Switch
+          id="speed-preserve-pitch"
+          checked={preservePitch}
+          onCheckedChange={setPreservePitch}
+        />
+      </div>
+    </EditModalShell>
+  )
+}

--- a/web/components/song/modals/StyleTextarea.tsx
+++ b/web/components/song/modals/StyleTextarea.tsx
@@ -54,6 +54,9 @@ export function StyleTextarea({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         rows={rows}
+        // Hard-cap input at the backend's field limit so an over-long paste is
+        // truncated in the browser instead of surfacing as an avoidable 422.
+        maxLength={maxLength}
         aria-invalid={overLimit}
       />
     </div>

--- a/web/components/song/modals/StyleTextarea.tsx
+++ b/web/components/song/modals/StyleTextarea.tsx
@@ -57,6 +57,8 @@ export function StyleTextarea({
         // Hard-cap input at the backend's field limit so an over-long paste is
         // truncated in the browser instead of surfacing as an avoidable 422.
         maxLength={maxLength}
+        required={required}
+        aria-required={required}
         aria-invalid={overLimit}
       />
     </div>

--- a/web/components/song/modals/StyleTextarea.tsx
+++ b/web/components/song/modals/StyleTextarea.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useId } from "react"
+
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { STYLE_MAX_LENGTH } from "@/lib/constants/generation"
+
+// Shared multi-line style/prompt input for the editing modals (US-17.3). A
+// labelled textarea with a live character counter capped at the backend's field
+// limit (default STYLE_MAX_LENGTH); `maxLength` overrides it for the longer
+// prompt/lyrics fields. Optional so it reads as an ordinary form field.
+
+export function StyleTextarea({
+  label,
+  value,
+  onChange,
+  placeholder,
+  maxLength = STYLE_MAX_LENGTH,
+  required = false,
+  rows = 3,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  maxLength?: number
+  required?: boolean
+  rows?: number
+}) {
+  const id = useId()
+  const overLimit = value.length > maxLength
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <Label htmlFor={id}>
+          {label}
+          {required && <span className="text-destructive"> *</span>}
+        </Label>
+        <span
+          className={
+            overLimit
+              ? "text-xs text-destructive"
+              : "text-xs text-muted-foreground"
+          }
+        >
+          {value.length}/{maxLength}
+        </span>
+      </div>
+      <Textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        rows={rows}
+        aria-invalid={overLimit}
+      />
+    </div>
+  )
+}

--- a/web/components/song/modals/TimeDurationInput.tsx
+++ b/web/components/song/modals/TimeDurationInput.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useId } from "react"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { formatMs, parseTimeString } from "@/lib/editing-validation"
+
+// Labelled time-string input for the editing modals (US-17.3). Accepts the
+// backend's human formats ("30s", "1m30s", "1.5s", "5") and shows a live parsed
+// preview so the user sees what a value resolves to. An externally-supplied
+// `error` (from the modal's validator) renders inline; otherwise a non-empty,
+// unparseable value shows a gentle format hint.
+
+export function TimeDurationInput({
+  label,
+  value,
+  onChange,
+  placeholder = "30s",
+  error,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  error?: string | null
+}) {
+  const id = useId()
+  const parsedMs = value.trim() ? parseTimeString(value) : null
+  const unparseable = value.trim() !== "" && parsedMs === null
+  const showError = error || (unparseable ? 'Use a time like "30s" or "1m30s".' : null)
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <Label htmlFor={id}>{label}</Label>
+        {parsedMs !== null && (
+          <span className="text-xs text-muted-foreground">= {formatMs(parsedMs)}</span>
+        )}
+      </div>
+      <Input
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        inputMode="text"
+        aria-invalid={Boolean(showError)}
+      />
+      {showError && <p className="text-xs text-destructive">{showError}</p>}
+    </div>
+  )
+}

--- a/web/components/song/modals/sub-components.test.tsx
+++ b/web/components/song/modals/sub-components.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { EditModalShell } from "@/components/song/modals/EditModalShell"
+import { RangeSelector } from "@/components/song/modals/RangeSelector"
+import { StyleTextarea } from "@/components/song/modals/StyleTextarea"
+import { TimeDurationInput } from "@/components/song/modals/TimeDurationInput"
+
+describe("StyleTextarea", () => {
+  it("shows a live character counter and forwards edits", async () => {
+    const onChange = vi.fn()
+    render(
+      <StyleTextarea label="Style" value="lofi" onChange={onChange} maxLength={100} />
+    )
+    expect(screen.getByText("4/100")).toBeInTheDocument()
+    await userEvent.type(screen.getByLabelText("Style"), "!")
+    expect(onChange).toHaveBeenCalledWith("lofi!")
+  })
+
+  it("flags going over the limit", () => {
+    render(<StyleTextarea label="Style" value="abcdef" onChange={vi.fn()} maxLength={3} />)
+    expect(screen.getByText("6/3")).toHaveClass("text-destructive")
+    expect(screen.getByLabelText("Style")).toHaveAttribute("aria-invalid", "true")
+  })
+})
+
+describe("TimeDurationInput", () => {
+  it("previews a parsed value and forwards edits", async () => {
+    const onChange = vi.fn()
+    render(<TimeDurationInput label="Duration" value="1m30s" onChange={onChange} />)
+    expect(screen.getByText("= 1m30s")).toBeInTheDocument()
+    await userEvent.type(screen.getByLabelText("Duration"), "x")
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  it("hints when the value is unparseable", () => {
+    render(<TimeDurationInput label="Duration" value="soon" onChange={vi.fn()} />)
+    expect(screen.getByText(/Use a time like/)).toBeInTheDocument()
+    expect(screen.getByLabelText("Duration")).toHaveAttribute("aria-invalid", "true")
+  })
+
+  it("shows an externally supplied error", () => {
+    render(
+      <TimeDurationInput label="Duration" value="30s" onChange={vi.fn()} error="Too long" />
+    )
+    expect(screen.getByText("Too long")).toBeInTheDocument()
+  })
+})
+
+describe("RangeSelector", () => {
+  it("renders start/end inputs and forwards edits to each bound", async () => {
+    const onChange = vi.fn()
+    render(
+      <RangeSelector
+        clipId="clip-1"
+        durationMs={60000}
+        start="10s"
+        end="30s"
+        onChange={onChange}
+      />
+    )
+    const start = screen.getByLabelText("Start")
+    const end = screen.getByLabelText("End")
+    expect(start).toHaveValue("10s")
+    expect(end).toHaveValue("30s")
+
+    // Controlled input: one keystroke appends to the current prop value and
+    // reports the whole [start, end] pair (the parent owns state).
+    await userEvent.type(start, "5")
+    expect(onChange).toHaveBeenLastCalledWith({ start: "10s5", end: "30s" })
+
+    onChange.mockClear()
+    await userEvent.type(end, "!")
+    expect(onChange).toHaveBeenLastCalledWith({ start: "10s", end: "30s!" })
+  })
+
+  it("exposes draggable handles", () => {
+    render(
+      <RangeSelector clipId="c" durationMs={60000} start="0s" end="60s" onChange={vi.fn()} />
+    )
+    expect(screen.getByLabelText("Selection start")).toBeInTheDocument()
+    expect(screen.getByLabelText("Selection end")).toBeInTheDocument()
+  })
+})
+
+describe("EditModalShell", () => {
+  function shell(state: Parameters<typeof EditModalShell>[0]["state"], extra = {}) {
+    return render(
+      <EditModalShell
+        open
+        onOpenChange={vi.fn()}
+        title="Crop"
+        description="Trim the clip"
+        state={state}
+        onSubmit={vi.fn()}
+        canSubmit
+        onRetry={vi.fn()}
+        {...extra}
+      >
+        <div>form fields</div>
+      </EditModalShell>
+    )
+  }
+
+  it("renders the form and a credit hint while idle", () => {
+    shell({ phase: "idle" }, { creditHint: "Uses 1 credit" })
+    expect(screen.getByText("form fields")).toBeInTheDocument()
+    expect(screen.getByText("Uses 1 credit")).toBeInTheDocument()
+  })
+
+  it("disables submit when canSubmit is false", () => {
+    render(
+      <EditModalShell
+        open
+        onOpenChange={vi.fn()}
+        title="Crop"
+        state={{ phase: "idle" }}
+        onSubmit={vi.fn()}
+        canSubmit={false}
+        onRetry={vi.fn()}
+      >
+        <div>fields</div>
+      </EditModalShell>
+    )
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled()
+  })
+
+  it("calls onSubmit when the submit button is pressed", async () => {
+    const onSubmit = vi.fn()
+    shell({ phase: "idle" }, { onSubmit })
+    await userEvent.click(screen.getByRole("button", { name: "Create" }))
+    expect(onSubmit).toHaveBeenCalledOnce()
+  })
+
+  it("shows a spinner while working and hides the form", () => {
+    shell({ phase: "polling", estimatedSeconds: 45 })
+    expect(screen.getByRole("status")).toHaveTextContent("~45s")
+    expect(screen.queryByText("form fields")).not.toBeInTheDocument()
+  })
+
+  it("shows an error with a retry action", async () => {
+    const onRetry = vi.fn()
+    shell({ phase: "error", message: "start before end" }, { onRetry })
+    expect(screen.getByRole("alert")).toHaveTextContent("start before end")
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it("offers a View action on success", () => {
+    shell({ phase: "success", clipIds: ["new-1"] })
+    expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "View" })).toBeEnabled()
+  })
+})

--- a/web/components/song/modals/sub-components.test.tsx
+++ b/web/components/song/modals/sub-components.test.tsx
@@ -23,6 +23,11 @@ describe("StyleTextarea", () => {
     expect(screen.getByText("6/3")).toHaveClass("text-destructive")
     expect(screen.getByLabelText("Style")).toHaveAttribute("aria-invalid", "true")
   })
+
+  it("hard-caps input via the native maxLength attribute", () => {
+    render(<StyleTextarea label="Lyrics" value="" onChange={vi.fn()} maxLength={5000} />)
+    expect(screen.getByLabelText("Lyrics")).toHaveAttribute("maxlength", "5000")
+  })
 })
 
 describe("TimeDurationInput", () => {

--- a/web/components/ui/radio-group.tsx
+++ b/web/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <span className="size-2 rounded-full bg-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/web/components/ui/slider.tsx
+++ b/web/components/ui/slider.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import * as React from "react"
+import { Slider as SliderPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted"
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className="absolute h-full bg-primary"
+        />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        data-slot="slider-thumb"
+        className="block size-4 shrink-0 rounded-full border border-primary bg-background shadow-sm transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none"
+      />
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/web/hooks/use-clip-edit.test.tsx
+++ b/web/hooks/use-clip-edit.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import type { EditSubmitResult } from "@/lib/editing"
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+const make = (result: EditSubmitResult) => vi.fn().mockResolvedValue(result)
+
+describe("useClipEdit", () => {
+  it("submits, polls, and surfaces the resulting clip ids on success", async () => {
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["new-1"] })
+    const { result } = renderHook(() => useClipEdit())
+
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "accepted", jobId: "j1", estimatedSeconds: 45 }),
+        "tok"
+      )
+    })
+
+    await waitFor(() => expect(result.current.state.phase).toBe("success"))
+    expect(result.current.state).toEqual({ phase: "success", clipIds: ["new-1"] })
+    expect(fetchJobStatus).toHaveBeenCalledWith("j1", "tok")
+  })
+
+  it("holds a polling state with the time estimate", async () => {
+    fetchJobStatus.mockResolvedValue({ kind: "pending" })
+    const { result } = renderHook(() => useClipEdit())
+
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "accepted", jobId: "j1", estimatedSeconds: 30 }),
+        "tok"
+      )
+    })
+
+    expect(result.current.state).toMatchObject({ phase: "polling", estimatedSeconds: 30 })
+    act(() => result.current.reset())
+    expect(result.current.state.phase).toBe("idle")
+  })
+
+  it("maps insufficient credits to an actionable error", async () => {
+    const { result } = renderHook(() => useClipEdit())
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "insufficientCredits", balance: 1, required: 4 }),
+        "tok"
+      )
+    })
+    expect(result.current.state).toEqual({
+      phase: "error",
+      message: "Not enough credits — this needs 4, you have 1.",
+    })
+  })
+
+  it("surfaces a validation error without polling", async () => {
+    const { result } = renderHook(() => useClipEdit())
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "invalid", detail: "start must be before end" }),
+        "tok"
+      )
+    })
+    expect(result.current.state).toEqual({
+      phase: "error",
+      message: "start must be before end",
+    })
+    expect(fetchJobStatus).not.toHaveBeenCalled()
+  })
+
+  it("surfaces a failed job", async () => {
+    fetchJobStatus.mockResolvedValue({ kind: "failed", error: "edit failed" })
+    const { result } = renderHook(() => useClipEdit())
+    await act(async () => {
+      await result.current.submit(
+        make({ status: "accepted", jobId: "j1", estimatedSeconds: 0 }),
+        "tok"
+      )
+    })
+    await waitFor(() => expect(result.current.state.phase).toBe("error"))
+    expect(result.current.state).toMatchObject({ message: "edit failed" })
+  })
+
+  it("redirects to login when the submit is unauthorized", async () => {
+    const { result } = renderHook(() => useClipEdit())
+    await act(async () => {
+      await result.current.submit(make({ status: "unauthorized" }), "tok")
+    })
+    expect(push).toHaveBeenCalledWith("/login")
+  })
+
+  it("retries the last submission", async () => {
+    fetchJobStatus.mockResolvedValue({ kind: "pending" })
+    const submitFn = make({ status: "accepted", jobId: "j1", estimatedSeconds: 5 })
+    const { result } = renderHook(() => useClipEdit())
+
+    await act(async () => {
+      await result.current.submit(submitFn, "tok")
+    })
+    act(() => result.current.retry())
+    await waitFor(() => expect(submitFn).toHaveBeenCalledTimes(2))
+    act(() => result.current.reset())
+  })
+})

--- a/web/hooks/use-clip-edit.test.tsx
+++ b/web/hooks/use-clip-edit.test.tsx
@@ -67,6 +67,26 @@ describe("useClipEdit", () => {
     expect(fetchJobStatus).not.toHaveBeenCalled()
   })
 
+  it("drops an accepted result and never starts polling after unmount", async () => {
+    // A submit whose request is still pending when the modal unmounts must not
+    // begin polling — the epoch bump on unmount invalidates the continuation.
+    let resolveSubmit: (r: EditSubmitResult) => void = () => {}
+    const pending = new Promise<EditSubmitResult>((r) => (resolveSubmit = r))
+    const { result, unmount } = renderHook(() => useClipEdit())
+
+    let submitting: Promise<void> = Promise.resolve()
+    await act(async () => {
+      submitting = result.current.submit(() => pending, "tok")
+    })
+    unmount()
+    await act(async () => {
+      resolveSubmit({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+      await submitting
+    })
+
+    expect(fetchJobStatus).not.toHaveBeenCalled()
+  })
+
   it("maps insufficient credits to an actionable error", async () => {
     const { result } = renderHook(() => useClipEdit())
     await act(async () => {

--- a/web/hooks/use-clip-edit.test.tsx
+++ b/web/hooks/use-clip-edit.test.tsx
@@ -98,17 +98,4 @@ describe("useClipEdit", () => {
     })
     expect(push).toHaveBeenCalledWith("/login")
   })
-
-  it("retries the last submission", async () => {
-    fetchJobStatus.mockResolvedValue({ kind: "pending" })
-    const submitFn = make({ status: "accepted", jobId: "j1", estimatedSeconds: 5 })
-    const { result } = renderHook(() => useClipEdit())
-
-    await act(async () => {
-      await result.current.submit(submitFn, "tok")
-    })
-    act(() => result.current.retry())
-    await waitFor(() => expect(submitFn).toHaveBeenCalledTimes(2))
-    act(() => result.current.reset())
-  })
 })

--- a/web/hooks/use-clip-edit.test.tsx
+++ b/web/hooks/use-clip-edit.test.tsx
@@ -49,6 +49,24 @@ describe("useClipEdit", () => {
     expect(result.current.state.phase).toBe("idle")
   })
 
+  it("drops an accepted result if reset() fired while the request was pending", async () => {
+    // A submit whose makeRequest resolves only after reset() runs must not
+    // resurrect polling for the dismissed operation.
+    let resolveSubmit: (r: EditSubmitResult) => void = () => {}
+    const pending = new Promise<EditSubmitResult>((r) => (resolveSubmit = r))
+    const { result } = renderHook(() => useClipEdit())
+
+    await act(async () => {
+      const submitting = result.current.submit(() => pending, "tok")
+      result.current.reset()
+      resolveSubmit({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+      await submitting
+    })
+
+    expect(result.current.state.phase).toBe("idle")
+    expect(fetchJobStatus).not.toHaveBeenCalled()
+  })
+
   it("maps insufficient credits to an actionable error", async () => {
     const { result } = renderHook(() => useClipEdit())
     await act(async () => {

--- a/web/hooks/use-clip-edit.ts
+++ b/web/hooks/use-clip-edit.ts
@@ -58,8 +58,16 @@ export function useClipEdit(): UseClipEdit {
     }
   }
 
-  // Clean up a pending poll if the modal unmounts mid-edit.
-  useEffect(() => clearTimer, [])
+  // Clean up if the modal unmounts mid-edit: clear the pending timer AND drop the
+  // active job, so a fetchJobStatus already in flight can't pass the staleness
+  // guard and reschedule another poll after the component is gone.
+  useEffect(
+    () => () => {
+      clearTimer()
+      jobRef.current = null
+    },
+    []
+  )
 
   const poll = useCallback(async () => {
     const job = jobRef.current

--- a/web/hooks/use-clip-edit.ts
+++ b/web/hooks/use-clip-edit.ts
@@ -1,0 +1,163 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { fetchJobStatus } from "@/lib/job-status"
+import type { EditSubmitResult } from "@/lib/editing"
+
+const POLL_INTERVAL_MS = 2000
+// Cap polling so a stuck/vanished job surfaces an error instead of spinning
+// forever. 150 × 2s ≈ 5 min — past the slowest edit's estimate. Mirrors
+// use-generation's cap.
+const MAX_POLLS = 150
+
+/** A single editing modal's lifecycle: idle → submitting → polling → success|error. */
+export type ClipEditState =
+  | { phase: "idle" }
+  | { phase: "submitting" }
+  | { phase: "polling"; estimatedSeconds: number; progress?: string }
+  | { phase: "success"; clipIds: string[] }
+  | { phase: "error"; message: string }
+
+/** A per-modal closure that builds + submits the request, returning the result. */
+export type ClipEditSubmitFn = () => Promise<EditSubmitResult>
+
+export type UseClipEdit = {
+  state: ClipEditState
+  /** Submit an editing request and drive it to completion; `token` is reused for polling. */
+  submit: (makeRequest: ClipEditSubmitFn, accessToken: string) => Promise<void>
+  /** Re-run the last submit (for the error state's Retry). No-op if nothing was submitted. */
+  retry: () => void
+  /** Clear back to idle (reset after success / dismiss an error). */
+  reset: () => void
+}
+
+/**
+ * Owns one editing operation's lifecycle for a workflow modal (US-17.3). After a
+ * 202 it polls the job through the BFF proxy until completed/failed, exposing
+ * progress so the modal can show a spinner, and surfacing the resulting
+ * `clipIds` on success so the modal can offer a "View" link. Distinct from
+ * `useGeneration` (which is coupled to the creation page's navigation): this is
+ * self-contained so any modal can drop it in.
+ */
+export function useClipEdit(): UseClipEdit {
+  const router = useRouter()
+  const [state, setState] = useState<ClipEditState>({ phase: "idle" })
+
+  // The active job, in a ref so the poll loop reads the latest without
+  // re-subscribing; cleared the moment the job is superseded or terminal.
+  const jobRef = useRef<{ id: string; token: string; polls: number } | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastArgsRef = useRef<{
+    makeRequest: ClipEditSubmitFn
+    accessToken: string
+  } | null>(null)
+  // Holds the latest `poll` so a scheduled timeout can call it without `poll`
+  // referencing itself (hook-immutability lint forbids the self-reference).
+  const pollRef = useRef<() => void>(() => {})
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  // Clean up a pending poll if the modal unmounts mid-edit.
+  useEffect(() => clearTimer, [])
+
+  const poll = useCallback(async () => {
+    const job = jobRef.current
+    if (!job) return
+    const result = await fetchJobStatus(job.id, job.token)
+    // A reset/retry between the request and its response supersedes this job.
+    if (jobRef.current?.id !== job.id) return
+
+    switch (result.kind) {
+      case "completed":
+        jobRef.current = null
+        clearTimer()
+        setState({ phase: "success", clipIds: result.clipIds })
+        return
+      case "failed":
+        jobRef.current = null
+        clearTimer()
+        setState({ phase: "error", message: result.error })
+        return
+      case "unauthorized":
+        jobRef.current = null
+        clearTimer()
+        router.push("/login")
+        return
+      case "pending":
+      case "transient":
+        job.polls += 1
+        if (job.polls >= MAX_POLLS) {
+          jobRef.current = null
+          clearTimer()
+          setState({
+            phase: "error",
+            message: "This is taking longer than expected. Please try again.",
+          })
+          return
+        }
+        if (result.kind === "pending" && result.progress) {
+          const { progress } = result
+          setState((s) => (s.phase === "polling" ? { ...s, progress } : s))
+        }
+        timerRef.current = setTimeout(() => void pollRef.current(), POLL_INTERVAL_MS)
+        return
+    }
+  }, [router])
+
+  useEffect(() => {
+    pollRef.current = poll
+  })
+
+  const submit = useCallback(
+    async (makeRequest: ClipEditSubmitFn, accessToken: string) => {
+      lastArgsRef.current = { makeRequest, accessToken }
+      clearTimer()
+      jobRef.current = null
+      setState({ phase: "submitting" })
+
+      const result = await makeRequest()
+      switch (result.status) {
+        case "accepted":
+          jobRef.current = { id: result.jobId, token: accessToken, polls: 0 }
+          setState({ phase: "polling", estimatedSeconds: result.estimatedSeconds })
+          // Poll immediately so a fast job doesn't idle through the first interval.
+          void poll()
+          return
+        case "unauthorized":
+          router.push("/login")
+          return
+        case "insufficientCredits":
+          setState({
+            phase: "error",
+            message: `Not enough credits — this needs ${result.required}, you have ${result.balance}.`,
+          })
+          return
+        case "invalid":
+        case "error":
+          setState({ phase: "error", message: result.detail })
+          return
+      }
+    },
+    [poll, router]
+  )
+
+  const retry = useCallback(() => {
+    const args = lastArgsRef.current
+    if (args) void submit(args.makeRequest, args.accessToken)
+  }, [submit])
+
+  const reset = useCallback(() => {
+    clearTimer()
+    jobRef.current = null
+    setState({ phase: "idle" })
+  }, [])
+
+  return { state, submit, retry, reset }
+}

--- a/web/hooks/use-clip-edit.ts
+++ b/web/hooks/use-clip-edit.ts
@@ -47,6 +47,12 @@ export function useClipEdit(): UseClipEdit {
   // re-subscribing; cleared the moment the job is superseded or terminal.
   const jobRef = useRef<{ id: string; token: string; polls: number } | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Monotonic epoch bumped on every submit, reset, and unmount. A submit
+  // captures its epoch and, after the async `makeRequest()` resolves, drops the
+  // result if the epoch moved — so a request in flight when the modal closes
+  // (reset/unmount) or is superseded by a newer submit can't resurrect polling
+  // or clobber a newer job.
+  const epochRef = useRef(0)
   // Holds the latest `poll` so a scheduled timeout can call it without `poll`
   // referencing itself (hook-immutability lint forbids the self-reference).
   const pollRef = useRef<() => void>(() => {})
@@ -63,6 +69,7 @@ export function useClipEdit(): UseClipEdit {
   // guard and reschedule another poll after the component is gone.
   useEffect(
     () => () => {
+      epochRef.current += 1
       clearTimer()
       jobRef.current = null
     },
@@ -119,11 +126,14 @@ export function useClipEdit(): UseClipEdit {
 
   const submit = useCallback(
     async (makeRequest: ClipEditSubmitFn, accessToken: string) => {
+      const epoch = (epochRef.current += 1)
       clearTimer()
       jobRef.current = null
       setState({ phase: "submitting" })
 
       const result = await makeRequest()
+      // Dropped if a reset/unmount/newer submit happened during the request.
+      if (epochRef.current !== epoch) return
       switch (result.status) {
         case "accepted":
           jobRef.current = { id: result.jobId, token: accessToken, polls: 0 }
@@ -150,6 +160,7 @@ export function useClipEdit(): UseClipEdit {
   )
 
   const reset = useCallback(() => {
+    epochRef.current += 1
     clearTimer()
     jobRef.current = null
     setState({ phase: "idle" })

--- a/web/hooks/use-clip-edit.ts
+++ b/web/hooks/use-clip-edit.ts
@@ -27,8 +27,6 @@ export type UseClipEdit = {
   state: ClipEditState
   /** Submit an editing request and drive it to completion; `token` is reused for polling. */
   submit: (makeRequest: ClipEditSubmitFn, accessToken: string) => Promise<void>
-  /** Re-run the last submit (for the error state's Retry). No-op if nothing was submitted. */
-  retry: () => void
   /** Clear back to idle (reset after success / dismiss an error). */
   reset: () => void
 }
@@ -49,10 +47,6 @@ export function useClipEdit(): UseClipEdit {
   // re-subscribing; cleared the moment the job is superseded or terminal.
   const jobRef = useRef<{ id: string; token: string; polls: number } | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const lastArgsRef = useRef<{
-    makeRequest: ClipEditSubmitFn
-    accessToken: string
-  } | null>(null)
   // Holds the latest `poll` so a scheduled timeout can call it without `poll`
   // referencing itself (hook-immutability lint forbids the self-reference).
   const pollRef = useRef<() => void>(() => {})
@@ -117,7 +111,6 @@ export function useClipEdit(): UseClipEdit {
 
   const submit = useCallback(
     async (makeRequest: ClipEditSubmitFn, accessToken: string) => {
-      lastArgsRef.current = { makeRequest, accessToken }
       clearTimer()
       jobRef.current = null
       setState({ phase: "submitting" })
@@ -148,16 +141,11 @@ export function useClipEdit(): UseClipEdit {
     [poll, router]
   )
 
-  const retry = useCallback(() => {
-    const args = lastArgsRef.current
-    if (args) void submit(args.makeRequest, args.accessToken)
-  }, [submit])
-
   const reset = useCallback(() => {
     clearTimer()
     jobRef.current = null
     setState({ phase: "idle" })
   }, [])
 
-  return { state, submit, retry, reset }
+  return { state, submit, reset }
 }

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -110,6 +110,28 @@ describe("useSongActions", () => {
     expect(submitRemaster).toHaveBeenCalledWith("c1", {}, "tok")
   })
 
+  it("ignores a repeat remaster while one is already running", async () => {
+    submitRemaster.mockResolvedValue({
+      status: "accepted",
+      jobId: "j1",
+      estimatedSeconds: 0,
+    })
+    // Job never completes, so the first remaster stays in the polling phase.
+    fetchJobStatus.mockResolvedValue({ kind: "pending" })
+    const { result } = setup()
+
+    await act(async () => {
+      result.current.handleAction("remaster")
+    })
+    await waitFor(() => expect(result.current.remasterState.phase).toBe("polling"))
+
+    // A second click while polling must not enqueue another job.
+    act(() => result.current.handleAction("remaster"))
+    expect(submitRemaster).toHaveBeenCalledTimes(1)
+
+    act(() => result.current.dismissRemaster())
+  })
+
   it("toggles publish state optimistically", () => {
     const { result } = setup()
     expect(result.current.isPublic).toBe(false)

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -9,6 +9,16 @@ import type { Clip } from "@/lib/workspace-clips"
 const push = vi.fn()
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
 
+const submitRemaster = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitRemaster: (...args: unknown[]) => submitRemaster(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
 const authValue = {
   user: { id: "u1", email: "a@b.co" },
   accessToken: "tok",
@@ -74,11 +84,30 @@ describe("useSongActions", () => {
 
   it("opens and closes the workflow modal for modal actions", () => {
     const { result } = setup()
-    act(() => result.current.handleAction("remaster"))
-    expect(result.current.activeModal).toBe("remaster")
+    act(() => result.current.handleAction("cover"))
+    expect(result.current.activeModal).toBe("cover")
 
     act(() => result.current.closeModal())
     expect(result.current.activeModal).toBeNull()
+  })
+
+  it("runs remaster inline (no modal) and drives its status to success", async () => {
+    submitRemaster.mockResolvedValue({
+      status: "accepted",
+      jobId: "j1",
+      estimatedSeconds: 0,
+    })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["remastered-1"] })
+    const { result } = setup()
+
+    await act(async () => {
+      result.current.handleAction("remaster")
+    })
+
+    // No modal opens for the one-click action.
+    expect(result.current.activeModal).toBeNull()
+    await waitFor(() => expect(result.current.remasterState.phase).toBe("success"))
+    expect(submitRemaster).toHaveBeenCalledWith("c1", {}, "tok")
   })
 
   it("toggles publish state optimistically", () => {

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -60,6 +60,14 @@ export function useSongActions(clip: Clip) {
       // One-click remaster (US-17.3): submit immediately with the default -14
       // LUFS streaming target and drive progress inline — no modal.
       if (!accessToken) return
+      // Ignore repeat clicks while a remaster is already running, so we don't
+      // enqueue a duplicate job and orphan the first (its poll would be dropped).
+      if (
+        remaster.state.phase === "submitting" ||
+        remaster.state.phase === "polling"
+      ) {
+        return
+      }
       void remaster.submit(
         () => submitRemaster(clip.id, {}, accessToken),
         accessToken

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -4,7 +4,9 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 
 import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
 import { downloadClipAudio, type DownloadFormat } from "@/lib/clips"
+import { submitRemaster } from "@/lib/editing"
 import { findSongAction, type SongActionId } from "@/lib/song-actions"
 import type { Clip } from "@/lib/workspace-clips"
 
@@ -22,6 +24,7 @@ const DOWNLOAD_FORMAT: Partial<Record<SongActionId, DownloadFormat>> = {
 export function useSongActions(clip: Clip) {
   const router = useRouter()
   const { accessToken } = useAuth()
+  const remaster = useClipEdit()
   const [activeModal, setActiveModal] = useState<SongActionId | null>(null)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -53,7 +56,15 @@ export function useSongActions(clip: Clip) {
       return
     }
     // Inline actions.
-    if (action === "publish-toggle") {
+    if (action === "remaster") {
+      // One-click remaster (US-17.3): submit immediately with the default -14
+      // LUFS streaming target and drive progress inline — no modal.
+      if (!accessToken) return
+      void remaster.submit(
+        () => submitRemaster(clip.id, {}, accessToken),
+        accessToken
+      )
+    } else if (action === "publish-toggle") {
       // Optimistic, like SongHeader/ClipCard — the publish route lands in
       // US-17.6; until then the toggle is local feedback only.
       setOptimisticPublic(!isPublic)
@@ -83,6 +94,9 @@ export function useSongActions(clip: Clip) {
 
   return {
     isPublic,
+    /** One-click remaster lifecycle (US-17.3); drives the inline progress line. */
+    remasterState: remaster.state,
+    dismissRemaster: remaster.reset,
     activeModal,
     closeModal: () => setActiveModal(null),
     confirmingDelete,

--- a/web/lib/constants/editing.ts
+++ b/web/lib/constants/editing.ts
@@ -1,0 +1,39 @@
+/**
+ * Bounds and option lists for the editing/iterative workflow modals (US-17.3).
+ *
+ * These mirror the backend request models in
+ * `src/acemusic/api/routers/editing.py` and `.../iterative.py` (both use
+ * `extra="forbid"` and validate every range), so the modals validate against the
+ * same numbers and surface errors inline instead of as a round-trip 422.
+ */
+
+/** `SpeedRequest.multiplier` range (editing.py SPEED_MULTIPLIER_MIN/MAX). */
+export const SPEED_MULTIPLIER_MIN = 0.5
+export const SPEED_MULTIPLIER_MAX = 2.0
+
+/** `SampleRequest.num_clips` range (iterative.py _MAX_SAMPLE_CLIPS). */
+export const SAMPLE_NUM_CLIPS_MIN = 1
+export const SAMPLE_NUM_CLIPS_MAX = 4
+
+/** `MashupRequest.clip_ids` length bounds (iterative.py _MAX_MASHUP_CLIPS). */
+export const MASHUP_CLIPS_MIN = 2
+export const MASHUP_CLIPS_MAX = 8
+
+/** `SampleRequest.role` — the musical role of an extracted sample. */
+export const SAMPLE_ROLES = [
+  { value: "loop-bed", label: "Loop bed" },
+  { value: "intro-outro", label: "Intro / outro" },
+  { value: "rhythmic-element", label: "Rhythmic element" },
+  { value: "melodic-hook", label: "Melodic hook" },
+] as const
+
+export type SampleRole = (typeof SAMPLE_ROLES)[number]["value"]
+
+/** `MashupRequest.blend_mode` — how a mashup combines its sources. */
+export const BLEND_MODES = [
+  { value: "layered", label: "Layered" },
+  { value: "sequential", label: "Sequential" },
+  { value: "ai-guided", label: "AI-guided" },
+] as const
+
+export type BlendMode = (typeof BLEND_MODES)[number]["value"]

--- a/web/lib/edit-proxy.test.ts
+++ b/web/lib/edit-proxy.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { POST as cropPOST } from "@/app/api/clips/[id]/crop/route"
+import { POST as mashupPOST } from "@/app/api/mashup/route"
+import { clipEditRoute, forwardEdit } from "@/lib/edit-proxy"
+
+afterEach(() => vi.restoreAllMocks())
+
+function req(init: RequestInit = {}): NextRequest {
+  return new Request("http://localhost/api/clips/c/crop", {
+    method: "POST",
+    ...init,
+  }) as unknown as NextRequest
+}
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) })
+
+describe("forwardEdit", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await forwardEdit(req(), "/api/v1/clips/c/crop")
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards token + body to the backend path and passes 202 through", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ job_id: "j1", status: "queued" }), {
+        status: 202,
+      })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await forwardEdit(
+      req({ headers: { authorization: "Bearer tok" }, body: '{"start":"0s"}' }),
+      "/api/v1/clips/c/crop"
+    )
+    expect(res.status).toBe(202)
+    expect(await res.json()).toMatchObject({ job_id: "j1" })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips/c/crop")
+    expect(opts.method).toBe("POST")
+    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+    expect(opts.body).toBe('{"start":"0s"}')
+  })
+
+  it("passes a 402 insufficient-credits body through verbatim", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ detail: { error: "insufficient_credits", required: 1 } }),
+          { status: 402 }
+        )
+      )
+    )
+    const res = await forwardEdit(
+      req({ headers: { authorization: "Bearer tok" }, body: "{}" }),
+      "/api/v1/clips/c/extend"
+    )
+    expect(res.status).toBe(402)
+    expect(await res.json()).toMatchObject({
+      detail: { error: "insufficient_credits" },
+    })
+  })
+
+  it("returns a controlled 502 when the upstream fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")))
+    const res = await forwardEdit(
+      req({ headers: { authorization: "Bearer tok" }, body: "{}" }),
+      "/api/v1/clips/c/crop"
+    )
+    expect(res.status).toBe(502)
+  })
+})
+
+describe("clipEditRoute", () => {
+  it("builds a handler that targets the op path with the url-encoded id", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("{}", { status: 202 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const handler = clipEditRoute("speed")
+    await handler(
+      req({ headers: { authorization: "Bearer tok" }, body: "{}" }),
+      params("id/with slash")
+    )
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      `/api/v1/clips/${encodeURIComponent("id/with slash")}/speed`
+    )
+  })
+})
+
+describe("route handlers", () => {
+  it("crop route forwards to the crop op", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ job_id: "j" }), { status: 202 }))
+    vi.stubGlobal("fetch", fetchMock)
+    const res = await cropPOST(
+      req({ headers: { authorization: "Bearer tok" }, body: "{}" }),
+      params("abc")
+    )
+    expect(res.status).toBe(202)
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/clips/abc/crop")
+  })
+
+  it("mashup route forwards to /api/v1/mashup", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ job_id: "m" }), { status: 202 }))
+    vi.stubGlobal("fetch", fetchMock)
+    const res = await mashupPOST(
+      req({ headers: { authorization: "Bearer tok" }, body: '{"clip_ids":["a","b"]}' })
+    )
+    expect(res.status).toBe(202)
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/mashup")
+  })
+
+  it("mashup route 401s without auth", async () => {
+    const res = await mashupPOST(req())
+    expect(res.status).toBe(401)
+  })
+})

--- a/web/lib/edit-proxy.ts
+++ b/web/lib/edit-proxy.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 
 import { BACKEND_URL } from "@/lib/auth-server"
+import { fetchWithTimeout } from "@/lib/proxy-fetch"
 
 // Shared same-origin proxy for the editing/iterative endpoints (US-17.3). Every
 // modal submits to an `app/api/...` route that delegates here; the client holds
@@ -25,7 +26,7 @@ export async function forwardEdit(
 
   let res: Response
   try {
-    res = await fetch(`${BACKEND_URL}${backendPath}`, {
+    res = await fetchWithTimeout(`${BACKEND_URL}${backendPath}`, {
       method: "POST",
       headers: {
         authorization: auth,

--- a/web/lib/edit-proxy.ts
+++ b/web/lib/edit-proxy.ts
@@ -1,0 +1,58 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Shared same-origin proxy for the editing/iterative endpoints (US-17.3). Every
+// modal submits to an `app/api/...` route that delegates here; the client holds
+// the access token in memory and sends it as a Bearer header, and this forwards
+// it to the backend so the backend URL stays server-side. Backend status/body
+// pass through verbatim, so 202 (queued), 401, 402 (insufficient credits), 404,
+// and 422 (validation) all surface unchanged to the modal's state machine.
+
+/**
+ * Forward a POST to `${BACKEND_URL}${backendPath}` with the caller's bearer
+ * token and JSON body. `backendPath` is the absolute backend path, e.g.
+ * `/api/v1/clips/abc/crop` or `/api/v1/mashup`.
+ */
+export async function forwardEdit(
+  request: NextRequest,
+  backendPath: string
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  let res: Response
+  try {
+    res = await fetch(`${BACKEND_URL}${backendPath}`, {
+      method: "POST",
+      headers: {
+        authorization: auth,
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: await request.text(),
+    })
+  } catch {
+    // Backend unreachable — a controlled 502 the modal can surface as a generic
+    // error instead of an opaque 500.
+    return NextResponse.json(
+      { detail: "Editing service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}
+
+/** Build a clip-scoped route handler for `${op}` (crop/speed/extend/…). */
+export function clipEditRoute(op: string) {
+  return async function POST(
+    request: NextRequest,
+    ctx: { params: Promise<{ id: string }> }
+  ): Promise<NextResponse> {
+    const { id } = await ctx.params
+    return forwardEdit(request, `/api/v1/clips/${encodeURIComponent(id)}/${op}`)
+  }
+}

--- a/web/lib/editing-validation.test.ts
+++ b/web/lib/editing-validation.test.ts
@@ -44,6 +44,12 @@ describe("formatMs", () => {
     expect(formatMs(NaN)).toBe("0s")
   })
 
+  it("carries a rounded 60s remainder into the minutes place", () => {
+    // 119999ms rounds to 120.00s — must render 2m0s, never 1m60s.
+    expect(formatMs(119999)).toBe("2m0s")
+    expect(formatMs(59999)).toBe("1m0s")
+  })
+
   it("round-trips through parseTimeString", () => {
     expect(parseTimeString(formatMs(90000))).toBe(90000)
   })

--- a/web/lib/editing-validation.test.ts
+++ b/web/lib/editing-validation.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  formatMs,
+  parseTimeString,
+  validateRange,
+  validateTimeField,
+} from "@/lib/editing-validation"
+
+describe("parseTimeString", () => {
+  it.each([
+    ["30s", 30000],
+    ["1m30s", 90000],
+    ["1.5s", 1500],
+    ["90s", 90000],
+    ["5", 5000],
+    ["2m0s", 120000],
+    ["  45s  ", 45000],
+  ])("parses %s to %d ms", (input, expected) => {
+    expect(parseTimeString(input)).toBe(expected)
+  })
+
+  it.each(["", "1m", "1m30", "abc", "30sec", "-5", "s", "1:30"])(
+    "returns null for invalid input %s",
+    (input) => {
+      expect(parseTimeString(input)).toBeNull()
+    }
+  )
+})
+
+describe("formatMs", () => {
+  it.each([
+    [45000, "45s"],
+    [90000, "1m30s"],
+    [120000, "2m0s"],
+    [1500, "1.5s"],
+    [0, "0s"],
+  ])("formats %d ms as %s", (input, expected) => {
+    expect(formatMs(input)).toBe(expected)
+  })
+
+  it("clamps negative/invalid input to 0s", () => {
+    expect(formatMs(-100)).toBe("0s")
+    expect(formatMs(NaN)).toBe("0s")
+  })
+
+  it("round-trips through parseTimeString", () => {
+    expect(parseTimeString(formatMs(90000))).toBe(90000)
+  })
+})
+
+describe("validateTimeField", () => {
+  it("requires a value", () => {
+    expect(validateTimeField("", "Duration")).toBe("Duration is required.")
+    expect(validateTimeField("   ", "Duration")).toBe("Duration is required.")
+  })
+
+  it("rejects an unparseable format", () => {
+    expect(validateTimeField("soon", "Duration")).toMatch(/time like/)
+  })
+
+  it("rejects a value beyond maxMs", () => {
+    expect(validateTimeField("100s", "End", { maxMs: 60000 })).toMatch(
+      /clip length \(1m0s\)/
+    )
+  })
+
+  it("accepts a valid in-bounds value", () => {
+    expect(validateTimeField("30s", "End", { maxMs: 60000 })).toBeNull()
+  })
+})
+
+describe("validateRange", () => {
+  it("requires start before end", () => {
+    expect(validateRange("30s", "10s", 60000)).toBe("Start must be before end.")
+    expect(validateRange("30s", "30s", 60000)).toBe("Start must be before end.")
+  })
+
+  it("rejects end beyond the clip duration", () => {
+    expect(validateRange("10s", "100s", 60000)).toMatch(/clip length/)
+  })
+
+  it("surfaces an unparseable bound", () => {
+    expect(validateRange("nope", "30s", 60000)).toMatch(/time like/)
+  })
+
+  it("accepts a valid range and tolerates unknown duration", () => {
+    expect(validateRange("10s", "30s", 60000)).toBeNull()
+    expect(validateRange("10s", "30s", null)).toBeNull()
+  })
+})

--- a/web/lib/editing-validation.ts
+++ b/web/lib/editing-validation.ts
@@ -34,7 +34,9 @@ export function parseTimeString(value: string): number | null {
 /** Format a millisecond duration as a compact "1m30s" / "45s" string. */
 export function formatMs(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return "0s"
-  const totalSeconds = ms / 1000
+  // Round to centiseconds first so the split can't leave a 60s remainder that
+  // fails to carry into minutes (e.g. 119999ms → "2m0s", not "1m60s").
+  const totalSeconds = Math.round(ms / 10) / 100
   const minutes = Math.floor(totalSeconds / 60)
   const seconds = Math.round((totalSeconds - minutes * 60) * 100) / 100
   return minutes > 0 ? `${minutes}m${seconds}s` : `${seconds}s`

--- a/web/lib/editing-validation.ts
+++ b/web/lib/editing-validation.ts
@@ -1,0 +1,83 @@
+/**
+ * Client-side validation for the editing workflow modals (US-17.3).
+ *
+ * The backend accepts human time strings ("30s", "1m30s", "1.5s", "90s", "5")
+ * for range/duration fields (`parse_time_string` in `src/acemusic/utils.py`) and
+ * validates every bound. These helpers mirror that parser and those bounds so a
+ * modal can reject bad input inline instead of round-tripping a 422. Validators
+ * follow the app convention of returning the first problem string, or `null`
+ * when valid (see `lib/generate.ts` `validateSounds`).
+ */
+
+// Mirrors backend _TIME_PATTERN: "<m>m<s>s" | "<s>s" | "<plain>" (plain seconds).
+// The minutes group is optional but a seconds value with the "s" suffix is
+// required unless the whole string is a bare number.
+const TIME_PATTERN = /^(?:(\d+)m)?(\d+(?:\.\d+)?)s$|^(\d+(?:\.\d+)?)$/
+
+/**
+ * Parse a time string into milliseconds, or `null` if it is not a valid format.
+ * Matches the backend's accepted formats exactly so a value that parses here is
+ * one the backend will also accept.
+ */
+export function parseTimeString(value: string): number | null {
+  const match = TIME_PATTERN.exec(value.trim())
+  if (!match) return null
+  const [, minutes, seconds, plain] = match
+  const totalSeconds =
+    plain !== undefined
+      ? Number(plain)
+      : Number(seconds) + Number(minutes ?? 0) * 60
+  if (!Number.isFinite(totalSeconds)) return null
+  return Math.round(totalSeconds * 1000)
+}
+
+/** Format a millisecond duration as a compact "1m30s" / "45s" string. */
+export function formatMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "0s"
+  const totalSeconds = ms / 1000
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.round((totalSeconds - minutes * 60) * 100) / 100
+  return minutes > 0 ? `${minutes}m${seconds}s` : `${seconds}s`
+}
+
+/**
+ * Validate a single time-string field. Returns an error message when the value
+ * is empty (required fields), unparseable, or — when `maxMs` is given — beyond
+ * the clip's bounds. Returns `null` when valid.
+ */
+export function validateTimeField(
+  value: string,
+  label: string,
+  { maxMs }: { maxMs?: number } = {}
+): string | null {
+  if (!value.trim()) return `${label} is required.`
+  const ms = parseTimeString(value)
+  if (ms === null) return `${label} must be a time like "30s" or "1m30s".`
+  if (ms < 0) return `${label} can't be negative.`
+  if (maxMs !== undefined && ms > maxMs) {
+    return `${label} can't exceed the clip length (${formatMs(maxMs)}).`
+  }
+  return null
+}
+
+/**
+ * Validate a `[start, end]` selection against the clip. Enforces the backend's
+ * `start < end <= duration` rule (`_check_range` in iterative.py). Returns the
+ * first problem, or `null` when valid.
+ */
+export function validateRange(
+  start: string,
+  end: string,
+  durationMs: number | null
+): string | null {
+  const maxMs = durationMs ?? undefined
+  const startError = validateTimeField(start, "Start", { maxMs })
+  if (startError) return startError
+  const endError = validateTimeField(end, "End", { maxMs })
+  if (endError) return endError
+  // Both parse (validateTimeField guaranteed it), so the non-null assertions hold.
+  const startMs = parseTimeString(start) as number
+  const endMs = parseTimeString(end) as number
+  if (startMs >= endMs) return "Start must be before end."
+  return null
+}

--- a/web/lib/editing.test.ts
+++ b/web/lib/editing.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  submitCrop,
+  submitMashup,
+  submitRemaster,
+  submitSample,
+  submitSpeed,
+} from "@/lib/editing"
+
+afterEach(() => vi.restoreAllMocks())
+
+function stubFetch(response: Response) {
+  const fetchMock = vi.fn().mockResolvedValue(response)
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+describe("submitCrop", () => {
+  it("POSTs to the crop route with the bearer token and returns the job", async () => {
+    const fetchMock = stubFetch(
+      new Response(JSON.stringify({ job_id: "job-1", status: "queued" }), {
+        status: 202,
+      })
+    )
+
+    const result = await submitCrop(
+      "clip-abc",
+      { start: "0s", end: "30s" },
+      "tok"
+    )
+
+    expect(result).toEqual({
+      status: "accepted",
+      jobId: "job-1",
+      estimatedSeconds: 0,
+    })
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/clips/clip-abc/crop")
+    expect(opts.method).toBe("POST")
+    expect(opts.headers.authorization).toBe("Bearer tok")
+    expect(JSON.parse(opts.body)).toEqual({ start: "0s", end: "30s" })
+  })
+
+  it("drops empty-string and undefined optionals from the payload", async () => {
+    const fetchMock = stubFetch(
+      new Response(JSON.stringify({ job_id: "j" }), { status: 202 })
+    )
+    await submitCrop(
+      "c",
+      { start: "0s", end: "10s", fade_in: "", fade_out: undefined, snap_to_beat: true },
+      "tok"
+    )
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      start: "0s",
+      end: "10s",
+      snap_to_beat: true,
+    })
+  })
+})
+
+describe("submitSpeed", () => {
+  it("carries the estimated time from an iterative-style 202", async () => {
+    stubFetch(
+      new Response(
+        JSON.stringify({ job_id: "j2", status: "queued", estimated_time_seconds: 45 }),
+        { status: 202 }
+      )
+    )
+    const result = await submitSpeed("c", { multiplier: 1.5 }, "tok")
+    expect(result).toEqual({ status: "accepted", jobId: "j2", estimatedSeconds: 45 })
+  })
+})
+
+describe("submitSample", () => {
+  it("maps a 402 into an insufficientCredits result", async () => {
+    stubFetch(
+      new Response(
+        JSON.stringify({
+          detail: { error: "insufficient_credits", balance: 2, required: 4 },
+        }),
+        { status: 402 }
+      )
+    )
+    const result = await submitSample(
+      "c",
+      { start: "0s", end: "5s", role: "loop-bed", prompt: "warm", num_clips: 4 },
+      "tok"
+    )
+    expect(result).toEqual({ status: "insufficientCredits", balance: 2, required: 4 })
+  })
+})
+
+describe("submitRemaster", () => {
+  it("classifies 401 as unauthorized", async () => {
+    stubFetch(new Response("{}", { status: 401 }))
+    expect(await submitRemaster("c", {}, "tok")).toEqual({ status: "unauthorized" })
+  })
+
+  it("classifies 422 as invalid with the field message", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ detail: [{ msg: "unsupported format" }] }), {
+        status: 422,
+      })
+    )
+    expect(await submitRemaster("c", {}, "tok")).toEqual({
+      status: "invalid",
+      detail: "unsupported format",
+    })
+  })
+
+  it("returns an error result when fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")))
+    const result = await submitRemaster("c", {}, "tok")
+    expect(result.status).toBe("error")
+  })
+
+  it("treats a 202 with no job id as an error", async () => {
+    stubFetch(new Response("{}", { status: 202 }))
+    const result = await submitRemaster("c", {}, "tok")
+    expect(result.status).toBe("error")
+  })
+})
+
+describe("submitMashup", () => {
+  it("POSTs the ordered clip ids to the mashup route", async () => {
+    const fetchMock = stubFetch(
+      new Response(JSON.stringify({ job_id: "m1", estimated_time_seconds: 45 }), {
+        status: 202,
+      })
+    )
+    await submitMashup({ clip_ids: ["a", "b"], blend_mode: "layered" }, "tok")
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/mashup")
+    expect(JSON.parse(opts.body)).toEqual({
+      clip_ids: ["a", "b"],
+      blend_mode: "layered",
+    })
+  })
+})

--- a/web/lib/editing.ts
+++ b/web/lib/editing.ts
@@ -1,0 +1,220 @@
+/**
+ * Typed client for the editing + iterative endpoints (US-17.3). Each modal
+ * builds one of these request payloads and submits it through the same-origin
+ * BFF proxy (`app/api/clips/[id]/*` and `app/api/mashup`), which forwards the
+ * Bearer token to the backend. Every submit classifies the response into an
+ * `EditSubmitResult` the modal's state machine switches on — mirroring
+ * `lib/generate.ts`, plus the 402 (insufficient credits) case the paid
+ * iterative endpoints can return.
+ */
+
+import type { BlendMode, SampleRole } from "@/lib/constants/editing"
+
+// --- Request payloads (mirror the Pydantic models; optionals omitted when unset) ---
+
+export type CropPayload = {
+  start: string
+  end: string
+  fade_in?: string
+  fade_out?: string
+  snap_to_beat?: boolean
+}
+
+export type SpeedPayload = {
+  multiplier?: number
+  target_bpm?: number
+  preserve_pitch?: boolean
+}
+
+export type RemasterPayload = {
+  target_lufs?: number
+}
+
+export type ExtendPayload = {
+  duration: string
+  from_point?: string
+  style_override?: string
+  lyrics?: string
+}
+
+export type CoverPayload = {
+  style: string
+  lyrics_override?: string
+}
+
+export type RemixPayload = {
+  style: string
+}
+
+export type RepaintPayload = {
+  start: string
+  end: string
+  prompt: string
+  style?: string
+}
+
+export type SamplePayload = {
+  start: string
+  end: string
+  role: SampleRole
+  prompt: string
+  num_clips?: number
+}
+
+export type AddVocalPayload = {
+  lyrics: string
+  vocal_style?: string
+}
+
+export type MashupPayload = {
+  clip_ids: string[]
+  blend_mode?: BlendMode
+  style?: string
+}
+
+/** One editing endpoint's accepted-job / error outcome, classified for the UI. */
+export type EditSubmitResult =
+  | { status: "accepted"; jobId: string; estimatedSeconds: number }
+  | { status: "unauthorized" }
+  | { status: "invalid"; detail: string }
+  | { status: "insufficientCredits"; balance: number; required: number }
+  | { status: "error"; detail: string }
+
+/** Pull a human message out of a FastAPI error body (string or [{msg}] detail). */
+function extractDetail(body: unknown, fallback: string): string {
+  if (body && typeof body === "object" && "detail" in body) {
+    const detail = (body as { detail: unknown }).detail
+    if (typeof detail === "string") return detail
+    if (Array.isArray(detail) && detail.length > 0) {
+      const first = detail[0]
+      if (first && typeof first === "object" && "msg" in first) {
+        return String((first as { msg: unknown }).msg)
+      }
+    }
+  }
+  return fallback
+}
+
+/** Pull `{balance, required}` out of a 402 insufficient-credits detail object. */
+function extractCredits(body: unknown): { balance: number; required: number } {
+  const detail =
+    body && typeof body === "object" && "detail" in body
+      ? (body as { detail: unknown }).detail
+      : undefined
+  const obj = detail && typeof detail === "object" ? (detail as Record<string, unknown>) : {}
+  const num = (v: unknown) => (typeof v === "number" ? v : 0)
+  return { balance: num(obj.balance), required: num(obj.required) }
+}
+
+/**
+ * POST a payload to a same-origin editing route and classify the response.
+ * Shared by every submit function below; `path` is the BFF route (e.g.
+ * `/api/clips/abc/crop`). Never throws — a network failure becomes an `error`
+ * result so a modal never gets stuck mid-submit.
+ */
+async function postEdit(
+  path: string,
+  payload: unknown,
+  accessToken: string
+): Promise<EditSubmitResult> {
+  let res: Response
+  try {
+    res = await fetch(path, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(payload),
+    })
+  } catch {
+    return { status: "error", detail: "Something went wrong. Please try again." }
+  }
+
+  if (res.status === 202) {
+    const body = await res.json().catch(() => ({}))
+    const { job_id: jobId, estimated_time_seconds: estimated } = body as {
+      job_id?: string
+      estimated_time_seconds?: number
+    }
+    if (!jobId) {
+      return { status: "error", detail: "Server returned an unexpected response." }
+    }
+    return {
+      status: "accepted",
+      jobId,
+      estimatedSeconds: typeof estimated === "number" ? estimated : 0,
+    }
+  }
+  if (res.status === 401) return { status: "unauthorized" }
+
+  const body = await res.json().catch(() => ({}))
+  if (res.status === 402) {
+    return { status: "insufficientCredits", ...extractCredits(body) }
+  }
+  if (res.status === 422) {
+    return { status: "invalid", detail: extractDetail(body, "Please check your input.") }
+  }
+  return {
+    status: "error",
+    detail: extractDetail(body, "Something went wrong. Please try again."),
+  }
+}
+
+/** Strip `undefined`/empty-string optionals so the `extra="forbid"` backend is happy. */
+function compact<T extends Record<string, unknown>>(payload: T): Partial<T> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(payload)) {
+    if (value === undefined) continue
+    if (typeof value === "string" && value.trim() === "") continue
+    out[key] = value
+  }
+  return out as Partial<T>
+}
+
+const clipPath = (clipId: string, op: string) =>
+  `/api/clips/${encodeURIComponent(clipId)}/${op}`
+
+// --- Editing endpoints (no credits) ---
+
+export function submitCrop(clipId: string, payload: CropPayload, token: string) {
+  return postEdit(clipPath(clipId, "crop"), compact(payload), token)
+}
+
+export function submitSpeed(clipId: string, payload: SpeedPayload, token: string) {
+  return postEdit(clipPath(clipId, "speed"), compact(payload), token)
+}
+
+export function submitRemaster(clipId: string, payload: RemasterPayload, token: string) {
+  return postEdit(clipPath(clipId, "remaster"), compact(payload), token)
+}
+
+// --- Iterative endpoints (consume credits) ---
+
+export function submitExtend(clipId: string, payload: ExtendPayload, token: string) {
+  return postEdit(clipPath(clipId, "extend"), compact(payload), token)
+}
+
+export function submitCover(clipId: string, payload: CoverPayload, token: string) {
+  return postEdit(clipPath(clipId, "cover"), compact(payload), token)
+}
+
+export function submitRemix(clipId: string, payload: RemixPayload, token: string) {
+  return postEdit(clipPath(clipId, "remix"), compact(payload), token)
+}
+
+export function submitRepaint(clipId: string, payload: RepaintPayload, token: string) {
+  return postEdit(clipPath(clipId, "repaint"), compact(payload), token)
+}
+
+export function submitSample(clipId: string, payload: SamplePayload, token: string) {
+  return postEdit(clipPath(clipId, "sample"), compact(payload), token)
+}
+
+export function submitAddVocal(clipId: string, payload: AddVocalPayload, token: string) {
+  return postEdit(clipPath(clipId, "add-vocal"), compact(payload), token)
+}
+
+export function submitMashup(payload: MashupPayload, token: string) {
+  return postEdit("/api/mashup", compact(payload), token)
+}

--- a/web/lib/song-actions.test.ts
+++ b/web/lib/song-actions.test.ts
@@ -74,8 +74,10 @@ describe("SONG_ACTION_GROUPS", () => {
     )
   })
 
-  it("routes studio to navigation and publish/delete inline", () => {
+  it("routes studio to navigation and remaster/publish/delete inline", () => {
     expect(findSongAction("open-studio")?.workflow).toBe("navigation")
+    // Remaster is one-click (US-17.3) — inline submit, no modal.
+    expect(findSongAction("remaster")?.workflow).toBe("inline")
     expect(findSongAction("publish-toggle")?.workflow).toBe("inline")
     expect(findSongAction("delete")?.workflow).toBe("inline")
   })
@@ -92,7 +94,6 @@ describe("SONG_ACTION_GROUPS", () => {
       "sample",
       "use-inspiration",
       "add-vocal",
-      "remaster",
       "replace-section",
       "crop",
       "adjust-speed",

--- a/web/lib/song-actions.ts
+++ b/web/lib/song-actions.ts
@@ -68,7 +68,7 @@ export type SongActionCategory = "edit" | "create" | "audio" | "export" | "manag
  * How an action is carried out when selected:
  * - `modal`      — opens a workflow modal (content lands in US-17.3+)
  * - `navigation` — routes to another page (editor/studio)
- * - `inline`     — acts in place (publish toggle, delete confirmation)
+ * - `inline`     — acts in place (remaster one-click, publish toggle, delete confirmation)
  * - `download`   — fetches the clip's audio as a file
  */
 export type SongActionWorkflow = "modal" | "navigation" | "inline" | "download"
@@ -151,10 +151,12 @@ export const SONG_ACTION_GROUPS: SongActionGroup[] = [
     actions: [
       { id: "add-vocal", label: "Add Vocal", icon: VoiceIcon, workflow: "modal" },
       {
+        // One-click, no modal (US-17.3): remaster runs immediately with the
+        // default -14 LUFS target and shows inline progress.
         id: "remaster",
         label: "Remaster",
         icon: MagicWand01Icon,
-        workflow: "modal",
+        workflow: "inline",
       },
       {
         id: "replace-section",

--- a/web/test/clip-factory.ts
+++ b/web/test/clip-factory.ts
@@ -1,0 +1,25 @@
+import type { Clip } from "@/lib/workspace-clips"
+
+/** A valid WAV clip with duration + BPM; override only what a test exercises. */
+export function makeClip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "clip-1",
+    workspace_id: "ws-1",
+    title: "Midnight Drive",
+    format: "wav",
+    duration: 60,
+    bpm: 120,
+    key: "C minor",
+    style_tags: ["lofi"],
+    lyrics: null,
+    vocal_language: null,
+    model: "ace-step-v1",
+    seed: 7,
+    inference_steps: 30,
+    parent_clip_ids: [],
+    generation_mode: "generate",
+    is_public: false,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -27,6 +27,13 @@ proto.setPointerCapture ??= () => {}
 proto.releasePointerCapture ??= () => {}
 proto.scrollIntoView ??= () => {}
 
+// jsdom lacks ResizeObserver, which Radix's Slider observes on mount (US-17.3).
+globalThis.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 afterEach(() => {
   cleanup()
   routerMock.pathname = "/"


### PR DESCRIPTION
## US-17.3: Editing Workflow Modals

Closes #197.

Fills the editing-modal seam left by US-17.2 (`SongActionModal` placeholder) with real modal
workflows on the Song Detail page. Each modal presents the right controls, validates inline,
submits to the backend, polls the job, and surfaces the resulting clip(s).

### What's included

**9 workflow modals** (song action menu → modal):
- **Local (no credits):** Crop (range + fades + snap-to-beat), Adjust Speed (multiplier slider *or* target BPM, preserve-pitch)
- **AI (credits):** Extend, Cover, Remix, Replace Section (repaint), Sample from Song, Add Vocal
- **Multi-clip:** Mashup (2–8 clip selector, blend mode)

**Remaster** is one-click (no modal) per the AC — inline submit with progress + a View link.

**Shared infrastructure:**
- `lib/editing.ts` — typed submit functions for all 10 endpoints → discriminated `EditSubmitResult` (incl. 402 insufficient-credits)
- `lib/editing-validation.ts` — time-string parser/validators mirroring the backend
- `hooks/use-clip-edit.ts` — submit→poll→success/error state machine (reuses `fetchJobStatus`)
- 10 same-origin BFF proxy routes (`app/api/clips/[id]/*`, `app/api/mashup`) via a shared `forwardEdit` helper
- Reusable sub-components: `RangeSelector`, `TimeDurationInput`, `StyleTextarea`, `EditModalShell`
- Two Shadcn primitives (`slider`, `radio-group`) from the existing `radix-ui` package

### Deviations from the CodeRabbit plan

The plan's research assumed `web/` was empty; it's fully built through US-17.2. So:
- **No new modal context/registry** — reused the existing `SongActionModal` dispatch keyed by `SongActionId`.
- **No wavesurfer.js** — reused the app's decorative canvas waveform (`barHeights`); the API takes time strings.
- **No Zod / react-hook-form** — hand-rolled `(data) => string | null` validators per the app's convention.
- **No new dependency** — `slider`/`radio-group` come from the already-installed unified `radix-ui` package.

### Acceptance criteria

- [x] Each editing modal opens with the correct controls for its workflow
- [x] Form validation prevents invalid submissions (empty required fields, bad ranges)
- [x] Submitting a modal triggers the correct API endpoint
- [x] Results appear as new clips (created in backend workspace; surfaced via success + View)
- [x] Remaster triggers immediately without a modal and shows progress

### Testing

- `npm test` — 509 passing (76 files); ~130 new tests across the editing modules
- `npm run typecheck`, `npm run lint`, `npm run build` — all clean

### Known limitations

- On the Song Detail page there's no workspace panel, so completed edits surface via a success
  state + "View" link to the new clip rather than appearing in a live list.
- `ClipMultiSelector` seeds the current clip as the mashup primary; if that clip isn't eligible
  (not WAV+duration, or not in the fetched page) it's pruned from the selection so nothing
  invalid is submitted — the user then picks two eligible clips from the list.
- Credit hints are static ("Uses 1 credit"); exact costs come from backend config. 402s are
  handled gracefully with the actual balance/required from the response.
- Modal close is an abrupt cut rather than a fade: the dispatch renders only the
  active modal and unmounts on close, so Radix's exit animation (keyed on the
  open→closed transition) doesn't play. Restoring it cleanly would mean mounting
  all modals (triggering the mashup selector's clip fetch prematurely), so it's
  deferred as a cosmetic trade-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full song editing workflow with modals for crop, speed, extend, cover, remix, replace section, sample, add vocal, and mashup actions.
  * Introduced inline remaster status updates, including progress, success, and error states.
  * Added improved time, range, selector, and style input controls for editing tasks.

* **Bug Fixes**
  * Added validation to prevent invalid clip edits and improve form behavior.
  * Updated action handling so remaster runs inline instead of opening a modal.

* **Documentation**
  * Expanded the README with guidance for the new editing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->