### PR TITLE
feat(web): Repaint Mode Integration (US-18.5)

### DIFF
--- a/web/components/editor/EditToolbar.test.tsx
+++ b/web/components/editor/EditToolbar.test.tsx
@@ -80,6 +80,31 @@ describe("EditToolbar", () => {
     expect(p.onGainApply).toHaveBeenCalledWith(0.5)
   })
 
+  it("freezes the whole toolbar (incl. open-popover Apply) when disabled", () => {
+    const onGainApply = vi.fn()
+    const base: EditToolbarProps = {
+      hasSelection: true,
+      onFadeIn: vi.fn(),
+      onFadeOut: vi.fn(),
+      onSilence: vi.fn(),
+      onNormalize: vi.fn(),
+      onGainPreview: vi.fn(),
+      onGainApply,
+      onCrossfade: vi.fn(),
+    }
+    const { rerender } = render(<EditToolbar {...base} disabled={false} />)
+    // Open the Gain popover while enabled, then a repaint starts (disabled=true).
+    fireEvent.click(btn("Gain"))
+    expect(btn("Apply gain")).toBeEnabled()
+
+    rerender(<EditToolbar {...base} disabled />)
+    // Triggers freeze, and the already-open Apply must not commit an edit either.
+    expect(btn("Normalize")).toBeDisabled()
+    expect(btn("Apply gain")).toBeDisabled()
+    fireEvent.click(btn("Apply gain"))
+    expect(onGainApply).not.toHaveBeenCalled()
+  })
+
   it("carries a non-default crossfade slider value through to Apply", () => {
     const p = renderToolbar()
     fireEvent.click(btn("Crossfade"))

--- a/web/components/editor/EditToolbar.tsx
+++ b/web/components/editor/EditToolbar.tsx
@@ -24,6 +24,8 @@ const CROSSFADE_DEFAULT_MS = 100
 
 export type EditToolbarProps = {
   hasSelection: boolean
+  /** Freeze the whole toolbar (e.g. while a repaint job is in flight). */
+  disabled?: boolean
   onFadeIn: () => void
   onFadeOut: () => void
   onSilence: () => void
@@ -36,6 +38,7 @@ export type EditToolbarProps = {
 
 export function EditToolbar({
   hasSelection,
+  disabled = false,
   onFadeIn,
   onFadeOut,
   onSilence,
@@ -90,7 +93,7 @@ export function EditToolbar({
         variant="outline"
         size="sm"
         onClick={onFadeIn}
-        disabled={!hasSelection}
+        disabled={disabled || !hasSelection}
       >
         Fade In
       </Button>
@@ -99,7 +102,7 @@ export function EditToolbar({
         variant="outline"
         size="sm"
         onClick={onFadeOut}
-        disabled={!hasSelection}
+        disabled={disabled || !hasSelection}
       >
         Fade Out
       </Button>
@@ -108,11 +111,17 @@ export function EditToolbar({
         variant="outline"
         size="sm"
         onClick={onSilence}
-        disabled={!hasSelection}
+        disabled={disabled || !hasSelection}
       >
         Silence
       </Button>
-      <Button type="button" variant="outline" size="sm" onClick={onNormalize}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onNormalize}
+        disabled={disabled}
+      >
         Normalize
       </Button>
 
@@ -122,7 +131,7 @@ export function EditToolbar({
             type="button"
             variant="outline"
             size="sm"
-            disabled={!hasSelection}
+            disabled={disabled || !hasSelection}
           >
             Gain
           </Button>
@@ -165,7 +174,7 @@ export function EditToolbar({
 
       <Popover open={crossfadeOpen} onOpenChange={setCrossfadeOpen}>
         <PopoverTrigger asChild>
-          <Button type="button" variant="outline" size="sm">
+          <Button type="button" variant="outline" size="sm" disabled={disabled}>
             Crossfade
           </Button>
         </PopoverTrigger>

--- a/web/components/editor/EditToolbar.tsx
+++ b/web/components/editor/EditToolbar.tsx
@@ -160,6 +160,9 @@ export function EditToolbar({
             size="sm"
             className="w-full"
             aria-label="Apply gain"
+            // Guard the commit itself, not just the trigger: an already-open
+            // popover must not commit an edit once the toolbar is frozen.
+            disabled={disabled}
             onClick={() => {
               cancelPreview()
               onGainApply(gainDb)
@@ -198,6 +201,7 @@ export function EditToolbar({
             size="sm"
             className="w-full"
             aria-label="Apply crossfade"
+            disabled={disabled}
             onClick={() => {
               onCrossfade(crossfadeMs / 1000)
               setCrossfadeOpen(false)

--- a/web/components/editor/RepaintPanel.test.tsx
+++ b/web/components/editor/RepaintPanel.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { RepaintPanel } from "@/components/editor/RepaintPanel"
+import type { ClipAudio } from "@/lib/audio-peaks"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok", isLoading: false, isAuthenticated: true }),
+}))
+
+const submitRepaint = vi.fn()
+vi.mock("@/lib/editing", () => ({
+  submitRepaint: (...args: unknown[]) => submitRepaint(...args),
+}))
+
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
+const decodeClipAudio = vi.fn()
+vi.mock("@/lib/audio-peaks", () => ({
+  decodeClipAudio: (...args: unknown[]) => decodeClipAudio(...args),
+}))
+
+const CHILD_AUDIO = {
+  mono: new Float32Array([0.1, 0.2, 0.3]),
+  sampleRate: 44100,
+  duration: 30,
+} as unknown as ClipAudio
+
+afterEach(() => vi.clearAllMocks())
+
+const selection = { startSec: 15, endSec: 30 }
+
+describe("RepaintPanel", () => {
+  it("shows the repaint heading and the instruction + style fields", () => {
+    render(
+      <RepaintPanel selection={selection} clipId="clip-1" onRepainted={vi.fn()} />
+    )
+    expect(screen.getByTestId("repaint-panel")).toHaveTextContent("Repaint selection")
+    expect(screen.getByLabelText(/Instructions/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Style/)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Regenerate" })).toBeInTheDocument()
+  })
+
+  it("disables Regenerate until instructions are provided", async () => {
+    render(
+      <RepaintPanel selection={selection} clipId="clip-1" onRepainted={vi.fn()} />
+    )
+    expect(screen.getByRole("button", { name: "Regenerate" })).toBeDisabled()
+    await userEvent.type(screen.getByLabelText(/Instructions/), "make it jazzy")
+    expect(screen.getByRole("button", { name: "Regenerate" })).toBeEnabled()
+  })
+
+  it("submits the repaint with Ns coords and applies the decoded child on success", async () => {
+    submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["child-1"] })
+    decodeClipAudio.mockResolvedValue(CHILD_AUDIO)
+    const onRepainted = vi.fn()
+
+    render(
+      <RepaintPanel selection={selection} clipId="clip-1" onRepainted={onRepainted} />
+    )
+    await userEvent.type(screen.getByLabelText(/Instructions/), "make it jazzy")
+    await userEvent.type(screen.getByLabelText(/Style/), "lofi")
+    await userEvent.click(screen.getByRole("button", { name: "Regenerate" }))
+
+    await waitFor(() => expect(onRepainted).toHaveBeenCalled())
+
+    expect(submitRepaint).toHaveBeenCalledWith(
+      "clip-1",
+      { start: "15s", end: "30s", prompt: "make it jazzy", style: "lofi" },
+      "tok"
+    )
+    expect(decodeClipAudio).toHaveBeenCalledWith("child-1", "tok")
+    expect(onRepainted).toHaveBeenCalledWith(CHILD_AUDIO, {
+      kind: "repaint",
+      startSec: 15,
+      endSec: 30,
+      prompt: "make it jazzy",
+      style: "lofi",
+    })
+  })
+
+  it("surfaces a failed job and offers retry, without applying anything", async () => {
+    submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "failed", error: "Generation failed." })
+    const onRepainted = vi.fn()
+
+    render(
+      <RepaintPanel selection={selection} clipId="clip-1" onRepainted={onRepainted} />
+    )
+    await userEvent.type(screen.getByLabelText(/Instructions/), "make it jazzy")
+    await userEvent.click(screen.getByRole("button", { name: "Regenerate" }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Generation failed.")
+    )
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument()
+    expect(onRepainted).not.toHaveBeenCalled()
+    expect(decodeClipAudio).not.toHaveBeenCalled()
+  })
+})

--- a/web/components/editor/RepaintPanel.test.tsx
+++ b/web/components/editor/RepaintPanel.test.tsx
@@ -84,6 +84,33 @@ describe("RepaintPanel", () => {
     })
   })
 
+  it("retries only the decode (no resubmit) after the job succeeded but the fetch failed", async () => {
+    submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["child-1"] })
+    // First decode fails (network blip on the already-generated clip), then succeeds.
+    decodeClipAudio.mockRejectedValueOnce(new Error("net")).mockResolvedValueOnce(CHILD_AUDIO)
+    const onRepainted = vi.fn()
+
+    render(
+      <RepaintPanel selection={selection} clipId="clip-1" onRepainted={onRepainted} />
+    )
+    await userEvent.type(screen.getByLabelText(/Instructions/), "make it jazzy")
+    await userEvent.click(screen.getByRole("button", { name: "Regenerate" }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Couldn't load the repainted audio/)
+    )
+    expect(submitRepaint).toHaveBeenCalledTimes(1)
+
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }))
+    await waitFor(() => expect(onRepainted).toHaveBeenCalled())
+
+    // Retry re-fetched the same child; it did NOT start a new (paid) generation.
+    expect(submitRepaint).toHaveBeenCalledTimes(1)
+    expect(decodeClipAudio).toHaveBeenCalledTimes(2)
+    expect(decodeClipAudio).toHaveBeenLastCalledWith("child-1", "tok")
+  })
+
   it("surfaces a failed job and offers retry, without applying anything", async () => {
     submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
     fetchJobStatus.mockResolvedValue({ kind: "failed", error: "Generation failed." })

--- a/web/components/editor/RepaintPanel.tsx
+++ b/web/components/editor/RepaintPanel.tsx
@@ -1,0 +1,179 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+import { StyleTextarea } from "@/components/song/modals/StyleTextarea"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/hooks/use-auth"
+import { useClipEdit } from "@/hooks/use-clip-edit"
+import { decodeClipAudio, type ClipAudio } from "@/lib/audio-peaks"
+import { PROMPT_MAX_LENGTH, STYLE_MAX_LENGTH } from "@/lib/constants/generation"
+import { submitRepaint } from "@/lib/editing"
+import type { EditOperation, Region } from "@/lib/waveform-edit"
+
+// Repaint panel for the waveform editor (US-18.5). Appears while a region is
+// selected: the musician writes new instructions and regenerates just that
+// section with AI. It reuses the Stage-17 repaint pipeline wholesale —
+// `submitRepaint` + `useClipEdit`'s submit→poll job lifecycle — and only adds
+// the editor-side glue: the selected region *is* the range, and the result is
+// folded back into the editor's own undo stack.
+//
+// On completion the backend has produced a full, crossfade-blended child clip
+// (US-6.3) with only [start,end] regenerated. We decode that child and hand it
+// up as a normal edit snapshot (`onRepainted`), so the existing Undo/Redo covers
+// repaint for free rather than needing a separate navigation-based undo. The
+// selected region's readout is the editor's own SelectionInfo, rendered directly
+// above this panel — no need to duplicate it here.
+
+type RepaintSubmitted = { prompt: string; style?: string; startSec: number; endSec: number }
+
+export function RepaintPanel({
+  selection,
+  clipId,
+  onRepainted,
+}: {
+  selection: Region
+  clipId: string
+  onRepainted: (audio: ClipAudio, op: EditOperation) => void
+}) {
+  const { accessToken } = useAuth()
+  const edit = useClipEdit()
+  const [prompt, setPrompt] = useState("")
+  const [style, setStyle] = useState("")
+  // The backend job is done but we still have to fetch + decode the child clip's
+  // audio before it can be shown; a distinct phase so the spinner stays up.
+  const [applying, setApplying] = useState(false)
+  const [applyError, setApplyError] = useState<string | null>(null)
+
+  // What we actually submitted, so the recorded op + decode target don't drift if
+  // the fields change during the async job.
+  const submittedRef = useRef<RepaintSubmitted | null>(null)
+  // One-shot guard: `useClipEdit`'s success state persists across the frequent
+  // re-renders the player's time-tick drives, so the decode must run exactly once.
+  const appliedRef = useRef(false)
+  // `onRepainted` in a ref so a changing parent closure doesn't re-arm the apply
+  // effect (which would cancel an in-flight decode and drop the result).
+  const onRepaintedRef = useRef(onRepainted)
+  useEffect(() => {
+    onRepaintedRef.current = onRepainted
+  })
+  const mountedRef = useRef(true)
+  useEffect(() => () => void (mountedRef.current = false), [])
+
+  const overPrompt = prompt.length > PROMPT_MAX_LENGTH
+  const overStyle = style.length > STYLE_MAX_LENGTH
+  const valid = prompt.trim().length > 0 && !overPrompt && !overStyle
+
+  const busy = edit.state.phase === "submitting" || edit.state.phase === "polling" || applying
+  const errorMsg =
+    applyError ?? (edit.state.phase === "error" ? edit.state.message : null)
+
+  function handleSubmit() {
+    if (!accessToken || !valid) return
+    appliedRef.current = false
+    setApplyError(null)
+    const p = prompt.trim()
+    const s = style.trim()
+    submittedRef.current = {
+      prompt: p,
+      style: s || undefined,
+      startSec: selection.startSec,
+      endSec: selection.endSec,
+    }
+    const payload = { start: `${selection.startSec}s`, end: `${selection.endSec}s`, prompt: p, ...(s ? { style: s } : {}) }
+    void edit.submit(() => submitRepaint(clipId, payload, accessToken), accessToken)
+  }
+
+  // When the job completes, pull the child clip's audio and hand it up as a
+  // repaint snapshot. Keyed on the job state (not on the parent closure), guarded
+  // one-shot; the parent clearing the selection through pushEdit unmounts us.
+  useEffect(() => {
+    if (edit.state.phase !== "success" || appliedRef.current) return
+    appliedRef.current = true
+    const childId = edit.state.clipIds[0]
+    const submitted = submittedRef.current
+    if (!childId || !accessToken || !submitted) {
+      setApplyError("Repaint finished but returned no clip.")
+      return
+    }
+    setApplying(true)
+    decodeClipAudio(childId, accessToken)
+      .then((audio) => {
+        const op: EditOperation = {
+          kind: "repaint",
+          startSec: submitted.startSec,
+          endSec: submitted.endSec,
+          prompt: submitted.prompt,
+          ...(submitted.style ? { style: submitted.style } : {}),
+        }
+        onRepaintedRef.current(audio, op)
+      })
+      .catch(() => {
+        if (!mountedRef.current) return
+        setApplying(false)
+        setApplyError("Couldn't load the repainted audio. Please try again.")
+      })
+  }, [edit.state, accessToken])
+
+  return (
+    <div
+      data-testid="repaint-panel"
+      className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3"
+    >
+      <h2 className="text-sm font-semibold">Repaint selection</h2>
+
+      {busy ? (
+        <div role="status" className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+          <HugeiconsIcon icon={Loading03Icon} className="animate-spin" data-icon="inline-start" />
+          <span>
+            {applying ? "Applying…" : "Regenerating…"}
+            {edit.state.phase === "polling" && edit.state.estimatedSeconds > 0
+              ? ` ~${edit.state.estimatedSeconds}s`
+              : ""}
+          </span>
+          {edit.state.phase === "polling" && edit.state.progress && (
+            <span className="text-xs">{edit.state.progress}</span>
+          )}
+        </div>
+      ) : errorMsg ? (
+        <div className="flex flex-col gap-2">
+          <p role="alert" className="text-sm text-destructive">
+            {errorMsg}
+          </p>
+          <div>
+            <Button type="button" size="sm" onClick={handleSubmit} disabled={!valid}>
+              Try again
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <StyleTextarea
+            label="Instructions"
+            value={prompt}
+            onChange={setPrompt}
+            placeholder="Describe how to regenerate this section…"
+            maxLength={PROMPT_MAX_LENGTH}
+            required
+          />
+          <StyleTextarea
+            label="Style (optional)"
+            value={style}
+            onChange={setStyle}
+            placeholder="e.g. lofi, orchestral"
+            maxLength={STYLE_MAX_LENGTH}
+            rows={2}
+          />
+          <div>
+            <Button type="button" size="sm" onClick={handleSubmit} disabled={!valid}>
+              Regenerate
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/components/editor/RepaintPanel.tsx
+++ b/web/components/editor/RepaintPanel.tsx
@@ -59,6 +59,10 @@ export function RepaintPanel({
   // audio before it can be shown; a distinct phase so the spinner stays up.
   const [applying, setApplying] = useState(false)
   const [applyError, setApplyError] = useState<string | null>(null)
+  // The completed job's child clip id, retained so a decode-only failure can
+  // retry the fetch without resubmitting (and re-charging) the generation. State,
+  // not a ref, so the retry button can branch on it during render.
+  const [childId, setChildId] = useState<string | null>(null)
 
   // What we actually submitted, so the recorded op + decode target don't drift if
   // the fields change during the async job.
@@ -66,9 +70,6 @@ export function RepaintPanel({
   // One-shot guard: `useClipEdit`'s success state persists across the frequent
   // re-renders the player's time-tick drives, so the decode must run exactly once.
   const appliedRef = useRef(false)
-  // The completed job's child clip id, retained so a decode-only failure can
-  // retry the fetch without resubmitting (and re-charging) the generation.
-  const childIdRef = useRef<string | null>(null)
   // `onRepainted` in a ref so a changing parent closure doesn't re-arm the apply
   // effect (which would cancel an in-flight decode and drop the result).
   const onRepaintedRef = useRef(onRepainted)
@@ -82,10 +83,13 @@ export function RepaintPanel({
   const overStyle = style.length > STYLE_MAX_LENGTH
   const valid = prompt.trim().length > 0 && !overPrompt && !overStyle
 
-  // Active == the poll is running. This must outlive a selection clear, so the
-  // editor keeps the panel mounted while it's true. (`applying`/success come
-  // after the poll; the decode promise survives an unmount on its own.)
-  const active = edit.state.phase === "submitting" || edit.state.phase === "polling"
+  // Active == a job is in flight, through both the poll AND the decode/apply that
+  // follows it. Reported up so the editor keeps this panel mounted and freezes
+  // other edits for the whole window — `applying` is included so the freeze
+  // doesn't lift during the decode (a fetch + decodeAudioData), which would
+  // reopen the concurrent-edit hole one step past the poll.
+  const active =
+    edit.state.phase === "submitting" || edit.state.phase === "polling" || applying
   useEffect(() => {
     onActiveChange?.(active)
   }, [active, onActiveChange])
@@ -99,16 +103,16 @@ export function RepaintPanel({
   // the decode-failure branch can retry just the fetch — the job (and its paid
   // child clip) already succeeded server-side.
   const applyChild = useCallback(
-    (childId: string) => {
+    (id: string) => {
       const submitted = submittedRef.current
-      if (!childId || !accessToken || !submitted) {
+      if (!id || !accessToken || !submitted) {
         setApplyError("Repaint finished but returned no clip.")
         return
       }
-      childIdRef.current = childId
+      setChildId(id)
       setApplyError(null)
       setApplying(true)
-      decodeClipAudio(childId, accessToken)
+      decodeClipAudio(id, accessToken)
         .then((audio) => {
           const op: EditOperation = {
             kind: "repaint",
@@ -139,7 +143,7 @@ export function RepaintPanel({
   function handleSubmit() {
     if (!accessToken || !valid) return
     appliedRef.current = false
-    childIdRef.current = null
+    setChildId(null)
     setApplyError(null)
     const p = prompt.trim()
     const s = style.trim()
@@ -153,14 +157,12 @@ export function RepaintPanel({
     void edit.submit(() => submitRepaint(clipId, payload, accessToken), accessToken)
   }
 
-  // A decode-only failure means the job succeeded but the fetch/decode afterward
-  // failed — retry just that, never a new (paid) generation.
-  const onRetry = applyError
-    ? () => {
-        if (childIdRef.current) applyChild(childIdRef.current)
-      }
-    : handleSubmit
-  const retryDisabled = applyError ? false : !valid
+  // A decode-only failure (job succeeded, we have the child id) retries just the
+  // fetch — never a new (paid) generation. A job failure, or the odd success with
+  // no clip id, falls back to a fresh submit so "Try again" is never a dead click.
+  const canRetryDecode = applyError !== null && childId !== null
+  const onRetry = canRetryDecode ? () => applyChild(childId) : handleSubmit
+  const retryDisabled = canRetryDecode ? false : !valid
 
   return (
     <div

--- a/web/components/editor/RepaintPanel.tsx
+++ b/web/components/editor/RepaintPanel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { HugeiconsIcon } from "@hugeicons/react"
 import { Loading03Icon } from "@hugeicons/core-free-icons"
@@ -27,17 +27,29 @@ import type { EditOperation, Region } from "@/lib/waveform-edit"
 // repaint for free rather than needing a separate navigation-based undo. The
 // selected region's readout is the editor's own SelectionInfo, rendered directly
 // above this panel — no need to duplicate it here.
+//
+// The submit → poll job can run for minutes and consumes a credit, but a bare
+// canvas click or any other edit clears the selection, which would unmount this
+// panel. So it reports its active (polling) state up via `onActiveChange`; the
+// editor keeps it mounted while a job is in flight so the paid result is never
+// silently dropped.
 
 type RepaintSubmitted = { prompt: string; style?: string; startSec: number; endSec: number }
+
+// Round seconds to millisecond precision so the "Ns" payload stays tidy
+// (e.g. "15.238s", not "15.23835616438356s" straight off the pixel→sec math).
+const coord = (sec: number) => `${Math.round(sec * 1000) / 1000}s`
 
 export function RepaintPanel({
   selection,
   clipId,
   onRepainted,
+  onActiveChange,
 }: {
   selection: Region
   clipId: string
   onRepainted: (audio: ClipAudio, op: EditOperation) => void
+  onActiveChange?: (active: boolean) => void
 }) {
   const { accessToken } = useAuth()
   const edit = useClipEdit()
@@ -54,6 +66,9 @@ export function RepaintPanel({
   // One-shot guard: `useClipEdit`'s success state persists across the frequent
   // re-renders the player's time-tick drives, so the decode must run exactly once.
   const appliedRef = useRef(false)
+  // The completed job's child clip id, retained so a decode-only failure can
+  // retry the fetch without resubmitting (and re-charging) the generation.
+  const childIdRef = useRef<string | null>(null)
   // `onRepainted` in a ref so a changing parent closure doesn't re-arm the apply
   // effect (which would cancel an in-flight decode and drop the result).
   const onRepaintedRef = useRef(onRepainted)
@@ -67,13 +82,64 @@ export function RepaintPanel({
   const overStyle = style.length > STYLE_MAX_LENGTH
   const valid = prompt.trim().length > 0 && !overPrompt && !overStyle
 
-  const busy = edit.state.phase === "submitting" || edit.state.phase === "polling" || applying
-  const errorMsg =
-    applyError ?? (edit.state.phase === "error" ? edit.state.message : null)
+  // Active == the poll is running. This must outlive a selection clear, so the
+  // editor keeps the panel mounted while it's true. (`applying`/success come
+  // after the poll; the decode promise survives an unmount on its own.)
+  const active = edit.state.phase === "submitting" || edit.state.phase === "polling"
+  useEffect(() => {
+    onActiveChange?.(active)
+  }, [active, onActiveChange])
+
+  const succeeded = edit.state.phase === "success"
+  const busy = active || succeeded || applying
+  const jobError = edit.state.phase === "error" ? edit.state.message : null
+  const errorMsg = applyError ?? jobError
+
+  // Decode the finished child clip and hand it up as a repaint edit. Split out so
+  // the decode-failure branch can retry just the fetch — the job (and its paid
+  // child clip) already succeeded server-side.
+  const applyChild = useCallback(
+    (childId: string) => {
+      const submitted = submittedRef.current
+      if (!childId || !accessToken || !submitted) {
+        setApplyError("Repaint finished but returned no clip.")
+        return
+      }
+      childIdRef.current = childId
+      setApplyError(null)
+      setApplying(true)
+      decodeClipAudio(childId, accessToken)
+        .then((audio) => {
+          const op: EditOperation = {
+            kind: "repaint",
+            startSec: submitted.startSec,
+            endSec: submitted.endSec,
+            prompt: submitted.prompt,
+            ...(submitted.style ? { style: submitted.style } : {}),
+          }
+          if (mountedRef.current) setApplying(false)
+          onRepaintedRef.current(audio, op)
+        })
+        .catch(() => {
+          if (!mountedRef.current) return
+          setApplying(false)
+          setApplyError("Couldn't load the repainted audio. Please try again.")
+        })
+    },
+    [accessToken]
+  )
+
+  // When the job completes, decode + apply exactly once (guarded by appliedRef).
+  useEffect(() => {
+    if (edit.state.phase !== "success" || appliedRef.current) return
+    appliedRef.current = true
+    applyChild(edit.state.clipIds[0])
+  }, [edit.state, applyChild])
 
   function handleSubmit() {
     if (!accessToken || !valid) return
     appliedRef.current = false
+    childIdRef.current = null
     setApplyError(null)
     const p = prompt.trim()
     const s = style.trim()
@@ -83,40 +149,18 @@ export function RepaintPanel({
       startSec: selection.startSec,
       endSec: selection.endSec,
     }
-    const payload = { start: `${selection.startSec}s`, end: `${selection.endSec}s`, prompt: p, ...(s ? { style: s } : {}) }
+    const payload = { start: coord(selection.startSec), end: coord(selection.endSec), prompt: p, ...(s ? { style: s } : {}) }
     void edit.submit(() => submitRepaint(clipId, payload, accessToken), accessToken)
   }
 
-  // When the job completes, pull the child clip's audio and hand it up as a
-  // repaint snapshot. Keyed on the job state (not on the parent closure), guarded
-  // one-shot; the parent clearing the selection through pushEdit unmounts us.
-  useEffect(() => {
-    if (edit.state.phase !== "success" || appliedRef.current) return
-    appliedRef.current = true
-    const childId = edit.state.clipIds[0]
-    const submitted = submittedRef.current
-    if (!childId || !accessToken || !submitted) {
-      setApplyError("Repaint finished but returned no clip.")
-      return
-    }
-    setApplying(true)
-    decodeClipAudio(childId, accessToken)
-      .then((audio) => {
-        const op: EditOperation = {
-          kind: "repaint",
-          startSec: submitted.startSec,
-          endSec: submitted.endSec,
-          prompt: submitted.prompt,
-          ...(submitted.style ? { style: submitted.style } : {}),
-        }
-        onRepaintedRef.current(audio, op)
-      })
-      .catch(() => {
-        if (!mountedRef.current) return
-        setApplying(false)
-        setApplyError("Couldn't load the repainted audio. Please try again.")
-      })
-  }, [edit.state, accessToken])
+  // A decode-only failure means the job succeeded but the fetch/decode afterward
+  // failed — retry just that, never a new (paid) generation.
+  const onRetry = applyError
+    ? () => {
+        if (childIdRef.current) applyChild(childIdRef.current)
+      }
+    : handleSubmit
+  const retryDisabled = applyError ? false : !valid
 
   return (
     <div
@@ -125,29 +169,33 @@ export function RepaintPanel({
     >
       <h2 className="text-sm font-semibold">Repaint selection</h2>
 
-      {busy ? (
-        <div role="status" className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
-          <HugeiconsIcon icon={Loading03Icon} className="animate-spin" data-icon="inline-start" />
-          <span>
-            {applying ? "Applying…" : "Regenerating…"}
-            {edit.state.phase === "polling" && edit.state.estimatedSeconds > 0
-              ? ` ~${edit.state.estimatedSeconds}s`
-              : ""}
-          </span>
-          {edit.state.phase === "polling" && edit.state.progress && (
-            <span className="text-xs">{edit.state.progress}</span>
-          )}
-        </div>
-      ) : errorMsg ? (
+      {/* Error takes precedence over `busy` — the sticky `success` phase keeps
+          `busy` true even after a decode-only failure, which would otherwise mask
+          the error behind the spinner. */}
+      {errorMsg ? (
         <div className="flex flex-col gap-2">
           <p role="alert" className="text-sm text-destructive">
             {errorMsg}
           </p>
           <div>
-            <Button type="button" size="sm" onClick={handleSubmit} disabled={!valid}>
+            <Button type="button" size="sm" onClick={onRetry} disabled={retryDisabled}>
               Try again
             </Button>
           </div>
+        </div>
+      ) : busy ? (
+        <div role="status" className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+          <HugeiconsIcon icon={Loading03Icon} className="animate-spin" data-icon="inline-start" />
+          <span>
+            {edit.state.phase === "polling"
+              ? `Regenerating…${edit.state.estimatedSeconds > 0 ? ` ~${edit.state.estimatedSeconds}s` : ""}`
+              : edit.state.phase === "submitting"
+                ? "Submitting…"
+                : "Applying…"}
+          </span>
+          {edit.state.phase === "polling" && edit.state.progress && (
+            <span className="text-xs">{edit.state.progress}</span>
+          )}
         </div>
       ) : (
         <div className="flex flex-col gap-3">

--- a/web/components/editor/UndoRedoControls.tsx
+++ b/web/components/editor/UndoRedoControls.tsx
@@ -17,11 +17,14 @@ export function UndoRedoControls({
   onRedo,
   canUndo,
   canRedo,
+  disabled = false,
 }: {
   onUndo: () => void
   onRedo: () => void
   canUndo: boolean
   canRedo: boolean
+  /** Freeze both controls (e.g. while a repaint job is in flight). */
+  disabled?: boolean
 }) {
   return (
     <div className="flex items-center gap-1">
@@ -32,7 +35,7 @@ export function UndoRedoControls({
         aria-label="Undo"
         title="Undo (Ctrl+Z)"
         onClick={onUndo}
-        disabled={!canUndo}
+        disabled={disabled || !canUndo}
       >
         <HugeiconsIcon icon={Undo02Icon} />
       </Button>
@@ -43,7 +46,7 @@ export function UndoRedoControls({
         aria-label="Redo"
         title="Redo (Ctrl+Shift+Z)"
         onClick={onRedo}
-        disabled={!canRedo}
+        disabled={disabled || !canRedo}
       >
         <HugeiconsIcon icon={Redo02Icon} />
       </Button>

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -448,4 +448,28 @@ describe("WaveformEditor", () => {
     key("z", { ctrlKey: true }) // keyboard undo is a no-op too
     expect(opCount()).toBe(1) // unchanged — the intervening undo was blocked
   })
+
+  it("stays frozen through the decode window, not just the poll", async () => {
+    submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["child-1"] })
+    // Hold the decode open so we can inspect the window between job-complete and
+    // the result landing — the freeze must persist across it.
+    let resolveDecode: (a: unknown) => void = () => {}
+    decodeClipAudio.mockReturnValue(new Promise((res) => { resolveDecode = res }))
+
+    renderEditor()
+    dragSelect(2, 5)
+    const panel = screen.getByTestId("repaint-panel")
+    await userEvent.type(within(panel).getByLabelText(/Instructions/), "make it jazzy")
+    await userEvent.click(within(panel).getByRole("button", { name: "Regenerate" }))
+
+    // Job completed, decode in flight ("Applying…"): edits must still be frozen.
+    await screen.findByText(/Applying/)
+    expect(screen.getByRole("button", { name: "Normalize" })).toBeDisabled()
+
+    // Finish the decode → the result lands and editing unfreezes.
+    resolveDecode({ mono: new Float32Array(480), sampleRate: 80, duration: 6 })
+    await waitFor(() => expect(editedDuration()).toBeCloseTo(6))
+    expect(screen.getByRole("button", { name: "Normalize" })).toBeEnabled()
+  })
 })

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -401,4 +401,25 @@ describe("WaveformEditor", () => {
     expect(editedDuration()).toBeCloseTo(10)
     expect(opCount()).toBe(0)
   })
+
+  it("keeps the repaint job alive when the selection is cleared mid-poll", async () => {
+    submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 30 })
+    fetchJobStatus.mockResolvedValue({ kind: "pending" }) // still generating
+
+    renderEditor()
+    dragSelect(2, 5)
+    const panel = screen.getByTestId("repaint-panel")
+    await userEvent.type(within(panel).getByLabelText(/Instructions/), "make it jazzy")
+    await userEvent.click(within(panel).getByRole("button", { name: "Regenerate" }))
+    await screen.findByRole("status") // reached submitting/polling
+
+    // A bare canvas click seeks and clears the selection mid-generation.
+    fireEvent.pointerDown(canvas(), { clientX: 160, pointerId: 1 })
+    fireEvent.pointerUp(canvas(), { clientX: 160, pointerId: 1 })
+
+    // Selection readout is gone, but the panel — and its poll — must survive so
+    // the paid result isn't silently dropped.
+    expect(screen.queryByTestId("selection-info")).not.toBeInTheDocument()
+    expect(screen.getByTestId("repaint-panel")).toBeInTheDocument()
+  })
 })

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { WaveformEditor } from "./WaveformEditor"
@@ -13,6 +14,25 @@ vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ accessToken: "test-token" }),
 }))
 
+// Repaint (US-18.5) reuses the real submit→poll pipeline; mock only its network
+// edges so a completed job flows back into the editor's undo stack. importActual
+// keeps the rest of these modules (SaveVersionModal's saveClipVersion, the real
+// peak helpers) intact.
+const submitRepaint = vi.fn()
+const decodeClipAudio = vi.fn()
+const fetchJobStatus = vi.fn()
+vi.mock("@/lib/editing", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/editing")>()),
+  submitRepaint: (...args: unknown[]) => submitRepaint(...args),
+}))
+vi.mock("@/lib/audio-peaks", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/audio-peaks")>()),
+  decodeClipAudio: (...args: unknown[]) => decodeClipAudio(...args),
+}))
+vi.mock("@/lib/job-status", () => ({
+  fetchJobStatus: (...args: unknown[]) => fetchJobStatus(...args),
+}))
+
 // jsdom reports clientWidth as 0, so the viewport never initializes. Stub a real
 // width so the canvas + controls render like they do in a browser.
 let widthSpy: PropertyDescriptor | undefined
@@ -25,6 +45,7 @@ beforeEach(() => {
 })
 afterEach(() => {
   if (widthSpy) Object.defineProperty(HTMLElement.prototype, "clientWidth", widthSpy)
+  vi.clearAllMocks()
 })
 
 function fakeClip(): Clip {
@@ -342,5 +363,42 @@ describe("WaveformEditor", () => {
     expect(saveBtn()).toBeEnabled()
     fireEvent.click(undoBtn()) // no edits applied again
     expect(saveBtn()).toBeDisabled()
+  })
+
+  // --- Repaint mode (US-18.5) ----------------------------------------------
+
+  it("shows the repaint panel only while a region is selected", () => {
+    renderEditor()
+    expect(screen.queryByTestId("repaint-panel")).not.toBeInTheDocument()
+    dragSelect(2, 5)
+    expect(screen.getByTestId("repaint-panel")).toBeInTheDocument()
+  })
+
+  it("applies a completed repaint as an undoable edit", async () => {
+    submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 0 })
+    fetchJobStatus.mockResolvedValue({ kind: "completed", clipIds: ["child-1"] })
+    // The child clip is the full crossfade-blended result; a 6s duration lets us
+    // see it land in the editor's buffer (and undo back to the original 10s).
+    decodeClipAudio.mockResolvedValue({ mono: new Float32Array(480), sampleRate: 80, duration: 6 })
+
+    renderEditor()
+    dragSelect(2, 5)
+    const panel = screen.getByTestId("repaint-panel")
+    await userEvent.type(within(panel).getByLabelText(/Instructions/), "make it jazzy")
+    await userEvent.click(within(panel).getByRole("button", { name: "Regenerate" }))
+
+    // The decoded child replaces the buffer as a recorded repaint op.
+    await waitFor(() => expect(editedDuration()).toBeCloseTo(6))
+    expect(opCount()).toBe(1)
+    expect(submitRepaint).toHaveBeenCalledWith(
+      "c1",
+      expect.objectContaining({ start: "2s", end: "5s", prompt: "make it jazzy" }),
+      "test-token"
+    )
+
+    // Undoable: back to the pristine original, op log cleared.
+    fireEvent.click(undoBtn())
+    expect(editedDuration()).toBeCloseTo(10)
+    expect(opCount()).toBe(0)
   })
 })

--- a/web/components/editor/WaveformEditor.test.tsx
+++ b/web/components/editor/WaveformEditor.test.tsx
@@ -422,4 +422,30 @@ describe("WaveformEditor", () => {
     expect(screen.queryByTestId("selection-info")).not.toBeInTheDocument()
     expect(screen.getByTestId("repaint-panel")).toBeInTheDocument()
   })
+
+  it("freezes other edits while a repaint is in flight", async () => {
+    submitRepaint.mockResolvedValue({ status: "accepted", jobId: "j1", estimatedSeconds: 30 })
+    fetchJobStatus.mockResolvedValue({ kind: "pending" }) // still generating
+
+    renderEditor()
+    // One prior edit so Undo would otherwise be available.
+    dragSelect(2, 5)
+    key("Delete")
+    expect(opCount()).toBe(1)
+
+    // Start a repaint on a fresh selection.
+    dragSelect(1, 3)
+    const panel = screen.getByTestId("repaint-panel")
+    await userEvent.type(within(panel).getByLabelText(/Instructions/), "make it jazzy")
+    await userEvent.click(within(panel).getByRole("button", { name: "Regenerate" }))
+    await screen.findByRole("status") // job in flight
+
+    // The buffer is about to be replaced wholesale — every mutating affordance is
+    // frozen so an intervening edit can't be silently reverted (and mislogged).
+    expect(screen.getByRole("button", { name: "Normalize" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Fade In" })).toBeDisabled()
+    expect(undoBtn()).toBeDisabled()
+    key("z", { ctrlKey: true }) // keyboard undo is a no-op too
+    expect(opCount()).toBe(1) // unchanged — the intervening undo was blocked
+  })
 })

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -6,6 +6,7 @@ import { HugeiconsIcon } from "@hugeicons/react"
 import { FloppyDiskIcon } from "@hugeicons/core-free-icons"
 
 import { EditToolbar } from "@/components/editor/EditToolbar"
+import { RepaintPanel } from "@/components/editor/RepaintPanel"
 import { SaveVersionModal } from "@/components/editor/SaveVersionModal"
 import { SelectionInfo } from "@/components/editor/SelectionInfo"
 import { SelectionOverlay } from "@/components/editor/SelectionOverlay"
@@ -416,6 +417,17 @@ export function WaveformEditor({
       <div className="flex min-h-4 items-center justify-between gap-2">
         <SelectionInfo selection={selection} />
       </div>
+
+      {/* Repaint mode (US-18.5): a live selection unlocks AI section-regenerate.
+          The backend returns a full crossfade-blended child clip; we decode it
+          and push it through the same undo stack as every other edit. */}
+      {selection && (
+        <RepaintPanel
+          selection={selection}
+          clipId={clip.id}
+          onRepainted={(nextAudio, op) => pushEdit(nextAudio, op)}
+        />
+      )}
 
       {vp && (
         <WaveformScrollbar

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -91,6 +91,14 @@ export function WaveformEditor({
   }))
   const [selection, setSelection] = useState<Region | null>(null)
   const [clipboard, setClipboard] = useState<Float32Array | null>(null)
+  // A repaint job outlives the selection that started it (any edit/seek clears
+  // the selection), so keep the panel mounted while its poll is active — else
+  // unmounting it would kill the poll and silently drop a paid generation.
+  // (US-18.5)
+  const [repaintActive, setRepaintActive] = useState(false)
+  // The region the repaint panel stays bound to once its job is in flight — the
+  // last non-null selection, so the panel survives the selection being cleared.
+  const [lastSelection, setLastSelection] = useState<Region | null>(null)
   // Pending gain (dB) while the Gain popover is open — drives a live, throwaway
   // waveform preview; null when nothing is being previewed. (US-18.3)
   const [gainPreview, setGainPreview] = useState<number | null>(null)
@@ -200,8 +208,13 @@ export function WaveformEditor({
     return r.endSec > r.startSec ? r : null
   }
 
-  // A drag on the canvas sweeps a new selection.
-  const select = (a: number, b: number) => setSelection(regionOrNull(a, b))
+  // A drag on the canvas sweeps a new selection. Remember the region so a repaint
+  // job started from it keeps the panel mounted after the selection is cleared.
+  const select = (a: number, b: number) => {
+    const r = regionOrNull(a, b)
+    setSelection(r)
+    if (r) setLastSelection(r)
+  }
 
   // A handle drag moves one edge; re-normalize so start ≤ end if they cross.
   const adjustEdge = (edge: "start" | "end", sec: number) =>
@@ -328,6 +341,12 @@ export function WaveformEditor({
   const atMin = !vp || vp.pxPerSec <= fitPx + 1e-6
   const atMax = !!vp && vp.pxPerSec >= MAX_PX_PER_SEC - 1e-6
 
+  // The repaint panel binds to the live selection, or (once its job is in flight
+  // and the selection has been cleared) the last region a drag produced — tracked
+  // in `select` below, so the panel keeps a stable region without reading a ref
+  // during render.
+  const repaintSelection = selection ?? lastSelection
+
   return (
     <div
       className="flex flex-col gap-2"
@@ -420,12 +439,16 @@ export function WaveformEditor({
 
       {/* Repaint mode (US-18.5): a live selection unlocks AI section-regenerate.
           The backend returns a full crossfade-blended child clip; we decode it
-          and push it through the same undo stack as every other edit. */}
-      {selection && (
+          and push it through the same undo stack as every other edit. Kept
+          mounted while a job is active even after the selection clears, so the
+          in-flight poll survives; `repaintSelection` falls back to the region the
+          job was started on for that window. */}
+      {repaintSelection && (selection || repaintActive) && (
         <RepaintPanel
-          selection={selection}
+          selection={repaintSelection}
           clipId={clip.id}
           onRepainted={(nextAudio, op) => pushEdit(nextAudio, op)}
+          onActiveChange={setRepaintActive}
         />
       )}
 

--- a/web/components/editor/WaveformEditor.tsx
+++ b/web/components/editor/WaveformEditor.tsx
@@ -265,14 +265,20 @@ export function WaveformEditor({
     })
   }
 
-  useEditorShortcuts({
-    onCut: () => removeSelected("cut"),
-    onCopy: copy,
-    onPaste: paste,
-    onDelete: () => removeSelected("delete"),
-    onUndo: undo,
-    onRedo: redo,
-  })
+  // Freeze buffer-mutating shortcuts while a repaint job is in flight — its
+  // result will replace the buffer wholesale, so an intervening edit would be
+  // silently reverted yet still logged in the save provenance. (US-18.5)
+  useEditorShortcuts(
+    {
+      onCut: () => removeSelected("cut"),
+      onCopy: copy,
+      onPaste: paste,
+      onDelete: () => removeSelected("delete"),
+      onUndo: undo,
+      onRedo: redo,
+    },
+    !repaintActive
+  )
 
   // --- Processing ops (US-18.3) --------------------------------------------
   // Commit an amplitude transform through the undo/redo history (US-18.4). The
@@ -364,6 +370,7 @@ export function WaveformEditor({
             onRedo={redo}
             canUndo={canUndo}
             canRedo={canRedo}
+            disabled={repaintActive}
           />
           <Button
             type="button"
@@ -390,6 +397,7 @@ export function WaveformEditor({
 
       <EditToolbar
         hasSelection={selection !== null}
+        disabled={repaintActive}
         onFadeIn={fadeIn}
         onFadeOut={fadeOut}
         onSilence={silence}

--- a/web/hooks/use-editor-shortcuts.ts
+++ b/web/hooks/use-editor-shortcuts.ts
@@ -31,14 +31,25 @@ function isEditableTarget(target: EventTarget | null): boolean {
   )
 }
 
-export function useEditorShortcuts(actions: EditorShortcutActions): void {
+export function useEditorShortcuts(
+  actions: EditorShortcutActions,
+  enabled = true
+): void {
   const ref = useRef(actions)
   useEffect(() => {
     ref.current = actions
   }, [actions])
+  // Read through a ref so the once-bound listener sees the latest value without
+  // re-binding — mirrors `actions`. Lets the parent freeze buffer-mutating
+  // shortcuts (cut/paste/delete/undo/redo) while a repaint job is in flight.
+  const enabledRef = useRef(enabled)
+  useEffect(() => {
+    enabledRef.current = enabled
+  }, [enabled])
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
+      if (!enabledRef.current) return
       if (isEditableTarget(e.target)) return
       const mod = e.metaKey || e.ctrlKey
       const a = ref.current

--- a/web/lib/waveform-edit.ts
+++ b/web/lib/waveform-edit.ts
@@ -29,6 +29,11 @@ export type EditOperation =
   | { kind: "gain"; startSec: number; endSec: number; gainDb: number }
   | { kind: "normalize"; startSec: number; endSec: number; targetDb: number }
   | { kind: "crossfade"; positionSec: number; durationSec: number }
+  // US-18.5 AI repaint. Unlike the transforms above, the new samples come from
+  // the backend (a full crossfade-blended child clip) rather than a local buffer
+  // math op; recorded here so the section-regenerate rides the same undo stack +
+  // save-provenance seam as every other edit.
+  | { kind: "repaint"; startSec: number; endSec: number; prompt: string; style?: string }
 
 /** Order two times into a Region with start ≤ end. */
 export function normalizeRegion(a: number, b: number): Region {


### PR DESCRIPTION
## US-18.5: Repaint Mode Integration

Closes #206. Wire the **existing** Stage-17 repaint pipeline into the waveform editor so a musician selects a region and regenerates just that section with AI.

### Key finding
The repaint API layer, form fields, and submit→poll job lifecycle were **already built** (US-17.3: `submitRepaint`, `RepaintPayload`, `useClipEdit`, `ReplaceSectionModal`). US-18.5 is the **editor integration**, not a rebuild — so this PR is a thin wiring layer that reuses all of it.

### What changed
- **`RepaintPanel`** (new) — appears inline when a region is selected. Required instructions + optional style (reusing `StyleTextarea`), a Regenerate button, and inline progress/error chrome driven by the existing `useClipEdit` poll loop. Submits the selected region as the range.
- **`WaveformEditor`** — renders `RepaintPanel` while a selection is live; on completion decodes the backend's child clip (`decodeClipAudio`) and folds it into the editor via `pushEdit`.
- **`EditOperation`** — new `repaint` variant so the operation rides the US-18.4 save-provenance seam.

### Design decisions
1. **Result handling — deviation from the issue's CodeRabbit plan (Design Choice 2).** The plan proposed navigating the editor to the new child clip with a separate navigation-based undo. Instead the full backend-blended child clip is pushed onto the **existing US-18.4 snapshot stack** via `pushEdit`. Rationale: the existing **Undo/Redo button covers repaint for free** (unified undo — a cleaner fit for the "undoable" AC than a second undo mechanism), no navigation flash, and it reuses the exact non-destructive pipeline every other edit already flows through. No backend/contract/data-model change — the child clip is still created server-side.
2. **No lyrics field** — `RepaintPayload`/the API don't accept lyrics (matches CodeRabbit Design Choice 1).
3. **Inline panel, not a modal** — the AC says "selecting a region enables the Repaint *panel*".

### Acceptance criteria
- [x] Selecting a region enables the Repaint mode panel
- [x] Providing instructions and clicking Regenerate submits to the API
- [x] Regenerated section replaces only the selected range in the waveform *(backend returns a full crossfade-blended child clip; loaded whole)*
- [x] Surrounding audio remains intact with smooth transitions *(backend-blended boundaries, US-6.3)*
- [x] Repaint result is undoable *(Undo/Redo, unified with all other edits)*
- [x] Saving creates a new clip version in the workspace *(the repaint job creates the child clip server-side; "Save as new version" still works for further local edits)*

### Testing
- New: `RepaintPanel.test.tsx` (4) — fields/validation, `Ns`-coord payload, success→decode→apply, failure+retry.
- New: `WaveformEditor.test.tsx` (2) — panel visibility gated on selection; completed repaint lands as an undoable edit.
- Full web suite green: **104 files / 735 tests**. `tsc --noEmit` + eslint clean.

### Known limitations
- The repaint result assumes the job returns a **full-length** child clip with only `[start,end]` regenerated + blended (same assumption the plan's navigate-to-clip approach relies on).
- Repaint targets the **persisted source clip** at the selection's seconds; repainting on a locally-dirty buffer (US-18.3 edits applied) is out of scope for this story.
- Playback-vs-edited desync after repaint is **pre-existing** editor behavior (the player holds the original track; edits re-render the canvas only).
- **Demo gate:** the live end-to-end demo needs the GPU/backend stack, which isn't available in this environment — verification here is the test suite. Requesting maintainer sign-off on that evidence before merge.
