### PR TITLE
feat(web): Undo/Redo & Non-Destructive Editing (US-18.4)

### DIFF
--- a/web/app/api/clips/[id]/version/route.ts
+++ b/web/app/api/clips/[id]/version/route.ts
@@ -1,0 +1,14 @@
+import { type NextRequest, type NextResponse } from "next/server"
+
+import { forwardEditUpload } from "@/lib/edit-proxy"
+
+// Same-origin proxy for POST /api/v1/clips/{id}/version (US-18.4). Uploads the
+// editor's encoded WAV as multipart form data — hence forwardEditUpload rather
+// than the JSON clipEditRoute the param-based edits use.
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await ctx.params
+  return forwardEditUpload(request, `/api/v1/clips/${encodeURIComponent(id)}/version`)
+}

--- a/web/components/editor/SaveVersionModal.test.tsx
+++ b/web/components/editor/SaveVersionModal.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SaveVersionModal } from "@/components/editor/SaveVersionModal"
+import type { ClipAudio } from "@/lib/audio-peaks"
+import type { EditOperation } from "@/lib/waveform-edit"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const saveClipVersion = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  saveClipVersion: (...args: unknown[]) => saveClipVersion(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+afterEach(() => vi.clearAllMocks())
+
+const audio: ClipAudio = { mono: new Float32Array(80), sampleRate: 8000, duration: 0.01 }
+const ops: EditOperation[] = [{ kind: "delete", startSec: 1, endSec: 2 }]
+
+function renderModal(operations = ops) {
+  return render(
+    <SaveVersionModal
+      clipId="clip-1"
+      audio={audio}
+      operations={operations}
+      open
+      onClose={vi.fn()}
+    />
+  )
+}
+
+describe("SaveVersionModal", () => {
+  it("shows an optional title field and the number of edits to save", () => {
+    renderModal()
+    expect(screen.getByRole("dialog")).toHaveTextContent("Save as new version")
+    expect(screen.getByLabelText(/Title/)).toBeInTheDocument()
+    expect(screen.getByText("1 edit will be saved.")).toBeInTheDocument()
+  })
+
+  it("disables save when there are no edits to persist", () => {
+    renderModal([])
+    expect(screen.getByRole("button", { name: "Save version" })).toBeDisabled()
+  })
+
+  it("uploads the encoded audio + operations and reaches success", async () => {
+    saveClipVersion.mockResolvedValue({ status: "accepted", jobId: "v1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["version-1"] })
+
+    renderModal()
+    await userEvent.type(screen.getByLabelText(/Title/), "Radio edit")
+    await userEvent.click(screen.getByRole("button", { name: "Save version" }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Your new clip is ready.")).toBeInTheDocument()
+    )
+    const [clipId, wav, meta, token] = saveClipVersion.mock.calls[0]
+    expect(clipId).toBe("clip-1")
+    expect(wav).toBeInstanceOf(Blob) // encoded WAV, not raw samples
+    expect(meta).toEqual({ title: "Radio edit", operations: ops })
+    expect(token).toBe("tok")
+  })
+
+  it("surfaces a backend error without crashing", async () => {
+    saveClipVersion.mockResolvedValue({ status: "error", detail: "Not Found" })
+    renderModal()
+    await userEvent.click(screen.getByRole("button", { name: "Save version" }))
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Not Found"))
+  })
+})

--- a/web/components/editor/SaveVersionModal.tsx
+++ b/web/components/editor/SaveVersionModal.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useState } from "react"
+
+import { EditModalShell } from "@/components/song/modals/EditModalShell"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import type { ClipAudio } from "@/lib/audio-peaks"
+import { saveClipVersion } from "@/lib/editing"
+import type { EditOperation } from "@/lib/waveform-edit"
+import { encodeWav } from "@/lib/wav-encode"
+
+// "Save as new version" modal for the waveform editor (US-18.4). Non-destructive
+// editing means the edited audio only lives in the browser, so this encodes it
+// to a WAV and uploads it as a new clip (with the source as parent) via
+// useClipEdit — the same submit → poll → "View the new clip" lifecycle every
+// other editing modal uses. The operation log rides along as provenance.
+
+export function SaveVersionModal({
+  clipId,
+  audio,
+  operations,
+  open,
+  onClose,
+}: {
+  clipId: string
+  audio: ClipAudio
+  operations: EditOperation[]
+  open: boolean
+  onClose: () => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+  const [title, setTitle] = useState("")
+
+  // Nothing to save with no edits applied; the parent already hides the entry
+  // point until the clip is dirty, but guard here too.
+  const canSubmit = accessToken != null && operations.length > 0
+
+  function handleSubmit() {
+    if (!accessToken || operations.length === 0) return
+    void edit.submit(
+      () =>
+        saveClipVersion(clipId, encodeWav(audio), { title, operations }, accessToken),
+      accessToken
+    )
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      edit.reset()
+      onClose()
+    }
+  }
+
+  return (
+    <EditModalShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Save as new version"
+      description="Save your edits as a new clip. The original clip is left unchanged."
+      state={edit.state}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      submitLabel="Save version"
+      onRetry={handleSubmit}
+    >
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="version-title">Title (optional)</Label>
+        <Input
+          id="version-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="e.g. Radio edit"
+          maxLength={200}
+        />
+        <p className="text-xs text-muted-foreground">
+          {operations.length} edit{operations.length === 1 ? "" : "s"} will be saved.
+        </p>
+      </div>
+    </EditModalShell>
+  )
+}

--- a/web/components/editor/UndoRedoControls.tsx
+++ b/web/components/editor/UndoRedoControls.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Redo02Icon, Undo02Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+
+// Undo / redo toolbar for the waveform editor (US-18.4). The keyboard shortcuts
+// (Ctrl+Z / Ctrl+Shift+Z) are the other affordance, wired in the parent via
+// use-editor-shortcuts. canUndo/canRedo disable each button at its stack
+// boundary so the control reflects what's actually possible; `title` surfaces
+// the shortcut on hover. Mirrors ZoomControls' shape so the header row is
+// visually uniform.
+
+export function UndoRedoControls({
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
+}: {
+  onUndo: () => void
+  onRedo: () => void
+  canUndo: boolean
+  canRedo: boolean
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        aria-label="Undo"
+        title="Undo (Ctrl+Z)"
+        onClick={onUndo}
+        disabled={!canUndo}
+      >
+        <HugeiconsIcon icon={Undo02Icon} />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        aria-label="Redo"
+        title="Redo (Ctrl+Shift+Z)"
+        onClick={onRedo}
+        disabled={!canRedo}
+      >
+        <HugeiconsIcon icon={Redo02Icon} />
+      </Button>
+    </div>
+  )
+}

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -1,10 +1,17 @@
 import { fireEvent, render, screen } from "@testing-library/react"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { WaveformEditor } from "./WaveformEditor"
 import { PlayerProvider, usePlayer } from "@/contexts/player-context"
 import type { ClipAudio } from "@/lib/audio-peaks"
 import type { Clip } from "@/lib/workspace-clips"
+
+// The always-mounted SaveVersionModal reads the auth context; stub it so the
+// editor renders without an AuthProvider (the modal stays closed here — its own
+// submit flow is covered in editing/SaveVersionModal tests).
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "test-token" }),
+}))
 
 // jsdom reports clientWidth as 0, so the viewport never initializes. Stub a real
 // width so the canvas + controls render like they do in a browser.
