### PR TITLE
feat(web): Generation Lineage Visualization (US-17.7)

### DIFF
--- a/web/app/api/clips/[id]/lineage/route.test.ts
+++ b/web/app/api/clips/[id]/lineage/route.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+import { GET } from "@/app/api/clips/[id]/lineage/route"
+
+function req(url: string, init: RequestInit = {}): NextRequest {
+  return new Request(url, init) as unknown as NextRequest
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("GET /api/clips/[id]/lineage", () => {
+  it("401s without an Authorization header", async () => {
+    const res = await GET(
+      req("http://localhost/api/clips/c1/lineage"),
+      ctx("c1")
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the token and clip id to the backend lineage endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ clip_id: "c1", depth_limit: 50, depth_truncated: false, nodes: [] }),
+        { status: 200 }
+      )
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await GET(
+      req("http://localhost/api/clips/c1/lineage", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(200)
+
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips/c1/lineage")
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok"
+    )
+  })
+
+  it("passes a backend 404 through verbatim", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "Clip not found." }), { status: 404 })
+      )
+    )
+    const res = await GET(
+      req("http://localhost/api/clips/nope/lineage", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("nope")
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 502 when the backend is unreachable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")))
+    const res = await GET(
+      req("http://localhost/api/clips/c1/lineage", {
+        headers: { authorization: "Bearer tok" },
+      }),
+      ctx("c1")
+    )
+    expect(res.status).toBe(502)
+  })
+})

