### PR TITLE
feat(web): Like, Dislike, Share, and Publish inline actions (US-17.6)

### DIFF
--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -2,12 +2,13 @@
 
 * ``GET    /clips``           → paginated list with search/filter/sort (US-9.4)
 * ``GET    /clips/{id}``      → clip metadata (404 if missing/not owned)
-* ``PATCH  /clips/{id}``      → rename (title is the only writable field)
+* ``PATCH  /clips/{id}``      → rename and/or publish (title, is_public; US-17.6)
 * ``DELETE /clips/{id}``      → remove the record and its stored audio
 * ``GET    /clips/{id}/audio``→ stream audio, byte ranges + ``?format=`` (US-9.3)
 
-CRUD is owner-scoped; only the audio endpoint honors ``is_public``. Access and
-filter rules live in :mod:`acemusic.api.services.clips`.
+CRUD is owner-scoped; the audio/stream endpoints honor ``is_public``, which the
+PATCH publish toggle sets (guarded — see :func:`acemusic.api.services.clips.update_clip_fields`).
+Access and filter rules live in :mod:`acemusic.api.services.clips`.
 """
 
 import asyncio
@@ -87,11 +88,16 @@ class ClipSearchParams(BaseModel):
 
 
 class ClipUpdate(BaseModel):
-    """Rename payload. ``extra="forbid"`` rejects any non-title field with 422."""
+    """Clip edit payload. ``extra="forbid"`` rejects any field other than the two
+    client-writable ones (title, is_public) with 422. Both are optional; an
+    omitted field is left unchanged."""
 
     model_config = ConfigDict(extra="forbid")
 
     title: Annotated[str, Field(min_length=1, max_length=CLIP_TITLE_MAX_LENGTH)] | None = None
+    # US-17.6 publish toggle. Going public is guarded (title + style tags) in the
+    # service; unpublishing is always allowed.
+    is_public: bool | None = None
 
     @field_validator("title")
     @classmethod
@@ -321,11 +327,9 @@ async def update_clip(
     body: ClipUpdate,
     current: CurrentUser = Depends(require_existing_user),
 ) -> ClipResponse:
-    """Rename the clip; an empty body is a no-op returning the current state."""
-    if body.title is None:
-        clip = await clip_service.get_owned_clip(clip_id, current.user_id)
-    else:
-        clip = await clip_service.update_clip_title(clip_id, current.user_id, body.title)
+    """Rename and/or publish the clip; an empty body is a no-op returning the
+    current state. Going public without a title or style tags is rejected 422."""
+    clip = await clip_service.update_clip_fields(clip_id, current.user_id, title=body.title, is_public=body.is_public)
     return ClipResponse.from_clip(clip)
 
 

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -283,11 +283,46 @@ async def list_clips(
     return items, total
 
 
-async def update_clip_title(clip_id: str, user_id: str, title: str) -> Clip:
-    """Rename the clip (title is the only client-writable field, as in the CLI)."""
+def _enforce_publish_guard(clip: Clip) -> None:
+    """Reject going public until the clip is presentable (US-17.6).
+
+    A public clip needs a real title and at least one style tag; publishing a
+    half-finished clip by accident is the failure this guards against. Fail-closed
+    with a 422 that names exactly what's missing so the UI can prompt for it.
+    Unpublishing is never guarded (see ``update_clip_fields``).
+    """
+    missing: list[str] = []
+    if not (clip.title and clip.title.strip()):
+        missing.append("a title")
+    if not clip.style_tags:
+        missing.append("at least one style tag")
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Publishing requires {' and '.join(missing)}.",
+        )
+
+
+async def update_clip_fields(
+    clip_id: str,
+    user_id: str,
+    *,
+    title: str | None = None,
+    is_public: bool | None = None,
+) -> Clip:
+    """Apply the client-writable clip fields — title (rename) and/or is_public
+    (the US-17.6 publish toggle). ``None`` leaves a field unchanged. A title
+    supplied in the same call is applied before the publish guard runs, so a
+    rename-and-publish request is validated against the new title."""
     clip = await get_owned_clip(clip_id, user_id)
-    clip.title = title
-    await clip.save()
+    if title is not None:
+        clip.title = title
+    if is_public:
+        _enforce_publish_guard(clip)
+    if is_public is not None:
+        clip.is_public = is_public
+    if title is not None or is_public is not None:
+        await clip.save()
     return clip
 
 

--- a/tests/test_clips_crud_api.py
+++ b/tests/test_clips_crud_api.py
@@ -445,6 +445,75 @@ class TestUpdateClip:
 
 
 @pytest.mark.integration
+class TestPublishClip:
+    """US-17.6: ``PATCH /clips/{id}`` also toggles ``is_public`` (the inline
+    Publish control). Going public is guarded — the clip must have a title and at
+    least one style tag — so a half-finished clip can't be published by accident.
+    Unpublishing is never guarded."""
+
+    async def test_publish_persists_when_title_and_style_tags_present(self, client, settings) -> None:
+        user = await _make_user("clips-publish@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title="Ready", style_tags=["lofi"], is_public=False)
+        headers = _auth_headers(user, settings)
+
+        resp = await client.patch(f"{CLIPS_URL}/{clip.id}", json={"is_public": True}, headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["is_public"] is True
+        assert (await Clip.get(clip.id)).is_public is True
+
+        # Survives a subsequent GET (the "persist after reload" criterion).
+        fetched = await client.get(f"{CLIPS_URL}/{clip.id}", headers=headers)
+        assert fetched.json()["is_public"] is True
+
+    @pytest.mark.parametrize(
+        ("title", "style_tags"),
+        [(None, ["lofi"]), ("   ", ["lofi"]), ("Ready", [])],
+    )
+    async def test_publish_without_title_or_style_tags_returns_422(self, client, settings, title, style_tags) -> None:
+        user = await _make_user(f"clips-publish-guard-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title=title, style_tags=style_tags, is_public=False)
+
+        resp = await client.patch(
+            f"{CLIPS_URL}/{clip.id}", json={"is_public": True}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 422
+        # Guard is fail-closed: the clip stays private.
+        assert (await Clip.get(clip.id)).is_public is False
+
+    async def test_unpublish_is_never_guarded(self, client, settings) -> None:
+        # A clip may have gone public before losing its title/tags; unpublishing
+        # it must always work so it can't get stuck public.
+        user = await _make_user("clips-unpublish@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title=None, style_tags=[], is_public=True)
+
+        resp = await client.patch(
+            f"{CLIPS_URL}/{clip.id}", json={"is_public": False}, headers=_auth_headers(user, settings)
+        )
+        assert resp.status_code == 200
+        assert resp.json()["is_public"] is False
+        assert (await Clip.get(clip.id)).is_public is False
+
+    async def test_rename_and_publish_in_one_request_uses_the_new_title(self, client, settings) -> None:
+        # The title supplied in the same PATCH satisfies the publish guard.
+        user = await _make_user("clips-rename-publish@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title=None, style_tags=["ambient"], is_public=False)
+
+        resp = await client.patch(
+            f"{CLIPS_URL}/{clip.id}",
+            json={"title": "Named", "is_public": True},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"] == "Named"
+        assert body["is_public"] is True
+
+
+@pytest.mark.integration
 class TestDeleteClip:
     async def test_delete_removes_record_and_stored_audio(self, client, settings, local_storage) -> None:
         user = await _make_user("clips-del@example.com")

--- a/web/README.md
+++ b/web/README.md
@@ -24,8 +24,8 @@ Run the layout smoke tests with `npm run test`.
 A persistent bottom player that keeps playing across client-side navigation.
 
 - `contexts/player-context.tsx` — `PlayerProvider` + `usePlayer`: a reducer
-  store for transport, queue/history, volume, repeat/shuffle, likes; durable
-  preferences persist to `localStorage`.
+  store for transport, queue/history, volume, repeat/shuffle, and likes/dislikes
+  (mutually exclusive per clip); durable preferences persist to `localStorage`.
 - `hooks/use-audio-engine.ts` — owns the single `<audio>` element (mounted once
   at the shell level) and syncs it to the store both ways.
 - `hooks/use-player-shortcuts.ts` — space / arrows / `m`, ignored while typing.
@@ -81,8 +81,9 @@ edit, remix, audio, export, and manage operation on a song in one place.
   `ClipCard`'s menus draw from, so the two surfaces can't drift apart.
 - `hooks/use-song-actions.ts` — dispatches a selected action to its workflow:
   navigation (studio today; editor when US-18 ships), a workflow modal, a file
-  download, or an inline operation (optimistic publish toggle, delete with
-  confirmation).
+  download, or an inline operation (publish toggle — optimistic with a
+  title/style-tag guard and rollback, persisted via `PATCH /clips/{id}`
+  (US-17.6) — and delete with confirmation).
 - `hooks/use-subscription-tier.ts` — lightweight subscription-tier lookup used
   to lock Pro-only menu items for free-tier users, without mounting the full
   model-selection context.

--- a/web/app/api/clips/[id]/route.test.ts
+++ b/web/app/api/clips/[id]/route.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { NextRequest } from "next/server"
 
-import { DELETE, GET } from "@/app/api/clips/[id]/route"
+import { DELETE, GET, PATCH } from "@/app/api/clips/[id]/route"
 
 function req(url: string, init: RequestInit = {}): NextRequest {
   return new Request(url, init) as unknown as NextRequest
@@ -67,6 +67,83 @@ describe("GET /api/clips/[id]", () => {
     const res = await GET(
       req("http://localhost/api/clips/c1", {
         headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(502)
+  })
+})
+
+describe("PATCH /api/clips/[id]", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await PATCH(
+      req("http://localhost/api/clips/c1", {
+        method: "PATCH",
+        body: JSON.stringify({ is_public: true }),
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the token, method, and body to the backend", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "c1", is_public: true }), {
+          status: 200,
+        })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await PATCH(
+      req("http://localhost/api/clips/c1", {
+        method: "PATCH",
+        headers: { authorization: "Bearer tok" },
+        body: JSON.stringify({ is_public: true }),
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: "c1", is_public: true })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips/c1")
+    expect(opts.method).toBe("PATCH")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+    expect(opts.body).toBe(JSON.stringify({ is_public: true }))
+  })
+
+  it("passes the publish-guard 422 through with its detail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "Publishing requires a title." }), {
+          status: 422,
+        })
+      )
+    )
+    const res = await PATCH(
+      req("http://localhost/api/clips/c1", {
+        method: "PATCH",
+        headers: { authorization: "Bearer tok" },
+        body: JSON.stringify({ is_public: true }),
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(422)
+    expect((await res.json()).detail).toContain("Publishing requires")
+  })
+
+  it("returns 502 when the backend is unreachable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")))
+    const res = await PATCH(
+      req("http://localhost/api/clips/c1", {
+        method: "PATCH",
+        headers: { authorization: "Bearer tok" },
+        body: JSON.stringify({ is_public: true }),
       }),
       ctx("c1")
     )

--- a/web/app/api/clips/[id]/route.ts
+++ b/web/app/api/clips/[id]/route.ts
@@ -3,12 +3,13 @@ import { NextResponse, type NextRequest } from "next/server"
 import { BACKEND_URL } from "@/lib/auth-server"
 import { fetchWithTimeout } from "@/lib/proxy-fetch"
 
-// Same-origin proxy for /api/v1/clips/{clip_id} (GET US-17.1, DELETE US-17.2).
-// The client holds the access token in memory and sends it as a Bearer header;
-// this route forwards it so the backend URL stays server-side. The song-detail
-// page fetches a single clip through here, and the full action menu deletes
-// through here. Status/body pass through verbatim (200 with the clip, 204 on
-// delete, 401, 404 when the clip is unknown or not owned).
+// Same-origin proxy for /api/v1/clips/{clip_id} (GET US-17.1, DELETE US-17.2,
+// PATCH US-17.6). The client holds the access token in memory and sends it as a
+// Bearer header; this route forwards it so the backend URL stays server-side.
+// The song-detail page fetches a single clip through here, the full action menu
+// deletes through here, and the inline Publish toggle PATCHes {is_public} here.
+// Status/body pass through verbatim (200 with the clip, 204 on delete, 401, 404
+// when the clip is unknown or not owned, 422 when the publish guard rejects).
 
 export async function GET(
   request: NextRequest,
@@ -25,6 +26,40 @@ export async function GET(
     res = await fetchWithTimeout(
       `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}`,
       { headers: { authorization: auth, accept: "application/json" } }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Clip service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}
+
+export async function PATCH(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { id } = await ctx.params
+  let res: Response
+  try {
+    res = await fetchWithTimeout(
+      `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}`,
+      {
+        method: "PATCH",
+        headers: {
+          authorization: auth,
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: await request.text(),
+      }
     )
   } catch {
     return NextResponse.json(

--- a/web/components/song/PublishGuardPrompt.test.tsx
+++ b/web/components/song/PublishGuardPrompt.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { PublishGuardPrompt } from "@/components/song/PublishGuardPrompt"
+
+describe("PublishGuardPrompt", () => {
+  it("renders nothing when guard is null", () => {
+    render(<PublishGuardPrompt guard={null} onClose={() => {}} />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("lists a missing style tag", () => {
+    render(
+      <PublishGuardPrompt
+        guard={{ missingTitle: false, missingStyleTags: true }}
+        onClose={() => {}}
+      />
+    )
+    expect(screen.getByText(/missing at least one style tag/i)).toBeInTheDocument()
+    expect(screen.queryByText(/missing a title/i)).not.toBeInTheDocument()
+  })
+
+  it("lists both when title and style tags are missing", () => {
+    render(
+      <PublishGuardPrompt
+        guard={{ missingTitle: true, missingStyleTags: true }}
+        onClose={() => {}}
+      />
+    )
+    expect(screen.getByText(/missing a title/i)).toBeInTheDocument()
+    expect(screen.getByText(/missing at least one style tag/i)).toBeInTheDocument()
+  })
+
+  it("dismisses via the button", async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <PublishGuardPrompt
+        guard={{ missingTitle: true, missingStyleTags: false }}
+        onClose={onClose}
+      />
+    )
+    await user.click(screen.getByRole("button", { name: /got it/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/web/components/song/PublishGuardPrompt.tsx
+++ b/web/components/song/PublishGuardPrompt.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Alert01Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import type { PublishGuard } from "@/hooks/use-song-actions"
+
+// US-17.6: shown when a publish is blocked because the clip isn't presentable
+// yet — it needs a title and at least one style tag before it can go public.
+// Purely informational (the repo has no per-clip style-tag editor surface in
+// this story); it names exactly what's missing and dismisses. `guard` is null
+// when there's nothing to show.
+
+export type PublishGuardPromptProps = {
+  guard: PublishGuard | null
+  onClose: () => void
+}
+
+export function PublishGuardPrompt({ guard, onClose }: PublishGuardPromptProps) {
+  const missing: string[] = []
+  if (guard?.missingTitle) missing.push("a title")
+  if (guard?.missingStyleTags) missing.push("at least one style tag")
+
+  return (
+    <Dialog open={guard !== null} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <HugeiconsIcon icon={Alert01Icon} size={20} />
+            Add details before publishing
+          </DialogTitle>
+          <DialogDescription>
+            Publishing makes this song public. Add {missing.join(" and ")} first,
+            then try again.
+          </DialogDescription>
+        </DialogHeader>
+        {missing.length > 0 && (
+          <ul className="list-disc pl-5 text-sm text-muted-foreground">
+            {missing.map((item) => (
+              <li key={item}>Missing {item}</li>
+            ))}
+          </ul>
+        )}
+        <DialogFooter>
+          <Button onClick={onClose}>Got it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/song/ShareModal.test.tsx
+++ b/web/components/song/ShareModal.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ShareModal, shareUrlForClip } from "@/components/song/ShareModal"
+
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  })
+  return writeText
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("shareUrlForClip", () => {
+  it("builds an origin-rooted /song path and encodes the id", () => {
+    expect(shareUrlForClip("c1")).toBe(`${window.location.origin}/song/c1`)
+    expect(shareUrlForClip("a/b")).toBe(`${window.location.origin}/song/a%2Fb`)
+  })
+})
+
+describe("ShareModal", () => {
+  it("shows the copyable share link", () => {
+    render(
+      <ShareModal open clipId="c1" clipTitle="My Song" onClose={() => {}} />
+    )
+    const input = screen.getByLabelText<HTMLInputElement>("Share link")
+    expect(input.value).toBe(shareUrlForClip("c1"))
+    expect(input).toHaveAttribute("readonly")
+  })
+
+  it("copies the link and shows confirmation", async () => {
+    // setup() installs its own clipboard stub, so ours must come after it.
+    const user = userEvent.setup()
+    const writeText = stubClipboard()
+    render(
+      <ShareModal open clipId="c1" clipTitle="My Song" onClose={() => {}} />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Copy link" }))
+    expect(writeText).toHaveBeenCalledWith(shareUrlForClip("c1"))
+    await waitFor(() =>
+      expect(screen.getByText("Copied!")).toBeInTheDocument()
+    )
+  })
+
+  it("offers X and Facebook share intents pointed at the link", () => {
+    render(
+      <ShareModal open clipId="c1" clipTitle="My Song" onClose={() => {}} />
+    )
+    const encoded = encodeURIComponent(shareUrlForClip("c1"))
+
+    const x = screen.getByRole("link", { name: /share on x/i })
+    expect(x).toHaveAttribute("href", expect.stringContaining(encoded))
+    expect(x).toHaveAttribute("target", "_blank")
+
+    const fb = screen.getByRole("link", { name: /share on facebook/i })
+    expect(fb).toHaveAttribute("href", expect.stringContaining(encoded))
+  })
+
+  it("calls onClose when dismissed", async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ShareModal open clipId="c1" clipTitle="My Song" onClose={onClose} />
+    )
+    await user.keyboard("{Escape}")
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/web/components/song/ShareModal.tsx
+++ b/web/components/song/ShareModal.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  CheckmarkCircle01Icon,
+  Copy01Icon,
+  Facebook01Icon,
+  NewTwitterIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+// US-17.6: the Share modal for a clip. Client-only — the share URL is built
+// from the clip id (Design Choice 2: no share_slug), so there's no backend
+// call. Copy-to-clipboard gives inline "Copied!" feedback (the repo has no
+// toast primitive); X/Facebook open their share-intent pages in a new tab.
+
+export type ShareModalProps = {
+  open: boolean
+  clipId: string
+  clipTitle: string | null
+  onClose: () => void
+}
+
+/** Public share URL for a clip: `{origin}/song/{clipId}`. */
+export function shareUrlForClip(clipId: string): string {
+  const origin =
+    typeof window !== "undefined" ? window.location.origin : ""
+  return `${origin}/song/${encodeURIComponent(clipId)}`
+}
+
+export function ShareModal({ open, clipId, clipTitle, onClose }: ShareModalProps) {
+  const [copied, setCopied] = useState(false)
+  const url = shareUrlForClip(clipId)
+  const title = clipTitle ?? "Untitled clip"
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      // Revert the label so a second copy still reads as an action.
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard blocked (permissions / insecure context) — the read-only
+      // field is still selectable, so the user can copy manually.
+      setCopied(false)
+    }
+  }
+
+  const shareIntents = [
+    {
+      label: "Share on X",
+      icon: NewTwitterIcon,
+      href: `https://twitter.com/intent/tweet?url=${encodeURIComponent(
+        url
+      )}&text=${encodeURIComponent(title)}`,
+    },
+    {
+      label: "Share on Facebook",
+      icon: Facebook01Icon,
+      href: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
+        url
+      )}`,
+    },
+  ]
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Share &ldquo;{title}&rdquo;</DialogTitle>
+          <DialogDescription>
+            Anyone with the link can open this song.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2">
+          <Input
+            aria-label="Share link"
+            readOnly
+            value={url}
+            onFocus={(e) => e.currentTarget.select()}
+          />
+          <Button
+            type="button"
+            variant={copied ? "outline" : "default"}
+            onClick={copyLink}
+            aria-label="Copy link"
+          >
+            <HugeiconsIcon
+              icon={copied ? CheckmarkCircle01Icon : Copy01Icon}
+              size={16}
+            />
+            {copied ? "Copied!" : "Copy"}
+          </Button>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {shareIntents.map((intent) => (
+            <Button
+              key={intent.label}
+              asChild
+              variant="outline"
+              size="sm"
+            >
+              <a href={intent.href} target="_blank" rel="noopener noreferrer">
+                <HugeiconsIcon icon={intent.icon} size={16} />
+                {intent.label}
+              </a>
+            </Button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/song/SongDetail.tsx
+++ b/web/components/song/SongDetail.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { DeleteSongDialog } from "@/components/song/DeleteSongDialog"
+import { PublishGuardPrompt } from "@/components/song/PublishGuardPrompt"
 import { RelatedSongs } from "@/components/song/RelatedSongs"
 import { SongActionModal } from "@/components/song/SongActionModal"
 import { SongActionsMenu } from "@/components/song/SongActionsMenu"
@@ -126,6 +127,10 @@ function SongDetailContent({ clip }: { clip: Clip }) {
         error={actions.actionError}
         onCancel={actions.cancelDelete}
         onConfirm={actions.confirmDelete}
+      />
+      <PublishGuardPrompt
+        guard={actions.publishGuard}
+        onClose={actions.dismissPublishGuard}
       />
     </div>
   )

--- a/web/components/song/SongHeader.test.tsx
+++ b/web/components/song/SongHeader.test.tsx
@@ -92,4 +92,21 @@ describe("SongHeader", () => {
     expect(onDislike).toHaveBeenCalledWith("c1")
     expect(onShare).toHaveBeenCalledWith("c1")
   })
+
+  it("persists dislike via the player store", async () => {
+    const user = userEvent.setup()
+    renderHeader()
+    const dislike = screen.getByRole("button", { name: "Dislike" })
+    expect(dislike).toHaveAttribute("aria-pressed", "false")
+    await user.click(dislike)
+    expect(dislike).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("opens the share modal with a copyable link", async () => {
+    const user = userEvent.setup()
+    renderHeader()
+    await user.click(screen.getByRole("button", { name: "Share" }))
+    expect(await screen.findByRole("dialog")).toHaveTextContent(/share/i)
+    expect(screen.getByLabelText("Share link")).toBeInTheDocument()
+  })
 })

--- a/web/components/song/SongHeader.tsx
+++ b/web/components/song/SongHeader.tsx
@@ -11,17 +11,19 @@ import {
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { ShareModal } from "@/components/song/ShareModal"
 import { usePlayer } from "@/contexts/player-context"
 import { modeLabel, versionLabel } from "@/lib/clip-labels"
 import { cn } from "@/lib/utils"
 import type { Clip } from "@/lib/workspace-clips"
 
-// Song-detail header (US-17.1): title, artist, style/version/mode badges, and
-// the inline Like / Dislike / Share / Publish controls. Like is wired to the
-// global player store (the one backend-free action with a real home, as in
-// ClipCard); dislike/share/publish have no backend yet, so they give local
-// optimistic feedback and emit callbacks the parent wires when routes land
-// (US-17.6). Matches ClipCard's behavior so actions read the same app-wide.
+// Song-detail header (US-17.1 / US-17.6): title, artist, style/version/mode
+// badges, and the inline Like / Dislike / Share / Publish controls. Like and
+// Dislike are wired to the global player store (persisted in localStorage, so
+// they survive a reload — as in ClipCard). Share opens the ShareModal. Publish
+// is prop-driven: SongDetail passes the persisted `isPublic` + a `onPublishToggle`
+// that hits the API with a guard; standalone it falls back to a local optimistic
+// toggle. `onDislike`/`onShare` remain optional observers.
 
 export type SongHeaderProps = {
   clip: Clip
@@ -47,17 +49,24 @@ export function SongHeader({
 }: SongHeaderProps) {
   const { state, dispatch } = usePlayer()
   const likedSet = useMemo(() => new Set(state.likedIds), [state.likedIds])
+  const dislikedSet = useMemo(() => new Set(state.dislikedIds), [state.dislikedIds])
   const liked = likedSet.has(clip.id)
-  const [disliked, setDisliked] = useState(false)
+  const disliked = dislikedSet.has(clip.id)
   const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
+  const [shareOpen, setShareOpen] = useState(false)
   const isPublic = isPublicProp ?? optimisticPublic ?? clip.is_public
 
   const version = versionLabel(clip.model)
   const mode = modeLabel(clip.generation_mode)
 
   function dislike() {
-    setDisliked((d) => !d)
+    dispatch({ type: "dislike/toggle", id: clip.id })
     onDislike?.(clip.id)
+  }
+
+  function share() {
+    setShareOpen(true)
+    onShare?.(clip.id)
   }
 
   function togglePublish() {
@@ -120,7 +129,7 @@ export function SongHeader({
           variant="ghost"
           size="icon-sm"
           aria-label="Share"
-          onClick={() => onShare?.(clip.id)}
+          onClick={share}
         >
           <HugeiconsIcon icon={Share01Icon} size={18} />
         </Button>
@@ -136,6 +145,13 @@ export function SongHeader({
         </Button>
         {actions && <div className="ml-auto">{actions}</div>}
       </div>
+
+      <ShareModal
+        open={shareOpen}
+        clipId={clip.id}
+        clipTitle={clip.title}
+        onClose={() => setShareOpen(false)}
+      />
     </header>
   )
 }

--- a/web/components/song/SongHeader.tsx
+++ b/web/components/song/SongHeader.tsx
@@ -72,9 +72,10 @@ export function SongHeader({
   function togglePublish() {
     const next = !isPublic
     onPublishToggle?.(clip.id, next)
-    // Reflect locally so the inline control visibly works on the detail page
-    // (which has no persisting parent yet); a real resync lands when the publish
-    // route exists (US-17.6). Mirrors the local dislike toggle above.
+    // When wired via SongDetail, `isPublic` is controlled by useSongActions
+    // (which persists + guards + rolls back), so this local flip is shadowed and
+    // the hook owns the visible state. It only takes effect for a standalone,
+    // uncontrolled SongHeader (no isPublic prop) as immediate local feedback.
     setOptimisticPublic(next)
   }
 

--- a/web/components/workspace/ClipCard.test.tsx
+++ b/web/components/workspace/ClipCard.test.tsx
@@ -174,16 +174,67 @@ describe("ClipCard", () => {
     expect(onShare).toHaveBeenCalledWith("c1")
   })
 
-  it("toggles publish and reports the next visibility", async () => {
+  it("publishes a ready clip, persisting via the PATCH proxy", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ id: "c1", is_public: true }), {
+          status: 200,
+        })
+      )
+    )
+    vi.stubGlobal("fetch", fetchMock)
     const onPublishToggle = vi.fn()
     renderCard({ onPublishToggle })
+
     const publish = screen.getByRole("button", { name: /publish|make public/i })
     expect(publish).toHaveAttribute("aria-pressed", "false")
     await userEvent.click(publish)
+
     expect(onPublishToggle).toHaveBeenCalledWith("c1", true)
-    expect(
-      screen.getByRole("button", { name: /publish|make public|public/i })
-    ).toHaveAttribute("aria-pressed", "true")
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /unpublish|make private/i })
+      ).toHaveAttribute("aria-pressed", "true")
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/clips/c1",
+      expect.objectContaining({ method: "PATCH" })
+    )
+    vi.unstubAllGlobals()
+  })
+
+  it("prompts instead of publishing an incomplete clip", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    render(
+      <AllProviders>
+        <ClipCard clip={clip({ style_tags: [] })} />
+      </AllProviders>
+    )
+    await userEvent.click(
+      screen.getByRole("button", { name: /publish|make public/i })
+    )
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      /before publishing/i
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+
+  it("persists dislike via the player store", async () => {
+    renderCard()
+    const dislike = screen.getByRole("button", { name: /dislike/i })
+    expect(dislike).toHaveAttribute("aria-pressed", "false")
+    await userEvent.click(dislike)
+    expect(dislike).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("opens the share modal with a copyable link", async () => {
+    renderCard()
+    await userEvent.click(screen.getByRole("button", { name: /share/i }))
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveTextContent(/share/i)
+    expect(screen.getByLabelText("Share link")).toBeInTheDocument()
   })
 
   it("shows Get Full Song only for clips under 60s", async () => {

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -30,6 +30,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { DeleteSongDialog } from "@/components/song/DeleteSongDialog"
+import { PublishGuardPrompt } from "@/components/song/PublishGuardPrompt"
+import { ShareModal } from "@/components/song/ShareModal"
 import { SongActionModal } from "@/components/song/SongActionModal"
 import { usePlayer } from "@/contexts/player-context"
 import { useSongActions } from "@/hooks/use-song-actions"
@@ -39,12 +41,14 @@ import { isFullSongEligible } from "@/lib/song-structure"
 import { cn } from "@/lib/utils"
 import type { Clip } from "@/lib/workspace-clips"
 
-// US-16.6 / US-17.5: the reusable clip card. Play + Like are wired to the global
-// player store; like/dislike/share/publish/rename stay callback props (no backend
-// routes proxied for them yet). The ⋯ menu and Remix CTA now dispatch through
-// useSongActions (US-17.5) — the same registry-driven seam the song-detail menu
-// uses — so any menu click opens its modal, navigates, downloads, or confirms a
-// delete wherever a card is rendered, with no per-location wiring.
+// US-16.6 / US-17.5 / US-17.6: the reusable clip card. Play, Like and Dislike are
+// wired to the global player store (Like/Dislike persist in localStorage). Share
+// opens the ShareModal; Publish persists through useSongActions (guarded — needs a
+// title + a style tag to go public). The ⋯ menu and Remix CTA also dispatch
+// through useSongActions (US-17.5) — the same registry-driven seam the song-detail
+// menu uses — so any action opens its modal, navigates, downloads, publishes, or
+// confirms a delete wherever a card is rendered. `onDislike`/`onShare`/
+// `onPublishToggle` remain optional observers for parent analytics/refetch.
 // The action vocabulary lives in lib/song-actions (US-17.2) and is re-exported
 // here so existing imports keep working.
 
@@ -116,23 +120,26 @@ export function ClipCard({
   onDeleted,
 }: ClipCardProps) {
   const { state, dispatch } = usePlayer()
-  // Registry-driven dispatch: modal / navigation / download / delete-confirm.
+  // Registry-driven dispatch: modal / navigation / download / delete-confirm /
+  // publish (persist + guard).
   const actions = useSongActions(clip, { onDeleted })
   // likedIds re-renders every player tick; scan a Set (cf. applyClientFilters).
   const likedSet = useMemo(() => new Set(state.likedIds), [state.likedIds])
+  const dislikedSet = useMemo(() => new Set(state.dislikedIds), [state.dislikedIds])
   const liked = likedSet.has(clip.id)
+  const disliked = dislikedSet.has(clip.id)
 
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState("")
+  const [shareOpen, setShareOpen] = useState(false)
   // Editing cancelled (Escape) — checked in the single onBlur commit path.
   const cancelRef = useRef(false)
-  // Optimistic overlays: null means "show the prop". This keeps an idle card in
-  // sync with parent/refetch updates while still reflecting a user's own edit.
-  // A real resync (e.g. a failed save) lands when backend mutation routes exist.
+  // Optimistic title overlay: null means "show the prop". Keeps an idle card in
+  // sync with parent/refetch updates while still reflecting the user's own edit.
   const [optimisticTitle, setOptimisticTitle] = useState<string | null>(null)
-  const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
   const title = optimisticTitle ?? clip.title
-  const isPublic = optimisticPublic ?? clip.is_public
+  // Publish visibility is owned by useSongActions (optimistic + persisted + rollback).
+  const isPublic = actions.isPublic
 
   const version = versionLabel(clip.model)
   const metadataLabel = modeLabel(clip.generation_mode)
@@ -168,11 +175,22 @@ export function ClipCard({
     onMenuAction?.(action, clip.id)
   }
 
+  function dislike() {
+    dispatch({ type: "dislike/toggle", id: clip.id })
+    onDislike?.(clip.id)
+  }
+
+  function share() {
+    setShareOpen(true)
+    onShare?.(clip.id)
+  }
+
   function togglePublish() {
     const next = !isPublic
-    onPublishToggle?.(clip.id, next)
-    // Only reflect the new visibility when a parent persists it.
-    if (onPublishToggle) setOptimisticPublic(next)
+    onPublishToggle?.(clip.id, next) // optional observer
+    // Persist + guard (needs a title + style tag to go public); optimistic with
+    // rollback lives in useSongActions.
+    actions.togglePublish(clip.id, next)
   }
 
   return (
@@ -292,7 +310,9 @@ export function ClipCard({
             variant="ghost"
             size="icon-sm"
             aria-label="Dislike"
-            onClick={() => onDislike?.(clip.id)}
+            aria-pressed={disliked}
+            onClick={dislike}
+            className={cn(disliked && "text-primary")}
           >
             <HugeiconsIcon icon={ThumbsDownIcon} size={16} />
           </Button>
@@ -300,7 +320,7 @@ export function ClipCard({
             variant="ghost"
             size="icon-sm"
             aria-label="Share"
-            onClick={() => onShare?.(clip.id)}
+            onClick={share}
           >
             <HugeiconsIcon icon={Share01Icon} size={16} />
           </Button>
@@ -469,6 +489,16 @@ export function ClipCard({
         error={actions.actionError}
         onCancel={actions.cancelDelete}
         onConfirm={actions.confirmDelete}
+      />
+      <ShareModal
+        open={shareOpen}
+        clipId={clip.id}
+        clipTitle={title}
+        onClose={() => setShareOpen(false)}
+      />
+      <PublishGuardPrompt
+        guard={actions.publishGuard}
+        onClose={actions.dismissPublishGuard}
       />
     </div>
   )

--- a/web/contexts/player-context.test.ts
+++ b/web/contexts/player-context.test.ts
@@ -198,4 +198,24 @@ describe("playerReducer modes + likes", () => {
     s = playerReducer(s, { type: "like/toggle", id: "x" })
     expect(s.likedIds).not.toContain("x")
   })
+
+  it("toggles dislike state for a track id", () => {
+    let s = base()
+    s = playerReducer(s, { type: "dislike/toggle", id: "x" })
+    expect(s.dislikedIds).toContain("x")
+    s = playerReducer(s, { type: "dislike/toggle", id: "x" })
+    expect(s.dislikedIds).not.toContain("x")
+  })
+
+  it("like and dislike are mutually exclusive per clip", () => {
+    let s = base({ dislikedIds: ["x"] })
+    // Liking a disliked clip clears the dislike.
+    s = playerReducer(s, { type: "like/toggle", id: "x" })
+    expect(s.likedIds).toContain("x")
+    expect(s.dislikedIds).not.toContain("x")
+    // Disliking a liked clip clears the like.
+    s = playerReducer(s, { type: "dislike/toggle", id: "x" })
+    expect(s.dislikedIds).toContain("x")
+    expect(s.likedIds).not.toContain("x")
+  })
 })

--- a/web/contexts/player-context.tsx
+++ b/web/contexts/player-context.tsx
@@ -32,6 +32,8 @@ export type PlayerState = {
   shuffle: boolean
   isQueueOpen: boolean
   likedIds: string[]
+  /** Disliked clip ids (US-17.6). Mutually exclusive with likedIds per clip. */
+  dislikedIds: string[]
   /** Set by a scrub; the audio engine seeks to it then dispatches "seek/done". */
   seekRequest: number | null
 }
@@ -52,6 +54,7 @@ export const initialPlayerState: PlayerState = {
   shuffle: false,
   isQueueOpen: false,
   likedIds: [],
+  dislikedIds: [],
   seekRequest: null,
 }
 
@@ -82,8 +85,13 @@ export type PlayerAction =
   | { type: "repeat/cycle" }
   | { type: "shuffle/toggle" }
   | { type: "like/toggle"; id: string }
+  | { type: "dislike/toggle"; id: string }
 
 const clampVolume = (v: number) => Math.min(1, Math.max(0, v))
+
+/** Add or remove `id` from a list (toggle). */
+const toggleId = (ids: string[], id: string): string[] =>
+  ids.includes(id) ? ids.filter((x) => x !== id) : [...ids, id]
 
 /** Pick the index of the next track to play from a queue, honoring shuffle. */
 function nextIndex(queueLength: number, shuffle: boolean): number {
@@ -267,13 +275,27 @@ export function playerReducer(
     }
     case "shuffle/toggle":
       return { ...state, shuffle: !state.shuffle }
-    case "like/toggle":
+    case "like/toggle": {
+      const liking = !state.likedIds.includes(action.id)
       return {
         ...state,
-        likedIds: state.likedIds.includes(action.id)
-          ? state.likedIds.filter((id) => id !== action.id)
-          : [...state.likedIds, action.id],
+        likedIds: toggleId(state.likedIds, action.id),
+        // A clip can't be liked and disliked at once — liking clears a dislike.
+        dislikedIds: liking
+          ? state.dislikedIds.filter((id) => id !== action.id)
+          : state.dislikedIds,
       }
+    }
+    case "dislike/toggle": {
+      const disliking = !state.dislikedIds.includes(action.id)
+      return {
+        ...state,
+        dislikedIds: toggleId(state.dislikedIds, action.id),
+        likedIds: disliking
+          ? state.likedIds.filter((id) => id !== action.id)
+          : state.likedIds,
+      }
+    }
     default:
       return state
   }
@@ -290,6 +312,7 @@ type Persisted = Pick<
   | "repeatMode"
   | "shuffle"
   | "likedIds"
+  | "dislikedIds"
 >
 
 function loadPersisted(): Partial<PlayerState> {
@@ -330,6 +353,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       repeatMode: state.repeatMode,
       shuffle: state.shuffle,
       likedIds: state.likedIds,
+      dislikedIds: state.dislikedIds,
     }
     try {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted))
@@ -343,6 +367,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     state.repeatMode,
     state.shuffle,
     state.likedIds,
+    state.dislikedIds,
   ])
 
   const value = useMemo(() => ({ state, dispatch }), [state])

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -198,6 +198,32 @@ describe("useSongActions", () => {
       expect(result.current.isPublic).toBe(false)
     })
 
+    it("shows the server message (not an empty guard) on a 422 for a locally-ready clip", async () => {
+      // Race: local clip looks ready, but the server rejects (fields changed
+      // since load). Recomputing the guard would be all-false → empty prompt;
+      // the server's specific message must win instead.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({ detail: "Publishing requires a title." }),
+            { status: 422 }
+          )
+        )
+      )
+      const { result } = setup(ready())
+
+      await act(async () => {
+        result.current.handleAction("publish-toggle")
+      })
+      await waitFor(() =>
+        expect(result.current.actionError).toBe("Publishing requires a title.")
+      )
+      // No empty guard prompt, and the optimistic publish rolled back.
+      expect(result.current.publishGuard).toBeNull()
+      expect(result.current.isPublic).toBe(false)
+    })
+
     it("unpublishes without guarding, even on an incomplete clip", async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ id: "c1", is_public: false }), {

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -132,15 +132,93 @@ describe("useSongActions", () => {
     act(() => result.current.dismissRemaster())
   })
 
-  it("toggles publish state optimistically", () => {
-    const { result } = setup()
-    expect(result.current.isPublic).toBe(false)
+  describe("publish toggle (US-17.6)", () => {
+    const ready = () => clip({ title: "My Song", style_tags: ["lofi"] })
 
-    act(() => result.current.handleAction("publish-toggle"))
-    expect(result.current.isPublic).toBe(true)
+    it("persists an optimistic publish when the clip is ready", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: "c1", is_public: true }), {
+          status: 200,
+        })
+      )
+      vi.stubGlobal("fetch", fetchMock)
+      const { result } = setup(ready())
+      expect(result.current.isPublic).toBe(false)
 
-    act(() => result.current.handleAction("publish-toggle"))
-    expect(result.current.isPublic).toBe(false)
+      await act(async () => {
+        result.current.handleAction("publish-toggle")
+      })
+      await waitFor(() => expect(result.current.isPublic).toBe(true))
+
+      const [url, opts] = fetchMock.mock.calls[0]
+      expect(url).toBe("/api/clips/c1")
+      expect(opts.method).toBe("PATCH")
+      expect(JSON.parse(opts.body as string)).toEqual({ is_public: true })
+      expect(result.current.publishGuard).toBeNull()
+    })
+
+    it("prompts (no request) when a style tag is missing", () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal("fetch", fetchMock)
+      const { result } = setup(clip({ title: "My Song", style_tags: [] }))
+
+      act(() => result.current.handleAction("publish-toggle"))
+      expect(result.current.publishGuard).toEqual({
+        missingTitle: false,
+        missingStyleTags: true,
+      })
+      expect(result.current.isPublic).toBe(false)
+      expect(fetchMock).not.toHaveBeenCalled()
+
+      act(() => result.current.dismissPublishGuard())
+      expect(result.current.publishGuard).toBeNull()
+    })
+
+    it("flags a missing title in the guard", () => {
+      const { result } = setup(clip({ title: null, style_tags: ["lofi"] }))
+      act(() => result.current.handleAction("publish-toggle"))
+      expect(result.current.publishGuard).toEqual({
+        missingTitle: true,
+        missingStyleTags: false,
+      })
+    })
+
+    it("rolls back and surfaces an error when the request fails", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(new Response("{}", { status: 500 }))
+      )
+      const { result } = setup(ready())
+
+      await act(async () => {
+        result.current.handleAction("publish-toggle")
+      })
+      await waitFor(() => expect(result.current.actionError).toBeTruthy())
+      // Optimistic publish reverted after the failure.
+      expect(result.current.isPublic).toBe(false)
+    })
+
+    it("unpublishes without guarding, even on an incomplete clip", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: "c1", is_public: false }), {
+          status: 200,
+        })
+      )
+      vi.stubGlobal("fetch", fetchMock)
+      const { result } = setup(
+        clip({ title: null, style_tags: [], is_public: true })
+      )
+      expect(result.current.isPublic).toBe(true)
+
+      await act(async () => {
+        result.current.handleAction("publish-toggle")
+      })
+      await waitFor(() => expect(result.current.isPublic).toBe(false))
+      expect(result.current.publishGuard).toBeNull()
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+        is_public: false,
+      })
+    })
   })
 
   it("asks for confirmation before deleting, then deletes and leaves", async () => {

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -5,15 +5,34 @@ import { useRouter } from "next/navigation"
 
 import { useAuth } from "@/hooks/use-auth"
 import { useClipEdit } from "@/hooks/use-clip-edit"
-import { downloadClipAudio, type DownloadFormat } from "@/lib/clips"
+import {
+  downloadClipAudio,
+  updateClipVisibility,
+  type DownloadFormat,
+} from "@/lib/clips"
 import { submitRemaster } from "@/lib/editing"
 import { findSongAction, type SongActionId } from "@/lib/song-actions"
 import type { Clip } from "@/lib/workspace-clips"
 
 // US-17.2: dispatch for the full action menu. Routes a selected action to its
 // workflow: navigation (editor/studio), a workflow modal (content lands in
-// US-17.3+), a file download, or an inline operation (optimistic publish
-// toggle — persistence lands with US-17.6 — and delete-with-confirmation).
+// US-17.3+), a file download, or an inline operation (the US-17.6 publish
+// toggle — optimistic with real persistence + rollback — and delete).
+
+/** Which publish requirements a clip is missing, for the guard prompt (US-17.6). */
+export type PublishGuard = {
+  missingTitle: boolean
+  missingStyleTags: boolean
+}
+
+/** Compute the publish guard for a clip; `null` when it's ready to go public. */
+function publishGuardFor(clip: Clip): PublishGuard | null {
+  const missingTitle = !clip.title?.trim()
+  const missingStyleTags = clip.style_tags.length === 0
+  return missingTitle || missingStyleTags
+    ? { missingTitle, missingStyleTags }
+    : null
+}
 
 const DOWNLOAD_FORMAT: Partial<Record<SongActionId, DownloadFormat>> = {
   "download-mp3": "mp3",
@@ -39,6 +58,9 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
   const [deleting, setDeleting] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
   const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
+  // Set when a publish is blocked (client guard) or rejected (server 422); drives
+  // the PublishGuardPrompt. Null means no prompt.
+  const [publishGuard, setPublishGuard] = useState<PublishGuard | null>(null)
 
   const isPublic = optimisticPublic ?? clip.is_public
 
@@ -82,14 +104,41 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
         accessToken
       )
     } else if (action === "publish-toggle") {
-      // Optimistic, like SongHeader/ClipCard — the publish route lands in
-      // US-17.6; until then the toggle is local feedback only.
-      setOptimisticPublic(!isPublic)
+      void doPublish(!isPublic)
     } else if (action === "delete") {
       // Start the confirmation clean — actionError is shared with the download
       // flow, so a prior download failure must not show up in this dialog.
       setActionError(null)
       setConfirmingDelete(true)
+    }
+  }
+
+  /**
+   * Publish/unpublish the clip with optimistic UI and rollback (US-17.6).
+   * Going public is guarded client-side (needs a title + a style tag) so the
+   * prompt shows before any request; a server 422 (fields changed since load)
+   * rolls back and prompts too. Other failures roll back and surface an error.
+   */
+  async function doPublish(next: boolean) {
+    if (!accessToken) return
+    if (next) {
+      const guard = publishGuardFor(clip)
+      if (guard) {
+        setPublishGuard(guard)
+        return
+      }
+    }
+    const prev = isPublic
+    setOptimisticPublic(next)
+    setActionError(null)
+    const result = await updateClipVisibility(clip.id, next, accessToken)
+    if (!result.ok) {
+      setOptimisticPublic(prev) // rollback
+      if (result.guardFailed) {
+        setPublishGuard(publishGuardFor(clip) ?? { missingTitle: false, missingStyleTags: false })
+      } else {
+        setActionError(result.message)
+      }
     }
   }
 
@@ -140,7 +189,10 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
     actionError,
     clearActionError: () => setActionError(null),
     handleAction,
-    /** SongHeader-compatible publish callback (id, next). */
-    togglePublish: (_id: string, next: boolean) => setOptimisticPublic(next),
+    /** SongHeader/ClipCard-compatible publish callback (id, next). Persists. */
+    togglePublish: (_id: string, next: boolean) => void doPublish(next),
+    /** Non-null while the publish guard prompt should show; names what's missing. */
+    publishGuard,
+    dismissPublishGuard: () => setPublishGuard(null),
   }
 }

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -134,8 +134,14 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
     const result = await updateClipVisibility(clip.id, next, accessToken)
     if (!result.ok) {
       setOptimisticPublic(prev) // rollback
-      if (result.guardFailed) {
-        setPublishGuard(publishGuardFor(clip) ?? { missingTitle: false, missingStyleTags: false })
+      // Prefer the client-side guard prompt, which names the missing fields.
+      // But a server 422 can win a race where local `clip` still looks ready
+      // (fields changed since load); recomputing the guard would then be
+      // all-false and render an empty prompt, so fall back to the server's
+      // specific message instead.
+      const guard = result.guardFailed ? publishGuardFor(clip) : null
+      if (guard) {
+        setPublishGuard(guard)
       } else {
         setActionError(result.message)
       }

--- a/web/lib/clips.test.ts
+++ b/web/lib/clips.test.ts
@@ -5,6 +5,7 @@ import {
   clipArtworkUrl,
   downloadClipAudio,
   formatTime,
+  updateClipVisibility,
 } from "@/lib/clips"
 
 describe("clip url builders", () => {
@@ -30,6 +31,66 @@ describe("formatTime", () => {
     expect(formatTime(9.9)).toBe("0:09")
     expect(formatTime(-3)).toBe("0:00")
     expect(formatTime(NaN)).toBe("0:00")
+  })
+})
+
+describe("updateClipVisibility", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it("PATCHes the BFF route with the token and is_public body", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "c1", is_public: true }), {
+          status: 200,
+        })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await updateClipVisibility("c1", true, "tok")
+    expect(result).toEqual({ ok: true, isPublic: true })
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/clips/c1")
+    expect(opts.method).toBe("PATCH")
+    expect(opts.headers.authorization).toBe("Bearer tok")
+    expect(JSON.parse(opts.body)).toEqual({ is_public: true })
+  })
+
+  it("flags a 422 as a guard failure and carries the detail message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ detail: "Publishing requires a title." }),
+          { status: 422 }
+        )
+      )
+    )
+    const result = await updateClipVisibility("c1", true, "tok")
+    expect(result).toEqual({
+      ok: false,
+      guardFailed: true,
+      message: "Publishing requires a title.",
+    })
+  })
+
+  it("returns a non-guard error on other failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 500 }))
+    )
+    const result = await updateClipVisibility("c1", true, "tok")
+    expect(result).toMatchObject({ ok: false, guardFailed: false })
+  })
+
+  it("returns a non-guard error when the request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("net down")))
+    const result = await updateClipVisibility("c1", false, "tok")
+    expect(result).toMatchObject({ ok: false, guardFailed: false })
   })
 })
 

--- a/web/lib/clips.ts
+++ b/web/lib/clips.ts
@@ -87,6 +87,48 @@ export async function downloadClipAudio(
   return true
 }
 
+/** Outcome of a publish-toggle attempt (US-17.6). */
+export type VisibilityResult =
+  | { ok: true; isPublic: boolean }
+  | { ok: false; guardFailed: boolean; message: string }
+
+/**
+ * Persist a clip's public/private state via `PATCH /api/clips/{id}` (US-17.6).
+ * A 422 is the backend publish guard (missing title/style tags) — surfaced as
+ * `guardFailed` so the caller can prompt for the missing fields instead of
+ * showing a generic error. All other failures return `guardFailed: false`.
+ */
+export async function updateClipVisibility(
+  id: string,
+  isPublic: boolean,
+  accessToken: string
+): Promise<VisibilityResult> {
+  let res: Response
+  try {
+    res = await fetch(`/api/clips/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ is_public: isPublic }),
+    })
+  } catch {
+    return {
+      ok: false,
+      guardFailed: false,
+      message: "Couldn't reach the server. Please try again.",
+    }
+  }
+  if (res.ok) return { ok: true, isPublic }
+  const detail = (await res.json().catch(() => ({}))) as { detail?: unknown }
+  const message =
+    typeof detail.detail === "string"
+      ? detail.detail
+      : "Couldn't update visibility. Please try again."
+  return { ok: false, guardFailed: res.status === 422, message }
+}
+
 /** Format a number of seconds as `m:ss` (negative/NaN → `0:00`). */
 export function formatTime(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds < 0) seconds = 0

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -38,4 +38,7 @@ afterEach(() => {
   cleanup()
   routerMock.pathname = "/"
   vi.clearAllMocks()
+  // The player store persists likes/dislikes to localStorage; clear it so state
+  // doesn't leak between tests (US-17.6 added the dislike slice).
+  window.localStorage.clear()
 })


### PR DESCRIPTION
## US-17.6 — Like, Dislike, Share, and Publish Actions

Closes #200.

Wires the inline clip action controls — which shipped as **local stubs** in US-16.6/17.1 and were explicitly marked "US-17.6 lands the routes" — to real behavior on both clip cards and the song detail page.

### What changed

**Publish (persisted, guarded, optimistic)**
- New `PATCH /api/clips/{id}` BFF route forwards `{is_public}` to the backend.
- Backend: `ClipUpdate` gains `is_public`; new `update_clip_fields` service applies title and/or visibility with a **publish guard** — going public requires a title **and** ≥1 style tag, else `422`. Unpublishing is never guarded.
- Client mirrors the guard (prompts *before* the request via `PublishGuardPrompt`) and is optimistic with **rollback** on failure; a server `422` also rolls back and prompts.

**Like / Dislike (persist across reload)**
- Dislike now lives in the player store + `localStorage` (mirrors like; the two are mutually exclusive per clip), so both survive a page reload.

**Share (client-only)**
- `ShareModal` with a copyable `{origin}/song/{id}` link (copy-to-clipboard + inline confirmation) and X/Facebook share intents. No backend call (share URL is derived from the clip id).

### Scope decision (user-approved: web-first / minimal)

This is a `web`/`layer-3` story, and every prior Stage-17 story was web-only. The stale CodeRabbit plan (written before the web app existed) proposed a full backend reaction subsystem; instead this ships the **one small backend change** needed for truthful publish persistence and keeps everything else in the web layer.

**Deferred to future layer-2 stories** (not required by the acceptance criteria):
- Server-side `ClipReaction` collection ("dislike affects recommendations")
- Three-state `unlisted` visibility (the inline control is binary public/private, matching the existing UI)

### Acceptance criteria
- [x] Like/dislike toggle correctly and persist after page reload
- [x] Share modal provides a copyable link
- [x] Publish toggle changes visibility with API confirmation
- [x] Publishing without a title or style tag shows a prompt to add them
- [x] UI updates optimistically and rolls back on error

### Testing
- **Backend** (real MongoDB): `TestPublishClip` (publish persists, 422 guard for missing title/tags, unpublish unguarded, rename+publish) — 6 passed; `TestUpdateClip`/`TestAuthGate` unaffected.
- **Web**: full suite **595 passed** (85 files); typecheck + ESLint clean; `next build` succeeds. New/updated suites cover the store slice, BFF PATCH route, `updateClipVisibility` lib, `use-song-actions` publish (guard/rollback), `ShareModal`, `PublishGuardPrompt`, and the ClipCard/SongHeader integrations.

### Known limitations
- **Shared links aren't yet viewable by non-owners** (flagged by the cross-family review, P1). The share URL points at the canonical `/song/{id}`, but that page uses `useRequireAuth` and `GET /clips/{id}` is owner-scoped even for public clips (see the intentional `test_other_users_clip_returns_404_even_when_public`). Public *audio streaming* already works anonymously (US-14.2 `stream_router`); a public, unauthenticated **song page** + a public metadata read is a separate layer-2 story and is out of this web-first story's approved scope. The links produced here will "just work" once that page ships. **Recommend a follow-up issue: "Public song page for shared/public clips."**
- Per project convention, this web story wasn't exercised via a live end-to-end browser demo (no GPU/backend/Mongo demo stack locally); verification rests on the automated suites above.
- Combined `{title, is_public:true}` PATCH that fails the guard rejects atomically (title not saved). In the UI, rename and publish are always separate requests, so this only affects direct API callers.