@@ -78,8 +85,17 @@ function opCount() {
     document.querySelector("[data-op-count]")?.getAttribute("data-op-count")
   )
 }
-function key(k: string, opts: { ctrlKey?: boolean } = {}) {
+function key(k: string, opts: { ctrlKey?: boolean; shiftKey?: boolean } = {}) {
   fireEvent.keyDown(document.body, { key: k, ...opts })
+}
+function undoBtn() {
+  return screen.getByRole("button", { name: "Undo" })
+}
+function redoBtn() {
+  return screen.getByRole("button", { name: "Redo" })
+}
+function saveBtn() {
+  return screen.getByRole("button", { name: /Save as new version/i })
 }
 
 describe("WaveformEditor", () => {
@@ -239,5 +255,92 @@ describe("WaveformEditor", () => {
     dragSelect(2, 5)
     expect(screen.getByRole("button", { name: "Fade In" })).toBeEnabled()
     expect(screen.getByRole("button", { name: "Gain" })).toBeEnabled()
+  })
+
+  // --- Undo / redo + save (US-18.4) ----------------------------------------
+
+  it("undo reverts the last edit and redo re-applies it", () => {
+    renderEditor()
+    dragSelect(2, 5) // 3s region
+    key("Delete")
+    expect(editedDuration()).toBeCloseTo(7)
+    expect(opCount()).toBe(1)
+
+    fireEvent.click(undoBtn())
+    expect(editedDuration()).toBeCloseTo(10) // original restored
+    expect(opCount()).toBe(0)
+
+    fireEvent.click(redoBtn())
+    expect(editedDuration()).toBeCloseTo(7) // edit re-applied
+    expect(opCount()).toBe(1)
+  })
+
+  it("multiple undos walk back through the full operation history", () => {
+    renderEditor()
+    dragSelect(2, 5) // delete 3s → 7
+    key("Delete")
+    const afterFirst = editedDuration()
+    expect(afterFirst).toBeCloseTo(7)
+    // The viewport re-fits after the length change, so a second drag selects a
+    // different span — its exact size doesn't matter, only that it walks back.
+    dragSelect(1, 2)
+    key("Delete")
+    const afterSecond = editedDuration()
+    expect(afterSecond).toBeLessThan(afterFirst)
+    expect(opCount()).toBe(2)
+
+    fireEvent.click(undoBtn())
+    expect(editedDuration()).toBeCloseTo(afterFirst)
+    fireEvent.click(undoBtn())
+    expect(editedDuration()).toBeCloseTo(10) // back to the pristine original
+    expect(opCount()).toBe(0)
+  })
+
+  it("a fresh edit after undo discards the redo branch", () => {
+    renderEditor()
+    dragSelect(2, 5)
+    key("Delete") // → 7
+    fireEvent.click(undoBtn()) // → 10, redo available
+    expect(redoBtn()).toBeEnabled()
+    dragSelect(0, 2)
+    key("Delete") // new branch → 8
+    expect(editedDuration()).toBeCloseTo(8)
+    expect(redoBtn()).toBeDisabled() // old redo branch dropped
+  })
+
+  it("undo/redo buttons are disabled at the stack boundaries", () => {
+    renderEditor()
+    expect(undoBtn()).toBeDisabled() // nothing to undo yet
+    expect(redoBtn()).toBeDisabled()
+
+    dragSelect(2, 5)
+    key("Delete")
+    expect(undoBtn()).toBeEnabled()
+    expect(redoBtn()).toBeDisabled() // at the tip
+
+    fireEvent.click(undoBtn())
+    expect(undoBtn()).toBeDisabled() // back at the origin
+    expect(redoBtn()).toBeEnabled()
+  })
+
+  it("Ctrl+Z undoes and Ctrl+Shift+Z redoes", () => {
+    renderEditor()
+    dragSelect(2, 5)
+    key("Delete")
+    expect(editedDuration()).toBeCloseTo(7)
+    key("z", { ctrlKey: true })
+    expect(editedDuration()).toBeCloseTo(10)
+    key("z", { ctrlKey: true, shiftKey: true })
+    expect(editedDuration()).toBeCloseTo(7)
+  })
+
+  it("Save as new version is disabled until an edit is made", () => {
+    renderEditor()
+    expect(saveBtn()).toBeDisabled()
+    dragSelect(2, 5)
+    key("Delete")
+    expect(saveBtn()).toBeEnabled()
+    fireEvent.click(undoBtn()) // no edits applied again
+    expect(saveBtn()).toBeDisabled()
   })
 })

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -2,13 +2,19 @@
 
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 
+import { HugeiconsIcon } from "@hugeicons/react"
+import { FloppyDiskIcon } from "@hugeicons/core-free-icons"
+
 import { EditToolbar } from "@/components/editor/EditToolbar"
+import { SaveVersionModal } from "@/components/editor/SaveVersionModal"
 import { SelectionInfo } from "@/components/editor/SelectionInfo"
 import { SelectionOverlay } from "@/components/editor/SelectionOverlay"
 import { TimeRuler } from "@/components/editor/TimeRuler"
+import { UndoRedoControls } from "@/components/editor/UndoRedoControls"
 import { WaveformCanvas } from "@/components/editor/WaveformCanvas"
 import { WaveformScrollbar } from "@/components/editor/WaveformScrollbar"
 import { ZoomControls } from "@/components/editor/ZoomControls"
+import { Button } from "@/components/ui/button"
 import { usePlayer } from "@/contexts/player-context"
 import { useEditorShortcuts } from "@/hooks/use-editor-shortcuts"
 import type { ClipAudio } from "@/lib/audio-peaks"
@@ -41,10 +47,12 @@ import type { Clip } from "@/lib/workspace-clips"
 // scroll) and — from US-18.2 — the region selection, the in-app clipboard, and
 // the edited audio. Playback state is borrowed from the shared player store.
 //
-// Edits (cut / delete / paste) splice the decoded samples directly, so the
-// canvas renders the *real* edited waveform with no operation-stack replay. They
-// are non-destructive: the original `audio` prop is untouched; the edit lives in
-// `edited` state and the `operations` log is the handoff seam for save (US-18.4).
+// Edits (cut / delete / paste / fade / gain / …) splice or transform the decoded
+// samples directly, so the canvas renders the *real* edited waveform with no
+// operation-stack replay. They are non-destructive: the original `audio` prop is
+// untouched; each edit produces a fresh ClipAudio pushed onto the undo/redo
+// history (US-18.4), and the per-snapshot operation log is the handoff seam for
+// "Save as new version".
 //
 // The stored viewport is the user's *intent* (absolute px/sec + scrollSec); the
 // effective viewport is derived + clamped against the measured width each
@@ -52,6 +60,11 @@ import type { Clip } from "@/lib/workspace-clips"
 
 const CANVAS_HEIGHT = 160
 const BUTTON_ZOOM_FACTOR = 1.6
+
+// One point in the edit timeline: the audio at that point plus the operation
+// that produced it (null for the pristine original at index 0).
+type Snapshot = { audio: ClipAudio; op: EditOperation | null }
+type EditHistory = { snapshots: Snapshot[]; cursor: number }
 
 export function WaveformEditor({
   clip,
@@ -62,17 +75,64 @@ export function WaveformEditor({
 }) {
   const { state, dispatch } = usePlayer()
 
-  // The audio actually shown/edited. Starts as the decoded prop; cut/paste/delete
-  // replace it. ClipEditor keys this subtree by clip id, so it resets per clip.
-  const [edited, setEdited] = useState<ClipAudio>(audio)
+  // Undo/redo history (US-18.4). Each edit is a pure, non-destructive
+  // ClipAudio→ClipAudio transform, so the edited buffer *is* a complete
+  // snapshot — history is a stack of snapshots + a cursor, no command replay.
+  // snapshots[0] is the untouched decoded prop, so undoing to the start restores
+  // the original and the source clip is never mutated. ClipEditor keys this
+  // subtree by clip id, so the whole stack resets per clip.
+  // ponytail: the stack is unbounded per the "unlimited undo" spec; each entry
+  // holds one full buffer, so memory grows with edit count — add a drop-oldest
+  // cap if a long-clip session ever pressures memory.
+  const [history, setHistory] = useState<EditHistory>(() => ({
+    snapshots: [{ audio, op: null }],
+    cursor: 0,
+  }))
   const [selection, setSelection] = useState<Region | null>(null)
   const [clipboard, setClipboard] = useState<Float32Array | null>(null)
-  const [operations, setOperations] = useState<EditOperation[]>([])
   // Pending gain (dB) while the Gain popover is open — drives a live, throwaway
   // waveform preview; null when nothing is being previewed. (US-18.3)
   const [gainPreview, setGainPreview] = useState<number | null>(null)
+  const [saveOpen, setSaveOpen] = useState(false)
+
+  const { snapshots, cursor } = history
+  const edited = snapshots[cursor].audio
+  const canUndo = cursor > 0
+  const canRedo = cursor < snapshots.length - 1
+  const isDirty = cursor > 0
+  // The operations applied to reach the current snapshot (index 0 is pristine),
+  // in order — what "Save as new version" ships as provenance.
+  const operations = useMemo(
+    () => snapshots.slice(1, cursor + 1).map((s) => s.op as EditOperation),
+    [snapshots, cursor]
+  )
 
   const duration = edited.duration
+
+  // --- Undo/redo history (US-18.4) -----------------------------------------
+  // Apply an edit: drop any redo tail, push the new snapshot, advance the
+  // cursor. Every edit routes through here, so undo/redo covers them uniformly.
+  // The selection is cleared because the buffer changed under it (the old code
+  // cleared it per-op).
+  const pushEdit = (nextAudio: ClipAudio, op: EditOperation) => {
+    setHistory((h) => {
+      const kept = h.snapshots.slice(0, h.cursor + 1)
+      return { snapshots: [...kept, { audio: nextAudio, op }], cursor: kept.length }
+    })
+    setSelection(null)
+  }
+  const undo = () => {
+    setHistory((h) => (h.cursor > 0 ? { ...h, cursor: h.cursor - 1 } : h))
+    setSelection(null)
+    setGainPreview(null)
+  }
+  const redo = () => {
+    setHistory((h) =>
+      h.cursor < h.snapshots.length - 1 ? { ...h, cursor: h.cursor + 1 } : h
+    )
+    setSelection(null)
+    setGainPreview(null)
+  }
 
   // Load this clip into the player so the playhead + seek reuse the real audio
   // engine. Async dispatch (not synchronous setState), only on clip change.
@@ -168,12 +228,11 @@ export function WaveformEditor({
     if (kind === "cut") {
       setClipboard(sliceRegion(edited, selection.startSec, selection.endSec))
     }
-    setEdited(removeRegion(edited, selection.startSec, selection.endSec))
-    setOperations((ops) => [
-      ...ops,
-      { kind, startSec: selection.startSec, endSec: selection.endSec },
-    ])
-    setSelection(null)
+    pushEdit(removeRegion(edited, selection.startSec, selection.endSec), {
+      kind,
+      startSec: selection.startSec,
+      endSec: selection.endSec,
+    })
   }
 
   const paste = () => {
@@ -184,9 +243,7 @@ export function WaveformEditor({
     const atSec = clampSec(playheadSec)
     const durationSec = clipboard.length / edited.sampleRate
     const next = insertRegion(edited, atSec, clipboard)
-    setEdited(next)
-    setOperations((ops) => [...ops, { kind: "paste", atSec, durationSec }])
-    setSelection(null)
+    pushEdit(next, { kind: "paste", atSec, durationSec })
     // Move the playhead to the end of the pasted region, in the NEW timeline.
     dispatch({
       type: "seek/request",
@@ -199,18 +256,16 @@ export function WaveformEditor({
     onCopy: copy,
     onPaste: paste,
     onDelete: () => removeSelected("delete"),
+    onUndo: undo,
+    onRedo: redo,
   })
 
   // --- Processing ops (US-18.3) --------------------------------------------
-  // Commit an amplitude transform: swap in the new audio, log the intent for the
-  // US-18.4 save seam, and clear the selection. The clear is deliberate for every
-  // op — the buffer changed, so the old selection's coordinates are stale (this
-  // includes crossfade, which is playhead-based and ignores the selection).
-  const commit = (next: ClipAudio, op: EditOperation) => {
-    setEdited(next)
-    setOperations((ops) => [...ops, op])
-    setSelection(null)
-  }
+  // Commit an amplitude transform through the undo/redo history (US-18.4). The
+  // selection clear happens in pushEdit — deliberate for every op, since the
+  // buffer changed and the old selection's coordinates are stale (crossfade
+  // included, which is playhead-based and ignores the selection).
+  const commit = (next: ClipAudio, op: EditOperation) => pushEdit(next, op)
 
   const fadeIn = () => {
     if (!selection) return
@@ -283,17 +338,34 @@ export function WaveformEditor({
         <h1 className="truncate text-lg font-semibold">
           {clip.title ?? "Untitled clip"}
         </h1>
-        <ZoomControls
-          onZoomIn={() =>
-            zoomAt((vp ? vp.pxPerSec : fitPx) * BUTTON_ZOOM_FACTOR, width / 2)
-          }
-          onZoomOut={() =>
-            zoomAt((vp ? vp.pxPerSec : fitPx) / BUTTON_ZOOM_FACTOR, width / 2)
-          }
-          onFit={fit}
-          atMin={atMin}
-          atMax={atMax}
-        />
+        <div className="flex items-center gap-2">
+          <UndoRedoControls
+            onUndo={undo}
+            onRedo={redo}
+            canUndo={canUndo}
+            canRedo={canRedo}
+          />
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => setSaveOpen(true)}
+            disabled={!isDirty}
+          >
+            <HugeiconsIcon icon={FloppyDiskIcon} data-icon="inline-start" />
+            Save as new version
+          </Button>
+          <ZoomControls
+            onZoomIn={() =>
+              zoomAt((vp ? vp.pxPerSec : fitPx) * BUTTON_ZOOM_FACTOR, width / 2)
+            }
+            onZoomOut={() =>
+              zoomAt((vp ? vp.pxPerSec : fitPx) / BUTTON_ZOOM_FACTOR, width / 2)
+            }
+            onFit={fit}
+            atMin={atMin}
+            atMax={atMax}
+          />
+        </div>
       </div>
 
       <EditToolbar
@@ -353,6 +425,14 @@ export function WaveformEditor({
           onScroll={scrollTo}
         />
       )}
+
+      <SaveVersionModal
+        clipId={clip.id}
+        audio={edited}
+        operations={operations}
+        open={saveOpen}
+        onClose={() => setSaveOpen(false)}
+      />
     </div>
   )
 }

--- a/web/hooks/use-editor-shortcuts.test.ts
+++ b/web/hooks/use-editor-shortcuts.test.ts
@@ -4,18 +4,31 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { useEditorShortcuts } from "./use-editor-shortcuts"
 
 function makeActions() {
-  return { onCut: vi.fn(), onCopy: vi.fn(), onPaste: vi.fn(), onDelete: vi.fn() }
+  return {
+    onCut: vi.fn(),
+    onCopy: vi.fn(),
+    onPaste: vi.fn(),
+    onDelete: vi.fn(),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+  }
 }
 
 /** Dispatch a keydown on window; returns whether default was prevented. */
 function press(
   key: string,
-  opts: { ctrlKey?: boolean; metaKey?: boolean; target?: EventTarget } = {}
+  opts: {
+    ctrlKey?: boolean
+    metaKey?: boolean
+    shiftKey?: boolean
+    target?: EventTarget
+  } = {}
 ) {
   const e = new KeyboardEvent("keydown", {
     key,
     ctrlKey: opts.ctrlKey,
     metaKey: opts.metaKey,
+    shiftKey: opts.shiftKey,
     cancelable: true,
     bubbles: true,
   })
@@ -47,6 +60,18 @@ describe("useEditorShortcuts", () => {
     press("Backspace")
     expect(actions.onCut).toHaveBeenCalledOnce()
     expect(actions.onDelete).toHaveBeenCalledOnce()
+  })
+
+  it("maps Ctrl+Z to undo and Ctrl+Shift+Z / Ctrl+Y to redo", () => {
+    press("z", { ctrlKey: true })
+    expect(actions.onUndo).toHaveBeenCalledOnce()
+    expect(actions.onRedo).not.toHaveBeenCalled()
+
+    press("z", { ctrlKey: true, shiftKey: true })
+    press("y", { ctrlKey: true })
+    expect(actions.onRedo).toHaveBeenCalledTimes(2)
+    // Shift+Z must not also fire undo.
+    expect(actions.onUndo).toHaveBeenCalledOnce()
   })
 
   it("prevents default for bound keys only", () => {

--- a/web/hooks/use-editor-shortcuts.ts
+++ b/web/hooks/use-editor-shortcuts.ts
@@ -2,8 +2,9 @@
 
 import { useEffect, useRef } from "react"
 
-// Keyboard shortcuts for the waveform editor (US-18.2): Ctrl/Cmd+X/C/V and
-// Delete/Backspace → cut / copy / paste / delete. A single window keydown
+// Keyboard shortcuts for the waveform editor: Ctrl/Cmd+X/C/V and
+// Delete/Backspace → cut / copy / paste / delete (US-18.2); Ctrl/Cmd+Z → undo
+// and Ctrl/Cmd+Shift+Z (or Ctrl+Y) → redo (US-18.4). A single window keydown
 // listener attached once; the latest actions are read through a ref (same
 // pattern as the canvas's wheel handler) so re-renders don't re-bind. Ignores
 // keystrokes aimed at a text field so typing elsewhere isn't hijacked.
@@ -13,6 +14,8 @@ export type EditorShortcutActions = {
   onCopy: () => void
   onPaste: () => void
   onDelete: () => void
+  onUndo: () => void
+  onRedo: () => void
 }
 
 /** True when the event targets an editable field (input/textarea/contenteditable). */
@@ -41,7 +44,11 @@ export function useEditorShortcuts(actions: EditorShortcutActions): void {
       const a = ref.current
       const key = e.key.toLowerCase()
 
-      if (mod && key === "x") a.onCut()
+      // Redo before undo: Ctrl/Cmd+Shift+Z is a superset match of the Z key.
+      if (mod && key === "z" && e.shiftKey) a.onRedo()
+      else if (mod && key === "y" && !e.shiftKey) a.onRedo()
+      else if (mod && key === "z" && !e.shiftKey) a.onUndo()
+      else if (mod && key === "x") a.onCut()
       else if (mod && key === "c") a.onCopy()
       else if (mod && key === "v") a.onPaste()
       else if (!mod && (e.key === "Delete" || e.key === "Backspace")) a.onDelete()

--- a/web/lib/edit-proxy.test.ts
+++ b/web/lib/edit-proxy.test.ts
@@ -123,3 +123,67 @@ describe("route handlers", () => {
     expect(res.status).toBe(401)
   })
 })
+
+import { POST as versionPOST } from "@/app/api/clips/[id]/version/route"
+import { forwardEditUpload } from "@/lib/edit-proxy"
+
+describe("forwardEditUpload", () => {
+  function uploadReq(init: RequestInit = {}): NextRequest {
+    return new Request("http://localhost/api/clips/c/version", {
+      method: "POST",
+      ...init,
+    }) as unknown as NextRequest
+  }
+
+  it("401s without an Authorization header", async () => {
+    const res = await forwardEditUpload(uploadReq(), "/api/v1/clips/c/version")
+    expect(res.status).toBe(401)
+  })
+
+  it("forwards the raw body and preserves the multipart content-type", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ job_id: "v" }), { status: 202 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await forwardEditUpload(
+      uploadReq({
+        headers: {
+          authorization: "Bearer tok",
+          "content-type": "multipart/form-data; boundary=xyz",
+        },
+        body: "raw-bytes",
+      }),
+      "/api/v1/clips/c/version"
+    )
+    expect(res.status).toBe(202)
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toContain("/api/v1/clips/c/version")
+    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+    expect((opts.headers as Record<string, string>)["content-type"]).toBe(
+      "multipart/form-data; boundary=xyz"
+    )
+  })
+
+  it("returns a controlled 502 when the upstream fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")))
+    const res = await forwardEditUpload(
+      uploadReq({ headers: { authorization: "Bearer tok" }, body: "x" }),
+      "/api/v1/clips/c/version"
+    )
+    expect(res.status).toBe(502)
+  })
+
+  it("version route forwards to the version op with the url-encoded id", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ job_id: "v" }), { status: 202 }))
+    vi.stubGlobal("fetch", fetchMock)
+    const res = await versionPOST(
+      uploadReq({ headers: { authorization: "Bearer tok" }, body: "x" }),
+      params("abc")
+    )
+    expect(res.status).toBe(202)
+    expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/clips/abc/version")
+  })
+})

--- a/web/lib/edit-proxy.ts
+++ b/web/lib/edit-proxy.ts
@@ -47,6 +47,43 @@ export async function forwardEdit(
   return NextResponse.json(body, { status: res.status })
 }
 
+/**
+ * Like `forwardEdit`, but for a multipart/binary upload (US-18.4 "Save as
+ * version" ships the encoded WAV, not JSON). Forwards the raw request body with
+ * its original content-type so the multipart boundary survives, keeping the
+ * backend URL server-side. Status/body pass through verbatim.
+ */
+export async function forwardEditUpload(
+  request: NextRequest,
+  backendPath: string
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+  const contentType = request.headers.get("content-type")
+
+  let res: Response
+  try {
+    res = await fetchWithTimeout(`${BACKEND_URL}${backendPath}`, {
+      method: "POST",
+      headers: {
+        authorization: auth,
+        accept: "application/json",
+        ...(contentType ? { "content-type": contentType } : {}),
+      },
+      body: await request.arrayBuffer(),
+    })
+  } catch {
+    return NextResponse.json(
+      { detail: "Editing service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}
+
 /** Build a clip-scoped route handler for `${op}` (crop/speed/extend/…). */
 export function clipEditRoute(op: string) {
   return async function POST(

--- a/web/lib/editing.test.ts
+++ b/web/lib/editing.test.ts
@@ -138,3 +138,57 @@ describe("submitMashup", () => {
     })
   })
 })
+
+import { saveClipVersion } from "@/lib/editing"
+
+describe("saveClipVersion", () => {
+  const wav = () => new Blob([new Uint8Array([1, 2, 3])], { type: "audio/wav" })
+
+  it("uploads the WAV + metadata as multipart to the version route and returns the job", async () => {
+    const fetchMock = stubFetch(
+      new Response(JSON.stringify({ job_id: "v1", status: "queued" }), { status: 202 })
+    )
+
+    const result = await saveClipVersion(
+      "clip-xyz",
+      wav(),
+      { title: "  Radio edit  ", operations: [{ kind: "delete", startSec: 1, endSec: 2 }] },
+      "tok"
+    )
+
+    expect(result).toEqual({ status: "accepted", jobId: "v1", estimatedSeconds: 0 })
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/clips/clip-xyz/version")
+    expect(opts.method).toBe("POST")
+    expect(opts.headers.authorization).toBe("Bearer tok")
+    // No explicit content-type: the browser sets multipart + boundary itself.
+    expect(opts.headers["content-type"]).toBeUndefined()
+
+    const form = opts.body as FormData
+    expect(form).toBeInstanceOf(FormData)
+    expect(form.get("title")).toBe("Radio edit") // trimmed
+    expect(JSON.parse(form.get("operations") as string)).toEqual([
+      { kind: "delete", startSec: 1, endSec: 2 },
+    ])
+    expect(form.get("file")).toBeInstanceOf(Blob)
+  })
+
+  it("omits a blank title", async () => {
+    const fetchMock = stubFetch(new Response("{}", { status: 202 }))
+    await saveClipVersion("c", wav(), { title: "   ", operations: [] }, "tok")
+    const form = fetchMock.mock.calls[0][1].body as FormData
+    expect(form.get("title")).toBeNull()
+  })
+
+  it("classifies a 404 (endpoint not yet deployed) as an error result", async () => {
+    stubFetch(new Response(JSON.stringify({ detail: "Not Found" }), { status: 404 }))
+    const result = await saveClipVersion("c", wav(), { operations: [] }, "tok")
+    expect(result).toEqual({ status: "error", detail: "Not Found" })
+  })
+
+  it("returns an error result when the network throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")))
+    const result = await saveClipVersion("c", wav(), { operations: [] }, "tok")
+    expect(result.status).toBe("error")
+  })
+})

