### PR TITLE
Add GLM inline review workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,11 +27,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # semver-*-days cooldowns are not supported for github-actions
     cooldown:
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
 
   - package-ecosystem: "docker"
     directory: "/docker"

--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -1,0 +1,23 @@
+name: GLM Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths-ignore:
+      - "**/*.md"
+      - ".gitignore"
+
+jobs:
+  review:
+    # Only review substantial changes (5+ files, or 20+ additions, or 20+ deletions)
+    if: |
+      github.event.pull_request.changed_files >= 5 ||
+      github.event.pull_request.additions >= 20 ||
+      github.event.pull_request.deletions >= 20
+    uses: frankbria/glm-review/.github/workflows/review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets:
+      ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}

--- a/.github/workflows/glm-review.yml
+++ b/.github/workflows/glm-review.yml
@@ -13,7 +13,7 @@ jobs:
       github.event.pull_request.changed_files >= 5 ||
       github.event.pull_request.additions >= 20 ||
       github.event.pull_request.deletions >= 20
-    uses: frankbria/glm-review/.github/workflows/review.yml@main
+    uses: frankbria/glm-review/.github/workflows/review.yml@b877d15a0f8c0855d0d2ebdcce32ae09cec1bb2d # main 2026-07-10
     permissions:
       contents: read
       pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ htmlcov/
 # Beads local issue tracking (local-only, not shared)
 .beads/
 
+# Claude local worktrees/config (local-only, not shared)
+/.claude/
+
 # Per-session planning scratch (local-only). Anchored to the repo root so it
 # does not also ignore source packages named "tasks" (e.g. acemusic/api/tasks).
 /tasks/


### PR DESCRIPTION
Adds the reusable GLM-5.2 inline PR reviewer (frankbria/glm-review): CodeRabbit-style inline comments on defective lines with committable suggestions, bugs-only scope. ZHIPU_API_KEY secret is set. Verified on hai-sh#75.