### PR TITLE
chore(deps): add dependabot config with cooldown stepdown policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot version updates with supply-chain cooldown stepdown:
+# semver ecosystems wait 7d (minor/patch) / 14d (major); others 14d flat.
+# Security-advisory updates bypass cooldown (GitHub behavior).
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
Standardizes dependabot version updates account-wide. Ecosystems auto-detected from the repo tree. Cooldown: semver ecosystems (npm, github-actions) wait 7 days on minor/patch, 14 on major; non-semver (pip/uv/docker) flat 14 days. Security-advisory updates bypass cooldown (GitHub behavior).