--- a/web/lib/editing.ts
+++ b/web/lib/editing.ts
@@ -130,7 +130,16 @@ async function postEdit(
   } catch {
     return { status: "error", detail: "Something went wrong. Please try again." }
   }
+  return classifyEditResponse(res)
+}
 
+/**
+ * Classify a BFF editing response into an `EditSubmitResult` — 202 (accepted
+ * job), 401, 402 (credits), 422 (validation), else error. Shared by the
+ * JSON `postEdit` above and the multipart `saveClipVersion` below so both hit
+ * the same status → UI mapping.
+ */
+async function classifyEditResponse(res: Response): Promise<EditSubmitResult> {
   if (res.status === 202) {
     const body = await res.json().catch(() => ({}))
     const { job_id: jobId, estimated_time_seconds: estimated } = body as {
@@ -217,4 +226,43 @@ export function submitAddVocal(clipId: string, payload: AddVocalPayload, token: 
 
 export function submitMashup(payload: MashupPayload, token: string) {
   return postEdit("/api/mashup", compact(payload), token)
+}
+
+// --- Save as new version (US-18.4) ---
+
+/** Operation metadata sent alongside the audio for lineage/provenance. */
+export type VersionOperationSummary = { kind: string } & Record<string, unknown>
+
+/**
+ * Save the editor's current audio as a new clip version (US-18.4). Unlike the
+ * param-based edits above, the edited buffer only exists in the browser, so this
+ * uploads the encoded WAV as multipart form data (with an optional title and the
+ * operation log for provenance) to the clip-scoped `version` BFF route. The
+ * backend `POST /clips/{id}/version` endpoint that persists it with lineage is
+ * the deferred half of this seam — until it lands the call surfaces a normal
+ * error result, exactly like any other unavailable editing endpoint.
+ */
+export async function saveClipVersion(
+  clipId: string,
+  wav: Blob,
+  meta: { title?: string; operations: VersionOperationSummary[] },
+  accessToken: string
+): Promise<EditSubmitResult> {
+  const form = new FormData()
+  form.append("file", wav, "version.wav")
+  if (meta.title && meta.title.trim() !== "") form.append("title", meta.title.trim())
+  form.append("operations", JSON.stringify(meta.operations))
+
+  let res: Response
+  try {
+    // No explicit content-type: the browser sets multipart/form-data + boundary.
+    res = await fetch(clipPath(clipId, "version"), {
+      method: "POST",
+      headers: { authorization: `Bearer ${accessToken}` },
+      body: form,
+    })
+  } catch {
+    return { status: "error", detail: "Something went wrong. Please try again." }
+  }
+  return classifyEditResponse(res)
 }

--- a/web/lib/wav-encode.test.ts
+++ b/web/lib/wav-encode.test.ts
@@ -50,4 +50,14 @@ describe("encodeWav", () => {
     expect(view.getInt16(44 + 2 * 2, true)).toBe(-0x8000) // -1.0
     expect(view.getInt16(44 + 3 * 2, true)).toBe(0x7fff) // clamped
   })
+
+  it("rounds to the nearest int16 rather than truncating toward zero", async () => {
+    // 0.5 * 32767 = 16383.5 → 16384 rounded (truncation would give 16383).
+    const view = await encodeToView({
+      mono: new Float32Array([0.5]),
+      sampleRate: 8000,
+      duration: 1 / 8000,
+    })
+    expect(view.getInt16(44, true)).toBe(16384)
+  })
 })

--- a/web/lib/wav-encode.test.ts
+++ b/web/lib/wav-encode.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import type { ClipAudio } from "@/lib/audio-peaks"
+import { encodeWav } from "@/lib/wav-encode"
+
+function ascii(view: DataView, offset: number, length: number): string {
+  let s = ""
+  for (let i = 0; i < length; i++) s += String.fromCharCode(view.getUint8(offset + i))
+  return s
+}
+
+async function encodeToView(audio: ClipAudio): Promise<DataView> {
+  const blob = encodeWav(audio)
+  return new DataView(await blob.arrayBuffer())
+}
+
+describe("encodeWav", () => {
+  it("writes a 44-byte header plus 2 bytes per mono sample", async () => {
+    const blob = encodeWav({ mono: new Float32Array(100), sampleRate: 44100, duration: 100 / 44100 })
+    expect(blob.type).toBe("audio/wav")
+    expect(blob.size).toBe(44 + 100 * 2)
+  })
+
+  it("emits a well-formed 16-bit PCM mono RIFF/WAVE header", async () => {
+    const view = await encodeToView({
+      mono: new Float32Array(4),
+      sampleRate: 48000,
+      duration: 4 / 48000,
+    })
+    expect(ascii(view, 0, 4)).toBe("RIFF")
+    expect(ascii(view, 8, 4)).toBe("WAVE")
+    expect(ascii(view, 12, 4)).toBe("fmt ")
+    expect(ascii(view, 36, 4)).toBe("data")
+    expect(view.getUint16(20, true)).toBe(1) // PCM
+    expect(view.getUint16(22, true)).toBe(1) // mono
+    expect(view.getUint32(24, true)).toBe(48000) // sample rate
+    expect(view.getUint16(34, true)).toBe(16) // bits per sample
+    expect(view.getUint32(40, true)).toBe(4 * 2) // data byte count
+    expect(view.getUint32(4, true)).toBe(36 + 4 * 2) // RIFF chunk size
+  })
+
+  it("quantizes samples to signed 16-bit and clamps out-of-range values", async () => {
+    const view = await encodeToView({
+      mono: new Float32Array([0, 1, -1, 2]), // 2 is out of range → clamps to +full scale
+      sampleRate: 8000,
+      duration: 4 / 8000,
+    })
+    expect(view.getInt16(44 + 0 * 2, true)).toBe(0)
+    expect(view.getInt16(44 + 1 * 2, true)).toBe(0x7fff) // +1.0
+    expect(view.getInt16(44 + 2 * 2, true)).toBe(-0x8000) // -1.0
+    expect(view.getInt16(44 + 3 * 2, true)).toBe(0x7fff) // clamped
+  })
+})

--- a/web/lib/wav-encode.ts
+++ b/web/lib/wav-encode.ts
@@ -8,11 +8,12 @@ import type { ClipAudio } from "@/lib/audio-peaks"
 
 const BYTES_PER_SAMPLE = 2 // 16-bit PCM
 
-/** Clamp to [-1, 1] and quantize to a signed 16-bit integer. */
+/** Clamp to [-1, 1] and quantize to the nearest signed 16-bit integer. */
 function toInt16(sample: number): number {
   const s = Math.max(-1, Math.min(1, sample))
-  // Asymmetric range: negative floor is -32768, positive ceiling +32767.
-  return s < 0 ? s * 0x8000 : s * 0x7fff
+  // Round (not truncate — setInt16 would truncate toward zero, biasing every
+  // sample down by up to ~1 LSB). Asymmetric range: floor -32768, ceiling +32767.
+  return s < 0 ? Math.round(s * 0x8000) : Math.round(s * 0x7fff)
 }
 
 /** Serialize mono `ClipAudio` as a 16-bit PCM WAV `Blob`. */

--- a/web/lib/wav-encode.ts
+++ b/web/lib/wav-encode.ts
@@ -1,0 +1,50 @@
+import type { ClipAudio } from "@/lib/audio-peaks"
+
+// Encode the editor's decoded audio back to a real file (US-18.4). The editor
+// holds audio as a mono Float32Array (see ClipAudio); "Save as new version"
+// needs bytes to upload, so this serializes it as a 16-bit PCM mono WAV — the
+// simplest lossless container every backend/decoder understands. No external
+// dependency: a WAV is a 44-byte header followed by the samples.
+
+const BYTES_PER_SAMPLE = 2 // 16-bit PCM
+
+/** Clamp to [-1, 1] and quantize to a signed 16-bit integer. */
+function toInt16(sample: number): number {
+  const s = Math.max(-1, Math.min(1, sample))
+  // Asymmetric range: negative floor is -32768, positive ceiling +32767.
+  return s < 0 ? s * 0x8000 : s * 0x7fff
+}
+
+/** Serialize mono `ClipAudio` as a 16-bit PCM WAV `Blob`. */
+export function encodeWav(audio: ClipAudio): Blob {
+  const { mono, sampleRate } = audio
+  const dataBytes = mono.length * BYTES_PER_SAMPLE
+  const buffer = new ArrayBuffer(44 + dataBytes)
+  const view = new DataView(buffer)
+
+  const writeAscii = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i))
+  }
+
+  // RIFF header
+  writeAscii(0, "RIFF")
+  view.setUint32(4, 36 + dataBytes, true) // file size minus the first 8 bytes
+  writeAscii(8, "WAVE")
+  // fmt chunk
+  writeAscii(12, "fmt ")
+  view.setUint32(16, 16, true) // PCM fmt chunk size
+  view.setUint16(20, 1, true) // audio format 1 = PCM
+  view.setUint16(22, 1, true) // channels = mono
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, sampleRate * BYTES_PER_SAMPLE, true) // byte rate
+  view.setUint16(32, BYTES_PER_SAMPLE, true) // block align
+  view.setUint16(34, 8 * BYTES_PER_SAMPLE, true) // bits per sample
+  // data chunk
+  writeAscii(36, "data")
+  view.setUint32(40, dataBytes, true)
+  for (let i = 0; i < mono.length; i++) {
+    view.setInt16(44 + i * BYTES_PER_SAMPLE, toInt16(mono[i]), true)
+  }
+
+  return new Blob([buffer], { type: "audio/wav" })
+}


