### PR TITLE
feat(web): Region Selection and Clipboard Operations (US-18.2)

### DIFF
--- a/web/components/editor/SelectionHandle.tsx
+++ b/web/components/editor/SelectionHandle.tsx
@@ -4,20 +4,31 @@ import { useRef } from "react"
 
 // A draggable edge of the selection region (US-18.2). Reused for both the start
 // and end boundary. A thin vertical line with a wider invisible grab target and
-// an ew-resize cursor. It only knows about screen pixels: on drag it reports the
-// raw pointer clientX; the overlay converts that to a time via the viewport and
-// clamps it so the two edges can't cross.
+// an ew-resize cursor. Pointer drags report the raw clientX (the overlay
+// converts it to a time and clamps); Arrow keys nudge the edge by NUDGE_SEC so
+// the boundary is keyboard-adjustable too. It's a real ARIA slider over the
+// time axis, so aria-value* carry seconds — not pixels.
+
+const NUDGE_SEC = 0.05
 
 export function SelectionHandle({
   xPx,
   height,
   edge,
+  valueSec,
+  minSec,
+  maxSec,
   onMoveClientX,
+  onNudge,
 }: {
   xPx: number
   height: number
   edge: "start" | "end"
+  valueSec: number
+  minSec: number
+  maxSec: number
   onMoveClientX: (clientX: number) => void
+  onNudge: (edge: "start" | "end", deltaSec: number) => void
 }) {
   const dragging = useRef(false)
 
@@ -25,10 +36,21 @@ export function SelectionHandle({
     <div
       role="slider"
       aria-label={`Selection ${edge} handle`}
-      aria-orientation="vertical"
-      aria-valuenow={Math.round(xPx)}
+      aria-orientation="horizontal"
+      aria-valuemin={minSec}
+      aria-valuemax={maxSec}
+      aria-valuenow={valueSec}
       tabIndex={0}
       data-edge={edge}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowLeft") {
+          e.preventDefault()
+          onNudge(edge, -NUDGE_SEC)
+        } else if (e.key === "ArrowRight") {
+          e.preventDefault()
+          onNudge(edge, NUDGE_SEC)
+        }
+      }}
       onPointerDown={(e) => {
         e.stopPropagation() // don't start a new selection on the canvas below
         e.currentTarget.setPointerCapture?.(e.pointerId)

--- a/web/components/editor/SelectionHandle.tsx
+++ b/web/components/editor/SelectionHandle.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useRef } from "react"
+
+// A draggable edge of the selection region (US-18.2). Reused for both the start
+// and end boundary. A thin vertical line with a wider invisible grab target and
+// an ew-resize cursor. It only knows about screen pixels: on drag it reports the
+// raw pointer clientX; the overlay converts that to a time via the viewport and
+// clamps it so the two edges can't cross.
+
+export function SelectionHandle({
+  xPx,
+  height,
+  edge,
+  onMoveClientX,
+}: {
+  xPx: number
+  height: number
+  edge: "start" | "end"
+  onMoveClientX: (clientX: number) => void
+}) {
+  const dragging = useRef(false)
+
+  return (
+    <div
+      role="slider"
+      aria-label={`Selection ${edge} handle`}
+      aria-orientation="vertical"
+      aria-valuenow={Math.round(xPx)}
+      tabIndex={0}
+      data-edge={edge}
+      onPointerDown={(e) => {
+        e.stopPropagation() // don't start a new selection on the canvas below
+        e.currentTarget.setPointerCapture?.(e.pointerId)
+        dragging.current = true
+      }}
+      onPointerMove={(e) => {
+        if (dragging.current) onMoveClientX(e.clientX)
+      }}
+      onPointerUp={(e) => {
+        dragging.current = false
+        e.currentTarget.releasePointerCapture?.(e.pointerId)
+      }}
+      className="absolute top-0 z-20 w-2 -translate-x-1/2 cursor-ew-resize touch-none"
+      style={{ left: xPx, height }}
+    >
+      <span className="absolute left-1/2 top-0 h-full w-px -translate-x-1/2 bg-primary" />
+    </div>
+  )
+}

--- a/web/components/editor/SelectionInfo.test.tsx
+++ b/web/components/editor/SelectionInfo.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { SelectionInfo } from "./SelectionInfo"
+
+describe("SelectionInfo", () => {
+  it("renders nothing without a selection", () => {
+    const { container } = render(<SelectionInfo selection={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("shows start, end, and duration with millisecond precision", () => {
+    render(<SelectionInfo selection={{ startSec: 8.2, endSec: 8.5 }} />)
+    const info = screen.getByTestId("selection-info")
+    expect(info).toHaveTextContent("Start 0:08.200")
+    expect(info).toHaveTextContent("End 0:08.500")
+    expect(info).toHaveTextContent("Duration 0:00.300")
+  })
+
+  it("formats minutes past 60 seconds", () => {
+    render(<SelectionInfo selection={{ startSec: 65.5, endSec: 90 }} />)
+    expect(screen.getByTestId("selection-info")).toHaveTextContent("Start 1:05.500")
+  })
+})

--- a/web/components/editor/SelectionInfo.tsx
+++ b/web/components/editor/SelectionInfo.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import type { Region } from "@/lib/waveform-edit"
+
+// Selection readout (US-18.2): start / end / duration for the current region.
+// Formatted as m:ss.mmm — audio edits are sub-second, so a 300ms selection must
+// not read as "0:00". Renders nothing when there's no selection.
+
+/** m:ss.mmm. Derived from integer total-ms so seconds carry with no FP flooring
+ *  artifact (8.2s → "0:08.200", not "0:08.199") and ms never rolls to 1000. */
+function fmt(sec: number): string {
+  const totalMs = Math.round(Math.max(0, sec) * 1000)
+  const ms = totalMs % 1000
+  const totalSec = Math.floor(totalMs / 1000)
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}:${s.toString().padStart(2, "0")}.${ms.toString().padStart(3, "0")}`
+}
+
+export function SelectionInfo({ selection }: { selection: Region | null }) {
+  if (!selection) return null
+  const duration = Math.max(0, selection.endSec - selection.startSec)
+
+  return (
+    <div
+      className="flex gap-4 text-xs text-muted-foreground tabular-nums"
+      data-testid="selection-info"
+    >
+      <span>
+        Start <span className="text-foreground">{fmt(selection.startSec)}</span>
+      </span>
+      <span>
+        End <span className="text-foreground">{fmt(selection.endSec)}</span>
+      </span>
+      <span>
+        Duration <span className="text-foreground">{fmt(duration)}</span>
+      </span>
+    </div>
+  )
+}

--- a/web/components/editor/SelectionOverlay.test.tsx
+++ b/web/components/editor/SelectionOverlay.test.tsx
@@ -16,6 +16,7 @@ function setup(selection: { startSec: number; endSec: number } | null) {
       viewport={viewport}
       width={800}
       height={160}
+      duration={10}
       onAdjust={onAdjust}
     />
   )
@@ -43,5 +44,36 @@ describe("SelectionOverlay", () => {
     fireEvent.pointerMove(startHandle, { clientX: 240, pointerId: 1 })
     // xToSec(240) = 0 + 240/80 = 3s.
     expect(onAdjust).toHaveBeenCalledWith("start", 3)
+  })
+
+  it("nudges an edge by a fine step with Arrow keys", () => {
+    const { onAdjust } = setup({ startSec: 2, endSec: 5 })
+    const startHandle = screen.getByRole("slider", { name: "Selection start handle" })
+    fireEvent.keyDown(startHandle, { key: "ArrowRight" })
+    expect(onAdjust).toHaveBeenLastCalledWith("start", expect.closeTo(2.05))
+    fireEvent.keyDown(startHandle, { key: "ArrowLeft" })
+    expect(onAdjust).toHaveBeenLastCalledWith("start", expect.closeTo(1.95))
+  })
+
+  it("keeps both handles mounted when an edge scrolls out of view", () => {
+    const onAdjust = vi.fn()
+    render(
+      <SelectionOverlay
+        selection={{ startSec: 2, endSec: 5 }}
+        viewport={{ pxPerSec: 80, scrollSec: 3 }} // start at x = -80 (off-left)
+        width={800}
+        height={160}
+        duration={10}
+        onAdjust={onAdjust}
+      />
+    )
+    // The start handle must stay mounted so an in-progress drag keeps its
+    // pointer capture instead of freezing at the edge.
+    expect(
+      screen.getByRole("slider", { name: "Selection start handle" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("slider", { name: "Selection end handle" })
+    ).toBeInTheDocument()
   })
 })

--- a/web/components/editor/SelectionOverlay.test.tsx
+++ b/web/components/editor/SelectionOverlay.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { SelectionOverlay } from "./SelectionOverlay"
+import type { Viewport } from "@/lib/waveform-viewport"
+
+// jsdom's getBoundingClientRect returns {left:0}, so clientX maps 1:1 to the
+// in-overlay x used for the time conversion.
+const viewport: Viewport = { pxPerSec: 80, scrollSec: 0 }
+
+function setup(selection: { startSec: number; endSec: number } | null) {
+  const onAdjust = vi.fn()
+  render(
+    <SelectionOverlay
+      selection={selection}
+      viewport={viewport}
+      width={800}
+      height={160}
+      onAdjust={onAdjust}
+    />
+  )
+  return { onAdjust }
+}
+
+describe("SelectionOverlay", () => {
+  it("renders nothing without a selection", () => {
+    setup(null)
+    expect(screen.queryByTestId("selection-overlay")).not.toBeInTheDocument()
+  })
+
+  it("positions the highlight from start to end (px = sec * pxPerSec)", () => {
+    setup({ startSec: 2, endSec: 5 })
+    const overlay = screen.getByTestId("selection-overlay")
+    const rect = overlay.firstElementChild as HTMLElement
+    expect(rect.style.left).toBe("160px") // 2s * 80
+    expect(rect.style.width).toBe("240px") // (5-2)s * 80
+  })
+
+  it("reports the dragged edge as a time under the pointer", () => {
+    const { onAdjust } = setup({ startSec: 2, endSec: 5 })
+    const startHandle = screen.getByRole("slider", { name: "Selection start handle" })
+    fireEvent.pointerDown(startHandle, { clientX: 160, pointerId: 1 })
+    fireEvent.pointerMove(startHandle, { clientX: 240, pointerId: 1 })
+    // xToSec(240) = 0 + 240/80 = 3s.
+    expect(onAdjust).toHaveBeenCalledWith("start", 3)
+  })
+})

--- a/web/components/editor/SelectionOverlay.tsx
+++ b/web/components/editor/SelectionOverlay.tsx
@@ -11,19 +11,25 @@ import type { Region } from "@/lib/waveform-edit"
 // canvas (same left origin / width), so it converts times through the same
 // secToX/xToSec the canvas uses. Renders nothing when there's no selection or
 // when the region is scrolled entirely out of view.
+//
+// Handles stay mounted (with their x clamped to the viewport) whenever the
+// overlay renders — unmounting one mid-drag would drop its pointer capture and
+// freeze the drag at the viewport edge.
 
 export function SelectionOverlay({
   selection,
   viewport,
   width,
   height,
+  duration,
   onAdjust,
 }: {
   selection: Region | null
   viewport: Viewport
   width: number
   height: number
-  /** A handle was dragged: set `edge` to the (unclamped) time under the pointer. */
+  duration: number
+  /** A handle moved (drag or Arrow key): set `edge` to the new time. */
   onAdjust: (edge: "start" | "end", sec: number) => void
 }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -35,13 +41,16 @@ export function SelectionOverlay({
   // Nothing to draw if the whole region sits off either side of the viewport.
   if (endX < 0 || startX > width) return null
 
-  const left = Math.max(0, startX)
-  const right = Math.min(width, endX)
+  const clamp = (x: number) => Math.max(0, Math.min(width, x))
+  const left = clamp(startX)
+  const right = clamp(endX)
 
   const clientXToSec = (clientX: number) => {
     const rectLeft = ref.current?.getBoundingClientRect().left ?? 0
     return xToSec(clientX - rectLeft, viewport)
   }
+  const nudge = (edge: "start" | "end", deltaSec: number) =>
+    onAdjust(edge, (edge === "start" ? selection.startSec : selection.endSec) + deltaSec)
 
   return (
     <div
@@ -53,26 +62,28 @@ export function SelectionOverlay({
         className="absolute top-0 bg-primary/25"
         style={{ left, width: Math.max(0, right - left), height }}
       />
-      {startX >= 0 && startX <= width && (
-        <div className="pointer-events-auto">
-          <SelectionHandle
-            xPx={startX}
-            height={height}
-            edge="start"
-            onMoveClientX={(c) => onAdjust("start", clientXToSec(c))}
-          />
-        </div>
-      )}
-      {endX >= 0 && endX <= width && (
-        <div className="pointer-events-auto">
-          <SelectionHandle
-            xPx={endX}
-            height={height}
-            edge="end"
-            onMoveClientX={(c) => onAdjust("end", clientXToSec(c))}
-          />
-        </div>
-      )}
+      <div className="pointer-events-auto">
+        <SelectionHandle
+          xPx={left}
+          height={height}
+          edge="start"
+          valueSec={selection.startSec}
+          minSec={0}
+          maxSec={selection.endSec}
+          onMoveClientX={(c) => onAdjust("start", clientXToSec(c))}
+          onNudge={nudge}
+        />
+        <SelectionHandle
+          xPx={right}
+          height={height}
+          edge="end"
+          valueSec={selection.endSec}
+          minSec={selection.startSec}
+          maxSec={duration}
+          onMoveClientX={(c) => onAdjust("end", clientXToSec(c))}
+          onNudge={nudge}
+        />
+      </div>
     </div>
   )
 }

--- a/web/components/editor/SelectionOverlay.tsx
+++ b/web/components/editor/SelectionOverlay.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useRef } from "react"
+
+import { SelectionHandle } from "@/components/editor/SelectionHandle"
+import { secToX, xToSec, type Viewport } from "@/lib/waveform-viewport"
+import type { Region } from "@/lib/waveform-edit"
+
+// The visual selection layer (US-18.2): a translucent highlight over the
+// selected time range plus a draggable handle on each edge. Positioned over the
+// canvas (same left origin / width), so it converts times through the same
+// secToX/xToSec the canvas uses. Renders nothing when there's no selection or
+// when the region is scrolled entirely out of view.
+
+export function SelectionOverlay({
+  selection,
+  viewport,
+  width,
+  height,
+  onAdjust,
+}: {
+  selection: Region | null
+  viewport: Viewport
+  width: number
+  height: number
+  /** A handle was dragged: set `edge` to the (unclamped) time under the pointer. */
+  onAdjust: (edge: "start" | "end", sec: number) => void
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  if (!selection) return null
+
+  const startX = secToX(selection.startSec, viewport)
+  const endX = secToX(selection.endSec, viewport)
+  // Nothing to draw if the whole region sits off either side of the viewport.
+  if (endX < 0 || startX > width) return null
+
+  const left = Math.max(0, startX)
+  const right = Math.min(width, endX)
+
+  const clientXToSec = (clientX: number) => {
+    const rectLeft = ref.current?.getBoundingClientRect().left ?? 0
+    return xToSec(clientX - rectLeft, viewport)
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="pointer-events-none absolute inset-0 z-10"
+      data-testid="selection-overlay"
+    >
+      <div
+        className="absolute top-0 bg-primary/25"
+        style={{ left, width: Math.max(0, right - left), height }}
+      />
+      {startX >= 0 && startX <= width && (
+        <div className="pointer-events-auto">
+          <SelectionHandle
+            xPx={startX}
+            height={height}
+            edge="start"
+            onMoveClientX={(c) => onAdjust("start", clientXToSec(c))}
+          />
+        </div>
+      )}
+      {endX >= 0 && endX <= width && (
+        <div className="pointer-events-auto">
+          <SelectionHandle
+            xPx={endX}
+            height={height}
+            edge="end"
+            onMoveClientX={(c) => onAdjust("end", clientXToSec(c))}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/components/editor/WaveformCanvas.test.tsx
+++ b/web/components/editor/WaveformCanvas.test.tsx
@@ -16,6 +16,7 @@ function setup() {
   const onSeek = vi.fn()
   const onZoom = vi.fn()
   const onScrollSec = vi.fn()
+  const onSelect = vi.fn()
   render(
     <WaveformCanvas
       audio={audio}
@@ -26,28 +27,35 @@ function setup() {
       onSeek={onSeek}
       onZoom={onZoom}
       onScrollSec={onScrollSec}
+      onSelect={onSelect}
     />
   )
-  return { canvas: screen.getByRole("img", { name: "Waveform" }), onSeek, onZoom, onScrollSec }
+  return {
+    canvas: screen.getByRole("img", { name: "Waveform" }),
+    onSeek,
+    onZoom,
+    onScrollSec,
+    onSelect,
+  }
 }
 
 describe("WaveformCanvas input", () => {
   it("seeks on a tap with no movement", () => {
-    const { canvas, onSeek, onScrollSec } = setup()
+    const { canvas, onSeek, onSelect } = setup()
     fireEvent.pointerDown(canvas, { clientX: 240, pointerId: 1 })
     fireEvent.pointerUp(canvas, { clientX: 240, pointerId: 1 })
     // xToSec(240) = scrollSec 5 + 240/80 = 8s.
     expect(onSeek).toHaveBeenCalledWith(8)
-    expect(onScrollSec).not.toHaveBeenCalled()
+    expect(onSelect).not.toHaveBeenCalled()
   })
 
-  it("pans (not seeks) when the pointer drags past the threshold", () => {
-    const { canvas, onSeek, onScrollSec } = setup()
+  it("selects (not seeks) when the pointer drags past the threshold", () => {
+    const { canvas, onSeek, onSelect } = setup()
     fireEvent.pointerDown(canvas, { clientX: 400, pointerId: 1 })
-    fireEvent.pointerMove(canvas, { clientX: 320, pointerId: 1 }) // dragged -80px
-    fireEvent.pointerUp(canvas, { clientX: 320, pointerId: 1 })
-    // scrollSec = startScroll 5 - (-80)/80 = 6.
-    expect(onScrollSec).toHaveBeenLastCalledWith(6)
+    fireEvent.pointerMove(canvas, { clientX: 480, pointerId: 1 }) // dragged +80px
+    fireEvent.pointerUp(canvas, { clientX: 480, pointerId: 1 })
+    // start xToSec(400) = 5 + 400/80 = 10s; end xToSec(480) = 5 + 480/80 = 11s.
+    expect(onSelect).toHaveBeenLastCalledWith(10, 11)
     expect(onSeek).not.toHaveBeenCalled()
   })
 

--- a/web/components/editor/WaveformCanvas.tsx
+++ b/web/components/editor/WaveformCanvas.tsx
@@ -11,9 +11,11 @@ import { secToX, xToSec, type Viewport } from "@/lib/waveform-viewport"
 // window each render, so it stays accurate from full-clip overview to
 // sample-level zoom without a giant off-screen canvas. Input maps to callbacks
 // the editor turns into viewport/seek changes:
-//   click        → seek        drag           → pan
+//   click        → seek        drag           → select a region (US-18.2)
 //   Ctrl+wheel   → zoom        wheel/trackpad → horizontal scroll
 //   two-finger pinch → zoom (touch)
+// Panning moved to the wheel/trackpad + scrollbar when US-18.2 made this an
+// editor: plain drag now sweeps out a selection (DAW convention).
 // Latest props are read through refs so the non-passive wheel listener (needed
 // to preventDefault) attaches once instead of on every zoom tick.
 
@@ -29,6 +31,7 @@ export function WaveformCanvas({
   onSeek,
   onZoom,
   onScrollSec,
+  onSelect,
 }: {
   audio: ClipAudio
   viewport: Viewport
@@ -38,6 +41,8 @@ export function WaveformCanvas({
   onSeek: (sec: number) => void
   onZoom: (nextPx: number, anchorX: number) => void
   onScrollSec: (sec: number) => void
+  /** A drag swept a region: both times in seconds (start may be > end mid-drag). */
+  onSelect: (startSec: number, endSec: number) => void
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -45,13 +50,13 @@ export function WaveformCanvas({
   // updated in effects (never during render) so the native wheel listener can
   // attach once yet always read fresh state.
   const vpRef = useRef(viewport)
-  const cbRef = useRef({ onSeek, onZoom, onScrollSec })
+  const cbRef = useRef({ onSeek, onZoom, onScrollSec, onSelect })
   useEffect(() => {
     vpRef.current = viewport
   }, [viewport])
   useEffect(() => {
-    cbRef.current = { onSeek, onZoom, onScrollSec }
-  }, [onSeek, onZoom, onScrollSec])
+    cbRef.current = { onSeek, onZoom, onScrollSec, onSelect }
+  }, [onSeek, onZoom, onScrollSec, onSelect])
 
   // Re-bucket peaks only when the audio or the visible window changes — NOT on
   // every playhead tick (~4Hz during playback), which would rescan millions of
@@ -104,7 +109,7 @@ export function WaveformCanvas({
 
   // --- Pointer input (click / drag / pinch) --------------------------------
   const pointers = useRef(new Map<number, number>()) // pointerId → clientX
-  const drag = useRef<{ startX: number; startScroll: number; moved: boolean } | null>(
+  const drag = useRef<{ startX: number; startSec: number; moved: boolean } | null>(
     null
   )
   const pinchDist = useRef<number | null>(null)
@@ -120,7 +125,7 @@ export function WaveformCanvas({
     if (pointers.current.size === 1) {
       drag.current = {
         startX: e.clientX,
-        startScroll: vpRef.current.scrollSec,
+        startSec: xToSec(rectX(e.clientX), vpRef.current),
         moved: false,
       }
     } else {
@@ -149,7 +154,8 @@ export function WaveformCanvas({
     const dx = e.clientX - d.startX
     if (Math.abs(dx) > DRAG_THRESHOLD_PX) d.moved = true
     if (d.moved) {
-      cbRef.current.onScrollSec(d.startScroll - dx / vpRef.current.pxPerSec)
+      // Sweep out a selection from where the drag began to the pointer now.
+      cbRef.current.onSelect(d.startSec, xToSec(rectX(e.clientX), vpRef.current))
     }
   }
 
@@ -197,7 +203,7 @@ export function WaveformCanvas({
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
       style={{ width, height }}
-      className="w-full touch-none cursor-pointer select-none"
+      className="w-full touch-none cursor-crosshair select-none"
     />
   )
 }

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -30,8 +30,10 @@ function fakeClip(): Clip {
   } as Clip
 }
 
+// 800 samples @ 80Hz = exactly 10s, so removeRegion/insertRegion recompute a
+// duration consistent with the fixture (mono.length / sampleRate).
 function fakeAudio(): ClipAudio {
-  return { mono: new Float32Array(800), sampleRate: 8000, duration: 10 }
+  return { mono: new Float32Array(800), sampleRate: 80, duration: 10 }
 }
 
 /** Surfaces player state so tests can assert the editor drives it. */
@@ -59,6 +61,20 @@ function canvas() {
 }
 function pxPerSec() {
   return Number(canvas().getAttribute("data-px-per-sec"))
+}
+/** At fit (80 px/sec, scrollSec 0) drag from `fromSec` to `toSec` to select. */
+function dragSelect(fromSec: number, toSec: number) {
+  fireEvent.pointerDown(canvas(), { clientX: fromSec * 80, pointerId: 1 })
+  fireEvent.pointerMove(canvas(), { clientX: toSec * 80, pointerId: 1 })
+  fireEvent.pointerUp(canvas(), { clientX: toSec * 80, pointerId: 1 })
+}
+function editedDuration() {
+  return Number(
+    document.querySelector("[data-edited-duration]")?.getAttribute("data-edited-duration")
+  )
+}
+function key(k: string, opts: { ctrlKey?: boolean } = {}) {
+  fireEvent.keyDown(document.body, { key: k, ...opts })
 }
 
 describe("WaveformEditor", () => {
@@ -105,5 +121,43 @@ describe("WaveformEditor", () => {
     expect(
       screen.getByRole("slider", { name: "Scroll waveform" })
     ).toBeInTheDocument()
+  })
+
+  it("shows the selection info and overlay after a click-and-drag", () => {
+    renderEditor()
+    expect(screen.queryByTestId("selection-info")).not.toBeInTheDocument()
+    dragSelect(2, 5)
+    expect(screen.getByTestId("selection-overlay")).toBeInTheDocument()
+    expect(screen.getByTestId("selection-info")).toHaveTextContent("Duration 0:03.000")
+  })
+
+  it("Delete removes the selected region and shortens the audio", () => {
+    renderEditor()
+    expect(editedDuration()).toBeCloseTo(10)
+    dragSelect(2, 5) // 3s region
+    key("Delete")
+    expect(editedDuration()).toBeCloseTo(7)
+    expect(screen.queryByTestId("selection-info")).not.toBeInTheDocument() // cleared
+  })
+
+  it("Ctrl+C then Ctrl+V duplicates the region at the playhead (lengthens audio)", () => {
+    renderEditor()
+    dragSelect(2, 5) // 3s region
+    key("c", { ctrlKey: true })
+    key("v", { ctrlKey: true }) // playhead at 0 → inserts 3s at the start
+    expect(editedDuration()).toBeCloseTo(13)
+    // seek moved the playhead to the end of the pasted region (3s).
+    expect(Number(screen.getByTestId("seek-req").textContent)).toBeCloseTo(3, 1)
+  })
+
+  it("Ctrl+X copies then removes (clipboard filled, audio shortened)", () => {
+    renderEditor()
+    dragSelect(2, 5)
+    key("x", { ctrlKey: true })
+    expect(editedDuration()).toBeCloseTo(7)
+    // 3s @ 80Hz = 240 samples now on the clipboard, ready to paste.
+    expect(
+      document.querySelector("[data-clipboard-samples]")?.getAttribute("data-clipboard-samples")
+    ).toBe("240")
   })
 })

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -150,6 +150,27 @@ describe("WaveformEditor", () => {
     expect(Number(screen.getByTestId("seek-req").textContent)).toBeCloseTo(3, 1)
   })
 
+  it("paste clamps the playhead into the edited timeline", () => {
+    renderEditor()
+    dragSelect(2, 5) // 3s clipboard
+    key("c", { ctrlKey: true })
+    // Move the playhead to 8s (clears the selection; the clipboard persists).
+    fireEvent.pointerDown(canvas(), { clientX: 8 * 80, pointerId: 1 })
+    fireEvent.pointerUp(canvas(), { clientX: 8 * 80, pointerId: 1 })
+    key("v", { ctrlKey: true }) // insert 3s at 8s → new duration 13, playhead 11
+    expect(editedDuration()).toBeCloseTo(13)
+    expect(Number(screen.getByTestId("seek-req").textContent)).toBeCloseTo(11, 1)
+  })
+
+  it("a drag that collapses back to its origin creates no selection", () => {
+    renderEditor()
+    fireEvent.pointerDown(canvas(), { clientX: 240, pointerId: 1 })
+    fireEvent.pointerMove(canvas(), { clientX: 300, pointerId: 1 }) // sweep out
+    fireEvent.pointerMove(canvas(), { clientX: 240, pointerId: 1 }) // back to origin
+    fireEvent.pointerUp(canvas(), { clientX: 240, pointerId: 1 })
+    expect(screen.queryByTestId("selection-info")).not.toBeInTheDocument()
+  })
+
   it("Ctrl+X copies then removes (clipboard filled, audio shortened)", () => {
     renderEditor()
     dragSelect(2, 5)

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -2,13 +2,24 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
 
+import { SelectionInfo } from "@/components/editor/SelectionInfo"
+import { SelectionOverlay } from "@/components/editor/SelectionOverlay"
 import { TimeRuler } from "@/components/editor/TimeRuler"
 import { WaveformCanvas } from "@/components/editor/WaveformCanvas"
 import { WaveformScrollbar } from "@/components/editor/WaveformScrollbar"
 import { ZoomControls } from "@/components/editor/ZoomControls"
 import { usePlayer } from "@/contexts/player-context"
+import { useEditorShortcuts } from "@/hooks/use-editor-shortcuts"
 import type { ClipAudio } from "@/lib/audio-peaks"
 import { trackFromClip } from "@/lib/clips"
+import {
+  insertRegion,
+  normalizeRegion,
+  removeRegion,
+  sliceRegion,
+  type EditOperation,
+  type Region,
+} from "@/lib/waveform-edit"
 import {
   MAX_PX_PER_SEC,
   clampPxPerSec,
@@ -19,15 +30,18 @@ import {
 } from "@/lib/waveform-viewport"
 import type { Clip } from "@/lib/workspace-clips"
 
-// The waveform editor panel (US-18.1). Owns the viewport (zoom + scroll) and
-// wires the canvas / ruler / zoom controls / scrollbar together. Playback state
-// is borrowed from the shared player store — entering the editor loads the clip
-// as the current track so the playhead follows real playback and click-to-seek
-// drives the same <audio> element the Playbar uses (no second audio engine).
+// The waveform editor panel (US-18.1 + US-18.2). Owns the viewport (zoom +
+// scroll) and — from US-18.2 — the region selection, the in-app clipboard, and
+// the edited audio. Playback state is borrowed from the shared player store.
+//
+// Edits (cut / delete / paste) splice the decoded samples directly, so the
+// canvas renders the *real* edited waveform with no operation-stack replay. They
+// are non-destructive: the original `audio` prop is untouched; the edit lives in
+// `edited` state and the `operations` log is the handoff seam for save (US-18.4).
 //
 // The stored viewport is the user's *intent* (absolute px/sec + scrollSec); the
 // effective viewport is derived + clamped against the measured width each
-// render, so a resize self-corrects without an effect or cascading setState.
+// render, so a resize — or an edit that changes the duration — self-corrects.
 
 const CANVAS_HEIGHT = 160
 const BUTTON_ZOOM_FACTOR = 1.6
@@ -40,7 +54,15 @@ export function WaveformEditor({
   audio: ClipAudio
 }) {
   const { state, dispatch } = usePlayer()
-  const duration = audio.duration
+
+  // The audio actually shown/edited. Starts as the decoded prop; cut/paste/delete
+  // replace it. ClipEditor keys this subtree by clip id, so it resets per clip.
+  const [edited, setEdited] = useState<ClipAudio>(audio)
+  const [selection, setSelection] = useState<Region | null>(null)
+  const [clipboard, setClipboard] = useState<Float32Array | null>(null)
+  const [operations, setOperations] = useState<EditOperation[]>([])
+
+  const duration = edited.duration
 
   // Load this clip into the player so the playhead + seek reuse the real audio
   // engine. Async dispatch (not synchronous setState), only on clip change.
@@ -96,11 +118,74 @@ export function WaveformEditor({
   }
   const fit = () => setIntent({ pxPerSec: fitPx, scrollSec: 0 })
 
+  // --- Selection + clipboard (US-18.2) -------------------------------------
+  const clampSec = (sec: number) => Math.max(0, Math.min(duration, sec))
+
+  // A drag on the canvas sweeps a new selection.
+  const select = (a: number, b: number) =>
+    setSelection(normalizeRegion(clampSec(a), clampSec(b)))
+
+  // A handle drag moves one edge; re-normalize so start ≤ end if they cross.
+  const adjustEdge = (edge: "start" | "end", sec: number) =>
+    setSelection((cur) => {
+      if (!cur) return cur
+      const s = clampSec(sec)
+      return edge === "start"
+        ? normalizeRegion(s, cur.endSec)
+        : normalizeRegion(cur.startSec, s)
+    })
+
+  // A bare click (seek) clears the selection, like clicking off it.
+  const seekAndClear = (sec: number) => {
+    setSelection(null)
+    seek(sec)
+  }
+
+  const copy = () => {
+    if (!selection) return
+    setClipboard(sliceRegion(edited, selection.startSec, selection.endSec))
+  }
+
+  const removeSelected = (kind: "cut" | "delete") => {
+    if (!selection) return
+    if (kind === "cut") {
+      setClipboard(sliceRegion(edited, selection.startSec, selection.endSec))
+    }
+    setEdited(removeRegion(edited, selection.startSec, selection.endSec))
+    setOperations((ops) => [
+      ...ops,
+      { kind, startSec: selection.startSec, endSec: selection.endSec },
+    ])
+    setSelection(null)
+  }
+
+  const paste = () => {
+    if (!clipboard || clipboard.length === 0) return
+    const atSec = playheadSec
+    const durationSec = clipboard.length / edited.sampleRate
+    setEdited(insertRegion(edited, atSec, clipboard))
+    setOperations((ops) => [...ops, { kind: "paste", atSec, durationSec }])
+    setSelection(null)
+    seek(atSec + durationSec) // move playhead to the end of the pasted region
+  }
+
+  useEditorShortcuts({
+    onCut: () => removeSelected("cut"),
+    onCopy: copy,
+    onPaste: paste,
+    onDelete: () => removeSelected("delete"),
+  })
+
   const atMin = !vp || vp.pxPerSec <= fitPx + 1e-6
   const atMax = !!vp && vp.pxPerSec >= MAX_PX_PER_SEC - 1e-6
 
   return (
-    <div className="flex flex-col gap-2">
+    <div
+      className="flex flex-col gap-2"
+      data-edited-duration={duration.toFixed(3)}
+      data-op-count={operations.length}
+      data-clipboard-samples={clipboard?.length ?? 0}
+    >
       <div className="flex items-center justify-between gap-2">
         <h1 className="truncate text-lg font-semibold">
           {clip.title ?? "Untitled clip"}
@@ -125,20 +210,34 @@ export function WaveformEditor({
         {vp ? (
           <>
             <TimeRuler viewport={vp} width={width} duration={duration} />
-            <WaveformCanvas
-              audio={audio}
-              viewport={vp}
-              width={width}
-              height={CANVAS_HEIGHT}
-              playheadSec={playheadSec}
-              onSeek={seek}
-              onZoom={zoomAt}
-              onScrollSec={scrollTo}
-            />
+            <div className="relative">
+              <WaveformCanvas
+                audio={edited}
+                viewport={vp}
+                width={width}
+                height={CANVAS_HEIGHT}
+                playheadSec={playheadSec}
+                onSeek={seekAndClear}
+                onZoom={zoomAt}
+                onScrollSec={scrollTo}
+                onSelect={select}
+              />
+              <SelectionOverlay
+                selection={selection}
+                viewport={vp}
+                width={width}
+                height={CANVAS_HEIGHT}
+                onAdjust={adjustEdge}
+              />
+            </div>
           </>
         ) : (
           <div style={{ height: CANVAS_HEIGHT + 20 }} />
         )}
+      </div>
+
+      <div className="flex min-h-4 items-center justify-between gap-2">
+        <SelectionInfo selection={selection} />
       </div>
 
       {vp && (

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -121,19 +121,26 @@ export function WaveformEditor({
   // --- Selection + clipboard (US-18.2) -------------------------------------
   const clampSec = (sec: number) => Math.max(0, Math.min(duration, sec))
 
+  // A clamped, ordered region — or null when it collapses to zero width, so a
+  // drag-back-to-origin or a handle dropped on its twin never leaves a 0-length
+  // selection that would log no-op cut/delete operations.
+  const regionOrNull = (a: number, b: number): Region | null => {
+    const r = normalizeRegion(clampSec(a), clampSec(b))
+    return r.endSec > r.startSec ? r : null
+  }
+
   // A drag on the canvas sweeps a new selection.
-  const select = (a: number, b: number) =>
-    setSelection(normalizeRegion(clampSec(a), clampSec(b)))
+  const select = (a: number, b: number) => setSelection(regionOrNull(a, b))
 
   // A handle drag moves one edge; re-normalize so start ≤ end if they cross.
   const adjustEdge = (edge: "start" | "end", sec: number) =>
-    setSelection((cur) => {
-      if (!cur) return cur
-      const s = clampSec(sec)
-      return edge === "start"
-        ? normalizeRegion(s, cur.endSec)
-        : normalizeRegion(cur.startSec, s)
-    })
+    setSelection((cur) =>
+      cur === null
+        ? cur
+        : edge === "start"
+          ? regionOrNull(sec, cur.endSec)
+          : regionOrNull(cur.startSec, sec)
+    )
 
   // A bare click (seek) clears the selection, like clicking off it.
   const seekAndClear = (sec: number) => {
@@ -161,12 +168,20 @@ export function WaveformEditor({
 
   const paste = () => {
     if (!clipboard || clipboard.length === 0) return
-    const atSec = playheadSec
+    // Clamp into the *current* (possibly already-edited) timeline so the insert
+    // point, the logged op, and the seek all agree — playheadSec can sit past
+    // the end after a delete shortened the clip.
+    const atSec = clampSec(playheadSec)
     const durationSec = clipboard.length / edited.sampleRate
-    setEdited(insertRegion(edited, atSec, clipboard))
+    const next = insertRegion(edited, atSec, clipboard)
+    setEdited(next)
     setOperations((ops) => [...ops, { kind: "paste", atSec, durationSec }])
     setSelection(null)
-    seek(atSec + durationSec) // move playhead to the end of the pasted region
+    // Move the playhead to the end of the pasted region, in the NEW timeline.
+    dispatch({
+      type: "seek/request",
+      time: Math.min(next.duration, atSec + durationSec),
+    })
   }
 
   useEditorShortcuts({
@@ -227,6 +242,7 @@ export function WaveformEditor({
                 viewport={vp}
                 width={width}
                 height={CANVAS_HEIGHT}
+                duration={duration}
                 onAdjust={adjustEdge}
               />
             </div>

--- a/web/hooks/use-editor-shortcuts.test.ts
+++ b/web/hooks/use-editor-shortcuts.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useEditorShortcuts } from "./use-editor-shortcuts"
+
+function makeActions() {
+  return { onCut: vi.fn(), onCopy: vi.fn(), onPaste: vi.fn(), onDelete: vi.fn() }
+}
+
+/** Dispatch a keydown on window; returns whether default was prevented. */
+function press(
+  key: string,
+  opts: { ctrlKey?: boolean; metaKey?: boolean; target?: EventTarget } = {}
+) {
+  const e = new KeyboardEvent("keydown", {
+    key,
+    ctrlKey: opts.ctrlKey,
+    metaKey: opts.metaKey,
+    cancelable: true,
+    bubbles: true,
+  })
+  if (opts.target) Object.defineProperty(e, "target", { value: opts.target })
+  window.dispatchEvent(e)
+  return e.defaultPrevented
+}
+
+describe("useEditorShortcuts", () => {
+  let actions: ReturnType<typeof makeActions>
+  beforeEach(() => {
+    actions = makeActions()
+    renderHook(() => useEditorShortcuts(actions))
+  })
+
+  it("maps Ctrl+X/C/V and Delete to the right actions", () => {
+    press("x", { ctrlKey: true })
+    press("c", { ctrlKey: true })
+    press("v", { ctrlKey: true })
+    press("Delete")
+    expect(actions.onCut).toHaveBeenCalledOnce()
+    expect(actions.onCopy).toHaveBeenCalledOnce()
+    expect(actions.onPaste).toHaveBeenCalledOnce()
+    expect(actions.onDelete).toHaveBeenCalledOnce()
+  })
+
+  it("also accepts Cmd (metaKey) and Backspace", () => {
+    press("x", { metaKey: true })
+    press("Backspace")
+    expect(actions.onCut).toHaveBeenCalledOnce()
+    expect(actions.onDelete).toHaveBeenCalledOnce()
+  })
+
+  it("prevents default for bound keys only", () => {
+    expect(press("x", { ctrlKey: true })).toBe(true)
+    expect(press("a", { ctrlKey: true })).toBe(false) // unbound → left alone
+  })
+
+  it("ignores shortcuts while typing in an input", () => {
+    const input = document.createElement("input")
+    press("x", { ctrlKey: true, target: input })
+    press("Delete", { target: input })
+    expect(actions.onCut).not.toHaveBeenCalled()
+    expect(actions.onDelete).not.toHaveBeenCalled()
+  })
+})

--- a/web/hooks/use-editor-shortcuts.ts
+++ b/web/hooks/use-editor-shortcuts.ts
@@ -1,0 +1,55 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+// Keyboard shortcuts for the waveform editor (US-18.2): Ctrl/Cmd+X/C/V and
+// Delete/Backspace → cut / copy / paste / delete. A single window keydown
+// listener attached once; the latest actions are read through a ref (same
+// pattern as the canvas's wheel handler) so re-renders don't re-bind. Ignores
+// keystrokes aimed at a text field so typing elsewhere isn't hijacked.
+
+export type EditorShortcutActions = {
+  onCut: () => void
+  onCopy: () => void
+  onPaste: () => void
+  onDelete: () => void
+}
+
+/** True when the event targets an editable field (input/textarea/contenteditable). */
+function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+  if (!el) return false
+  const tag = el.tagName
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    el.isContentEditable === true
+  )
+}
+
+export function useEditorShortcuts(actions: EditorShortcutActions): void {
+  const ref = useRef(actions)
+  useEffect(() => {
+    ref.current = actions
+  }, [actions])
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (isEditableTarget(e.target)) return
+      const mod = e.metaKey || e.ctrlKey
+      const a = ref.current
+      const key = e.key.toLowerCase()
+
+      if (mod && key === "x") a.onCut()
+      else if (mod && key === "c") a.onCopy()
+      else if (mod && key === "v") a.onPaste()
+      else if (!mod && (e.key === "Delete" || e.key === "Backspace")) a.onDelete()
+      else return
+
+      e.preventDefault()
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [])
+}

--- a/web/lib/waveform-edit.test.ts
+++ b/web/lib/waveform-edit.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+
+import type { ClipAudio } from "@/lib/audio-peaks"
+import {
+  insertRegion,
+  normalizeRegion,
+  removeRegion,
+  secToSample,
+  sliceRegion,
+} from "@/lib/waveform-edit"
+
+// 10 samples @ 10Hz = 1s clip; each sample's value is its index so splices are
+// easy to read (mono[3] === 3). Everything is in seconds; 0.1s === 1 sample.
+function ramp(): ClipAudio {
+  return {
+    mono: Float32Array.from({ length: 10 }, (_, i) => i),
+    sampleRate: 10,
+    duration: 1,
+  }
+}
+
+describe("normalizeRegion", () => {
+  it("orders the two times", () => {
+    expect(normalizeRegion(0.8, 0.2)).toEqual({ startSec: 0.2, endSec: 0.8 })
+    expect(normalizeRegion(0.2, 0.8)).toEqual({ startSec: 0.2, endSec: 0.8 })
+  })
+})
+
+describe("secToSample", () => {
+  it("rounds to the nearest sample and clamps to [0, length]", () => {
+    expect(secToSample(0.3, 10, 10)).toBe(3)
+    expect(secToSample(-1, 10, 10)).toBe(0)
+    expect(secToSample(5, 10, 10)).toBe(10) // past the end → clamped
+  })
+})
+
+describe("sliceRegion", () => {
+  it("copies the samples in the range, order-independent", () => {
+    expect([...sliceRegion(ramp(), 0.3, 0.6)]).toEqual([3, 4, 5])
+    expect([...sliceRegion(ramp(), 0.6, 0.3)]).toEqual([3, 4, 5]) // reversed
+  })
+  it("does not mutate the source", () => {
+    const a = ramp()
+    sliceRegion(a, 0.3, 0.6)
+    expect([...a.mono]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+  })
+})
+
+describe("removeRegion", () => {
+  it("removes the range, shifts the tail left, and shrinks the duration", () => {
+    const out = removeRegion(ramp(), 0.3, 0.6)
+    expect([...out.mono]).toEqual([0, 1, 2, 6, 7, 8, 9])
+    expect(out.duration).toBeCloseTo(0.7)
+  })
+  it("removing an empty range is a no-op copy", () => {
+    const out = removeRegion(ramp(), 0.4, 0.4)
+    expect([...out.mono]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+  })
+})
+
+describe("insertRegion", () => {
+  it("splices samples in at the position and grows the duration", () => {
+    const out = insertRegion(ramp(), 0.3, Float32Array.from([100, 101]))
+    expect([...out.mono]).toEqual([0, 1, 2, 100, 101, 3, 4, 5, 6, 7, 8, 9])
+    expect(out.duration).toBeCloseTo(1.2)
+  })
+  it("appends when pasting at the end", () => {
+    const out = insertRegion(ramp(), 1, Float32Array.from([100]))
+    expect([...out.mono]).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 100])
+  })
+})
+
+describe("cut → paste round-trip", () => {
+  it("copy then remove then insert relocates the region intact", () => {
+    const src = ramp()
+    const clip = sliceRegion(src, 0.3, 0.6) // [3,4,5]
+    const cut = removeRegion(src, 0.3, 0.6) // [0,1,2,6,7,8,9]
+    const pasted = insertRegion(cut, cut.duration, clip) // append at new end
+    expect([...pasted.mono]).toEqual([0, 1, 2, 6, 7, 8, 9, 3, 4, 5])
+  })
+})

--- a/web/lib/waveform-edit.ts
+++ b/web/lib/waveform-edit.ts
@@ -1,0 +1,86 @@
+// Pure audio-editing helpers for the waveform editor (US-18.2). The truthful
+// counterpart to waveform-viewport.ts: instead of viewport math, this splices
+// the decoded mono samples so cut / copy / paste / delete produce a *real*
+// edited ClipAudio the existing canvas renders unchanged (no operation-stack
+// replay, no separate duration model — duration is always mono.length /
+// sampleRate). Kept free of React so the splice math is unit-testable.
+//
+// Non-destructive: every function returns a NEW ClipAudio; the caller keeps the
+// original prop untouched and holds the edit in component state. Persisting the
+// edits (and re-encoding audio for playback) is the save story, US-18.4 — the
+// `operations` log below is the handoff seam.
+
+import type { ClipAudio } from "@/lib/audio-peaks"
+
+/** A time range on the clip, always stored start ≤ end. */
+export type Region = { startSec: number; endSec: number }
+
+/** A recorded edit — the user's intent, for the US-18.4 save handoff + tests. */
+export type EditOperation =
+  | { kind: "cut"; startSec: number; endSec: number }
+  | { kind: "delete"; startSec: number; endSec: number }
+  | { kind: "paste"; atSec: number; durationSec: number }
+
+/** Order two times into a Region with start ≤ end. */
+export function normalizeRegion(a: number, b: number): Region {
+  return a <= b ? { startSec: a, endSec: b } : { startSec: b, endSec: a }
+}
+
+/** Sample index for a time, clamped to [0, length]. */
+export function secToSample(
+  sec: number,
+  sampleRate: number,
+  length: number
+): number {
+  const s = Math.round(Math.max(0, sec) * sampleRate)
+  return Math.min(length, Math.max(0, s))
+}
+
+/** Ordered, clamped [startSample, endSample) for a region. */
+function regionSamples(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number
+): { startSample: number; endSample: number } {
+  const r = normalizeRegion(startSec, endSec)
+  const startSample = secToSample(r.startSec, audio.sampleRate, audio.mono.length)
+  const endSample = secToSample(r.endSec, audio.sampleRate, audio.mono.length)
+  return { startSample, endSample: Math.max(startSample, endSample) }
+}
+
+/** Copy the samples in [startSec, endSec) as a new array (for the clipboard). */
+export function sliceRegion(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number
+): Float32Array {
+  const { startSample, endSample } = regionSamples(audio, startSec, endSec)
+  return audio.mono.slice(startSample, endSample)
+}
+
+/** Remove [startSec, endSec) and shift the tail left (cut / delete). */
+export function removeRegion(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number
+): ClipAudio {
+  const { startSample, endSample } = regionSamples(audio, startSec, endSec)
+  const mono = new Float32Array(audio.mono.length - (endSample - startSample))
+  mono.set(audio.mono.subarray(0, startSample), 0)
+  mono.set(audio.mono.subarray(endSample), startSample)
+  return { ...audio, mono, duration: mono.length / audio.sampleRate }
+}
+
+/** Insert `samples` at `atSec`, shifting the tail right (paste). */
+export function insertRegion(
+  audio: ClipAudio,
+  atSec: number,
+  samples: Float32Array
+): ClipAudio {
+  const at = secToSample(atSec, audio.sampleRate, audio.mono.length)
+  const mono = new Float32Array(audio.mono.length + samples.length)
+  mono.set(audio.mono.subarray(0, at), 0)
+  mono.set(samples, at)
+  mono.set(audio.mono.subarray(at), at + samples.length)
+  return { ...audio, mono, duration: mono.length / audio.sampleRate }
+}


### PR DESCRIPTION
## US-18.2: Region Selection and Clipboard Operations

Closes #203. Builds region selection + cut/copy/paste/delete on top of the US-18.1 waveform editor.

### What changed
- **`lib/waveform-edit.ts`** — pure Float32Array splice helpers (`sliceRegion`, `removeRegion`, `insertRegion`, `secToSample`, `normalizeRegion`). Edits produce a **real** edited `ClipAudio` the existing US-18.1 canvas renders unchanged — no operation-stack replay, no separate duration model (duration = `mono.length / sampleRate`).
- **`SelectionOverlay` / `SelectionHandle` / `SelectionInfo`** — translucent highlight, draggable + Arrow-key-nudgeable edge handles (real ARIA slider), and an `m:ss.mmm` start/end/duration readout.
- **`use-editor-shortcuts.ts`** — Ctrl/Cmd+X/C/V and Delete/Backspace, ignored while typing in a form field.
- **`WaveformCanvas`** — plain drag now sweeps a selection (was pan); a tap still seeks.
- **`WaveformEditor`** — owns selection / clipboard / edited-audio / operations state and composes the layer; paste moves the playhead to the end of the pasted region.

### Design notes (deviations from the stale CodeRabbit plan)
The issue's CodeRabbit plan was authored **before US-18.1 merged** ("web/ is empty"), so it was reconciled against the shipped architecture:
1. **Drag = select, not pan.** US-18.1 bound plain drag to panning; now that this is an *editor*, drag creates a selection (DAW convention + the AC). Panning is preserved via the wheel/trackpad and the scrollbar — no capability lost.
2. **Splice real samples** instead of a virtual operation stack + region-reference clipboard: far simpler, gives real visual feedback, and reuses the entire US-18.1 render path. A thin `operations[]` log is kept as the save (US-18.4) handoff seam.

### Acceptance criteria → evidence
| Criterion | Evidence |
|---|---|
| Click-and-drag creates a visible selection | `WaveformEditor.test` "shows the selection info and overlay after a click-and-drag"; `WaveformCanvas.test` drag→select; `SelectionOverlay.test` position |
| Handles fine-tune start/end | `SelectionOverlay.test` pointer-drag + Arrow-key nudge; `WaveformEditor` `adjustEdge` clamps + re-normalizes |
| Cut removes audio & shortens the clip | `WaveformEditor.test` "Ctrl+X copies then removes" (10s → 7s); `waveform-edit.test` `removeRegion` |
| Copy + paste duplicates at the playhead | `WaveformEditor.test` "Ctrl+C then Ctrl+V …lengthens" (10s → 13s, playhead → region end); `waveform-edit.test` round-trip |
| Delete removes selected audio | `WaveformEditor.test` "Delete removes the selected region and shortens" |
| Keyboard shortcuts work | `use-editor-shortcuts.test` — all bindings, Cmd + Backspace, input-guard, preventDefault |

### Testing
`npm run typecheck` ✓ · `npm run lint` ✓ · `npx vitest run` → **683 passed** (100 files). New: `waveform-edit.test.ts`, `use-editor-shortcuts.test.ts`, `SelectionOverlay.test.tsx`, `SelectionInfo.test.tsx`, plus editor/canvas cases.

Reviews: cross-family (**codex**) + **CodeRabbit** — paste stale-duration, zero-width selection, handle-freeze-on-drag, and handle ARIA all fixed (`4aceccf`). CodeRabbit's "remove all comments" findings were declined: intent comments match the established US-18.1 file convention.

### Known limitations (deferred, in scope of later stories)
- **Edits are visual + recorded only.** The waveform and edit history update, but the shared player still plays the *original* file — audible playback of edits and persistence land with **save (US-18.4)**. Paste's playhead move is clamped to the new visual timeline.
- **Drag-to-pan retired** in favour of drag-to-select; pan stays on wheel/trackpad + scrollbar.
- **Undo/redo** not in scope; the `operations[]` log is the seam for it and for save.
- **No live browser demo** in this environment (web story has no GPU/backend audio stack — see project notes); verified via unit/component tests mapped to each AC above.
