### PR TITLE
feat(web): Audio Processing Toolbar (US-18.3)

### DIFF
--- a/web/components/editor/EditToolbar.test.tsx
+++ b/web/components/editor/EditToolbar.test.tsx
@@ -53,6 +53,16 @@ describe("EditToolbar", () => {
     expect(p.onGainPreview).toHaveBeenLastCalledWith(null) // preview cleared on close
   })
 
+  it("closing the gain popover without Apply reverts and commits nothing", () => {
+    const p = renderToolbar()
+    fireEvent.click(btn("Gain"))
+    fireEvent.keyDown(screen.getByRole("slider", { name: "Gain in decibels" }), {
+      key: "Escape",
+    })
+    expect(p.onGainPreview).toHaveBeenLastCalledWith(null) // preview reverted
+    expect(p.onGainApply).not.toHaveBeenCalled() // nothing committed
+  })
+
   it("applies a crossfade at the default duration (100 ms)", () => {
     const p = renderToolbar()
     fireEvent.click(btn("Crossfade"))

--- a/web/components/editor/EditToolbar.test.tsx
+++ b/web/components/editor/EditToolbar.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { EditToolbar, type EditToolbarProps } from "./EditToolbar"
+
+function renderToolbar(overrides: Partial<EditToolbarProps> = {}) {
+  const props: EditToolbarProps = {
+    hasSelection: true,
+    onFadeIn: vi.fn(),
+    onFadeOut: vi.fn(),
+    onSilence: vi.fn(),
+    onNormalize: vi.fn(),
+    onGainPreview: vi.fn(),
+    onGainApply: vi.fn(),
+    onCrossfade: vi.fn(),
+    ...overrides,
+  }
+  render(<EditToolbar {...props} />)
+  return props
+}
+
+const btn = (name: string) => screen.getByRole("button", { name })
+
+describe("EditToolbar", () => {
+  it("fires the region ops on click when a selection exists", () => {
+    const p = renderToolbar()
+    fireEvent.click(btn("Fade In"))
+    fireEvent.click(btn("Fade Out"))
+    fireEvent.click(btn("Silence"))
+    fireEvent.click(btn("Normalize"))
+    expect(p.onFadeIn).toHaveBeenCalledOnce()
+    expect(p.onFadeOut).toHaveBeenCalledOnce()
+    expect(p.onSilence).toHaveBeenCalledOnce()
+    expect(p.onNormalize).toHaveBeenCalledOnce()
+  })
+
+  it("disables selection-only tools without a selection (Normalize/Crossfade stay on)", () => {
+    renderToolbar({ hasSelection: false })
+    expect(btn("Fade In")).toBeDisabled()
+    expect(btn("Fade Out")).toBeDisabled()
+    expect(btn("Silence")).toBeDisabled()
+    expect(btn("Gain")).toBeDisabled()
+    expect(btn("Normalize")).toBeEnabled()
+    expect(btn("Crossfade")).toBeEnabled()
+  })
+
+  it("previews on open, commits on Apply, reverts on close (gain)", () => {
+    const p = renderToolbar()
+    fireEvent.click(btn("Gain"))
+    expect(p.onGainPreview).toHaveBeenLastCalledWith(0) // live preview starts at 0 dB
+    fireEvent.click(btn("Apply gain"))
+    expect(p.onGainApply).toHaveBeenCalledWith(0)
+    expect(p.onGainPreview).toHaveBeenLastCalledWith(null) // preview cleared on close
+  })
+
+  it("applies a crossfade at the default duration (100 ms)", () => {
+    const p = renderToolbar()
+    fireEvent.click(btn("Crossfade"))
+    fireEvent.click(btn("Apply crossfade"))
+    expect(p.onCrossfade).toHaveBeenCalledWith(0.1)
+  })
+})

--- a/web/components/editor/EditToolbar.test.tsx
+++ b/web/components/editor/EditToolbar.test.tsx
@@ -59,4 +59,26 @@ describe("EditToolbar", () => {
     fireEvent.click(btn("Apply crossfade"))
     expect(p.onCrossfade).toHaveBeenCalledWith(0.1)
   })
+
+  it("carries a non-default gain slider value through to Apply", () => {
+    const p = renderToolbar()
+    fireEvent.click(btn("Gain"))
+    const slider = screen.getByRole("slider", { name: "Gain in decibels" })
+    slider.focus()
+    fireEvent.keyDown(slider, { key: "ArrowRight" }) // +0.5 dB step
+    fireEvent.click(btn("Apply gain"))
+    expect(p.onGainApply).toHaveBeenCalledWith(0.5)
+  })
+
+  it("carries a non-default crossfade slider value through to Apply", () => {
+    const p = renderToolbar()
+    fireEvent.click(btn("Crossfade"))
+    const slider = screen.getByRole("slider", {
+      name: "Crossfade duration in milliseconds",
+    })
+    slider.focus()
+    fireEvent.keyDown(slider, { key: "ArrowRight" }) // +10 ms step → 110 ms
+    fireEvent.click(btn("Apply crossfade"))
+    expect(p.onCrossfade).toHaveBeenCalledWith(0.11)
+  })
 })

