### PR TITLE
feat(web): Waveform Display with Zoom and Scroll (US-18.1)

### DIFF
--- a/web/app/editor/[id]/page.tsx
+++ b/web/app/editor/[id]/page.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useParams } from "next/navigation"
+
+import { ClipEditor } from "@/components/editor/ClipEditor"
+
+// Waveform-editor route /editor/[id] (US-18.1, first story of Stage 18). Thin
+// shim: pull the id from the route and hand off to ClipEditor, which owns auth,
+// data fetching, audio decoding, and layout. Reached from the song menu's
+// "Open in Editor" action (song-actions → navigation).
+
+export default function EditorPage() {
+  const params = useParams<{ id: string }>()
+  const id = params?.id
+  if (!id) return null
+  return <ClipEditor clipId={id} />
+}

--- a/web/components/editor/ClipEditor.test.tsx
+++ b/web/components/editor/ClipEditor.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ClipEditor } from "./ClipEditor"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Controllable hook returns.
+const auth = { isLoading: false, isAuthenticated: true }
+let tier: { isFreeTier: boolean; isLoading: boolean }
+let clipResult: { clip: Clip | null; loading: boolean; error: boolean; notFound: boolean }
+const useClipAudioSpy = vi.fn(() => ({ status: "loading" }) as { status: string })
+
+vi.mock("@/hooks/use-require-auth", () => ({ useRequireAuth: () => auth }))
+vi.mock("@/hooks/use-subscription-tier", () => ({
+  useSubscriptionTier: () => tier,
+}))
+vi.mock("@/hooks/use-clip", () => ({ useClip: () => clipResult }))
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => ({ accessToken: "t" }) }))
+vi.mock("@/hooks/use-clip-audio", () => ({
+  useClipAudio: (...args: unknown[]) => useClipAudioSpy(...(args as [])),
+}))
+// next/link renders a plain anchor in jsdom.
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+const clip = { id: "c1", title: "Test", duration: 10 } as Clip
+
+beforeEach(() => {
+  tier = { isFreeTier: false, isLoading: false }
+  clipResult = { clip, loading: false, error: false, notFound: false }
+})
+afterEach(() => vi.clearAllMocks())
+
+describe("ClipEditor Pro gate", () => {
+  it("blocks a free-tier user before decoding any audio", () => {
+    tier = { isFreeTier: true, isLoading: false }
+    render(<ClipEditor clipId="c1" />)
+    expect(screen.getByTestId("editor-locked")).toBeInTheDocument()
+    // The gate must run before the audio is fetched/decoded.
+    expect(useClipAudioSpy).not.toHaveBeenCalled()
+  })
+
+  it("waits for the tier to resolve instead of flashing the editor", () => {
+    tier = { isFreeTier: true, isLoading: true }
+    render(<ClipEditor clipId="c1" />)
+    expect(screen.getByTestId("editor-loading")).toBeInTheDocument()
+    expect(useClipAudioSpy).not.toHaveBeenCalled()
+  })
+
+  it("lets a Pro user through to audio decoding", () => {
+    tier = { isFreeTier: false, isLoading: false }
+    render(<ClipEditor clipId="c1" />)
+    expect(screen.queryByTestId("editor-locked")).not.toBeInTheDocument()
+    expect(screen.getByTestId("editor-audio-loading")).toBeInTheDocument()
+    expect(useClipAudioSpy).toHaveBeenCalled()
+  })
+})

--- a/web/components/editor/ClipEditor.tsx
+++ b/web/components/editor/ClipEditor.tsx
@@ -1,10 +1,13 @@
 "use client"
 
+import Link from "next/link"
+
 import { WaveformEditor } from "@/components/editor/WaveformEditor"
 import { useAuth } from "@/hooks/use-auth"
 import { useClip } from "@/hooks/use-clip"
 import { useClipAudio } from "@/hooks/use-clip-audio"
 import { useRequireAuth } from "@/hooks/use-require-auth"
+import { useSubscriptionTier } from "@/hooks/use-subscription-tier"
 import type { Clip } from "@/lib/workspace-clips"
 
 // Waveform-editor view (US-18.1). Mirrors SongDetail's shape: holds all the
@@ -13,9 +16,39 @@ import type { Clip } from "@/lib/workspace-clips"
 
 export function ClipEditor({ clipId }: { clipId: string }) {
   const { isLoading: authLoading, isAuthenticated } = useRequireAuth()
+  const { isFreeTier, isLoading: tierLoading } = useSubscriptionTier()
   const { clip, loading, error, notFound } = useClip(clipId)
 
   if (authLoading || !isAuthenticated) return null
+
+  // "Open in Editor" is Pro-only (song-actions). The menu locks it for free
+  // users, but that alone doesn't stop a direct visit to /editor/{id}, so gate
+  // the route itself here — before any audio is fetched or decoded. Default is
+  // free until the tier resolves, so wait for it rather than flash the editor.
+  if (tierLoading) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-3 p-8" data-testid="editor-loading">
+        <div className="h-8 w-64 animate-pulse rounded bg-muted" />
+        <div className="h-48 animate-pulse rounded-lg bg-muted" />
+      </div>
+    )
+  }
+  if (isFreeTier) {
+    return (
+      <div className="mx-auto max-w-6xl p-8" data-testid="editor-locked">
+        <h1 className="text-xl font-semibold">The editor is a Pro feature</h1>
+        <p className="text-sm text-muted-foreground">
+          Upgrade to Pro to open clips in the waveform editor.
+        </p>
+        <Link
+          href="/settings"
+          className="mt-3 inline-block text-sm font-medium text-primary underline"
+        >
+          Manage subscription
+        </Link>
+      </div>
+    )
+  }
 
   if (loading) {
     return (

--- a/web/components/editor/ClipEditor.tsx
+++ b/web/components/editor/ClipEditor.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { WaveformEditor } from "@/components/editor/WaveformEditor"
+import { useAuth } from "@/hooks/use-auth"
+import { useClip } from "@/hooks/use-clip"
+import { useClipAudio } from "@/hooks/use-clip-audio"
+import { useRequireAuth } from "@/hooks/use-require-auth"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Waveform-editor view (US-18.1). Mirrors SongDetail's shape: holds all the
+// auth / data / audio-decode logic so the App Router page stays a thin
+// params→component shim. Takes a plain clipId, so it's easy to test.
+
+export function ClipEditor({ clipId }: { clipId: string }) {
+  const { isLoading: authLoading, isAuthenticated } = useRequireAuth()
+  const { clip, loading, error, notFound } = useClip(clipId)
+
+  if (authLoading || !isAuthenticated) return null
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-3 p-8" data-testid="editor-loading">
+        <div className="h-8 w-64 animate-pulse rounded bg-muted" />
+        <div className="h-48 animate-pulse rounded-lg bg-muted" />
+      </div>
+    )
+  }
+
+  if (notFound) {
+    return (
+      <div className="mx-auto max-w-6xl p-8" data-testid="editor-not-found">
+        <h1 className="text-xl font-semibold">Clip not found</h1>
+        <p className="text-sm text-muted-foreground">
+          This clip doesn&apos;t exist or you don&apos;t have access to it.
+        </p>
+      </div>
+    )
+  }
+
+  if (error || !clip) {
+    return (
+      <div className="mx-auto max-w-6xl p-8" data-testid="editor-error">
+        <h1 className="text-xl font-semibold">Couldn&apos;t load this clip</h1>
+        <p className="text-sm text-muted-foreground">
+          Something went wrong. Please try again.
+        </p>
+      </div>
+    )
+  }
+
+  // key by clip id so the viewport/audio reset cleanly between clips.
+  return <ClipEditorContent key={clip.id} clip={clip} />
+}
+
+function ClipEditorContent({ clip }: { clip: Clip }) {
+  const { accessToken } = useAuth()
+  const audioState = useClipAudio(clip.id, accessToken)
+
+  return (
+    <div className="mx-auto max-w-6xl p-8">
+      {audioState.status === "loading" && (
+        <div className="space-y-3" data-testid="editor-audio-loading">
+          <div className="h-8 w-64 animate-pulse rounded bg-muted" />
+          <div className="h-48 animate-pulse rounded-lg bg-muted" />
+          <p className="text-sm text-muted-foreground">Decoding audio…</p>
+        </div>
+      )}
+
+      {audioState.status === "error" && (
+        <div data-testid="editor-audio-error">
+          <h1 className="text-xl font-semibold">Couldn&apos;t load the audio</h1>
+          <p className="text-sm text-muted-foreground">
+            The clip&apos;s audio couldn&apos;t be decoded. Please try again.
+          </p>
+        </div>
+      )}
+
+      {audioState.status === "ready" && (
+        <WaveformEditor clip={clip} audio={audioState.audio} />
+      )}
+    </div>
+  )
+}