--- a/web/app/api/clips/[id]/lineage/route.ts
+++ b/web/app/api/clips/[id]/lineage/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+import { fetchWithTimeout } from "@/lib/proxy-fetch"
+
+// Same-origin proxy for GET /api/v1/clips/{clip_id}/lineage (US-17.7). Forwards
+// the Bearer token so the song-detail "Generation history" panel can fetch a
+// clip's ancestry without exposing the backend URL. The backend endpoint takes
+// no query params, so none are forwarded. Status/body pass through verbatim — a
+// 404 (clip not found or not owned) surfaces to the client unchanged.
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { id } = await ctx.params
+  let res: Response
+  try {
+    res = await fetchWithTimeout(
+      `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}/lineage`,
+      { headers: { authorization: auth, accept: "application/json" } }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Clip service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/components/song/LineageChain.test.tsx
+++ b/web/components/song/LineageChain.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { LineageChain } from "@/components/song/LineageChain"
+import type { LineageColumn } from "@/lib/lineage"
+
+function labeled(id: string, label: string) {
+  return {
+    id,
+    title: id,
+    generation_mode: null,
+    parent_clip_ids: [],
+    depth: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    label,
+  }
+}
+
+const chain: LineageColumn[] = [
+  { depth: 2, nodes: [labeled("A", "Extended from")] },
+  { depth: 1, nodes: [labeled("B", "Remixed from")] },
+]
+
+describe("LineageChain", () => {
+  it("renders ancestors left-to-right in the given (oldest-first) column order", () => {
+    render(<LineageChain columns={chain} />)
+    const links = screen.getAllByTestId("lineage-node")
+    expect(links.map((l) => l.getAttribute("href"))).toEqual([
+      "/song/A",
+      "/song/B",
+    ])
+  })
+
+  it("stacks a mashup's multiple parents inside one column", () => {
+    render(
+      <LineageChain
+        columns={[
+          {
+            depth: 1,
+            nodes: [labeled("X", "Mashup of"), labeled("Y", "Mashup of")],
+          },
+        ]}
+      />
+    )
+    expect(screen.getAllByTestId("lineage-node")).toHaveLength(2)
+    expect(screen.getAllByText("Mashup of")).toHaveLength(2)
+  })
+
+  it("shows a truncation marker only when the tree was capped", () => {
+    const { rerender } = render(<LineageChain columns={chain} />)
+    expect(screen.queryByTestId("lineage-truncated")).not.toBeInTheDocument()
+
+    rerender(<LineageChain columns={chain} truncated />)
+    expect(screen.getByTestId("lineage-truncated")).toBeInTheDocument()
+  })
+})

--- a/web/components/song/LineageChain.tsx
+++ b/web/components/song/LineageChain.tsx
@@ -1,0 +1,59 @@
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowRight01Icon, MoreHorizontalIcon } from "@hugeicons/core-free-icons"
+
+import { LineageNode } from "@/components/song/LineageNode"
+import type { LineageColumn } from "@/lib/lineage"
+
+// Horizontal ancestry chain for the song-detail lineage panel (US-17.7). Renders
+// columns oldest → newest (left → right) with arrows pointing toward the current
+// song; a mashup's multiple parents stack vertically inside one column. When the
+// backend truncated the tree (`truncated`), a "⋯ earlier" marker leads the chain
+// to show ancestors continue beyond what's displayed. Pure/presentational — data
+// fetching lives in LineageSection.
+
+export function LineageChain({
+  columns,
+  truncated,
+}: {
+  columns: LineageColumn[]
+  truncated?: boolean
+}) {
+  return (
+    <div
+      className="flex items-stretch gap-2 overflow-x-auto pb-1"
+      data-testid="lineage-chain"
+    >
+      {truncated && (
+        <>
+          <span
+            className="flex w-24 shrink-0 flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-border p-3 text-center text-xs text-muted-foreground"
+            data-testid="lineage-truncated"
+          >
+            <HugeiconsIcon icon={MoreHorizontalIcon} size={16} />
+            earlier ancestors
+          </span>
+          <Arrow />
+        </>
+      )}
+      {columns.map((col, i) => (
+        <div key={col.depth} className="flex items-stretch gap-2">
+          <div className="flex flex-col justify-center gap-2">
+            {col.nodes.map((node) => (
+              <LineageNode key={node.id} node={node} />
+            ))}
+          </div>
+          {i < columns.length - 1 && <Arrow />}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Connector arrow pointing toward the newer clip (rightward). */
+function Arrow() {
+  return (
+    <span className="flex shrink-0 items-center text-muted-foreground" aria-hidden>
+      <HugeiconsIcon icon={ArrowRight01Icon} size={18} />
+    </span>
+  )
+}

--- a/web/components/song/LineageNode.test.tsx
+++ b/web/components/song/LineageNode.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { LineageNode } from "@/components/song/LineageNode"
+import type { LabeledNode } from "@/lib/lineage"
+
+function node(overrides: Partial<LabeledNode> = {}): LabeledNode {
+  return {
+    id: "p1",
+    title: "Parent Song",
+    generation_mode: "remix",
+    parent_clip_ids: [],
+    depth: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    label: "Remixed from",
+    ...overrides,
+  }
+}
+
+describe("LineageNode", () => {
+  it("shows the relationship label and title, linking to the clip's song page", () => {
+    render(<LineageNode node={node()} />)
+    expect(screen.getByText("Remixed from")).toBeInTheDocument()
+    expect(screen.getByText("Parent Song")).toBeInTheDocument()
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/song/p1")
+  })
+
+  it("falls back to 'Untitled clip' and keeps the full title in a tooltip", () => {
+    render(<LineageNode node={node({ id: "p2", title: null })} />)
+    expect(screen.getByText("Untitled clip")).toBeInTheDocument()
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/song/p2")
+  })
+})

--- a/web/components/song/LineageNode.tsx
+++ b/web/components/song/LineageNode.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { MusicNote01Icon } from "@hugeicons/core-free-icons"
+
+import type { LabeledNode } from "@/lib/lineage"
+
+// A single ancestor in the generation-lineage chain (US-17.7): a clickable card
+// with a relationship label ("Remixed from"), the clip title, and a link to that
+// clip's song page. Lineage nodes are light summaries with no artwork field, and
+// there's no authed same-origin artwork proxy yet, so the thumbnail is a music
+// glyph placeholder — swap in a real cover once /api/clips/{id}/artwork exists.
+
+export function LineageNode({ node }: { node: LabeledNode }) {
+  const title = node.title ?? "Untitled clip"
+  return (
+    <Link
+      href={`/song/${encodeURIComponent(node.id)}`}
+      data-testid="lineage-node"
+      className="flex w-40 shrink-0 flex-col gap-2 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+    >
+      <span className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+        {node.label}
+      </span>
+      <span className="flex items-center gap-2">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <HugeiconsIcon icon={MusicNote01Icon} size={16} />
+        </span>
+        <span className="truncate text-sm font-medium" title={title}>
+          {title}
+        </span>
+      </span>
+    </Link>
+  )
+}

--- a/web/components/song/LineageSection.test.tsx
+++ b/web/components/song/LineageSection.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { LineageSection } from "@/components/song/LineageSection"
+import { makeClip } from "@/test/clip-factory"
+import type { LineageNode } from "@/lib/lineage"
+
+const useLineage = vi.fn()
+vi.mock("@/hooks/use-lineage", () => ({
+  useLineage: (id: string) => useLineage(id),
+}))
+
+type HookState = {
+  nodes: LineageNode[]
+  truncated: boolean
+  loading: boolean
+  error: boolean
+}
+
+function setHook(state: Partial<HookState>) {
+  useLineage.mockReturnValue({
+    nodes: [],
+    truncated: false,
+    loading: false,
+    error: false,
+    ...state,
+  })
+}
+
+function node(id: string, depth: number, extra: Partial<LineageNode> = {}): LineageNode {
+  return {
+    id,
+    title: id,
+    generation_mode: null,
+    parent_clip_ids: [],
+    depth,
+    created_at: "2026-01-01T00:00:00Z",
+    ...extra,
+  }
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("LineageSection", () => {
+  it("renders nothing and skips the fetch for an original clip (no parents)", () => {
+    const { container } = render(
+      <LineageSection clip={makeClip({ parent_clip_ids: [] })} />
+    )
+    expect(container).toBeEmptyDOMElement()
+    expect(useLineage).not.toHaveBeenCalled()
+  })
+
+  it("shows a loading skeleton while the ancestry fetches", () => {
+    setHook({ loading: true })
+    render(<LineageSection clip={makeClip({ parent_clip_ids: ["p1"] })} />)
+    expect(screen.getByTestId("lineage-loading")).toBeInTheDocument()
+  })
+
+  it("renders the chain when ancestors resolve", () => {
+    setHook({
+      nodes: [
+        node("c1", 0, { generation_mode: "remix", parent_clip_ids: ["p1"] }),
+        node("p1", 1),
+      ],
+    })
+    render(<LineageSection clip={makeClip({ id: "c1", parent_clip_ids: ["p1"] })} />)
+    expect(
+      screen.getByRole("heading", { name: "Generation history" })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("lineage-node")).toHaveAttribute("href", "/song/p1")
+    expect(screen.getByText("Remixed from")).toBeInTheDocument()
+  })
+
+  it("hides itself when no ancestors resolve (all filtered out / error)", () => {
+    setHook({ nodes: [node("c1", 0, { parent_clip_ids: ["p1"] })], error: true })
+    const { container } = render(
+      <LineageSection clip={makeClip({ id: "c1", parent_clip_ids: ["p1"] })} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/web/components/song/LineageSection.tsx
+++ b/web/components/song/LineageSection.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { LineageChain } from "@/components/song/LineageChain"
+import { useLineage } from "@/hooks/use-lineage"
+import { lineageColumns } from "@/lib/lineage"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Song-detail "Generation history" panel (US-17.7). Shows how the current clip was
+// derived from its ancestors as a horizontal chain. An original clip (no parents)
+// renders nothing — and skips the fetch entirely, since the subject clip already
+// tells us it has no lineage. Errors/empty degrade quietly like RelatedSongs;
+// lineage is supplementary and shouldn't leave a dead block on the page.
+
+export function LineageSection({ clip }: { clip: Clip }) {
+  // Originals have no ancestry to show; short-circuit before hitting the API.
+  if (clip.parent_clip_ids.length === 0) return null
+  return <LineageSectionInner clipId={clip.id} />
+}
+
+function LineageSectionInner({ clipId }: { clipId: string }) {
+  const { nodes, truncated, loading } = useLineage(clipId)
+
+  if (loading) {
+    return (
+      <section aria-label="Generation history" className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold">Generation history</h2>
+        <div className="h-24 animate-pulse rounded-lg bg-muted" data-testid="lineage-loading" />
+      </section>
+    )
+  }
+
+  const columns = lineageColumns(nodes)
+  // No ancestors resolved (all owned by others, or the fetch failed) — hide.
+  if (columns.length === 0) return null
+
+  return (
+    <section aria-label="Generation history" className="flex flex-col gap-3">
+      <h2 className="text-sm font-semibold">Generation history</h2>
+      <LineageChain columns={columns} truncated={truncated} />
+    </section>
+  )
+}

--- a/web/components/song/SongDetail.tsx
+++ b/web/components/song/SongDetail.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { DeleteSongDialog } from "@/components/song/DeleteSongDialog"
+import { LineageSection } from "@/components/song/LineageSection"
 import { PublishGuardPrompt } from "@/components/song/PublishGuardPrompt"
 import { RelatedSongs } from "@/components/song/RelatedSongs"
 import { SongActionModal } from "@/components/song/SongActionModal"
@@ -107,6 +108,8 @@ function SongDetailContent({ clip }: { clip: Clip }) {
           <h2 className="text-sm font-semibold">Details</h2>
           <SongMetadata clip={clip} />
         </section>
+        {/* Provenance chain — renders nothing for an original clip (US-17.7). */}
+        <LineageSection clip={clip} />
         <section aria-label="Lyrics" className="flex flex-col gap-3">
           <h2 className="text-sm font-semibold">Lyrics</h2>
           <SongLyrics lyrics={clip.lyrics} />

--- a/web/hooks/use-lineage.ts
+++ b/web/hooks/use-lineage.ts
@@ -1,0 +1,62 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import type { ClipLineageResponse, LineageNode } from "@/lib/lineage"
+
+/**
+ * Fetch a clip's ancestry from the same-origin BFF (/api/clips/{id}/lineage) for
+ * the song-detail "Generation history" panel (US-17.7). Mirrors useSimilarClips:
+ * empty/error both resolve quietly (lineage is supplementary) and the result is
+ * tagged with the id it belongs to so the page — which stays mounted across
+ * /song/:id navigations — never shows the previous song's ancestry under a new
+ * clip while its fetch is in flight.
+ */
+type Result = {
+  id: string
+  nodes: LineageNode[]
+  truncated: boolean
+  error: boolean
+}
+
+export function useLineage(id: string | undefined) {
+  const { accessToken, isLoading: authLoading } = useAuth()
+  const [result, setResult] = useState<Result | null>(null)
+
+  useEffect(() => {
+    if (authLoading || !accessToken || !id) return
+    let active = true
+    fetch(`/api/clips/${encodeURIComponent(id)}/lineage`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("fetch failed")
+        return (await res.json()) as ClipLineageResponse
+      })
+      .then((next) => {
+        if (active) {
+          setResult({
+            id,
+            nodes: next.nodes ?? [],
+            truncated: !!next.depth_truncated,
+            error: false,
+          })
+        }
+      })
+      .catch(() => {
+        if (active) setResult({ id, nodes: [], truncated: false, error: true })
+      })
+    return () => {
+      active = false
+    }
+  }, [id, accessToken, authLoading])
+
+  const matches = result !== null && result.id === id
+  const nodes = matches ? result.nodes : []
+  const truncated = matches && result.truncated
+  const error = matches && result.error
+  const loading = authLoading || (!!accessToken && !!id && !matches)
+
+  return { nodes, truncated, loading, error }
+}

--- a/web/lib/lineage.test.ts
+++ b/web/lib/lineage.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  lineageColumns,
+  relationshipLabel,
+  type LineageNode,
+} from "@/lib/lineage"
+
+function node(overrides: Partial<LineageNode> & { id: string }): LineageNode {
+  return {
+    title: overrides.id,
+    generation_mode: null,
+    parent_clip_ids: [],
+    depth: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("relationshipLabel", () => {
+  it("maps every known generation mode to its relationship phrase", () => {
+    expect(relationshipLabel("extend")).toBe("Extended from")
+    expect(relationshipLabel("cover")).toBe("Cover of")
+    expect(relationshipLabel("remix")).toBe("Remixed from")
+    expect(relationshipLabel("mashup")).toBe("Mashup of")
+    expect(relationshipLabel("repaint")).toBe("Repainted from")
+    expect(relationshipLabel("add_vocal")).toBe("Vocals added to")
+    expect(relationshipLabel("sample")).toBe("Sampled from")
+  })
+
+  it("falls back to a generic phrase for null/unknown modes", () => {
+    expect(relationshipLabel(null)).toBe("Derived from")
+    expect(relationshipLabel("wormhole")).toBe("Derived from")
+  })
+})
+
+describe("lineageColumns", () => {
+  it("returns no columns for an original clip (subject only)", () => {
+    expect(lineageColumns([node({ id: "c", depth: 0 })])).toEqual([])
+  })
+
+  it("orders ancestors oldest-first and labels each by its child's mode", () => {
+    // C (remix) -> B (extend) -> A (original)
+    const cols = lineageColumns([
+      node({ id: "C", depth: 0, generation_mode: "remix", parent_clip_ids: ["B"] }),
+      node({ id: "B", depth: 1, generation_mode: "extend", parent_clip_ids: ["A"] }),
+      node({ id: "A", depth: 2, generation_mode: null, parent_clip_ids: [] }),
+    ])
+    // Leftmost = oldest (depth 2), rightmost = immediate parent (depth 1).
+    expect(cols.map((c) => c.depth)).toEqual([2, 1])
+    expect(cols[0].nodes[0]).toMatchObject({ id: "A", label: "Extended from" })
+    expect(cols[1].nodes[0]).toMatchObject({ id: "B", label: "Remixed from" })
+  })
+
+  it("stacks multiple parents of a mashup in one column", () => {
+    const cols = lineageColumns([
+      node({ id: "M", depth: 0, generation_mode: "mashup", parent_clip_ids: ["X", "Y"] }),
+      node({ id: "X", depth: 1 }),
+      node({ id: "Y", depth: 1 }),
+    ])
+    expect(cols).toHaveLength(1)
+    expect(cols[0].nodes.map((n) => n.id)).toEqual(["X", "Y"])
+    expect(cols[0].nodes.every((n) => n.label === "Mashup of")).toBe(true)
+  })
+
+  it("labels a diamond ancestor by its closest child", () => {
+    // D is a parent of both the subject S (depth 0) and C (depth 1); the
+    // shallowest child wins, so D is labeled by S's mode, not C's.
+    const cols = lineageColumns([
+      node({ id: "S", depth: 0, generation_mode: "cover", parent_clip_ids: ["C", "D"] }),
+      node({ id: "C", depth: 1, generation_mode: "remix", parent_clip_ids: ["D"] }),
+      node({ id: "D", depth: 1, generation_mode: null, parent_clip_ids: [] }),
+    ])
+    const d = cols.flatMap((c) => c.nodes).find((n) => n.id === "D")
+    expect(d?.label).toBe("Cover of") // via subject S (depth 0 child), the closest
+  })
+})

--- a/web/lib/lineage.ts
+++ b/web/lib/lineage.ts
@@ -1,0 +1,93 @@
+// Types + pure transforms for the song-detail generation-lineage panel (US-17.7).
+//
+// The backend GET /api/v1/clips/{id}/lineage (US-10.6) returns the subject clip's
+// full ancestry as a flat, breadth-first list of light summaries: node[0] is the
+// subject at depth 0, depth 1 its immediate parents, depth 2 their parents, and so
+// on. `lineageColumns` turns that flat list into left-to-right columns (oldest
+// ancestor first) with a per-node relationship label, ready for the chain view.
+
+/** A lineage node as returned by the backend (a clip summary + its depth). */
+export type LineageNode = {
+  id: string
+  title: string | null
+  generation_mode: string | null
+  parent_clip_ids: string[]
+  /** 0 is the subject clip; 1 its parents; 2 their parents; … */
+  depth: number
+  created_at: string
+}
+
+/** Response shape of GET /api/v1/clips/{id}/lineage (ClipLineageResponse). */
+export type ClipLineageResponse = {
+  clip_id: string
+  depth_limit: number
+  /** True when ancestors remain beyond the depth cap (tree was truncated). */
+  depth_truncated: boolean
+  nodes: LineageNode[]
+}
+
+/** A lineage node paired with the label describing how its child derives from it. */
+export type LabeledNode = LineageNode & { label: string }
+
+/** One depth level of the chain (a mashup puts >1 node in a column). */
+export type LineageColumn = { depth: number; nodes: LabeledNode[] }
+
+/**
+ * generation_mode → the relationship a *child* has to this parent. The label sits
+ * on the parent because that's what the AC asks for ("Remixed from", "Cover of").
+ * A child made by `remix` means its parent is what it was "Remixed from".
+ */
+const RELATIONSHIP_LABELS: Record<string, string> = {
+  extend: "Extended from",
+  cover: "Cover of",
+  remix: "Remixed from",
+  mashup: "Mashup of",
+  repaint: "Repainted from",
+  add_vocal: "Vocals added to",
+  sample: "Sampled from",
+}
+
+/** Human-readable relationship label for a child's generation_mode. */
+export function relationshipLabel(mode: string | null): string {
+  if (!mode) return "Derived from"
+  return RELATIONSHIP_LABELS[mode] ?? "Derived from"
+}
+
+/**
+ * Turn the flat lineage node list into ordered columns for the chain view.
+ *
+ * Columns run oldest → newest (highest depth on the left, the subject's immediate
+ * parents on the right); the subject itself (depth 0) is dropped — it's the page
+ * you're on. Each ancestor is labeled by *its closest child's* generation_mode,
+ * so a `remix` subject labels its parent "Remixed from". Ancestors owned by other
+ * users are absent from the backend list, so they simply don't render.
+ *
+ * ponytail: a diamond ancestor (shared via two paths) is labeled by whichever
+ * child is closest to the subject (smallest depth wins). Good enough until
+ * multi-path lineage needs per-edge labels.
+ */
+export function lineageColumns(nodes: LineageNode[]): LineageColumn[] {
+  // parent id → the generation_mode of its closest child. Walk children shallow
+  // first so the nearest-to-subject child wins when an ancestor has several.
+  const childMode = new Map<string, string | null>()
+  for (const node of [...nodes].sort((a, b) => a.depth - b.depth)) {
+    for (const pid of node.parent_clip_ids) {
+      if (!childMode.has(pid)) childMode.set(pid, node.generation_mode)
+    }
+  }
+
+  const byDepth = new Map<number, LabeledNode[]>()
+  for (const node of nodes) {
+    if (node.depth < 1) continue // drop the subject
+    const label = relationshipLabel(
+      childMode.has(node.id) ? childMode.get(node.id)! : null
+    )
+    const col = byDepth.get(node.depth) ?? []
+    col.push({ ...node, label })
+    byDepth.set(node.depth, col)
+  }
+
+  return [...byDepth.keys()]
+    .sort((a, b) => b - a) // oldest (deepest) column first / leftmost
+    .map((depth) => ({ depth, nodes: byDepth.get(depth)! }))
+}


### PR DESCRIPTION
Closes #201

## What

Adds a **Generation history** panel to the song-detail page (`/song/[id]`) showing how a clip was derived from its ancestors, as a horizontal chain of clickable parent clips flowing oldest → current song.

- Each ancestor shows a **relationship label** derived from *its child's* `generation_mode` — "Remixed from", "Cover of", "Extended from", "Mashup of", "Repainted from", "Vocals added to", "Sampled from" (generic "Derived from" fallback).
- **Mashups** stack their multiple parents vertically in one column.
- **Truncation** marker ("earlier ancestors") when the backend caps the tree at `MAX_LINEAGE_DEPTH`.
- **Original clips** (no parents) render nothing and skip the network call entirely.
- Clicking any ancestor navigates to that clip's song page.

## How

Web-only wiring to the **existing** backend `GET /api/v1/clips/{id}/lineage` (US-10.6, PR #146) — no backend changes.

| File | Role |
|---|---|
| `web/app/api/clips/[id]/lineage/route.ts` | Same-origin BFF proxy (mirrors the `similar` route) |
| `web/lib/lineage.ts` | Types, `relationshipLabel()`, pure `lineageColumns()` transform (depth-grouping, child-mode labels, mashup stacking) |
| `web/hooks/use-lineage.ts` | Fetch hook mirroring `useSimilarClips` (quiet degrade, id-tagged result) |
| `web/components/song/LineageNode.tsx` | Single clickable ancestor |
| `web/components/song/LineageChain.tsx` | Pure column layout + connectors + truncation |
| `web/components/song/LineageSection.tsx` | Fetch/states/heading; short-circuits for originals |
| `web/components/song/SongDetail.tsx` | Renders `<LineageSection>` after Details |

## Acceptance criteria

- [x] Lineage section displays parent clips with correct relationship labels
- [x] Clicking a parent navigates to that clip's song detail page
- [x] Mashup clips show multiple parents
- [x] Clips with no parents (originals) omit the section

## Known limitations

- **Node thumbnails are a music-glyph placeholder, not real cover art.** Backend `LineageNode` summaries carry no artwork field, and there's no authed same-origin artwork proxy yet (only `/audio`). A plain `<img>` to the backend `/artwork` path can't attach the Bearer token. Upgrade path noted in `LineageNode.tsx` for when an authed artwork proxy lands.
- **Diamond ancestors** (a clip reached via two paths) are labeled by whichever child is closest to the subject — good enough until multi-path lineage needs per-edge labels (`ponytail:` note in `lineageColumns`).
- Ancestors owned by other users are already filtered out by the backend, so they simply don't render.

## Testing

- 19 new tests: `lib/lineage` (label map + column ordering/mashup/diamond), the BFF route (401/forward/404/502), and the three components.
- Full web suite: **615 passed**. `tsc --noEmit`, `eslint`, and `next build` all clean.

> ⚠️ Web tests/lint/typecheck are **not** run by CI (Python-only pipeline) and the live demo gate needs the GPU/backend stack, which isn't available in this environment. Merge decision rests on the test evidence above + manual review.