### PR TITLE
feat(web): Clip Context Menu (US-17.5)

### DIFF
--- a/web/components/song/RelatedSongs.tsx
+++ b/web/components/song/RelatedSongs.tsx
@@ -8,7 +8,14 @@ import { useSimilarClips } from "@/hooks/use-similar-clips"
 // skeletons; an empty/failed result hides the panel rather than showing a dead
 // "no results" block — related songs are supplementary.
 
-export function RelatedSongs({ clipId }: { clipId: string }) {
+export function RelatedSongs({
+  clipId,
+  isFreeTier,
+}: {
+  clipId: string
+  /** Threaded to each card so Pro-gating matches the page's main action menu (US-17.5). */
+  isFreeTier?: boolean
+}) {
   const { clips, loading } = useSimilarClips(clipId)
 
   if (loading) {
@@ -28,7 +35,7 @@ export function RelatedSongs({ clipId }: { clipId: string }) {
       <h2 className="text-sm font-semibold">Related songs</h2>
       <div className="flex flex-col gap-2">
         {clips.map((clip) => (
-          <ClipCard key={clip.id} clip={clip} />
+          <ClipCard key={clip.id} clip={clip} isFreeTier={isFreeTier} />
         ))}
       </div>
     </section>

--- a/web/components/song/SongDetail.tsx
+++ b/web/components/song/SongDetail.tsx
@@ -112,7 +112,7 @@ function SongDetailContent({ clip }: { clip: Clip }) {
         </section>
       </main>
       <aside className="w-full shrink-0 lg:w-80">
-        <RelatedSongs clipId={clip.id} />
+        <RelatedSongs clipId={clip.id} isFreeTier={isFreeTier} />
       </aside>
       <SongActionModal
         clip={clip}

--- a/web/components/workspace/ClipCard.test.tsx
+++ b/web/components/workspace/ClipCard.test.tsx
@@ -1,10 +1,45 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
 
 import { ClipCard, type ClipCardProps } from "@/components/workspace/ClipCard"
+import { AuthContext } from "@/contexts/auth-context"
 import { PlayerProvider, usePlayer } from "@/contexts/player-context"
 import type { Clip } from "@/lib/workspace-clips"
+
+// The ⋯ menu now dispatches through useSongActions (US-17.5): navigation uses the
+// router, downloads call downloadClipAudio, delete hits the DELETE proxy. Capture
+// the router push and stub the download so those effects are observable/inert.
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+
+const downloadClipAudio = vi.fn<(...args: unknown[]) => Promise<boolean>>(() =>
+  Promise.resolve(true)
+)
+vi.mock("@/lib/clips", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/clips")>()),
+  downloadClipAudio: (...args: unknown[]) => downloadClipAudio(...args),
+}))
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+/** Auth + player context every card needs now that the menu is wired. */
+function AllProviders({ children }: { children: ReactNode }) {
+  return (
+    <AuthContext.Provider value={authValue}>
+      <PlayerProvider>{children}</PlayerProvider>
+    </AuthContext.Provider>
+  )
+}
 
 function clip(overrides: Partial<Clip> = {}): Clip {
   return {
@@ -42,10 +77,10 @@ function PlayerProbe() {
 
 function renderCard(props: Partial<ClipCardProps> = {}) {
   return render(
-    <PlayerProvider>
+    <AllProviders>
       <ClipCard clip={clip()} {...props} />
       <PlayerProbe />
-    </PlayerProvider>
+    </AllProviders>
   )
 }
 
@@ -59,20 +94,20 @@ describe("ClipCard", () => {
 
   it("falls back to a placeholder title for untitled clips", () => {
     render(
-      <PlayerProvider>
+      <AllProviders>
         <ClipCard clip={clip({ title: null })} />
-      </PlayerProvider>
+      </AllProviders>
     )
     expect(screen.getByText("Untitled clip")).toBeInTheDocument()
   })
 
   it("renders version and metadata badges from model/generation_mode", () => {
     render(
-      <PlayerProvider>
+      <AllProviders>
         <ClipCard
           clip={clip({ model: "ace-step-v1", generation_mode: "extend" })}
         />
-      </PlayerProvider>
+      </AllProviders>
     )
     expect(screen.getByText("XL")).toBeInTheDocument()
     expect(screen.getByText("Extend")).toBeInTheDocument()
@@ -154,18 +189,18 @@ describe("ClipCard", () => {
   it("shows Get Full Song only for clips under 60s", async () => {
     const onGetFullSong = vi.fn()
     const { unmount } = render(
-      <PlayerProvider>
+      <AllProviders>
         <ClipCard clip={clip({ duration: 30 })} onGetFullSong={onGetFullSong} />
-      </PlayerProvider>
+      </AllProviders>
     )
     await userEvent.click(screen.getByRole("button", { name: /get full song/i }))
     expect(onGetFullSong).toHaveBeenCalledWith("c1")
     unmount()
 
     render(
-      <PlayerProvider>
+      <AllProviders>
         <ClipCard clip={clip({ duration: 120 })} onGetFullSong={onGetFullSong} />
-      </PlayerProvider>
+      </AllProviders>
     )
     expect(
       screen.queryByRole("button", { name: /get full song/i })
@@ -231,5 +266,68 @@ describe("ClipCard", () => {
     await userEvent.click(screen.getByRole("menuitem", { name: "Download" }))
     await userEvent.click(screen.getByRole("menuitem", { name: "WAV" }))
     expect(onMenuAction).toHaveBeenCalledWith("download-wav", "c1")
+  })
+
+  // US-17.5: the ⋯ menu is now wired to real workflows, not just an observer.
+  it("navigates to the studio for Open in Studio", async () => {
+    renderCard()
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    await userEvent.click(screen.getByRole("menuitem", { name: "Open in Studio" }))
+    expect(push).toHaveBeenCalledWith("/studio?song=c1")
+  })
+
+  it("opens a workflow modal for an editing action", async () => {
+    renderCard()
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Use as Inspiration" })
+    )
+    // Placeholder modal until the workflow ships — proves modal dispatch is wired.
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      /Use as Inspiration/i
+    )
+  })
+
+  it("downloads the clip's audio in the chosen format", async () => {
+    renderCard()
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download" }))
+    await userEvent.click(screen.getByRole("menuitem", { name: "MP3" }))
+    expect(downloadClipAudio).toHaveBeenCalledWith("c1", "mp3", "tok", "Midnight")
+  })
+
+  it("confirms before deleting, then calls the proxy and drops the card", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ status: 204 } as Response))
+    vi.stubGlobal("fetch", fetchMock)
+    const onDeleted = vi.fn()
+    renderCard({ onDeleted })
+
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }))
+    // A confirmation dialog gates the delete — nothing is called yet.
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      /Delete this song\?/i
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }))
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/clips/c1",
+        expect.objectContaining({ method: "DELETE" })
+      )
+    )
+    expect(onDeleted).toHaveBeenCalledWith("c1")
+    vi.unstubAllGlobals()
+  })
+
+  it("locks Pro-only items and flags Beta for free-tier users", async () => {
+    renderCard({ isFreeTier: true })
+    await userEvent.click(screen.getByRole("button", { name: /more options/i }))
+    expect(screen.getByText("Beta")).toBeInTheDocument()
+    // Open in Editor is Pro-gated: disabled so a click can never dispatch it.
+    expect(
+      screen.getByRole("menuitem", { name: /Open in Editor/i })
+    ).toHaveAttribute("aria-disabled", "true")
   })
 })

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -8,6 +8,7 @@ import {
   Edit02Icon,
   FavouriteIcon,
   GlobeIcon,
+  LockIcon,
   MoreHorizontalIcon,
   MusicNote01Icon,
   PlayIcon,
@@ -28,45 +29,66 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { DeleteSongDialog } from "@/components/song/DeleteSongDialog"
+import { SongActionModal } from "@/components/song/SongActionModal"
 import { usePlayer } from "@/contexts/player-context"
+import { useSongActions } from "@/hooks/use-song-actions"
 import { modeLabel, versionLabel } from "@/lib/clip-labels"
 import { formatTime, trackFromClip } from "@/lib/clips"
 import { isFullSongEligible } from "@/lib/song-structure"
 import { cn } from "@/lib/utils"
 import type { Clip } from "@/lib/workspace-clips"
 
-// US-16.6: the reusable clip card. Play + Like are wired to the global player
-// store (the only backend-free actions that already have a home — see
-// LikeButton). Everything else is exposed as a callback prop because the backend
-// has no like/dislike/share/publish/title/menu endpoints proxied in web/ yet;
-// the parent (or a future hook) wires those when the routes land.
+// US-16.6 / US-17.5: the reusable clip card. Play + Like are wired to the global
+// player store; like/dislike/share/publish/rename stay callback props (no backend
+// routes proxied for them yet). The ⋯ menu and Remix CTA now dispatch through
+// useSongActions (US-17.5) — the same registry-driven seam the song-detail menu
+// uses — so any menu click opens its modal, navigates, downloads, or confirms a
+// delete wherever a card is rendered, with no per-location wiring.
 // The action vocabulary lives in lib/song-actions (US-17.2) and is re-exported
 // here so existing imports keep working.
 
 export type { ClipMenuAction } from "@/lib/song-actions"
-import type { ClipMenuAction } from "@/lib/song-actions"
+import type { ClipMenuAction, SongActionId } from "@/lib/song-actions"
 
 export type ClipCardProps = {
   clip: Clip
   /** Inline-rename committed (blur/Enter). */
   onTitleChange?: (id: string, title: string) => void
-  /** Any menu item from the Remix/Edit CTA or the ⋯ menu. */
+  /**
+   * Observer for menu selections (analytics / parent refetch). The action is
+   * also dispatched internally through useSongActions — this fires alongside it.
+   */
   onMenuAction?: (action: ClipMenuAction, clipId: string) => void
   onGetFullSong?: (id: string) => void
   onDislike?: (id: string) => void
   onShare?: (id: string) => void
   /** Publish toggle; `next` is the requested visibility. */
   onPublishToggle?: (id: string, next: boolean) => void
+  /** Free-tier users see Pro-only menu items locked (badge + lock, disabled). */
+  isFreeTier?: boolean
+  /** Called after this clip is deleted so the list can drop the card. */
+  onDeleted?: (id: string) => void
+}
+
+/** Map the clip-menu vocabulary to a registry action id (only remix-edit differs). */
+function toSongAction(action: ClipMenuAction): SongActionId {
+  return action === "remix-edit" ? "remix" : action
 }
 
 /** Remix/Edit sub-options, shared by the primary CTA and the ⋯ submenu. */
-const REMIX_ITEMS: { action: ClipMenuAction; label: string; pro?: boolean }[] = [
+const REMIX_ITEMS: {
+  action: ClipMenuAction
+  label: string
+  pro?: boolean
+  beta?: boolean
+}[] = [
   { action: "open-studio", label: "Open in Studio" },
   { action: "open-editor", label: "Open in Editor", pro: true },
   { action: "cover", label: "Cover" },
   { action: "extend", label: "Extend" },
   { action: "mashup", label: "Mashup" },
-  { action: "sample", label: "Sample from Song" },
+  { action: "sample", label: "Sample from Song", beta: true },
 ]
 
 const DOWNLOAD_ITEMS: { action: ClipMenuAction; label: string }[] = [
@@ -85,8 +107,12 @@ export function ClipCard({
   onDislike,
   onShare,
   onPublishToggle,
+  isFreeTier = false,
+  onDeleted,
 }: ClipCardProps) {
   const { state, dispatch } = usePlayer()
+  // Registry-driven dispatch: modal / navigation / download / delete-confirm.
+  const actions = useSongActions(clip, { onDeleted })
   // likedIds re-renders every player tick; scan a Set (cf. applyClientFilters).
   const likedSet = useMemo(() => new Set(state.likedIds), [state.likedIds])
   const liked = likedSet.has(clip.id)
@@ -132,6 +158,8 @@ export function ClipCard({
   }
 
   function emitMenu(action: ClipMenuAction) {
+    // Dispatch to the shared workflow seam, then notify any observer.
+    actions.handleAction(toSongAction(action))
     onMenuAction?.(action, clip.id)
   }
 
@@ -303,19 +331,31 @@ export function ClipCard({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {REMIX_ITEMS.map((item) => (
-                  <DropdownMenuItem
-                    key={item.action}
-                    onSelect={() => emitMenu(item.action)}
-                  >
-                    {item.label}
-                    {item.pro && (
-                      <Badge variant="outline" className="ml-auto text-[10px]">
-                        Pro
-                      </Badge>
-                    )}
-                  </DropdownMenuItem>
-                ))}
+                {REMIX_ITEMS.map((item) => {
+                  const locked = !!item.pro && isFreeTier
+                  return (
+                    <DropdownMenuItem
+                      key={item.action}
+                      disabled={locked}
+                      onSelect={() => emitMenu(item.action)}
+                    >
+                      {item.label}
+                      {item.pro && (
+                        <Badge variant="outline" className="ml-auto text-[10px]">
+                          {locked && (
+                            <HugeiconsIcon icon={LockIcon} data-icon="inline-start" />
+                          )}
+                          Pro
+                        </Badge>
+                      )}
+                      {item.beta && (
+                        <Badge variant="secondary" className="ml-auto text-[10px]">
+                          Beta
+                        </Badge>
+                      )}
+                    </DropdownMenuItem>
+                  )
+                })}
               </DropdownMenuContent>
             </DropdownMenu>
 
@@ -336,9 +376,15 @@ export function ClipCard({
                 <DropdownMenuItem onSelect={() => emitMenu("open-studio")}>
                   Open in Studio
                 </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => emitMenu("open-editor")}>
+                <DropdownMenuItem
+                  disabled={isFreeTier}
+                  onSelect={() => emitMenu("open-editor")}
+                >
                   Open in Editor
                   <Badge variant="outline" className="ml-auto text-[10px]">
+                    {isFreeTier && (
+                      <HugeiconsIcon icon={LockIcon} data-icon="inline-start" />
+                    )}
                     Pro
                   </Badge>
                 </DropdownMenuItem>
@@ -353,6 +399,9 @@ export function ClipCard({
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => emitMenu("sample")}>
                   Sample from Song
+                  <Badge variant="secondary" className="ml-auto text-[10px]">
+                    Beta
+                  </Badge>
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => emitMenu("use-inspiration")}>
                   Use as Inspiration
@@ -393,7 +442,29 @@ export function ClipCard({
             </DropdownMenu>
           </div>
         </div>
+
+        {/* Download failures surface here; delete errors show in their dialog. */}
+        {actions.actionError && !actions.confirmingDelete && (
+          <p role="alert" className="text-xs text-destructive">
+            {actions.actionError}
+          </p>
+        )}
       </div>
+
+      {/* Modal-workflow actions (extend/cover/…) and delete confirmation. */}
+      <SongActionModal
+        clip={clip}
+        action={actions.activeModal}
+        onClose={actions.closeModal}
+      />
+      <DeleteSongDialog
+        open={actions.confirmingDelete}
+        title={title}
+        deleting={actions.deleting}
+        error={actions.actionError}
+        onCancel={actions.cancelDelete}
+        onConfirm={actions.confirmDelete}
+      />
     </div>
   )
 }

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -76,7 +76,12 @@ function toSongAction(action: ClipMenuAction): SongActionId {
   return action === "remix-edit" ? "remix" : action
 }
 
-/** Remix/Edit sub-options, shared by the primary CTA and the ⋯ submenu. */
+/**
+ * Remix/Edit sub-options for the primary CTA dropdown. The flat ⋯ menu below is
+ * a deliberately different shape (full §9.2 list with separators) and hardcodes
+ * its own open-editor Pro lock / sample Beta badge — keep those in sync with the
+ * `pro`/`beta` flags here by hand until a third consumer justifies a shared renderer.
+ */
 const REMIX_ITEMS: {
   action: ClipMenuAction
   label: string

--- a/web/components/workspace/ClipList.test.tsx
+++ b/web/components/workspace/ClipList.test.tsx
@@ -1,9 +1,30 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+
+import type { ReactNode } from "react"
 
 import { ClipList } from "@/components/workspace/ClipList"
+import { AuthContext } from "@/contexts/auth-context"
 import { PlayerProvider } from "@/contexts/player-context"
 import type { Clip } from "@/lib/workspace-clips"
+
+// Cards render a wired context menu (US-17.5), which needs auth + player context.
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+function AllProviders({ children }: { children: ReactNode }) {
+  return (
+    <AuthContext.Provider value={authValue}>
+      <PlayerProvider>{children}</PlayerProvider>
+    </AuthContext.Provider>
+  )
+}
 
 function clip(id: string): Clip {
   return {
@@ -40,9 +61,9 @@ describe("ClipList", () => {
 
   it("renders a card per clip", () => {
     render(
-      <PlayerProvider>
+      <AllProviders>
         <ClipList clips={[clip("a"), clip("b")]} loading={false} />
-      </PlayerProvider>
+      </AllProviders>
     )
     expect(screen.getAllByTestId("clip-card")).toHaveLength(2)
   })

--- a/web/components/workspace/ClipList.tsx
+++ b/web/components/workspace/ClipList.tsx
@@ -9,12 +9,18 @@ export function ClipList({
   loading,
   emptyMessage = "No clips found.",
   onGetFullSong,
+  isFreeTier,
+  onDeleted,
 }: {
   clips: Clip[]
   loading: boolean
   emptyMessage?: string
   /** Open the Get Full Song wizard for an eligible clip (US-17.4). */
   onGetFullSong?: (id: string) => void
+  /** Locks Pro-only context-menu items for free-tier users (US-17.5). */
+  isFreeTier?: boolean
+  /** Drop a card after its clip is deleted from the context menu (US-17.5). */
+  onDeleted?: (id: string) => void
 }) {
   if (loading) {
     return (
@@ -37,7 +43,13 @@ export function ClipList({
   return (
     <div className="flex flex-col gap-2">
       {clips.map((clip) => (
-        <ClipCard key={clip.id} clip={clip} onGetFullSong={onGetFullSong} />
+        <ClipCard
+          key={clip.id}
+          clip={clip}
+          onGetFullSong={onGetFullSong}
+          isFreeTier={isFreeTier}
+          onDeleted={onDeleted}
+        />
       ))}
     </div>
   )

--- a/web/components/workspace/WorkspacePanel.test.tsx
+++ b/web/components/workspace/WorkspacePanel.test.tsx
@@ -2,7 +2,10 @@ import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import type { ReactNode } from "react"
+
 import { WorkspacePanel } from "@/components/workspace/WorkspacePanel"
+import { AuthContext } from "@/contexts/auth-context"
 import type { Clip, Workspace } from "@/lib/workspace-clips"
 
 let clipsResult: { data: unknown; loading: boolean; fetching: boolean; error: boolean }
@@ -12,8 +15,27 @@ let likedIds: string[]
 vi.mock("@/hooks/use-clips", () => ({ useClips: () => clipsResult }))
 vi.mock("@/hooks/use-workspaces", () => ({ useWorkspaces: () => wsResult }))
 vi.mock("@/contexts/player-context", () => ({
-  usePlayer: () => ({ state: { likedIds } }),
+  usePlayer: () => ({ state: { likedIds }, dispatch: () => {} }),
 }))
+// The panel reads the tier once for its cards' Pro gating (US-17.5); stub it so
+// no profile fetch runs during these list-focused tests.
+vi.mock("@/hooks/use-subscription-tier", () => ({
+  useSubscriptionTier: () => ({ tier: "free", isFreeTier: true, isLoading: false }),
+}))
+
+// Cards mount a wired context menu (US-17.5) that needs auth context.
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+function renderPanel(ui: ReactNode = <WorkspacePanel />) {
+  return render(<AuthContext.Provider value={authValue}>{ui}</AuthContext.Provider>)
+}
 
 function clip(id: string, overrides: Partial<Clip> = {}): Clip {
   return {
@@ -72,13 +94,13 @@ afterEach(() => vi.clearAllMocks())
 
 describe("WorkspacePanel", () => {
   it("renders the workspace breadcrumb and one card per clip", () => {
-    render(<WorkspacePanel />)
+    renderPanel()
     expect(screen.getByText("My Beats")).toBeInTheDocument()
     expect(screen.getAllByTestId("clip-card")).toHaveLength(3)
   })
 
   it("narrows the list with the client-side Public filter", async () => {
-    render(<WorkspacePanel />)
+    renderPanel()
     await userEvent.click(screen.getByRole("button", { name: /filters/i }))
     await userEvent.click(screen.getByLabelText("Public"))
     expect(screen.getAllByTestId("clip-card")).toHaveLength(1)
@@ -87,7 +109,7 @@ describe("WorkspacePanel", () => {
 
   it("narrows to liked clips using the player's likedIds", async () => {
     likedIds = ["uploaded-three"]
-    render(<WorkspacePanel />)
+    renderPanel()
     await userEvent.click(screen.getByRole("button", { name: /filters/i }))
     await userEvent.click(screen.getByLabelText("Liked"))
     expect(screen.getAllByTestId("clip-card")).toHaveLength(1)
@@ -95,7 +117,7 @@ describe("WorkspacePanel", () => {
   })
 
   it("shows a filtered empty message when nothing matches", async () => {
-    render(<WorkspacePanel />)
+    renderPanel()
     await userEvent.click(screen.getByRole("button", { name: /filters/i }))
     await userEvent.click(screen.getByLabelText("Liked")) // no liked ids
     expect(
@@ -105,14 +127,14 @@ describe("WorkspacePanel", () => {
 
   it("surfaces a load error instead of an empty-library message", () => {
     clipsResult = { data: null, loading: false, fetching: false, error: true }
-    render(<WorkspacePanel />)
+    renderPanel()
     expect(
       screen.getByText("Couldn't load clips. Please try again.")
     ).toBeInTheDocument()
   })
 
   it("renders the pagination indicator", () => {
-    render(<WorkspacePanel />)
+    renderPanel()
     expect(within(screen.getByTestId("workspace-panel")).getByText("Page 1 of 1")).toBeInTheDocument()
   })
 })

--- a/web/components/workspace/WorkspacePanel.tsx
+++ b/web/components/workspace/WorkspacePanel.tsx
@@ -11,6 +11,7 @@ import { SortDropdown } from "@/components/workspace/SortDropdown"
 import { WorkspaceBreadcrumb } from "@/components/workspace/WorkspaceBreadcrumb"
 import { usePlayer } from "@/contexts/player-context"
 import { useClips } from "@/hooks/use-clips"
+import { useSubscriptionTier } from "@/hooks/use-subscription-tier"
 import { useWorkspaces } from "@/hooks/use-workspaces"
 import {
   activeFilterCount,
@@ -54,6 +55,8 @@ export function WorkspacePanel({
   const [page, setPage] = useState(1)
   // The clip whose Get Full Song wizard is open, if any (US-17.4).
   const [fullSongClip, setFullSongClip] = useState<Clip | null>(null)
+  // Bumped on a context-menu delete to refetch and drop the removed card (US-17.5).
+  const [deleteBump, setDeleteBump] = useState(0)
 
   const debouncedSearch = useDebouncedValue(search, 300)
 
@@ -92,9 +95,15 @@ export function WorkspacePanel({
       page,
       per_page: PER_PAGE,
     },
-    { enabled: defaultWorkspace !== null, refreshKey }
+    {
+      enabled: defaultWorkspace !== null,
+      // Combine the parent's generation refresh with local delete bumps so both
+      // force a refetch through the same channel.
+      refreshKey: (refreshKey ?? 0) + deleteBump,
+    }
   )
 
+  const { isFreeTier } = useSubscriptionTier()
   const { state } = usePlayer()
   const visibleClips = useMemo(
     () => applyClientFilters(data?.clips ?? [], filters, state.likedIds),
@@ -123,6 +132,8 @@ export function WorkspacePanel({
         <ClipList
           clips={visibleClips}
           loading={loading}
+          isFreeTier={isFreeTier}
+          onDeleted={() => setDeleteBump((n) => n + 1)}
           onGetFullSong={(id) => {
             const seed = visibleClips.find((c) => c.id === id)
             if (seed) setFullSongClip(seed)

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -219,6 +219,8 @@ describe("useSongActions", () => {
 
     act(() => result.current.cancelDelete())
     expect(result.current.confirmingDelete).toBe(false)
+    // Cancelling clears the error so it doesn't linger as a below-menu alert.
+    expect(result.current.actionError).toBeNull()
   })
 
   it("downloads audio in the requested format", async () => {

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -58,8 +58,8 @@ function clip(overrides: Partial<Clip> = {}): Clip {
   }
 }
 
-function setup(c: Clip = clip()) {
-  return renderHook(() => useSongActions(c), { wrapper })
+function setup(c: Clip = clip(), opts?: { onDeleted?: (id: string) => void }) {
+  return renderHook(() => useSongActions(c, opts), { wrapper })
 }
 
 afterEach(() => {
@@ -163,6 +163,22 @@ describe("useSongActions", () => {
       (opts.headers as Record<string, string>).authorization
     ).toBe("Bearer tok")
     expect(push).toHaveBeenCalledWith("/")
+  })
+
+  it("calls onDeleted instead of navigating when given (clip-list context)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal("fetch", fetchMock)
+    const onDeleted = vi.fn()
+
+    const { result } = setup(clip(), { onDeleted })
+    act(() => result.current.handleAction("delete"))
+    await act(() => result.current.confirmDelete())
+
+    expect(onDeleted).toHaveBeenCalledWith("c1")
+    // The list drops the card itself, so the hook must not navigate home.
+    expect(push).not.toHaveBeenCalled()
   })
 
   it("surfaces a delete failure and stays on the page", async () => {

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -179,6 +179,26 @@ describe("useSongActions", () => {
     expect(onDeleted).toHaveBeenCalledWith("c1")
     // The list drops the card itself, so the hook must not navigate home.
     expect(push).not.toHaveBeenCalled()
+    // Dialog must close so it can't fire a redundant DELETE on the gone clip.
+    expect(result.current.confirmingDelete).toBe(false)
+  })
+
+  it("clears a stale download error when the delete dialog opens", async () => {
+    // 404 makes the real downloadClipAudio return false and seed actionError.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 404 }))
+    )
+    const { result } = setup()
+
+    act(() => {
+      result.current.handleAction("download-mp3")
+    })
+    await waitFor(() => expect(result.current.actionError).toMatch(/download/i))
+
+    // Opening the delete confirmation must start clean, not show the download error.
+    act(() => result.current.handleAction("delete"))
+    expect(result.current.actionError).toBeNull()
   })
 
   it("surfaces a delete failure and stays on the page", async () => {

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -21,7 +21,16 @@ const DOWNLOAD_FORMAT: Partial<Record<SongActionId, DownloadFormat>> = {
   "download-flac": "flac",
 }
 
-export function useSongActions(clip: Clip) {
+export type UseSongActionsOptions = {
+  /**
+   * Where to go after a successful delete. Song detail navigates home (the song
+   * is gone); the clip list (US-17.5) passes a callback to drop the card in place
+   * instead. Defaults to navigating to `/`.
+   */
+  onDeleted?: (id: string) => void
+}
+
+export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions = {}) {
   const router = useRouter()
   const { accessToken } = useAuth()
   const remaster = useClipEdit()
@@ -91,7 +100,8 @@ export function useSongActions(clip: Clip) {
         headers: { authorization: `Bearer ${accessToken}` },
       })
       if (res.status !== 204) throw new Error(`delete failed (${res.status})`)
-      router.push("/")
+      if (onDeleted) onDeleted(clip.id)
+      else router.push("/")
     } catch {
       // Keep the dialog open so the user can retry or cancel.
       setActionError("Couldn't delete this song. Please try again.")

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -86,6 +86,9 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
       // US-17.6; until then the toggle is local feedback only.
       setOptimisticPublic(!isPublic)
     } else if (action === "delete") {
+      // Start the confirmation clean — actionError is shared with the download
+      // flow, so a prior download failure must not show up in this dialog.
+      setActionError(null)
       setConfirmingDelete(true)
     }
   }
@@ -100,8 +103,16 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
         headers: { authorization: `Bearer ${accessToken}` },
       })
       if (res.status !== 204) throw new Error(`delete failed (${res.status})`)
-      if (onDeleted) onDeleted(clip.id)
-      else router.push("/")
+      if (onDeleted) {
+        // List context: the card is dropped by an async refetch, so close the
+        // dialog now — otherwise it lingers with a live Delete button on an
+        // already-deleted clip and a second click fires a redundant DELETE.
+        onDeleted(clip.id)
+        setConfirmingDelete(false)
+      } else {
+        // Song-detail context: navigating home unmounts the dialog.
+        router.push("/")
+      }
     } catch {
       // Keep the dialog open so the user can retry or cancel.
       setActionError("Couldn't delete this song. Please try again.")

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -129,7 +129,12 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
     activeModal,
     closeModal: () => setActiveModal(null),
     confirmingDelete,
-    cancelDelete: () => setConfirmingDelete(false),
+    // Clear the delete error too, so a failed-then-cancelled delete doesn't
+    // linger as a stale below-menu alert (actionError is shared with download).
+    cancelDelete: () => {
+      setActionError(null)
+      setConfirmingDelete(false)
+    },
     confirmDelete,
     deleting,
     actionError,


### PR DESCRIPTION
## US-17.5: Clip Context Menu

Closes #199.

### What this actually needed
The issue's CodeRabbit plan was written when `web/` was empty and prescribed six **new** files (`clip-context-menu.tsx`, `lib/api/clips.ts`, `modal-context.tsx`, `use-clip-actions.ts`, `clip-menu-rules.ts`, `delete-clip-dialog.tsx`). Since then US-16.6/17.1–17.4 shipped, and **every one of those already exists in a better form**:

- The context menu → `ClipCard` already renders all 13 §9.2 items + Download submenu + Delete.
- Modal context → the `SongActionModal` + `lib/song-actions` registry + `useSongActions` dispatch seam.
- API layer → `lib/clips.ts` (`downloadClipAudio`) + the existing `/api/clips/[id]` DELETE proxy.

The real gap was that **nothing was wired**: `ClipList`/`WorkspacePanel` never passed `onMenuAction`, so every menu click in the workspace was a dead end, and Delete had no confirmation dialog. This PR wires the card through the same seam the song-detail menu already uses.

### Changes (8 files, 0 new)
- **`useSongActions`** — new `onDeleted?` option. In a list, delete drops the card in place; song detail still navigates home.
- **`ClipCard`** — dispatches menu selections through `useSongActions` (`remix-edit` → the remix modal), renders `SongActionModal` + `DeleteSongDialog`, surfaces download errors. New `isFreeTier` (Pro lock) + `onDeleted` props; adds the **Beta** badge on "Sample from Song" and ties the existing Pro badge/lock to actual tier.
- **`ClipList`** — threads `isFreeTier` / `onDeleted` to every card.
- **`WorkspacePanel`** — reads the tier once (not per-card, avoids N profile fetches) and refetches on delete via the existing `refreshKey` channel.

### Acceptance criteria
- [x] Context menu renders all §9.2 action items — already did (US-16.6/17.2), verified by test.
- [x] Download submenu expands to format options — already did.
- [x] Delete shows a confirmation dialog before proceeding — **now wired** (`DeleteSongDialog`).
- [x] Menu items correctly trigger their workflows — **now wired** (navigation / modal / download / delete).
- [x] Renders consistently across all clip card locations — single `ClipCard` self-wires, so any location that renders it (workspace today) gets full behavior with no per-site wiring.

### Tests
`web/` suite: **566 passed**. Added coverage for: `onDeleted` delete branch; menu → studio navigation; menu → workflow modal; download-by-format; delete → confirm → DELETE proxy → card drop; free-tier Pro lock + Beta badge. Typecheck, lint, and `next build` all clean.

### Known limitations
- "Export to DAW", "Send to Mastering", "Create Music Video", "Use as Inspiration", and "Download → Stems" open the shared **placeholder** modal (their workflows land in later stories) — consistent with the song-detail menu.
- Download formats are not individually Pro-gated on the card (WAV/FLAC are plain downloads, matching the shipped song menu; only Stems is registry-`proOnly` and routes to the placeholder).
- CI is Python-only, so web checks were run locally (per repo convention).