### PR DESCRIPTION
Closes #205 — US-18.4: Undo/Redo & Non-Destructive Editing (web / Stage 18).

## What & why

Adds unlimited undo/redo and a **Save as new version** flow to the waveform editor.

The key realization: every US-18.2/18.3 edit is already a **pure, non-destructive `ClipAudio → ClipAudio` transform** producing a fresh buffer. So the edited buffer *is* a complete state snapshot, and undo/redo collapses to a **snapshot stack + cursor** in `WaveformEditor` — no Zustand, no command-pattern `apply()/reverse()`, no context provider. `snapshots[0]` is the untouched decoded prop, so undoing to the start restores the original and the source clip is never mutated (AC #4 falls out for free).

## Changes

- **Undo/redo history** (`WaveformEditor.tsx`): `edited`/`operations` become derived from a `{ snapshots, cursor }` state; every edit path (`removeSelected`, `paste`, the US-18.3 `commit`) routes through one `pushEdit(audio, op)` that truncates the redo tail. `undo`/`redo` move the cursor and clear the (now-stale) selection.
- **Buttons + shortcuts**: `UndoRedoControls` (Hugeicons, disabled at boundaries, shortcut tooltips) in the header row; `use-editor-shortcuts` gains Ctrl/Cmd+Z (undo) and Ctrl/Cmd+Shift+Z / Ctrl+Y (redo).
- **Save as new version**: `lib/wav-encode.ts` encodes the edited mono buffer to a 16-bit PCM WAV; `saveClipVersion` uploads it + the operation log as multipart through a new BFF proxy route (`app/api/clips/[id]/version`, `forwardEditUpload`) to `POST /api/v1/clips/{id}/version`. `SaveVersionModal` reuses `EditModalShell` + `useClipEdit` (same submit → poll → "View the new clip" lifecycle as every other edit modal). The Save button is disabled until the clip is dirty.

## Deviations from the issue's CodeRabbit plan

The plan predates US-18.1's browser-side editor and mostly doesn't fit this repo:
- **Paths** — assumed `web/src/*`; the app is flat (`web/*`).
- **Libs** — assumed Zustand + React Context + a command-pattern operation hierarchy; none are needed (and none are installed). The existing `operations[]` client seam is used directly.
- **Backend** — assumed a full `version` job pipeline. Per this stage's web-only rule, that's the deferred half of the seam (see Known Limitations).
- **History panel** — the issue marks it optional; skipped (YAGNI).

## Acceptance criteria

- [x] Undo reverts the last operation and redo re-applies it
- [x] Multiple undos walk back through the full operation history
- [x] "Save as new version" wired: encodes audio + posts to `/clips/{id}/version` with the operation log (client-verified; real clip creation pending backend — see below)
- [x] Original clip remains unchanged after any number of edits (`snapshots[0]` is pristine; source clip never mutated)
- [x] Undo/redo buttons disabled at the start/end of the stack

## Known Limitations

- **Backend `POST /clips/{id}/version` is not yet implemented.** Consistent with the Stage 17/18 web-only pattern (US-18.2/18.3 left the save seam deferred), this PR ships the complete client half — WAV encoding, the multipart proxy route, and the submit/poll UI. Until the backend endpoint lands, "Save as new version" surfaces a normal error result (the same path a 404 from any editing endpoint takes; covered by tests). AC #3's "new clip in the workspace with correct lineage" is verified end-to-end once the backend endpoint is deployed.
- **Undo history is unbounded** (per the "unlimited undo" spec) and holds one full audio buffer per edit; memory grows with edit count. Marked with a `ponytail:` comment noting a drop-oldest cap as the upgrade path if a long-clip session ever pressures memory.

## Testing

- `npx vitest run` — **728 pass** (102 files); new coverage for wav-encode, `saveClipVersion`, `forwardEditUpload` + version route, the undo/redo shortcuts, and WaveformEditor integration (undo/redo, boundary-disabled buttons, redo-branch discard, original-preserved, save-gated-on-dirty) + `SaveVersionModal`.
- `npx tsc --noEmit` clean, `npm run lint` clean, pre-commit hooks pass.

Per the web-story demo gate (no local GPU/backend stack), test evidence stands in for the live demo; the undo/redo behavior is fully exercised in jsdom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added undo/redo controls in the editor, including keyboard shortcuts for faster navigation.
  * Added a “Save as new version” flow with an optional title and progress/status feedback.
  * Enabled saving edited audio as a new version from the waveform editor.

* **Bug Fixes**
  * Improved handling of edit history so undoing and redoing works consistently, including after new changes.
  * Added more robust upload handling for editor saves and version uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->