--- a/web/components/editor/TimeRuler.test.tsx
+++ b/web/components/editor/TimeRuler.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { TimeRuler } from "./TimeRuler"
+
+describe("TimeRuler", () => {
+  it("labels major ticks as mm:ss for the current viewport", () => {
+    // 60s clip at fit zoom (10px/sec in 600px) → 10s ticks.
+    render(
+      <TimeRuler
+        viewport={{ pxPerSec: 10, scrollSec: 0 }}
+        width={600}
+        duration={60}
+      />
+    )
+    expect(screen.getByText("0:00")).toBeInTheDocument()
+    expect(screen.getByText("0:10")).toBeInTheDocument()
+    expect(screen.getByText("1:00")).toBeInTheDocument()
+  })
+
+  it("shows finer, consecutive-second labels when zoomed in", () => {
+    // 200px/sec → 0.5s ticks, so a 600px window shows 0–3s with consecutive
+    // whole-second labels — impossible at the coarse fit zoom (10s jumps).
+    render(
+      <TimeRuler
+        viewport={{ pxPerSec: 200, scrollSec: 0 }}
+        width={600}
+        duration={60}
+      />
+    )
+    expect(screen.getAllByText("0:01").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("0:02").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("0:03").length).toBeGreaterThan(0)
+  })
+
+  it("renders nothing before the width is measured", () => {
+    const { container } = render(
+      <TimeRuler
+        viewport={{ pxPerSec: 10, scrollSec: 0 }}
+        width={0}
+        duration={60}
+      />
+    )
+    expect(container.querySelectorAll("span").length).toBe(0)
+  })
+})