--- a/web/components/editor/EditToolbar.tsx
+++ b/web/components/editor/EditToolbar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -49,11 +49,32 @@ export function EditToolbar({
   const [gainOpen, setGainOpen] = useState(false)
   const [crossfadeOpen, setCrossfadeOpen] = useState(false)
 
+  // The preview recompute upstream copies the whole mono buffer, but the slider
+  // fires per pointer-move. Coalesce those into one rAF so a drag triggers at
+  // most one recompute per frame — the dB readout still updates instantly off
+  // local state. Open/Apply/close report their preview values directly (below).
+  const previewRaf = useRef<number | null>(null)
+  const schedulePreview = (gainDb: number) => {
+    if (previewRaf.current !== null) cancelAnimationFrame(previewRaf.current)
+    previewRaf.current = requestAnimationFrame(() => {
+      previewRaf.current = null
+      onGainPreview(gainDb)
+    })
+  }
+  const cancelPreview = () => {
+    if (previewRaf.current !== null) {
+      cancelAnimationFrame(previewRaf.current)
+      previewRaf.current = null
+    }
+  }
+  useEffect(() => cancelPreview, [])
+
   // Reset + drop any live preview whenever the gain popover closes; commit only
   // happens through Apply. Opening starts from a clean 0 dB. Controlled so Apply
   // can close it (else a second Apply would fire on a now-cleared selection).
   const onGainOpenChange = (open: boolean) => {
     setGainOpen(open)
+    cancelPreview()
     if (open) {
       setGainDb(0)
       onGainPreview(0)
@@ -122,7 +143,7 @@ export function EditToolbar({
             value={[gainDb]}
             onValueChange={([v]) => {
               setGainDb(v)
-              onGainPreview(v)
+              schedulePreview(v)
             }}
           />
           <Button
@@ -131,6 +152,7 @@ export function EditToolbar({
             className="w-full"
             aria-label="Apply gain"
             onClick={() => {
+              cancelPreview()
               onGainApply(gainDb)
               onGainPreview(null) // controlled close won't fire onOpenChange
               setGainOpen(false)

--- a/web/components/editor/EditToolbar.tsx
+++ b/web/components/editor/EditToolbar.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Slider } from "@/components/ui/slider"
+
+// Audio-processing toolbar for the waveform editor (US-18.3). Sits above the
+// waveform and applies the pure transforms in lib/waveform-edit.ts to the
+// current selection (or, for normalize, the whole clip when nothing is
+// selected). Edits are non-destructive — the parent holds them in state.
+//
+// Region ops (fade / gain / silence) need a selection, so they disable without
+// one. Normalize falls back to the whole clip; crossfade acts at the playhead.
+// Gain previews live: the slider reports each value up via onGainPreview so the
+// parent can show the pending change on the waveform before Apply commits it.
+
+const GAIN_MIN_DB = -24
+const GAIN_MAX_DB = 24
+const CROSSFADE_MIN_MS = 10
+const CROSSFADE_MAX_MS = 500
+const CROSSFADE_DEFAULT_MS = 100
+
+export type EditToolbarProps = {
+  hasSelection: boolean
+  onFadeIn: () => void
+  onFadeOut: () => void
+  onSilence: () => void
+  onNormalize: () => void
+  /** Live visual preview of a pending gain; null clears it (cancel/close). */
+  onGainPreview: (gainDb: number | null) => void
+  onGainApply: (gainDb: number) => void
+  onCrossfade: (durationSec: number) => void
+}
+
+export function EditToolbar({
+  hasSelection,
+  onFadeIn,
+  onFadeOut,
+  onSilence,
+  onNormalize,
+  onGainPreview,
+  onGainApply,
+  onCrossfade,
+}: EditToolbarProps) {
+  const [gainDb, setGainDb] = useState(0)
+  const [crossfadeMs, setCrossfadeMs] = useState(CROSSFADE_DEFAULT_MS)
+  const [gainOpen, setGainOpen] = useState(false)
+  const [crossfadeOpen, setCrossfadeOpen] = useState(false)
+
+  // Reset + drop any live preview whenever the gain popover closes; commit only
+  // happens through Apply. Opening starts from a clean 0 dB. Controlled so Apply
+  // can close it (else a second Apply would fire on a now-cleared selection).
+  const onGainOpenChange = (open: boolean) => {
+    setGainOpen(open)
+    if (open) {
+      setGainDb(0)
+      onGainPreview(0)
+    } else {
+      onGainPreview(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1" data-testid="edit-toolbar">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onFadeIn}
+        disabled={!hasSelection}
+      >
+        Fade In
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onFadeOut}
+        disabled={!hasSelection}
+      >
+        Fade Out
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onSilence}
+        disabled={!hasSelection}
+      >
+        Silence
+      </Button>
+      <Button type="button" variant="outline" size="sm" onClick={onNormalize}>
+        Normalize
+      </Button>
+
+      <Popover open={gainOpen} onOpenChange={onGainOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!hasSelection}
+          >
+            Gain
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 space-y-3">
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">Gain</span>
+            <span className="text-muted-foreground tabular-nums">
+              {gainDb > 0 ? "+" : ""}
+              {gainDb.toFixed(1)} dB
+            </span>
+          </div>
+          <Slider
+            aria-label="Gain in decibels"
+            min={GAIN_MIN_DB}
+            max={GAIN_MAX_DB}
+            step={0.5}
+            value={[gainDb]}
+            onValueChange={([v]) => {
+              setGainDb(v)
+              onGainPreview(v)
+            }}
+          />
+          <Button
+            type="button"
+            size="sm"
+            className="w-full"
+            aria-label="Apply gain"
+            onClick={() => {
+              onGainApply(gainDb)
+              onGainPreview(null) // controlled close won't fire onOpenChange
+              setGainOpen(false)
+            }}
+          >
+            Apply
+          </Button>
+        </PopoverContent>
+      </Popover>
+
+      <Popover open={crossfadeOpen} onOpenChange={setCrossfadeOpen}>
+        <PopoverTrigger asChild>
+          <Button type="button" variant="outline" size="sm">
+            Crossfade
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-64 space-y-3">
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">Crossfade at playhead</span>
+            <span className="text-muted-foreground tabular-nums">
+              {crossfadeMs} ms
+            </span>
+          </div>
+          <Slider
+            aria-label="Crossfade duration in milliseconds"
+            min={CROSSFADE_MIN_MS}
+            max={CROSSFADE_MAX_MS}
+            step={10}
+            value={[crossfadeMs]}
+            onValueChange={([v]) => setCrossfadeMs(v)}
+          />
+          <Button
+            type="button"
+            size="sm"
+            className="w-full"
+            aria-label="Apply crossfade"
+            onClick={() => {
+              onCrossfade(crossfadeMs / 1000)
+              setCrossfadeOpen(false)
+            }}
+          >
+            Apply
+          </Button>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -213,6 +213,25 @@ describe("WaveformEditor", () => {
     expect(opCount()).toBe(1) // whole-clip fallback, no selection required
   })
 
+  it("Gain applies to the selection and records an op", () => {
+    renderEditor()
+    dragSelect(2, 5)
+    fireEvent.click(screen.getByRole("button", { name: "Gain" }))
+    fireEvent.click(screen.getByRole("button", { name: "Apply gain" }))
+    expect(opCount()).toBe(1)
+    expect(editedDuration()).toBeCloseTo(10) // amplitude-only
+  })
+
+  it("Crossfade at the clip start no-ops and logs nothing (no-fit guard)", () => {
+    renderEditor()
+    // Playhead sits at 0 (no real audio in jsdom), so the window can't fit and
+    // the guard must skip the commit — no ghost op in the save seam.
+    fireEvent.click(screen.getByRole("button", { name: "Crossfade" }))
+    fireEvent.click(screen.getByRole("button", { name: "Apply crossfade" }))
+    expect(opCount()).toBe(0)
+    expect(editedDuration()).toBeCloseTo(10)
+  })
+
   it("region tools are disabled until there is a selection", () => {
     renderEditor()
     expect(screen.getByRole("button", { name: "Fade In" })).toBeDisabled()

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -73,6 +73,11 @@ function editedDuration() {
     document.querySelector("[data-edited-duration]")?.getAttribute("data-edited-duration")
   )
 }
+function opCount() {
+  return Number(
+    document.querySelector("[data-op-count]")?.getAttribute("data-op-count")
+  )
+}
 function key(k: string, opts: { ctrlKey?: boolean } = {}) {
   fireEvent.keyDown(document.body, { key: k, ...opts })
 }
@@ -180,5 +185,40 @@ describe("WaveformEditor", () => {
     expect(
       document.querySelector("[data-clipboard-samples]")?.getAttribute("data-clipboard-samples")
     ).toBe("240")
+  })
+
+  // --- Processing toolbar (US-18.3) ----------------------------------------
+
+  it("Fade In records an op and keeps the duration, then clears the selection", () => {
+    renderEditor()
+    dragSelect(2, 5)
+    fireEvent.click(screen.getByRole("button", { name: "Fade In" }))
+    expect(opCount()).toBe(1)
+    expect(editedDuration()).toBeCloseTo(10) // amplitude-only, no length change
+    expect(screen.queryByTestId("selection-info")).not.toBeInTheDocument()
+  })
+
+  it("Silence keeps the length (unlike Delete which removes samples)", () => {
+    renderEditor()
+    dragSelect(2, 5)
+    fireEvent.click(screen.getByRole("button", { name: "Silence" }))
+    expect(editedDuration()).toBeCloseTo(10)
+    expect(opCount()).toBe(1)
+  })
+
+  it("Normalize works on the whole clip when nothing is selected", () => {
+    renderEditor()
+    expect(screen.queryByTestId("selection-info")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Normalize" }))
+    expect(opCount()).toBe(1) // whole-clip fallback, no selection required
+  })
+
+  it("region tools are disabled until there is a selection", () => {
+    renderEditor()
+    expect(screen.getByRole("button", { name: "Fade In" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Gain" })).toBeDisabled()
+    dragSelect(2, 5)
+    expect(screen.getByRole("button", { name: "Fade In" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Gain" })).toBeEnabled()
   })
 })

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 
+import { EditToolbar } from "@/components/editor/EditToolbar"
 import { SelectionInfo } from "@/components/editor/SelectionInfo"
 import { SelectionOverlay } from "@/components/editor/SelectionOverlay"
 import { TimeRuler } from "@/components/editor/TimeRuler"
@@ -13,6 +14,12 @@ import { useEditorShortcuts } from "@/hooks/use-editor-shortcuts"
 import type { ClipAudio } from "@/lib/audio-peaks"
 import { trackFromClip } from "@/lib/clips"
 import {
+  applyCrossfade,
+  applyFadeIn,
+  applyFadeOut,
+  applyGain,
+  applyNormalize,
+  applySilence,
   insertRegion,
   normalizeRegion,
   removeRegion,
@@ -61,6 +68,9 @@ export function WaveformEditor({
   const [selection, setSelection] = useState<Region | null>(null)
   const [clipboard, setClipboard] = useState<Float32Array | null>(null)
   const [operations, setOperations] = useState<EditOperation[]>([])
+  // Pending gain (dB) while the Gain popover is open — drives a live, throwaway
+  // waveform preview; null when nothing is being previewed. (US-18.3)
+  const [gainPreview, setGainPreview] = useState<number | null>(null)
 
   const duration = edited.duration
 
@@ -191,6 +201,72 @@ export function WaveformEditor({
     onDelete: () => removeSelected("delete"),
   })
 
+  // --- Processing ops (US-18.3) --------------------------------------------
+  // Commit an amplitude transform: swap in the new audio, log the intent for the
+  // US-18.4 save seam, and clear the selection (the edit is now baked in).
+  const commit = (next: ClipAudio, op: EditOperation) => {
+    setEdited(next)
+    setOperations((ops) => [...ops, op])
+    setSelection(null)
+  }
+
+  const fadeIn = () => {
+    if (!selection) return
+    const { startSec, endSec } = selection
+    commit(applyFadeIn(edited, startSec, endSec), { kind: "fade-in", startSec, endSec })
+  }
+  const fadeOut = () => {
+    if (!selection) return
+    const { startSec, endSec } = selection
+    commit(applyFadeOut(edited, startSec, endSec), { kind: "fade-out", startSec, endSec })
+  }
+  const silence = () => {
+    if (!selection) return
+    const { startSec, endSec } = selection
+    commit(applySilence(edited, startSec, endSec), { kind: "silence", startSec, endSec })
+  }
+  const gain = (gainDb: number) => {
+    if (!selection) return
+    const { startSec, endSec } = selection
+    commit(applyGain(edited, startSec, endSec, gainDb), {
+      kind: "gain",
+      startSec,
+      endSec,
+      gainDb,
+    })
+  }
+  // Normalize the selection, or the whole clip when nothing is selected.
+  const normalize = () => {
+    const startSec = selection?.startSec ?? 0
+    const endSec = selection?.endSec ?? duration
+    commit(applyNormalize(edited, startSec, endSec, 0), {
+      kind: "normalize",
+      startSec,
+      endSec,
+      targetDb: 0,
+    })
+  }
+  // Crossfade at the current playhead (clamped inside the transform). Skip the
+  // commit when the window can't fit (playhead at the very start/end), so a
+  // no-op never logs a ghost op into the US-18.4 save seam.
+  const crossfade = (durationSec: number) => {
+    const next = applyCrossfade(edited, playheadSec, durationSec)
+    if (next.mono.length === edited.mono.length) return
+    commit(next, { kind: "crossfade", positionSec: playheadSec, durationSec })
+  }
+
+  // The audio shown on the canvas: while a gain preview is live, apply it to the
+  // selection so the pending change is visible before Apply. Memoized so the
+  // buffer copy only runs when the preview or audio actually changes — not on
+  // every unrelated re-render while the Gain popover is open.
+  const shown = useMemo(
+    () =>
+      gainPreview !== null && selection
+        ? applyGain(edited, selection.startSec, selection.endSec, gainPreview)
+        : edited,
+    [edited, selection, gainPreview]
+  )
+
   const atMin = !vp || vp.pxPerSec <= fitPx + 1e-6
   const atMax = !!vp && vp.pxPerSec >= MAX_PX_PER_SEC - 1e-6
 
@@ -218,6 +294,17 @@ export function WaveformEditor({
         />
       </div>
 
+      <EditToolbar
+        hasSelection={selection !== null}
+        onFadeIn={fadeIn}
+        onFadeOut={fadeOut}
+        onSilence={silence}
+        onNormalize={normalize}
+        onGainPreview={setGainPreview}
+        onGainApply={gain}
+        onCrossfade={crossfade}
+      />
+
       <div
         ref={containerRef}
         className="overflow-hidden rounded-lg border border-border bg-card"
@@ -227,7 +314,7 @@ export function WaveformEditor({
             <TimeRuler viewport={vp} width={width} duration={duration} />
             <div className="relative">
               <WaveformCanvas
-                audio={edited}
+                audio={shown}
                 viewport={vp}
                 width={width}
                 height={CANVAS_HEIGHT}

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -203,7 +203,9 @@ export function WaveformEditor({
 
   // --- Processing ops (US-18.3) --------------------------------------------
   // Commit an amplitude transform: swap in the new audio, log the intent for the
-  // US-18.4 save seam, and clear the selection (the edit is now baked in).
+  // US-18.4 save seam, and clear the selection. The clear is deliberate for every
+  // op — the buffer changed, so the old selection's coordinates are stale (this
+  // includes crossfade, which is playhead-based and ignores the selection).
   const commit = (next: ClipAudio, op: EditOperation) => {
     setEdited(next)
     setOperations((ops) => [...ops, op])

--- a/web/components/ui/slider.tsx
+++ b/web/components/ui/slider.tsx
@@ -7,10 +7,12 @@ import { cn } from "@/lib/utils"
 
 function Slider({
   className,
-  // Forward the label to the Thumb — it's the element with role="slider", so a
-  // label on Root alone never reaches assistive tech (or getByRole name lookups).
+  // Label/id belong on the Thumb — it's the element with role="slider". A label
+  // (aria-label, or a <Label htmlFor={id}>) resolved against Root never reaches
+  // assistive tech, since Root isn't the slider. Single-thumb only, as used here.
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
+  id,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   return (
@@ -33,6 +35,7 @@ function Slider({
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb
         data-slot="slider-thumb"
+        id={id}
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}
         className="block size-4 shrink-0 rounded-full border border-primary bg-background shadow-sm transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none"

--- a/web/components/ui/slider.tsx
+++ b/web/components/ui/slider.tsx
@@ -7,6 +7,10 @@ import { cn } from "@/lib/utils"
 
 function Slider({
   className,
+  // Forward the label to the Thumb — it's the element with role="slider", so a
+  // label on Root alone never reaches assistive tech (or getByRole name lookups).
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledby,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   return (
@@ -29,6 +33,8 @@ function Slider({
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb
         data-slot="slider-thumb"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
         className="block size-4 shrink-0 rounded-full border border-primary bg-background shadow-sm transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none"
       />
     </SliderPrimitive.Root>

--- a/web/lib/waveform-edit.test.ts
+++ b/web/lib/waveform-edit.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest"
 
 import type { ClipAudio } from "@/lib/audio-peaks"
 import {
+  applyCrossfade,
+  applyFadeIn,
+  applyFadeOut,
+  applyGain,
+  applyNormalize,
+  applySilence,
+  dbToGain,
   insertRegion,
   normalizeRegion,
   removeRegion,
@@ -16,6 +23,17 @@ function ramp(): ClipAudio {
     mono: Float32Array.from({ length: 10 }, (_, i) => i),
     sampleRate: 10,
     duration: 1,
+  }
+}
+
+// A clip with explicit fractional samples (real audio lives in [-1, 1]); 10Hz so
+// 0.1s === 1 sample. For the amplitude ops, where the ramp's 0..9 values would
+// all clamp to 1.
+function clip(samples: number[]): ClipAudio {
+  return {
+    mono: Float32Array.from(samples),
+    sampleRate: 10,
+    duration: samples.length / 10,
   }
 }
 
@@ -73,9 +91,90 @@ describe("insertRegion", () => {
 describe("cut → paste round-trip", () => {
   it("copy then remove then insert relocates the region intact", () => {
     const src = ramp()
-    const clip = sliceRegion(src, 0.3, 0.6) // [3,4,5]
+    const region = sliceRegion(src, 0.3, 0.6) // [3,4,5]
     const cut = removeRegion(src, 0.3, 0.6) // [0,1,2,6,7,8,9]
-    const pasted = insertRegion(cut, cut.duration, clip) // append at new end
+    const pasted = insertRegion(cut, cut.duration, region) // append at new end
     expect([...pasted.mono]).toEqual([0, 1, 2, 6, 7, 8, 9, 3, 4, 5])
+  })
+})
+
+// --- Processing ops (US-18.3) --------------------------------------------
+
+const close = (out: ClipAudio, expected: number[]) => {
+  expect(out.mono.length).toBe(expected.length)
+  expected.forEach((v, i) => expect(out.mono[i]).toBeCloseTo(v, 5))
+}
+
+describe("dbToGain", () => {
+  it("maps dB to a linear factor", () => {
+    expect(dbToGain(0)).toBeCloseTo(1)
+    expect(dbToGain(6.0206)).toBeCloseTo(2) // +6 dB ≈ ×2
+    expect(dbToGain(-6.0206)).toBeCloseTo(0.5)
+  })
+})
+
+describe("applyFadeIn", () => {
+  it("ramps the region silence → full, hitting both endpoints exactly", () => {
+    const out = applyFadeIn(clip([1, 1, 1, 1]), 0, 0.4)
+    close(out, [0, 1 / 3, 2 / 3, 1])
+    expect(out.duration).toBeCloseTo(0.4) // length preserved
+  })
+})
+
+describe("applyFadeOut", () => {
+  it("ramps the region full → true silence at the end", () => {
+    close(applyFadeOut(clip([1, 1, 1, 1]), 0, 0.4), [1, 2 / 3, 1 / 3, 0])
+  })
+})
+
+describe("applyGain", () => {
+  it("scales only the selected region", () => {
+    // +6 dB ≈ ×2 over samples 1..2 (0.1s..0.3s).
+    close(applyGain(clip([0.1, 0.2, 0.3, 0.4]), 0.1, 0.3, 6.0206), [
+      0.1, 0.4, 0.6, 0.4,
+    ])
+  })
+  it("clamps to [-1, 1] so a boost can't exceed full scale", () => {
+    close(applyGain(clip([0.8, -0.8]), 0, 0.2, 6.0206), [1, -1])
+  })
+})
+
+describe("applySilence", () => {
+  it("zeroes the selection but keeps the length", () => {
+    const out = applySilence(clip([1, 1, 1, 1]), 0.1, 0.3)
+    close(out, [1, 0, 0, 1])
+    expect(out.duration).toBeCloseTo(0.4)
+  })
+})
+
+describe("applyNormalize", () => {
+  it("scales the region so its peak reaches the target (0 dBFS)", () => {
+    // peak 0.5 → ×2 to hit 1.0.
+    close(applyNormalize(clip([0.1, 0.2, 0.5, 0.25]), 0, 0.4, 0), [
+      0.2, 0.4, 1, 0.5,
+    ])
+  })
+  it("is a no-op on a silent region (no divide-by-zero)", () => {
+    close(applyNormalize(clip([0, 0, 0]), 0, 0.3, 0), [0, 0, 0])
+  })
+})
+
+describe("applyCrossfade", () => {
+  it("overlap-mixes the two windows and shortens by the duration", () => {
+    // pos 0.3s (sample 3), dur 0.2s (2 samples): pre [0.2,0.2] fades out, post
+    // [0.8,0.8] fades in; result loses 2 samples.
+    const out = applyCrossfade(clip([0.2, 0.2, 0.2, 0.8, 0.8, 0.8]), 0.3, 0.2)
+    expect(out.mono.length).toBe(4)
+    expect(out.duration).toBeCloseTo(0.4)
+    expect(out.mono[0]).toBeCloseTo(0.2) // untouched head
+    expect(out.mono[1]).toBeCloseTo(0.2) // start of fade (all pre)
+    expect(out.mono[2]).toBeCloseTo(0.7071, 3) // equal-power midpoint blend
+    expect(out.mono[3]).toBeCloseTo(0.8) // untouched tail
+  })
+  it("clamps the window to the clip and no-ops when it can't fit", () => {
+    // position at the very start: nothing before it, so a copy.
+    const src = clip([0.5, 0.5, 0.5])
+    const out = applyCrossfade(src, 0, 0.2)
+    close(out, [0.5, 0.5, 0.5])
   })
 })

--- a/web/lib/waveform-edit.ts
+++ b/web/lib/waveform-edit.ts
@@ -20,6 +20,15 @@ export type EditOperation =
   | { kind: "cut"; startSec: number; endSec: number }
   | { kind: "delete"; startSec: number; endSec: number }
   | { kind: "paste"; atSec: number; durationSec: number }
+  // US-18.3 processing ops. These transform sample amplitudes in place (fade /
+  // gain / silence / normalize keep the length; crossfade shortens it), unlike
+  // the US-18.2 splice ops above which move samples around.
+  | { kind: "fade-in"; startSec: number; endSec: number }
+  | { kind: "fade-out"; startSec: number; endSec: number }
+  | { kind: "silence"; startSec: number; endSec: number }
+  | { kind: "gain"; startSec: number; endSec: number; gainDb: number }
+  | { kind: "normalize"; startSec: number; endSec: number; targetDb: number }
+  | { kind: "crossfade"; positionSec: number; durationSec: number }
 
 /** Order two times into a Region with start ≤ end. */
 export function normalizeRegion(a: number, b: number): Region {
@@ -83,4 +92,130 @@ export function insertRegion(
   mono.set(samples, at)
   mono.set(audio.mono.subarray(at), at + samples.length)
   return { ...audio, mono, duration: mono.length / audio.sampleRate }
+}
+
+// --- Processing ops (US-18.3) --------------------------------------------
+// These keep the sample layout (same length + duration) except crossfade, which
+// overlap-mixes two windows and so shrinks the clip. All are non-destructive and
+// clamp to [-1, 1] so gain/normalize can't push a real signal past full scale.
+
+/** Linear gain factor for a dB value (0 dB → 1, +6 dB → ~2, −∞ dB → 0). */
+export function dbToGain(db: number): number {
+  return 10 ** (db / 20)
+}
+
+const clampSample = (v: number) => (v > 1 ? 1 : v < -1 ? -1 : v)
+
+/** Multiply [startSec, endSec) by a per-sample factor, clamped to [-1, 1]. */
+function mapRegion(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number,
+  factorAt: (offset: number, span: number) => number
+): ClipAudio {
+  const { startSample, endSample } = regionSamples(audio, startSec, endSec)
+  const span = endSample - startSample
+  const mono = audio.mono.slice()
+  for (let i = startSample; i < endSample; i++) {
+    mono[i] = clampSample(mono[i] * factorAt(i - startSample, span))
+  }
+  return { ...audio, mono }
+}
+
+// Fades divide by (span - 1) so the ramp hits its endpoints exactly: fade-in
+// reaches full scale on the region's last sample, fade-out reaches true silence
+// there. A 1-sample region can't be ramped, so it's left unchanged.
+
+/** Ramp the selection from silence to full volume (linear fade-in). */
+export function applyFadeIn(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number
+): ClipAudio {
+  return mapRegion(audio, startSec, endSec, (o, span) =>
+    span > 1 ? o / (span - 1) : 1
+  )
+}
+
+/** Ramp the selection from full volume to silence (linear fade-out). */
+export function applyFadeOut(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number
+): ClipAudio {
+  return mapRegion(audio, startSec, endSec, (o, span) =>
+    span > 1 ? 1 - o / (span - 1) : 1
+  )
+}
+
+/** Raise/lower the selection's volume by `gainDb` decibels. */
+export function applyGain(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number,
+  gainDb: number
+): ClipAudio {
+  const g = dbToGain(gainDb)
+  return mapRegion(audio, startSec, endSec, () => g)
+}
+
+/** Replace the selection with silence (zero samples), keeping the length. */
+export function applySilence(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number
+): ClipAudio {
+  return mapRegion(audio, startSec, endSec, () => 0)
+}
+
+/** Peak amplitude in [startSample, endSample). */
+function regionPeak(mono: Float32Array, start: number, end: number): number {
+  let peak = 0
+  for (let i = start; i < end; i++) {
+    const a = Math.abs(mono[i])
+    if (a > peak) peak = a
+  }
+  return peak
+}
+
+/** Scale the selection so its loudest sample hits `targetDb` dBFS (peak
+ *  normalize). No-op when the region is already silent. */
+export function applyNormalize(
+  audio: ClipAudio,
+  startSec: number,
+  endSec: number,
+  targetDb = 0
+): ClipAudio {
+  const { startSample, endSample } = regionSamples(audio, startSec, endSec)
+  const peak = regionPeak(audio.mono, startSample, endSample)
+  if (peak === 0) return { ...audio, mono: audio.mono.slice() }
+  const factor = dbToGain(targetDb) / peak
+  return mapRegion(audio, startSec, endSec, () => factor)
+}
+
+/** Equal-power crossfade at `positionSec`: overlap-mix the `durationSec` before
+ *  the position (fading out) with the `durationSec` after (fading in) so a hard
+ *  cut becomes a smooth transition. Shortens the clip by `durationSec`. The
+ *  window is clamped to what fits; a zero/degenerate window is a no-op copy. */
+export function applyCrossfade(
+  audio: ClipAudio,
+  positionSec: number,
+  durationSec: number
+): ClipAudio {
+  const { mono: src, sampleRate } = audio
+  const pos = secToSample(positionSec, sampleRate, src.length)
+  const want = Math.max(0, Math.round(durationSec * sampleRate))
+  const d = Math.min(want, pos, src.length - pos) // fit both windows
+  if (d <= 0) return { ...audio, mono: src.slice() }
+
+  const mono = new Float32Array(src.length - d)
+  mono.set(src.subarray(0, pos - d), 0)
+  for (let k = 0; k < d; k++) {
+    const t = (k / d) * (Math.PI / 2) // 0 → π/2
+    const out = Math.cos(t) // 1 → 0 over the pre-window tail
+    const inn = Math.sin(t) // 0 → 1 over the post-window head
+    mono[pos - d + k] = clampSample(src[pos - d + k] * out + src[pos + k] * inn)
+  }
+  mono.set(src.subarray(pos + d), pos)
+  return { ...audio, mono, duration: mono.length / sampleRate }
 }


### PR DESCRIPTION
Closes #204.

## What

Adds the audio-processing toolbar to the waveform editor (Stage 18, US-18.3): **Fade In, Fade Out, Silence, Normalize, Gain (with live preview), and Crossfade**, sitting above the canvas.

## Approach — extends the US-18.1/18.2 client-side editor (not the issue's backend plan)

The issue's CodeRabbit "Coding Plan" proposes a full backend pipeline (pydub functions in `audio.py`, FastAPI endpoints, async task handlers producing derived clips). **That plan predates US-18.1** and contradicts how the two prior Stage-18 stories actually shipped. US-18.1/18.2 built a **browser-side** editor: edits splice a decoded mono `Float32Array` and log to an `operations[]` array that is the save seam for US-18.4. The acceptance criteria confirm the client-side reading — "accessible from the editor **toolbar**", "**real-time preview** of gain changes before applying", "non-destructive and **preview in real time**" — none of which a backend job pipeline provides.

So this PR extends the established seam:

- **`lib/waveform-edit.ts`** — six pure `ClipAudio → ClipAudio` transforms: `applyFadeIn`, `applyFadeOut`, `applyGain`, `applySilence`, `applyNormalize`, `applyCrossfade` (+ `dbToGain`). Amplitude ops preserve length and clamp to `[-1, 1]`; crossfade equal-power overlap-mixes the windows around a position and shortens the clip. Fades divide by `(span-1)` so they hit exact silence/full at their endpoints. `EditOperation` union extended with the six new op kinds.
- **`components/editor/EditToolbar.tsx`** — the toolbar. Region tools (fade/gain/silence) disable without a selection; Normalize falls back to the whole clip; Crossfade acts at the playhead. Gain and Crossfade use Slider popovers.
- **`components/editor/WaveformEditor.tsx`** — wires handlers (region = selection ?? whole clip), records each op to `operations[]`, and holds a `gainPreview` state that feeds a **memoized** gain-applied copy to the canvas for a live visual preview.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Fade-in / fade-out audible in region | `applyFadeIn/Out` (linear envelope) |
| Crossfade smooth transition | `applyCrossfade` (equal-power overlap-mix) |
| Normalize adjusts peak to target | `applyNormalize` (peak → 0 dBFS) |
| Silence replaces region with zero | `applySilence` |
| Gain changes volume by dB + real-time preview | `applyGain` + `gainPreview` visual preview |
| All tools in the editor toolbar | `EditToolbar` |

## Tests

- `lib/waveform-edit.test.ts` — unit vectors for every transform (fade endpoints, gain + clamp, normalize peak/silent-guard, crossfade shorten/no-op).
- `components/editor/EditToolbar.test.tsx` — disabled states, callbacks, gain preview/apply/revert, crossfade apply.
- `components/editor/WaveformEditor.test.tsx` — integration: op recorded + selection cleared, silence keeps length, whole-clip normalize, region tools gated on selection.

`web/` suite: **701 passed**. Lint + `tsc --noEmit` + `next build` all clean. (Web tests/lint/typecheck are not in CI — Python-only — so run locally.)

## Third-party review

Reviewed by **opencode (GLM)** pre-PR; all findings (fade endpoint precision, crossfade ghost-op, duplicate Apply a11y label, gain preview memoization, popover-close-on-apply) triaged and fixed. Core audio arithmetic verified against the unit vectors.

## Known limitations (carried from US-18.2, not introduced here)

- Gain preview is **visual** (waveform reflects the pending change). **Audible** playback of edits rides on US-18.4's player wiring — the shared player still streams the original file (documented US-18.2 gap).
- Edits are non-destructive and recorded only; persistence/undo is US-18.4 (the `operations[]` log is the handoff seam).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an audio editing toolbar with quick actions for fade in, fade out, silence, normalize, gain, and crossfade.
  * Gain adjustments now support live preview before applying, with controls for applying or closing the preview.
  * Editing actions now better respect waveform selection, with some tools disabled until a region is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->