--- a/web/components/editor/TimeRuler.tsx
+++ b/web/components/editor/TimeRuler.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { formatTime } from "@/lib/clips"
+import { visibleTicks, type Viewport } from "@/lib/waveform-viewport"
+
+// Time ruler for the waveform editor (US-18.1). Renders major ticks + mm:ss
+// labels for the current viewport; the tick interval adapts to zoom (see
+// chooseTickInterval), so labels stay ~80px apart from full-clip overview down
+// to sub-second detail. DOM (absolutely-positioned spans) rather than canvas so
+// the labels are real text — selectable, testable, and crisp at any DPR.
+
+export function TimeRuler({
+  viewport,
+  width,
+  duration,
+}: {
+  viewport: Viewport
+  width: number
+  duration: number
+}) {
+  const ticks = width > 0 ? visibleTicks(viewport, width, duration) : []
+
+  return (
+    <div
+      className="relative h-5 w-full select-none border-b border-border text-[10px] text-muted-foreground"
+      aria-hidden="true"
+    >
+      {ticks.map((tick) => (
+        <div
+          key={tick.sec}
+          className="absolute top-0 flex h-full flex-col items-start"
+          style={{ left: `${tick.x}px` }}
+        >
+          <span className="h-1.5 w-px bg-border" />
+          <span className="pl-1 tabular-nums">{formatTime(tick.sec)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/components/editor/WaveformCanvas.test.tsx
+++ b/web/components/editor/WaveformCanvas.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { WaveformCanvas } from "./WaveformCanvas"
+import type { ClipAudio } from "@/lib/audio-peaks"
+import type { Viewport } from "@/lib/waveform-viewport"
+
+// Direct coverage for the canvas's pointer/wheel input translation — the most
+// stateful code in the editor. jsdom's getBoundingClientRect returns {left:0},
+// so clientX maps 1:1 to the in-canvas x used by the seek/pan/zoom math.
+
+const audio: ClipAudio = { mono: new Float32Array(8000), sampleRate: 8000, duration: 10 }
+const viewport: Viewport = { pxPerSec: 80, scrollSec: 5 } // zoomed in, mid-clip
+
+function setup() {
+  const onSeek = vi.fn()
+  const onZoom = vi.fn()
+  const onScrollSec = vi.fn()
+  render(
+    <WaveformCanvas
+      audio={audio}
+      viewport={viewport}
+      width={800}
+      height={160}
+      playheadSec={5}
+      onSeek={onSeek}
+      onZoom={onZoom}
+      onScrollSec={onScrollSec}
+    />
+  )
+  return { canvas: screen.getByRole("img", { name: "Waveform" }), onSeek, onZoom, onScrollSec }
+}
+
+describe("WaveformCanvas input", () => {
+  it("seeks on a tap with no movement", () => {
+    const { canvas, onSeek, onScrollSec } = setup()
+    fireEvent.pointerDown(canvas, { clientX: 240, pointerId: 1 })
+    fireEvent.pointerUp(canvas, { clientX: 240, pointerId: 1 })
+    // xToSec(240) = scrollSec 5 + 240/80 = 8s.
+    expect(onSeek).toHaveBeenCalledWith(8)
+    expect(onScrollSec).not.toHaveBeenCalled()
+  })
+
+  it("pans (not seeks) when the pointer drags past the threshold", () => {
+    const { canvas, onSeek, onScrollSec } = setup()
+    fireEvent.pointerDown(canvas, { clientX: 400, pointerId: 1 })
+    fireEvent.pointerMove(canvas, { clientX: 320, pointerId: 1 }) // dragged -80px
+    fireEvent.pointerUp(canvas, { clientX: 320, pointerId: 1 })
+    // scrollSec = startScroll 5 - (-80)/80 = 6.
+    expect(onScrollSec).toHaveBeenLastCalledWith(6)
+    expect(onSeek).not.toHaveBeenCalled()
+  })
+
+  it("zooms on a two-finger pinch", () => {
+    const { canvas, onZoom } = setup()
+    fireEvent.pointerDown(canvas, { clientX: 100, pointerId: 1 })
+    fireEvent.pointerDown(canvas, { clientX: 200, pointerId: 2 })
+    fireEvent.pointerMove(canvas, { clientX: 300, pointerId: 2 }) // dist 200, primes
+    fireEvent.pointerMove(canvas, { clientX: 400, pointerId: 2 }) // dist 300 → 1.5x
+    expect(onZoom).toHaveBeenCalled()
+    const [nextPx] = onZoom.mock.calls.at(-1)!
+    expect(nextPx).toBeCloseTo(80 * 1.5) // pxPerSec * (300/200)
+  })
+
+  it("zooms on Ctrl+wheel and scrolls on a plain wheel", () => {
+    const { canvas, onZoom, onScrollSec } = setup()
+    fireEvent.wheel(canvas, { deltaY: -100, ctrlKey: true, clientX: 400 })
+    expect(onZoom).toHaveBeenCalled()
+    fireEvent.wheel(canvas, { deltaY: 40, clientX: 400 })
+    expect(onScrollSec).toHaveBeenCalled()
+  })
+})

--- a/web/components/editor/WaveformCanvas.tsx
+++ b/web/components/editor/WaveformCanvas.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 
 import type { ClipAudio } from "@/lib/audio-peaks"
 import { columnPeaks } from "@/lib/audio-peaks"
@@ -53,6 +53,19 @@ export function WaveformCanvas({
     cbRef.current = { onSeek, onZoom, onScrollSec }
   }, [onSeek, onZoom, onScrollSec])
 
+  // Re-bucket peaks only when the audio or the visible window changes — NOT on
+  // every playhead tick (~4Hz during playback), which would rescan millions of
+  // samples just to move the cursor line. The draw effect below reruns each
+  // tick, but only to repaint the (cheap) bars + cursor from this cached array.
+  const peaks = useMemo(() => {
+    if (width <= 0) return new Float32Array(0)
+    const columns = Math.max(1, Math.floor(width))
+    const visibleSec = width / viewport.pxPerSec
+    const startSample = viewport.scrollSec * audio.sampleRate
+    const endSample = (viewport.scrollSec + visibleSec) * audio.sampleRate
+    return columnPeaks(audio.mono, startSample, endSample, columns)
+  }, [audio, viewport, width])
+
   // --- Drawing -------------------------------------------------------------
   useEffect(() => {
     const canvas = canvasRef.current
@@ -71,12 +84,7 @@ export function WaveformCanvas({
     const unplayed =
       styles.getPropertyValue("--muted-foreground").trim() || "#9ca3af"
 
-    const columns = Math.max(1, Math.floor(width))
-    const visibleSec = width / viewport.pxPerSec
-    const startSample = viewport.scrollSec * audio.sampleRate
-    const endSample = (viewport.scrollSec + visibleSec) * audio.sampleRate
-    const peaks = columnPeaks(audio.mono, startSample, endSample, columns)
-
+    const columns = peaks.length
     const mid = height / 2
     const playheadX = secToX(playheadSec, viewport)
     for (let x = 0; x < columns; x++) {
@@ -92,7 +100,7 @@ export function WaveformCanvas({
       ctx.fillStyle = played
       ctx.fillRect(Math.floor(playheadX), 0, 1.5, height)
     }
-  }, [audio, viewport, width, height, playheadSec])
+  }, [peaks, viewport, width, height, playheadSec])
 
   // --- Pointer input (click / drag / pinch) --------------------------------
   const pointers = useRef(new Map<number, number>()) // pointerId → clientX

--- a/web/components/editor/WaveformCanvas.tsx
+++ b/web/components/editor/WaveformCanvas.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import type { ClipAudio } from "@/lib/audio-peaks"
+import { columnPeaks } from "@/lib/audio-peaks"
+import { secToX, xToSec, type Viewport } from "@/lib/waveform-viewport"
+
+// The waveform drawing + input surface (US-18.1). Virtual-scrolled: the canvas
+// is only ever `width` px wide and re-buckets peaks for the visible sample
+// window each render, so it stays accurate from full-clip overview to
+// sample-level zoom without a giant off-screen canvas. Input maps to callbacks
+// the editor turns into viewport/seek changes:
+//   click        → seek        drag           → pan
+//   Ctrl+wheel   → zoom        wheel/trackpad → horizontal scroll
+//   two-finger pinch → zoom (touch)
+// Latest props are read through refs so the non-passive wheel listener (needed
+// to preventDefault) attaches once instead of on every zoom tick.
+
+const DRAG_THRESHOLD_PX = 4
+const WHEEL_ZOOM_SENSITIVITY = 0.002
+
+export function WaveformCanvas({
+  audio,
+  viewport,
+  width,
+  height,
+  playheadSec,
+  onSeek,
+  onZoom,
+  onScrollSec,
+}: {
+  audio: ClipAudio
+  viewport: Viewport
+  width: number
+  height: number
+  playheadSec: number
+  onSeek: (sec: number) => void
+  onZoom: (nextPx: number, anchorX: number) => void
+  onScrollSec: (sec: number) => void
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  // Refs mirror the latest values for the imperative wheel/pointer handlers,
+  // updated in effects (never during render) so the native wheel listener can
+  // attach once yet always read fresh state.
+  const vpRef = useRef(viewport)
+  const cbRef = useRef({ onSeek, onZoom, onScrollSec })
+  useEffect(() => {
+    vpRef.current = viewport
+  }, [viewport])
+  useEffect(() => {
+    cbRef.current = { onSeek, onZoom, onScrollSec }
+  }, [onSeek, onZoom, onScrollSec])
+
+  // --- Drawing -------------------------------------------------------------
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || width <= 0 || height <= 0) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = Math.floor(width * dpr)
+    canvas.height = Math.floor(height * dpr)
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, width, height)
+
+    const styles = getComputedStyle(canvas)
+    const played = styles.getPropertyValue("--primary").trim() || "#6d28d9"
+    const unplayed =
+      styles.getPropertyValue("--muted-foreground").trim() || "#9ca3af"
+
+    const columns = Math.max(1, Math.floor(width))
+    const visibleSec = width / viewport.pxPerSec
+    const startSample = viewport.scrollSec * audio.sampleRate
+    const endSample = (viewport.scrollSec + visibleSec) * audio.sampleRate
+    const peaks = columnPeaks(audio.mono, startSample, endSample, columns)
+
+    const mid = height / 2
+    const playheadX = secToX(playheadSec, viewport)
+    for (let x = 0; x < columns; x++) {
+      const barH = Math.max(1, peaks[x] * mid)
+      ctx.fillStyle = x <= playheadX ? played : unplayed
+      ctx.globalAlpha = x <= playheadX ? 0.9 : 0.45
+      ctx.fillRect(x, mid - barH, 1, barH * 2)
+    }
+
+    // Playhead cursor.
+    if (playheadX >= 0 && playheadX <= width) {
+      ctx.globalAlpha = 1
+      ctx.fillStyle = played
+      ctx.fillRect(Math.floor(playheadX), 0, 1.5, height)
+    }
+  }, [audio, viewport, width, height, playheadSec])
+
+  // --- Pointer input (click / drag / pinch) --------------------------------
+  const pointers = useRef(new Map<number, number>()) // pointerId → clientX
+  const drag = useRef<{ startX: number; startScroll: number; moved: boolean } | null>(
+    null
+  )
+  const pinchDist = useRef<number | null>(null)
+
+  function rectX(clientX: number): number {
+    const r = canvasRef.current?.getBoundingClientRect()
+    return clientX - (r?.left ?? 0)
+  }
+
+  function onPointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
+    canvasRef.current?.setPointerCapture?.(e.pointerId)
+    pointers.current.set(e.pointerId, e.clientX)
+    if (pointers.current.size === 1) {
+      drag.current = {
+        startX: e.clientX,
+        startScroll: vpRef.current.scrollSec,
+        moved: false,
+      }
+    } else {
+      drag.current = null // a second finger cancels the drag/click gesture
+    }
+  }
+
+  function onPointerMove(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (!pointers.current.has(e.pointerId)) return
+    pointers.current.set(e.pointerId, e.clientX)
+
+    if (pointers.current.size >= 2) {
+      const xs = [...pointers.current.values()]
+      const dist = Math.abs(xs[0] - xs[1])
+      const midX = rectX((xs[0] + xs[1]) / 2)
+      if (pinchDist.current != null && pinchDist.current > 0 && dist > 0) {
+        const ratio = dist / pinchDist.current
+        cbRef.current.onZoom(vpRef.current.pxPerSec * ratio, midX)
+      }
+      pinchDist.current = dist
+      return
+    }
+
+    const d = drag.current
+    if (!d) return
+    const dx = e.clientX - d.startX
+    if (Math.abs(dx) > DRAG_THRESHOLD_PX) d.moved = true
+    if (d.moved) {
+      cbRef.current.onScrollSec(d.startScroll - dx / vpRef.current.pxPerSec)
+    }
+  }
+
+  function onPointerUp(e: React.PointerEvent<HTMLCanvasElement>) {
+    pointers.current.delete(e.pointerId)
+    if (pointers.current.size < 2) pinchDist.current = null
+    const d = drag.current
+    drag.current = null
+    if (d && !d.moved && pointers.current.size === 0) {
+      // A tap/click with no pan → seek to the clicked time.
+      cbRef.current.onSeek(xToSec(rectX(e.clientX), vpRef.current))
+    }
+  }
+
+  // --- Wheel (native, non-passive so Ctrl-zoom can preventDefault) ----------
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    function onWheel(e: WheelEvent) {
+      const vp = vpRef.current
+      const x = rectX(e.clientX)
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault()
+        const factor = Math.exp(-e.deltaY * WHEEL_ZOOM_SENSITIVITY)
+        cbRef.current.onZoom(vp.pxPerSec * factor, x)
+      } else {
+        e.preventDefault()
+        const delta = e.deltaX !== 0 ? e.deltaX : e.deltaY
+        cbRef.current.onScrollSec(vp.scrollSec + delta / vp.pxPerSec)
+      }
+    }
+    canvas.addEventListener("wheel", onWheel, { passive: false })
+    return () => canvas.removeEventListener("wheel", onWheel)
+  }, [])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      role="img"
+      aria-label="Waveform"
+      data-px-per-sec={Math.round(viewport.pxPerSec)}
+      data-scroll-sec={viewport.scrollSec.toFixed(3)}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      style={{ width, height }}
+      className="w-full touch-none cursor-pointer select-none"
+    />
+  )
+}

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { WaveformEditor } from "./WaveformEditor"
+import { PlayerProvider, usePlayer } from "@/contexts/player-context"
+import type { ClipAudio } from "@/lib/audio-peaks"
+import type { Clip } from "@/lib/workspace-clips"
+
+// jsdom reports clientWidth as 0, so the viewport never initializes. Stub a real
+// width so the canvas + controls render like they do in a browser.
+let widthSpy: PropertyDescriptor | undefined
+beforeEach(() => {
+  widthSpy = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth")
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => 800,
+  })
+})
+afterEach(() => {
+  if (widthSpy) Object.defineProperty(HTMLElement.prototype, "clientWidth", widthSpy)
+})
+
+function fakeClip(): Clip {
+  return {
+    id: "c1",
+    workspace_id: "w1",
+    title: "Test Clip",
+    duration: 10,
+    bpm: 120,
+  } as Clip
+}
+
+function fakeAudio(): ClipAudio {
+  return { mono: new Float32Array(800), sampleRate: 8000, duration: 10 }
+}
+
+/** Surfaces player state so tests can assert the editor drives it. */
+function Probe() {
+  const { state } = usePlayer()
+  return (
+    <div>
+      <span data-testid="current-id">{state.current?.id ?? "none"}</span>
+      <span data-testid="seek-req">{state.seekRequest ?? "null"}</span>
+    </div>
+  )
+}
+
+function renderEditor() {
+  return render(
+    <PlayerProvider>
+      <WaveformEditor clip={fakeClip()} audio={fakeAudio()} />
+      <Probe />
+    </PlayerProvider>
+  )
+}
+
+function canvas() {
+  return screen.getByRole("img", { name: "Waveform" })
+}
+function pxPerSec() {
+  return Number(canvas().getAttribute("data-px-per-sec"))
+}
+
+describe("WaveformEditor", () => {
+  it("loads the clip into the player so the playhead/seek use the real engine", () => {
+    renderEditor()
+    expect(screen.getByTestId("current-id")).toHaveTextContent("c1")
+  })
+
+  it("opens at the full-clip fit zoom (800px / 10s = 80 px/sec)", () => {
+    renderEditor()
+    expect(pxPerSec()).toBe(80)
+  })
+
+  it("zooms in and back to fit", async () => {
+    renderEditor()
+    const start = pxPerSec()
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }))
+    expect(pxPerSec()).toBeGreaterThan(start)
+    fireEvent.click(screen.getByRole("button", { name: "Fit to view" }))
+    expect(pxPerSec()).toBe(start)
+  })
+
+  it("disables zoom-out and fit at the fit floor", () => {
+    renderEditor()
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Fit to view" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeEnabled()
+  })
+
+  it("seeks the player when the waveform is clicked (no drag)", () => {
+    renderEditor()
+    // At fit, 80 px/sec: clicking at x=160 seeks to 2s.
+    fireEvent.pointerDown(canvas(), { clientX: 160, pointerId: 1 })
+    fireEvent.pointerUp(canvas(), { clientX: 160, pointerId: 1 })
+    expect(Number(screen.getByTestId("seek-req").textContent)).toBeCloseTo(2, 1)
+  })
+
+  it("hides the scrollbar at fit (nothing to scroll) and shows it when zoomed in", () => {
+    renderEditor()
+    expect(
+      screen.queryByRole("slider", { name: "Scroll waveform" })
+    ).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }))
+    expect(
+      screen.getByRole("slider", { name: "Scroll waveform" })
+    ).toBeInTheDocument()
+  })
+})

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+
+import { TimeRuler } from "@/components/editor/TimeRuler"
+import { WaveformCanvas } from "@/components/editor/WaveformCanvas"
+import { WaveformScrollbar } from "@/components/editor/WaveformScrollbar"
+import { ZoomControls } from "@/components/editor/ZoomControls"
+import { usePlayer } from "@/contexts/player-context"
+import type { ClipAudio } from "@/lib/audio-peaks"
+import { trackFromClip } from "@/lib/clips"
+import {
+  MAX_PX_PER_SEC,
+  clampPxPerSec,
+  clampScrollSec,
+  fitPxPerSec,
+  zoomAtX,
+  type Viewport,
+} from "@/lib/waveform-viewport"
+import type { Clip } from "@/lib/workspace-clips"
+
+// The waveform editor panel (US-18.1). Owns the viewport (zoom + scroll) and
+// wires the canvas / ruler / zoom controls / scrollbar together. Playback state
+// is borrowed from the shared player store — entering the editor loads the clip
+// as the current track so the playhead follows real playback and click-to-seek
+// drives the same <audio> element the Playbar uses (no second audio engine).
+//
+// The stored viewport is the user's *intent* (absolute px/sec + scrollSec); the
+// effective viewport is derived + clamped against the measured width each
+// render, so a resize self-corrects without an effect or cascading setState.
+
+const CANVAS_HEIGHT = 160
+const BUTTON_ZOOM_FACTOR = 1.6
+
+export function WaveformEditor({
+  clip,
+  audio,
+}: {
+  clip: Clip
+  audio: ClipAudio
+}) {
+  const { state, dispatch } = usePlayer()
+  const duration = audio.duration
+
+  // Load this clip into the player so the playhead + seek reuse the real audio
+  // engine. Async dispatch (not synchronous setState), only on clip change.
+  useEffect(() => {
+    if (state.current?.id !== clip.id) {
+      dispatch({ type: "load", tracks: [trackFromClip(clip)] })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clip.id])
+
+  const isCurrent = state.current?.id === clip.id
+  const playheadSec = isCurrent ? state.currentTime : 0
+
+  // Measure the available width; the viewport is expressed in px/sec, so every
+  // zoom/scroll bound depends on it. ResizeObserver keeps it responsive.
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(0)
+  useLayoutEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const ro = new ResizeObserver(() => setWidth(el.clientWidth))
+    ro.observe(el)
+    setWidth(el.clientWidth)
+    return () => ro.disconnect()
+  }, [])
+
+  // Stored intent (null = "use the fit overview"); the effective viewport below
+  // is always derived and clamped to the current width.
+  const [intent, setIntent] = useState<Viewport | null>(null)
+
+  const ready = width > 0 && duration > 0
+  const fitPx = ready ? fitPxPerSec(duration, width) : 1
+  const vp: Viewport | null = !ready
+    ? null
+    : intent
+      ? (() => {
+          const pxPerSec = clampPxPerSec(intent.pxPerSec, duration, width)
+          return {
+            pxPerSec,
+            scrollSec: clampScrollSec(intent.scrollSec, duration, pxPerSec, width),
+          }
+        })()
+      : { pxPerSec: fitPx, scrollSec: 0 }
+
+  const zoomAt = (nextPx: number, anchorX: number) => {
+    if (vp) setIntent(zoomAtX(vp, nextPx, anchorX, duration, width))
+  }
+  const scrollTo = (scrollSec: number) => {
+    if (vp) setIntent({ ...vp, scrollSec })
+  }
+  const seek = (sec: number) => {
+    dispatch({ type: "seek/request", time: Math.max(0, Math.min(duration, sec)) })
+  }
+  const fit = () => setIntent({ pxPerSec: fitPx, scrollSec: 0 })
+
+  const atMin = !vp || vp.pxPerSec <= fitPx + 1e-6
+  const atMax = !!vp && vp.pxPerSec >= MAX_PX_PER_SEC - 1e-6
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <h1 className="truncate text-lg font-semibold">
+          {clip.title ?? "Untitled clip"}
+        </h1>
+        <ZoomControls
+          onZoomIn={() =>
+            zoomAt((vp ? vp.pxPerSec : fitPx) * BUTTON_ZOOM_FACTOR, width / 2)
+          }
+          onZoomOut={() =>
+            zoomAt((vp ? vp.pxPerSec : fitPx) / BUTTON_ZOOM_FACTOR, width / 2)
+          }
+          onFit={fit}
+          atMin={atMin}
+          atMax={atMax}
+        />
+      </div>
+
+      <div
+        ref={containerRef}
+        className="overflow-hidden rounded-lg border border-border bg-card"
+      >
+        {vp ? (
+          <>
+            <TimeRuler viewport={vp} width={width} duration={duration} />
+            <WaveformCanvas
+              audio={audio}
+              viewport={vp}
+              width={width}
+              height={CANVAS_HEIGHT}
+              playheadSec={playheadSec}
+              onSeek={seek}
+              onZoom={zoomAt}
+              onScrollSec={scrollTo}
+            />
+          </>
+        ) : (
+          <div style={{ height: CANVAS_HEIGHT + 20 }} />
+        )}
+      </div>
+
+      {vp && (
+        <WaveformScrollbar
+          viewport={vp}
+          width={width}
+          duration={duration}
+          onScroll={scrollTo}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/components/editor/WaveformScrollbar.tsx
+++ b/web/components/editor/WaveformScrollbar.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { maxScrollSec, type Viewport } from "@/lib/waveform-viewport"
+
+// Horizontal scrollbar for the waveform editor (US-18.1). Appears only when the
+// clip is zoomed past the viewport width (otherwise the whole clip is visible
+// and there's nothing to scroll). A plain range input — click, drag, and
+// keyboard scrolling come for free and stay in sync with wheel/drag panning on
+// the canvas because both write the same `scrollSec`.
+
+export function WaveformScrollbar({
+  viewport,
+  width,
+  duration,
+  onScroll,
+}: {
+  viewport: Viewport
+  width: number
+  duration: number
+  onScroll: (scrollSec: number) => void
+}) {
+  const max = maxScrollSec(duration, viewport.pxPerSec, width)
+  if (max <= 0) return null
+
+  return (
+    <input
+      type="range"
+      aria-label="Scroll waveform"
+      min={0}
+      max={max}
+      step={Math.max(0.01, max / 500)}
+      value={Math.min(viewport.scrollSec, max)}
+      onChange={(e) => onScroll(Number(e.target.value))}
+      className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
+    />
+  )
+}

--- a/web/components/editor/ZoomControls.tsx
+++ b/web/components/editor/ZoomControls.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  FitToScreenIcon,
+  ZoomInAreaIcon,
+  ZoomOutAreaIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+
+// Zoom toolbar for the waveform editor (US-18.1). Buttons are one of the three
+// zoom affordances (the others are Ctrl+wheel and pinch, handled on the canvas).
+// "Fit" resets to the full-clip overview. atMin/atMax disable the buttons at the
+// zoom boundaries so the control reflects what's actually possible.
+
+export function ZoomControls({
+  onZoomIn,
+  onZoomOut,
+  onFit,
+  atMin,
+  atMax,
+}: {
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onFit: () => void
+  atMin: boolean
+  atMax: boolean
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        aria-label="Zoom out"
+        onClick={onZoomOut}
+        disabled={atMin}
+      >
+        <HugeiconsIcon icon={ZoomOutAreaIcon} />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        aria-label="Zoom in"
+        onClick={onZoomIn}
+        disabled={atMax}
+      >
+        <HugeiconsIcon icon={ZoomInAreaIcon} />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        aria-label="Fit to view"
+        onClick={onFit}
+        disabled={atMin}
+      >
+        <HugeiconsIcon icon={FitToScreenIcon} />
+      </Button>
+    </div>
+  )
+}

--- a/web/components/song/SongActionModal.tsx
+++ b/web/components/song/SongActionModal.tsx
@@ -25,8 +25,9 @@ import type { Clip } from "@/lib/workspace-clips"
 // (crop/speed/extend/cover/remix/replace-section/sample/add-vocal/mashup).
 // `repaint` and `replace-section` are the same regenerate-a-range operation, so
 // both open the Replace Section modal. Actions whose modals ship in later
-// stories (open-editor, use-inspiration, export/mastering/video, stems) keep the
-// "not available yet" placeholder so a menu click never dead-ends.
+// stories (use-inspiration, export/mastering/video, stems) keep the "not
+// available yet" placeholder so a menu click never dead-ends. (open-editor is a
+// navigation action now — it routes to /editor/{id} before reaching here.)
 
 export type SongActionModalProps = {
   clip: Clip

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -239,18 +239,14 @@ describe("SongDetail full action menu (US-17.2)", () => {
     expect(push).toHaveBeenCalledWith("/studio?song=c1")
   })
 
-  it("shows the placeholder modal for Open in Editor (pro user) until US-18", async () => {
+  it("navigates a pro user to the waveform editor for Open in Editor (US-18.1)", async () => {
     stubFetch({ clip: clip(), tier: "pro" })
     renderDetail()
     await openActions()
     await userEvent.click(
       screen.getByRole("menuitem", { name: /open in editor/i })
     )
-    // No /editor route exists yet — navigating would 404.
-    expect(push).not.toHaveBeenCalledWith("/editor/c1")
-    expect(await screen.findByRole("dialog")).toHaveTextContent(
-      "Open in Editor"
-    )
+    expect(push).toHaveBeenCalledWith("/editor/c1")
   })
 
   it("locks Pro-only actions for a free user", async () => {

--- a/web/hooks/use-clip-audio.ts
+++ b/web/hooks/use-clip-audio.ts
@@ -1,0 +1,49 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { decodeClipAudio, type ClipAudio } from "@/lib/audio-peaks"
+
+export type ClipAudioState =
+  | { status: "loading" }
+  | { status: "ready"; audio: ClipAudio }
+  | { status: "error" }
+
+/** Decode outcome tagged with the clip id it belongs to (mirrors useClip). */
+type Outcome =
+  | { id: string; kind: "ready"; audio: ClipAudio }
+  | { id: string; kind: "error" }
+
+/**
+ * Decode a clip's audio into peak data for the waveform editor (US-18.1).
+ * Fetches through the authed same-origin proxy and re-decodes when the id or
+ * token changes; the in-flight decode is aborted on change/unmount. The outcome
+ * is tagged with its clip id, so a result whose id no longer matches the
+ * requested one reads as "loading" — no stale audio flashes under a new id, and
+ * no synchronous setState is needed to reset between clips.
+ */
+export function useClipAudio(
+  clipId: string | undefined,
+  token: string | null
+): ClipAudioState {
+  const [outcome, setOutcome] = useState<Outcome | null>(null)
+
+  useEffect(() => {
+    if (!clipId || !token) return
+    const ctl = new AbortController()
+    decodeClipAudio(clipId, token, ctl.signal)
+      .then((audio) => {
+        if (!ctl.signal.aborted) setOutcome({ id: clipId, kind: "ready", audio })
+      })
+      .catch(() => {
+        if (!ctl.signal.aborted) setOutcome({ id: clipId, kind: "error" })
+      })
+    return () => ctl.abort()
+  }, [clipId, token])
+
+  const current = outcome?.id === clipId ? outcome : null
+  if (!current) return { status: "loading" }
+  return current.kind === "ready"
+    ? { status: "ready", audio: current.audio }
+    : { status: "error" }
+}

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -75,11 +75,11 @@ describe("useSongActions", () => {
     expect(push).toHaveBeenCalledWith("/studio?song=c1")
   })
 
-  it("keeps open-editor on the placeholder modal until the editor ships", () => {
+  it("routes open-editor to the waveform editor (US-18.1)", () => {
     const { result } = setup()
     act(() => result.current.handleAction("open-editor"))
-    expect(push).not.toHaveBeenCalled()
-    expect(result.current.activeModal).toBe("open-editor")
+    expect(push).toHaveBeenCalledWith("/editor/c1")
+    expect(result.current.activeModal).toBeNull()
   })
 
   it("opens and closes the workflow modal for modal actions", () => {

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -67,9 +67,9 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
   function handleAction(action: SongActionId) {
     const workflow = findSongAction(action)?.workflow
     if (workflow === "navigation") {
-      // Only open-studio navigates today; open-editor joins when the editor
-      // page ships (US-18) and its registry entry flips back to navigation.
-      router.push(`/studio?song=${encodeURIComponent(clip.id)}`)
+      // open-editor → the waveform editor (US-18.1); open-studio → the studio.
+      const id = encodeURIComponent(clip.id)
+      router.push(action === "open-editor" ? `/editor/${id}` : `/studio?song=${id}`)
       return
     }
     if (workflow === "modal") {

--- a/web/lib/audio-peaks.test.ts
+++ b/web/lib/audio-peaks.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+
+import { columnPeaks, mixToMono } from "./audio-peaks"
+
+describe("mixToMono", () => {
+  it("averages channels sample-by-sample", () => {
+    const l = new Float32Array([1, 0, -1, 0.5])
+    const r = new Float32Array([1, 1, 1, 0.5])
+    expect(Array.from(mixToMono([l, r], 4))).toEqual([1, 0.5, 0, 0.5])
+  })
+  it("returns silence for no channels", () => {
+    expect(Array.from(mixToMono([], 3))).toEqual([0, 0, 0])
+  })
+  it("passes a single channel through", () => {
+    const m = new Float32Array([0.2, -0.4])
+    const mono = mixToMono([m], 2)
+    // Float32 storage → compare with tolerance, not exact equality.
+    expect(mono[0]).toBeCloseTo(0.2)
+    expect(mono[1]).toBeCloseTo(-0.4)
+  })
+})
+
+describe("columnPeaks", () => {
+  it("returns the max absolute amplitude per column", () => {
+    // 8 samples, 2 columns → each column spans 4 samples.
+    const mono = new Float32Array([0.1, -0.9, 0.2, 0.3, -0.4, 0.5, -0.2, 0.1])
+    const peaks = columnPeaks(mono, 0, 8, 2)
+    expect(peaks[0]).toBeCloseTo(0.9)
+    expect(peaks[1]).toBeCloseTo(0.5)
+  })
+  it("only reads the requested sample window", () => {
+    const mono = new Float32Array([1, 1, 0.25, 0.5, 1, 1])
+    // Window [2,4) excludes the loud edges → peak is 0.5.
+    const peaks = columnPeaks(mono, 2, 4, 1)
+    expect(peaks[0]).toBe(0.5)
+  })
+  it("clamps peaks over 1", () => {
+    const mono = new Float32Array([1.5, -2])
+    expect(columnPeaks(mono, 0, 2, 1)[0]).toBe(1)
+  })
+  it("returns an empty array for zero columns", () => {
+    expect(columnPeaks(new Float32Array([1]), 0, 1, 0).length).toBe(0)
+  })
+  it("survives out-of-range windows", () => {
+    const mono = new Float32Array([0.3, 0.6])
+    // end past the buffer clamps to the buffer length.
+    expect(columnPeaks(mono, 0, 999, 1)[0]).toBeCloseTo(0.6)
+    // start past the end → all-zero output, no crash.
+    expect(Array.from(columnPeaks(mono, 50, 60, 2))).toEqual([0, 0])
+  })
+})

--- a/web/lib/audio-peaks.ts
+++ b/web/lib/audio-peaks.ts
@@ -1,0 +1,104 @@
+// Real audio peak extraction for the waveform editor (US-18.1). This is the
+// truthful counterpart to the seeded bar-chart in lib/waveform.ts: instead of
+// hashing the clip id, it decodes the clip's actual audio bytes and reads
+// amplitude peaks straight from the samples. The decode needs the browser
+// AudioContext; the bucketing math is pure so it stays unit-testable.
+//
+// ponytail: the decoded mono track is held in memory at full resolution
+// (~44.1k floats/sec → ~32 MB for a 3-min song). Fine for an editor opened one
+// clip at a time; downsample to a capped peak buffer if multi-clip memory ever
+// bites.
+
+export type ClipAudio = {
+  /** Mono mixdown of the decoded audio, one sample per element in ~[-1, 1]. */
+  mono: Float32Array
+  sampleRate: number
+  /** Duration in seconds. */
+  duration: number
+}
+
+/** Average every channel into a single mono track of `length` samples. */
+export function mixToMono(
+  channels: Float32Array[],
+  length: number
+): Float32Array {
+  const mono = new Float32Array(length)
+  if (channels.length === 0) return mono
+  for (const ch of channels) {
+    const n = Math.min(length, ch.length)
+    for (let i = 0; i < n; i++) mono[i] += ch[i]
+  }
+  for (let i = 0; i < length; i++) mono[i] /= channels.length
+  return mono
+}
+
+/**
+ * Peak amplitude (max |sample|) per output column across the sample window
+ * [startSample, endSample). Reads raw samples, so it is exact at any zoom and
+ * only touches the visible slice. Returns `columns` values in [0, 1].
+ */
+export function columnPeaks(
+  mono: Float32Array,
+  startSample: number,
+  endSample: number,
+  columns: number
+): Float32Array {
+  const out = new Float32Array(Math.max(0, columns))
+  if (columns <= 0) return out
+  const start = Math.max(0, Math.min(Math.floor(startSample), mono.length))
+  const end = Math.max(start, Math.min(Math.ceil(endSample), mono.length))
+  const span = end - start
+  if (span <= 0) return out
+  const per = span / columns
+  for (let c = 0; c < columns; c++) {
+    const s = start + Math.floor(c * per)
+    const e = Math.min(end, start + Math.floor((c + 1) * per))
+    let peak = 0
+    for (let i = s; i < e; i++) {
+      const a = Math.abs(mono[i])
+      if (a > peak) peak = a
+    }
+    out[c] = peak > 1 ? 1 : peak
+  }
+  return out
+}
+
+/**
+ * Fetch the clip's audio through the authed same-origin proxy
+ * (/api/clips/{id}/audio, which forwards the Bearer token) and decode it to
+ * peak data. Throws on fetch failure or an undecodable body so the caller can
+ * show an error state.
+ */
+export async function decodeClipAudio(
+  clipId: string,
+  token: string,
+  signal?: AbortSignal
+): Promise<ClipAudio> {
+  const res = await fetch(`/api/clips/${encodeURIComponent(clipId)}/audio`, {
+    headers: { authorization: `Bearer ${token}` },
+    signal,
+  })
+  if (!res.ok) throw new Error(`audio fetch failed: ${res.status}`)
+  const bytes = await res.arrayBuffer()
+
+  const Ctx =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext
+  if (!Ctx) throw new Error("Web Audio API unavailable")
+  const ctx = new Ctx()
+  try {
+    const buffer = await ctx.decodeAudioData(bytes)
+    const channels: Float32Array[] = []
+    for (let c = 0; c < buffer.numberOfChannels; c++) {
+      channels.push(buffer.getChannelData(c))
+    }
+    return {
+      mono: mixToMono(channels, buffer.length),
+      sampleRate: buffer.sampleRate,
+      duration: buffer.duration,
+    }
+  } finally {
+    void ctx.close()
+  }
+}

--- a/web/lib/song-actions.test.ts
+++ b/web/lib/song-actions.test.ts
@@ -77,6 +77,8 @@ describe("SONG_ACTION_GROUPS", () => {
 
   it("routes studio to navigation and remaster/publish/delete inline", () => {
     expect(findSongAction("open-studio")?.workflow).toBe("navigation")
+    // Open in Editor navigates to /editor/{id} (US-18.1).
+    expect(findSongAction("open-editor")?.workflow).toBe("navigation")
     // Remaster is one-click (US-17.3) — inline submit, no modal.
     expect(findSongAction("remaster")?.workflow).toBe("inline")
     expect(findSongAction("publish-toggle")?.workflow).toBe("inline")
@@ -87,8 +89,6 @@ describe("SONG_ACTION_GROUPS", () => {
     for (const id of [
       "remix",
       "repaint",
-      // open-editor flips to navigation when the editor page ships (US-18).
-      "open-editor",
       "cover",
       "extend",
       "mashup",

--- a/web/lib/song-actions.ts
+++ b/web/lib/song-actions.ts
@@ -105,12 +105,11 @@ export const SONG_ACTION_GROUPS: SongActionGroup[] = [
         workflow: "modal",
       },
       {
-        // Becomes "navigation" to /editor/{id} when the editor page ships
-        // (US-18); until then the placeholder modal keeps users off a 404.
+        // Navigates to /editor/{id}, the waveform editor (US-18.1).
         id: "open-editor",
         label: "Open in Editor",
         icon: PencilEdit02Icon,
-        workflow: "modal",
+        workflow: "navigation",
         proOnly: true,
       },
       {

--- a/web/lib/waveform-viewport.test.ts
+++ b/web/lib/waveform-viewport.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  MAX_PX_PER_SEC,
+  chooseTickInterval,
+  clampPxPerSec,
+  clampScrollSec,
+  fitPxPerSec,
+  maxScrollSec,
+  secToX,
+  visibleTicks,
+  xToSec,
+  zoomAtX,
+  type Viewport,
+} from "./waveform-viewport"
+
+describe("fitPxPerSec", () => {
+  it("packs the whole clip into the given width", () => {
+    // 60s clip, 600px wide → 10 px/sec fills the view exactly.
+    expect(fitPxPerSec(60, 600)).toBe(10)
+  })
+  it("guards against zero/negative inputs", () => {
+    expect(fitPxPerSec(0, 600)).toBe(1)
+    expect(fitPxPerSec(60, 0)).toBe(1)
+  })
+})
+
+describe("clampPxPerSec", () => {
+  it("floors at the fit zoom (can't zoom out past full clip)", () => {
+    expect(clampPxPerSec(1, 60, 600)).toBe(10) // fit is 10
+  })
+  it("ceils at MAX_PX_PER_SEC", () => {
+    expect(clampPxPerSec(1e9, 60, 600)).toBe(MAX_PX_PER_SEC)
+  })
+  it("passes through an in-range zoom", () => {
+    expect(clampPxPerSec(50, 60, 600)).toBe(50)
+  })
+})
+
+describe("scroll clamping", () => {
+  it("maxScrollSec keeps the right edge inside the clip", () => {
+    // 60s clip at 20px/sec in a 600px view → 30s visible → can scroll 30s.
+    expect(maxScrollSec(60, 20, 600)).toBe(30)
+  })
+  it("is zero when the whole clip fits", () => {
+    expect(maxScrollSec(60, 10, 600)).toBe(0)
+  })
+  it("clampScrollSec pins to [0, max]", () => {
+    expect(clampScrollSec(-5, 60, 20, 600)).toBe(0)
+    expect(clampScrollSec(1000, 60, 20, 600)).toBe(30)
+    expect(clampScrollSec(10, 60, 20, 600)).toBe(10)
+  })
+})
+
+describe("secToX / xToSec are inverses", () => {
+  const vp: Viewport = { pxPerSec: 25, scrollSec: 4 }
+  it("round-trips a time through pixels", () => {
+    expect(xToSec(secToX(9.3, vp), vp)).toBeCloseTo(9.3)
+  })
+  it("maps the left edge to x=0", () => {
+    expect(secToX(4, vp)).toBe(0)
+  })
+})
+
+describe("zoomAtX", () => {
+  it("keeps the audio under the anchor pixel fixed while zooming in", () => {
+    const vp: Viewport = { pxPerSec: 10, scrollSec: 0 }
+    const anchorX = 300 // audio at 30s under the cursor (0 + 300/10)
+    const before = xToSec(anchorX, vp)
+    const next = zoomAtX(vp, 40, anchorX, 60, 600)
+    expect(next.pxPerSec).toBe(40)
+    // Same audio time still sits under the anchor pixel after the zoom.
+    expect(xToSec(anchorX, next)).toBeCloseTo(before)
+  })
+  it("clamps zoom-out to the fit floor", () => {
+    const vp: Viewport = { pxPerSec: 40, scrollSec: 10 }
+    const next = zoomAtX(vp, 1, 300, 60, 600)
+    expect(next.pxPerSec).toBe(10) // fit
+    expect(next.scrollSec).toBe(0) // whole clip fits → no scroll
+  })
+})
+
+describe("chooseTickInterval", () => {
+  it("uses coarse ticks when zoomed out, fine ticks when zoomed in", () => {
+    // Zoomed way out (2px/sec): target 40s → ladder picks 60s.
+    expect(chooseTickInterval(2)).toBe(60)
+    // Zoomed in (200px/sec): target 0.4s → ladder picks 0.5s.
+    expect(chooseTickInterval(200)).toBe(0.5)
+  })
+  it("monotonically shrinks as zoom grows", () => {
+    const a = chooseTickInterval(5)
+    const b = chooseTickInterval(50)
+    const c = chooseTickInterval(500)
+    expect(a).toBeGreaterThanOrEqual(b)
+    expect(b).toBeGreaterThanOrEqual(c)
+  })
+  it("falls back to the coarsest step at absurdly low zoom", () => {
+    expect(chooseTickInterval(0.0001)).toBe(600)
+  })
+})
+
+describe("visibleTicks", () => {
+  it("emits ticks on interval boundaries within the window", () => {
+    // 60s clip, fit zoom 10px/sec in 600px → interval 10s (target 8s → 10).
+    const vp: Viewport = { pxPerSec: 10, scrollSec: 0 }
+    const ticks = visibleTicks(vp, 600, 60)
+    expect(ticks.map((t) => t.sec)).toEqual([0, 10, 20, 30, 40, 50, 60])
+    expect(ticks[0].x).toBe(0)
+    expect(ticks[1].x).toBe(100) // 10s * 10px/sec
+  })
+  it("starts at the first boundary at or after the scroll offset", () => {
+    const vp: Viewport = { pxPerSec: 20, scrollSec: 12 }
+    const ticks = visibleTicks(vp, 600, 120)
+    // interval at 20px/sec: target 4s → 5s. First boundary ≥12 is 15.
+    expect(ticks[0].sec).toBe(15)
+    expect(ticks.every((t) => t.x >= 0 && t.x <= 600)).toBe(true)
+  })
+})

--- a/web/lib/waveform-viewport.ts
+++ b/web/lib/waveform-viewport.ts
@@ -1,0 +1,127 @@
+// Pure viewport math for the waveform editor (US-18.1). Kept free of React and
+// canvas so the zoom / scroll / tick-interval logic is unit-testable in
+// isolation. All audio positions are in seconds; `x` is a pixel offset from the
+// left edge of the visible viewport (not the whole clip — the canvas is
+// virtual-scrolled, so it only ever draws `width` pixels).
+
+/** Zoom-in ceiling, in canvas pixels per second (~sample-level detail). */
+export const MAX_PX_PER_SEC = 4000
+
+/** The visible window: how zoomed in we are, and where the left edge sits. */
+export type Viewport = {
+  /** Horizontal zoom: canvas pixels per second of audio. */
+  pxPerSec: number
+  /** Left edge of the visible window, in seconds from the clip start. */
+  scrollSec: number
+}
+
+/**
+ * px/sec at which the whole clip exactly fills `width`. This is the min-zoom
+ * floor: you can never zoom out further than "the entire clip on screen".
+ */
+export function fitPxPerSec(duration: number, width: number): number {
+  if (duration <= 0 || width <= 0) return 1
+  return width / duration
+}
+
+/** Clamp a desired zoom to [fit, MAX]. */
+export function clampPxPerSec(
+  px: number,
+  duration: number,
+  width: number
+): number {
+  const min = fitPxPerSec(duration, width)
+  return Math.min(MAX_PX_PER_SEC, Math.max(min, px))
+}
+
+/** Largest scrollSec that keeps the right edge of the window within the clip. */
+export function maxScrollSec(
+  duration: number,
+  pxPerSec: number,
+  width: number
+): number {
+  const visibleSec = pxPerSec > 0 ? width / pxPerSec : duration
+  return Math.max(0, duration - visibleSec)
+}
+
+/** Clamp a desired scroll position to [0, maxScrollSec]. */
+export function clampScrollSec(
+  scrollSec: number,
+  duration: number,
+  pxPerSec: number,
+  width: number
+): number {
+  return Math.min(
+    maxScrollSec(duration, pxPerSec, width),
+    Math.max(0, scrollSec)
+  )
+}
+
+/** Screen x (px) for an audio time, under the given viewport. */
+export function secToX(sec: number, vp: Viewport): number {
+  return (sec - vp.scrollSec) * vp.pxPerSec
+}
+
+/** Audio time (sec) for a screen x (px), under the given viewport. */
+export function xToSec(x: number, vp: Viewport): number {
+  return vp.scrollSec + x / vp.pxPerSec
+}
+
+/**
+ * Zoom to `nextPx` while pinning the audio currently under screen-x `anchorX`
+ * in place — so wheel-zoom homes on the cursor and +/- buttons hold the view
+ * centre (AC: "maintain center point when zoom level changes"). Returns a fully
+ * clamped viewport.
+ */
+export function zoomAtX(
+  vp: Viewport,
+  nextPx: number,
+  anchorX: number,
+  duration: number,
+  width: number
+): Viewport {
+  const pxPerSec = clampPxPerSec(nextPx, duration, width)
+  const anchorSec = xToSec(anchorX, vp) // audio pinned under the anchor
+  const scrollSec = clampScrollSec(
+    anchorSec - anchorX / pxPerSec,
+    duration,
+    pxPerSec,
+    width
+  )
+  return { pxPerSec, scrollSec }
+}
+
+// Ruler tick spacing. A "nice" ladder of intervals (seconds) so labels land on
+// human-friendly boundaries; we pick the smallest step that keeps labels at
+// least ~TARGET_TICK_PX apart, so the ruler stays readable at every zoom.
+const TICK_LADDER = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600]
+const TARGET_TICK_PX = 80
+
+/** Seconds between major ruler ticks at the given zoom. */
+export function chooseTickInterval(pxPerSec: number): number {
+  if (pxPerSec <= 0) return TICK_LADDER[TICK_LADDER.length - 1]
+  const targetSec = TARGET_TICK_PX / pxPerSec
+  for (const step of TICK_LADDER) if (step >= targetSec) return step
+  return TICK_LADDER[TICK_LADDER.length - 1]
+}
+
+export type Tick = { sec: number; x: number }
+
+/** Major ticks visible in the viewport, each with its screen-x position. */
+export function visibleTicks(
+  vp: Viewport,
+  width: number,
+  duration: number
+): Tick[] {
+  const interval = chooseTickInterval(vp.pxPerSec)
+  const ticks: Tick[] = []
+  // scrollSec is always ≥ 0 (clamped), so the first tick index is ≥ 0; the
+  // Math.max also normalizes a -0 from Math.ceil back to +0.
+  const first = Math.max(0, Math.ceil(vp.scrollSec / interval - 1e-9)) * interval
+  for (let sec = first; sec <= duration + 1e-6; sec += interval) {
+    const x = secToX(sec, vp)
+    if (x > width) break
+    if (x >= 0) ticks.push({ sec, x })
+  }
+  return ticks
+}


### PR DESCRIPTION
Closes #202 — **US-18.1: Waveform Display with Zoom and Scroll** (first story of Stage 18).

## What this does
Adds a real, zoomable/scrollable waveform editor at a new `/editor/[id]` route and wires the song menu's **Open in Editor** action to it.

> [!NOTE]
> The issue's CodeRabbit "Coding Plan" was authored (June 2026) when `web/` was an empty `.gitkeep` and is entirely stale — it prescribes bootstrapping a fresh Next.js app + **WaveSurfer.js**. Reality: `web/` is a mature Next.js 16 app, and project convention explicitly bans wavesurfer. This PR follows the actual codebase, not that plan.

## Approach
- **Real audio peaks, no new deps.** `lib/audio-peaks.ts` fetches the clip's bytes through the **authed same-origin proxy** (`/api/clips/{id}/audio`) and decodes them with the Web Audio API. `columnPeaks()` reads `max|sample|` per pixel column straight from the decoded `Float32Array`, so rendering is accurate at every zoom. (The decorative seeded bar-chart in `lib/waveform.ts` is untouched — it still backs the mini-player / song page.)
- **Virtual-scroll canvas.** The canvas stays viewport-sized and re-buckets only the visible sample window each frame — avoids the browser's ~32,767px canvas limit at deep zoom.
- **Reuses the existing audio engine.** The editor loads the clip into the shared player store (`player-context`), so the playhead follows real playback and click-to-seek drives the same `<audio>` element the Playbar uses — no second engine.
- **Pure, tested viewport math** in `lib/waveform-viewport.ts` (zoom clamp, anchor-preserving zoom, scroll clamp, adaptive tick interval).

## Files
- `lib/waveform-viewport.ts` + test — zoom/scroll/tick math (pure)
- `lib/audio-peaks.ts` + test — decode + peak extraction (pure bucketing tested)
- `hooks/use-clip-audio.ts` — decode hook (id-tagged, mirrors `useClip`)
- `components/editor/` — `WaveformCanvas`, `TimeRuler`, `ZoomControls`, `WaveformScrollbar`, `WaveformEditor`, `ClipEditor` (+ tests)
- `app/editor/[id]/page.tsx` — thin route shim
- Flipped `open-editor` from placeholder-modal → `navigation` (`song-actions.ts`, `use-song-actions.ts`); updated the tests that pinned the old behavior

## Acceptance criteria → evidence
| Criterion | Evidence |
|---|---|
| Waveform renders accurately from audio data | `audio-peaks.test.ts` (peak bucketing from raw samples); canvas draws from `columnPeaks(audio.mono, …)` |
| Zoom in/out with visible detail change | `WaveformEditor.test.tsx` "zooms in and back to fit"; `waveform-viewport.test.ts` `zoomAtX`/`chooseTickInterval` |
| Scrolling navigates a zoomed-in waveform | scrollbar appears only when zoomed (`WaveformEditor.test.tsx`); `clampScrollSec`/`maxScrollSec` tests |
| Playhead moves during playback + click-to-seek | click-to-seek dispatches a player seek (`WaveformEditor.test.tsx`); playhead bound to `state.currentTime` when current |
| Time-ruler labels update at different zoom | `TimeRuler.test.tsx` (mm:ss, finer consecutive-second labels when zoomed) |

**Gates:** 649/649 web tests pass · `lint` clean · `typecheck` clean · `build` succeeds (`/editor/[id]` registered).

## Known limitations
- **Live audio streaming for real clips is a pre-existing backend gap**, not addressed here. Peak decoding works (authed proxy), and the playhead/seek wiring is unit-verified, but a plain `<audio>` element can't attach the Bearer token, so real-clip *playback* won't advance the playhead in a running app until streaming auth is wired (the app still plays demo tracks today). Click-to-seek still moves the playhead via the store's optimistic time.
- **Opening the editor stages this clip as the current player track** (replaces any staged demo queue, paused — no autoplay). Expected for a focused "Open in Editor" surface.
- **Zoom is capped at 4000 px/sec** (deep detail, not literally 1px/sample) — a practical ceiling, marked `ponytail:` in `lib/audio-peaks.ts` for full-resolution memory.
- Keyboard **space/seek** already work via the global player shortcuts; dedicated in-editor zoom keys were not added (out of this story's AC — buttons + Ctrl/wheel + pinch cover zoom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
