### PR TITLE
feat(web): US-19.2 track types and clip import

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -202,6 +202,29 @@ Reached from the song menu's "Open in Studio" action (`open-studio` in
   centralizes the wire shape so drag sources and the lane's drop handler can't
   drift apart.
 
+## Track Types and Clip Import (US-19.2)
+
+Tracks are typed — AI-Generated, Audio, Sound/Loop, Vocal — each with its own
+color and icon; the Add Track button opens a type selector dropdown.
+
+- `lib/track-types.ts` — the type config (label/description/color/icon),
+  `inferTrackType(generation_mode)` (`"upload"` → audio, `"stems"` → vocal,
+  `"sound"` → loop, everything else → ai — matching what the API persists),
+  and `placementPlaybackRate` (loop-track clips stretch to the project tempo:
+  `projectBpm / clipBpm`, 1x elsewhere or without BPM metadata).
+- Strict type matching is enforced authoritatively in the reducer (`ADD_CLIP`
+  re-infers from the payload's `generationMode`; `MOVE_CLIP` rejects
+  cross-type track moves). During dragover, lanes show valid/invalid feedback
+  from a `dataTransfer` *type* entry (`setDragTrackType`/`readDragTrackType`
+  in `lib/clip-drag.ts`) because `getData()` is unavailable until drop; an
+  invalid lane skips `preventDefault`, so the browser itself disallows the
+  drop.
+- Project tempo lives in studio state (`bpm`, default 120, clamped 60–180 to
+  mirror the backend's bounds) behind the header's BPM input. Placements store
+  `clipBpm` and the playback rate is derived at render/schedule time, so a
+  tempo change re-stretches placed loops — including mid-playback, where an
+  effective `SET_BPM` bumps `seekEpoch` to reschedule the running sources.
+
 ## Adding components
 
 To add components to your app, run the following command:

--- a/web/app/studio/page.test.tsx
+++ b/web/app/studio/page.test.tsx
@@ -37,6 +37,7 @@ class FakeGainNode {
 
 class FakeSourceNode {
   buffer: AudioBuffer | null = null
+  playbackRate = { value: 1 }
   connect = vi.fn()
   disconnect = vi.fn()
   start = vi.fn()
@@ -165,6 +166,30 @@ describe("StudioPage header", () => {
     expect(
       screen.getByRole("button", { name: "Return to start" })
     ).toBeInTheDocument()
+  })
+
+  it("renders a project tempo input defaulting to 120 BPM (US-19.2)", () => {
+    renderPage()
+    expect(
+      screen.getByRole("spinbutton", { name: "Project tempo (BPM)" })
+    ).toHaveValue(120)
+  })
+
+  it("commits an edited tempo on blur, clamped to the supported range", async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const input = () =>
+      screen.getByRole("spinbutton", { name: "Project tempo (BPM)" })
+
+    await user.clear(input())
+    await user.type(input(), "90")
+    await user.tab()
+    expect(input()).toHaveValue(90)
+
+    await user.clear(input())
+    await user.type(input(), "999")
+    await user.tab()
+    expect(input()).toHaveValue(180)
   })
 })
 
@@ -361,6 +386,15 @@ describe("StudioPage ?song= preload", () => {
     stubStudioFetch()
     renderPage()
     await waitFor(() => expect(screen.getByText("My Song")).toBeInTheDocument())
+  })
+
+  it("creates the preloaded track with the clip's inferred type (US-19.2)", async () => {
+    searchParamsRef.current = new URLSearchParams("song=clip-1")
+    stubStudioFetch({ ...SONG_CLIP_JSON, generation_mode: "sound" })
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByLabelText("Sound/Loop track")).toBeInTheDocument()
+    )
   })
 
   it("fetches the clip named by the song query param", async () => {

--- a/web/app/studio/page.test.tsx
+++ b/web/app/studio/page.test.tsx
@@ -192,6 +192,22 @@ describe("StudioPage header", () => {
     expect(input()).toHaveValue(180)
   })
 
+  it("re-labels the bars-beats ruler from the project tempo (US-19.2)", async () => {
+    const user = userEvent.setup()
+    renderPage()
+    // 120 BPM: bar = 2s → the "2.1" tick sits at 200px (100px/sec, zoom 1).
+    const tick = () => screen.getByText("2.1").parentElement as HTMLElement
+    expect(tick().style.left).toBe("200px")
+
+    const input = screen.getByRole("spinbutton", { name: "Project tempo (BPM)" })
+    await user.clear(input)
+    await user.type(input, "60")
+    await user.tab()
+
+    // 60 BPM: bar = 4s → the same bar label moves to 400px.
+    expect(tick().style.left).toBe("400px")
+  })
+
   it("reverts to the previous tempo when the input is committed empty (Number('') === 0 footgun)", async () => {
     const user = userEvent.setup()
     renderPage()

--- a/web/app/studio/page.test.tsx
+++ b/web/app/studio/page.test.tsx
@@ -191,6 +191,23 @@ describe("StudioPage header", () => {
     await user.tab()
     expect(input()).toHaveValue(180)
   })
+
+  it("reverts to the previous tempo when the input is committed empty (Number('') === 0 footgun)", async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const input = () =>
+      screen.getByRole("spinbutton", { name: "Project tempo (BPM)" })
+
+    await user.clear(input())
+    await user.type(input(), "140")
+    await user.tab()
+    expect(input()).toHaveValue(140)
+
+    // Clearing and blurring must not commit SET_BPM 0 (which would clamp to 60).
+    await user.clear(input())
+    await user.tab()
+    expect(input()).toHaveValue(140)
+  })
 })
 
 describe("StudioPage playhead", () => {

--- a/web/app/studio/page.tsx
+++ b/web/app/studio/page.tsx
@@ -73,7 +73,9 @@ function TempoInput() {
   const [draft, setDraft] = useState<string | null>(null)
 
   function commit() {
-    if (draft !== null) {
+    // Number("") === 0, so an emptied field would otherwise commit SET_BPM 0
+    // and clamp the project to BPM_MIN — treat blank as "revert" instead.
+    if (draft !== null && draft.trim() !== "") {
       const bpm = Number(draft)
       if (Number.isFinite(bpm)) dispatch({ type: "SET_BPM", bpm })
     }

--- a/web/app/studio/page.tsx
+++ b/web/app/studio/page.tsx
@@ -203,6 +203,7 @@ function StudioTimeline() {
             pxPerSec={pxPerSec}
             durationSec={durationSec}
             displayMode={state.displayMode}
+            bpm={state.bpm}
             onSeek={(sec) => dispatch({ type: "SEEK", sec })}
           />
         </div>

--- a/web/app/studio/page.tsx
+++ b/web/app/studio/page.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { Suspense, useEffect, useMemo, useRef } from "react"
+import { Suspense, useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { ZoomInAreaIcon, ZoomOutAreaIcon } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { AddTrackButton, TrackLane } from "@/components/studio/TrackLane"
 import { Playhead } from "@/components/studio/Playhead"
 import { TimeRuler } from "@/components/studio/TimeRuler"
@@ -23,6 +24,7 @@ import {
   timelineDurationSec,
   zoomToPxPerSec,
 } from "@/lib/timeline"
+import { BPM_MAX, BPM_MIN, inferTrackType } from "@/lib/track-types"
 
 const ZOOM_BUTTON_FACTOR = 1.5
 // Matches the sensitivity used for Ctrl+wheel zoom on the waveform canvas.
@@ -43,7 +45,13 @@ function useSongPreload() {
     if (!clip || preloadedRef.current.has(clip.id)) return
     preloadedRef.current.add(clip.id)
     const trackId = crypto.randomUUID()
-    dispatch({ type: "ADD_TRACK", id: trackId })
+    // The preloaded track takes the clip's own type (US-19.2), so the clip is
+    // guaranteed to land on it.
+    dispatch({
+      type: "ADD_TRACK",
+      id: trackId,
+      trackType: inferTrackType(clip.generation_mode),
+    })
     dispatch({
       type: "ADD_CLIP",
       id: crypto.randomUUID(),
@@ -52,8 +60,44 @@ function useSongPreload() {
       startSec: 0,
       title: clip.title,
       durationSec: clip.duration,
+      generationMode: clip.generation_mode,
+      clipBpm: clip.bpm,
     })
   }, [clip, dispatch])
+}
+
+/** Project tempo control (US-19.2): drafts locally while typing, commits a
+ * clamped SET_BPM on blur/Enter — mirrors TrackLane's rename commit pattern. */
+function TempoInput() {
+  const { state, dispatch } = useStudio()
+  const [draft, setDraft] = useState<string | null>(null)
+
+  function commit() {
+    if (draft !== null) {
+      const bpm = Number(draft)
+      if (Number.isFinite(bpm)) dispatch({ type: "SET_BPM", bpm })
+    }
+    setDraft(null)
+  }
+
+  return (
+    <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      BPM
+      <Input
+        type="number"
+        aria-label="Project tempo (BPM)"
+        min={BPM_MIN}
+        max={BPM_MAX}
+        value={draft ?? state.bpm}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur()
+        }}
+        className="h-8 w-20"
+      />
+    </label>
+  )
 }
 
 function StudioHeader() {
@@ -63,6 +107,7 @@ function StudioHeader() {
       <h1 className="text-2xl font-semibold">Studio</h1>
       <div className="flex items-center gap-2">
         <TransportControls />
+        <TempoInput />
         <Button
           type="button"
           variant="outline"

--- a/web/components/studio/ClipBlock.test.tsx
+++ b/web/components/studio/ClipBlock.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { ClipBlock } from "./ClipBlock"
-import { parseClipDragData } from "@/lib/clip-drag"
+import { parseClipDragData, readDragTrackType } from "@/lib/clip-drag"
 import type { Placement } from "@/lib/timeline"
 
 const { getClipAudioMock } = vi.hoisted(() => ({
@@ -39,6 +39,21 @@ describe("ClipBlock layout", () => {
     const block = getByTestId("clip-block")
     expect(block.style.left).toBe("80px") // 4s * 20px/sec
     expect(block.style.width).toBe("160px") // 8s * 20px/sec
+  })
+
+  it("compresses its width by the playback rate (loop tempo inheritance, US-19.2)", () => {
+    getClipAudioMock.mockReturnValue(new Promise(() => {}))
+    const { getByTestId } = render(
+      <ClipBlock
+        placement={placement}
+        pxPerSec={20}
+        color="#123456"
+        token="tok"
+        playbackRate={4 / 3}
+      />
+    )
+    // 8s of audio at 4/3 speed occupies 6s of timeline → 120px.
+    expect(getByTestId("clip-block").style.width).toBe("120px")
   })
 
   it("renders a null-duration clip at a visible minimum width, not a 1px sliver", () => {
@@ -159,5 +174,29 @@ describe("ClipBlock drag source (reposition via MOVE_CLIP)", () => {
       placementId: "p1",
       grabOffsetSec: 0,
     })
+  })
+
+  it("marks the drag with its track's type so lanes can validate during dragover (US-19.2)", () => {
+    getClipAudioMock.mockReturnValue(new Promise(() => {}))
+    render(
+      <ClipBlock
+        placement={placement}
+        pxPerSec={20}
+        color="#123456"
+        token="tok"
+        trackType="vocal"
+      />
+    )
+    const store = new Map<string, string>()
+    const dataTransfer = {
+      setData: (type: string, value: string) => store.set(type, value),
+      getData: (type: string) => store.get(type) ?? "",
+      get types() {
+        return [...store.keys()]
+      },
+    } as unknown as DataTransfer
+    fireEvent.dragStart(screen.getByTestId("clip-block"), { dataTransfer })
+
+    expect(readDragTrackType(dataTransfer)).toBe("vocal")
   })
 })

--- a/web/components/studio/ClipBlock.tsx
+++ b/web/components/studio/ClipBlock.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useRef, useState, type DragEvent } from "react"
 
 import { getClipAudio } from "@/lib/clip-audio-cache"
-import { setClipDragData } from "@/lib/clip-drag"
+import { setClipDragData, setDragTrackType } from "@/lib/clip-drag"
 import type { Placement } from "@/lib/timeline"
+import type { TrackType } from "@/lib/track-types"
 
 // A clip placed on a Studio track lane (US-19.1). Positioned/sized purely from
 // startSec/durationSec × pxPerSec; the waveform thumbnail draws the cached
@@ -25,14 +26,24 @@ export function ClipBlock({
   pxPerSec,
   color,
   token,
+  trackType,
+  playbackRate = 1,
 }: {
   placement: Placement
   pxPerSec: number
   color: string
   token: string | null
+  /** The owning track's type, marked on move-drags so other lanes can show
+   * valid/invalid feedback during dragover (US-19.2). */
+  trackType?: TrackType
+  /** Loop-track tempo stretch (US-19.2): >1 compresses the clip on screen. */
+  playbackRate?: number
 }) {
   const left = placement.startSec * pxPerSec
-  const width = Math.max(MIN_WIDTH_PX, (placement.durationSec ?? 0) * pxPerSec)
+  const width = Math.max(
+    MIN_WIDTH_PX,
+    ((placement.durationSec ?? 0) / playbackRate) * pxPerSec
+  )
 
   const [peaks, setPeaks] = useState<Float32Array | null>(null)
   useEffect(() => {
@@ -83,6 +94,7 @@ export function ClipBlock({
       // under the cursor instead of snapping the left edge to it.
       grabOffsetSec: Math.max(0, (e.clientX - rect.left) / pxPerSec),
     })
+    if (trackType) setDragTrackType(e.dataTransfer, trackType)
   }
 
   return (

--- a/web/components/studio/TrackLane.test.tsx
+++ b/web/components/studio/TrackLane.test.tsx
@@ -341,6 +341,23 @@ describe("TrackLane drop zone — adding a new clip", () => {
     expect(region.className).not.toMatch(/destructive/)
   })
 
+  it("only allows the native drop (preventDefault on dragover) for matching clip types", () => {
+    // Not calling preventDefault on dragover is how the browser itself
+    // disallows the drop and shows the no-drop cursor.
+    render(<Harness trackType="vocal" />)
+    const region = screen.getByRole("region", { name: "Track 1 timeline" })
+
+    const mismatched = fireEvent.dragOver(region, {
+      dataTransfer: { types: ["application/x-ams-track-type-ai"] },
+    })
+    expect(mismatched).toBe(true) // not prevented → drop disallowed
+
+    const matching = fireEvent.dragOver(region, {
+      dataTransfer: { types: ["application/x-ams-track-type-vocal"] },
+    })
+    expect(matching).toBe(false) // prevented → drop allowed
+  })
+
   it("stretches a dropped loop clip to the project tempo (width from playbackRate)", async () => {
     // 90 BPM, 8s loop in a 120 BPM project → 4/3 rate → 6s × 20px = 120px.
     render(<Harness trackType="loop" />)

--- a/web/components/studio/TrackLane.test.tsx
+++ b/web/components/studio/TrackLane.test.tsx
@@ -3,9 +3,10 @@ import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { act, useEffect, useRef } from "react"
 
-import { TrackLane } from "./TrackLane"
+import { AddTrackButton, TrackLane } from "./TrackLane"
 import { StudioProvider, useStudio } from "@/contexts/studio-context"
 import { TRACK_STRIP_PX } from "@/lib/timeline"
+import { TRACK_TYPES, type TrackType } from "@/lib/track-types"
 
 const { getClipAudioMock } = vi.hoisted(() => ({
   getClipAudioMock: vi.fn(),
@@ -19,27 +20,41 @@ type SeedClip = {
   title: string
   duration: number
   startSec: number
+  generationMode?: string | null
+  clipBpm?: number | null
 }
 
 /** Seeds one track (t1) — optionally with clips — then renders TrackLane bound
  * to the live context state, so a dispatch from within TrackLane (rename, drop)
  * is immediately visible, the same way the real Studio page re-renders lanes
  * off `state.tracks`. */
-function Harness({ clips = [] }: { clips?: SeedClip[] }) {
+function Harness({
+  clips = [],
+  trackType = "ai",
+}: {
+  clips?: SeedClip[]
+  trackType?: TrackType
+}) {
   return (
     <StudioProvider>
-      <Seed clips={clips} />
+      <Seed clips={clips} trackType={trackType} />
     </StudioProvider>
   )
 }
 
-function Seed({ clips }: { clips: SeedClip[] }) {
+function Seed({
+  clips,
+  trackType,
+}: {
+  clips: SeedClip[]
+  trackType: TrackType
+}) {
   const { state, dispatch } = useStudio()
   const seededRef = useRef(false)
   useEffect(() => {
     if (seededRef.current) return
     seededRef.current = true
-    dispatch({ type: "ADD_TRACK", id: "t1", name: "Track 1" })
+    dispatch({ type: "ADD_TRACK", id: "t1", trackType, name: "Track 1" })
     clips.forEach((c, i) => {
       dispatch({
         type: "ADD_CLIP",
@@ -49,6 +64,8 @@ function Seed({ clips }: { clips: SeedClip[] }) {
         startSec: c.startSec,
         title: c.title,
         durationSec: c.duration,
+        generationMode: c.generationMode,
+        clipBpm: c.clipBpm,
       })
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -98,6 +115,70 @@ describe("TrackLane control strip", () => {
     // drift from the ruler spacer / playhead offset that share this constant.
     expect(screen.getByTestId("track-strip").style.width).toBe(
       `${TRACK_STRIP_PX}px`
+    )
+  })
+})
+
+describe("TrackLane track-type indicator (US-19.2)", () => {
+  it("shows the track type's icon with an accessible label", () => {
+    render(<Harness trackType="loop" />)
+    expect(screen.getByLabelText("Sound/Loop track")).toBeInTheDocument()
+  })
+
+  it("accents the strip with the track type's color", () => {
+    render(<Harness trackType="vocal" />)
+    // jsdom normalizes hex to rgb(), so compare in that form.
+    const [r, g, b] = [1, 3, 5].map((i) =>
+      parseInt(TRACK_TYPES.vocal.color.slice(i, i + 2), 16)
+    )
+    expect(screen.getByTestId("track-strip").style.borderLeft).toContain(
+      `rgb(${r}, ${g}, ${b})`
+    )
+  })
+})
+
+describe("AddTrackButton type selector (US-19.2)", () => {
+  function MenuHarness() {
+    return (
+      <StudioProvider>
+        <AddTrackButton />
+        <TrackProbe />
+      </StudioProvider>
+    )
+  }
+  function TrackProbe() {
+    const { state } = useStudio()
+    return (
+      <div data-testid="track-probe">
+        {state.tracks.map((t) => t.trackType).join(",")}
+      </div>
+    )
+  }
+
+  it("offers all four track types and creates a track of the chosen type", async () => {
+    const user = userEvent.setup()
+    render(<MenuHarness />)
+    await user.click(screen.getByRole("button", { name: /Add Track/i }))
+    for (const label of ["AI-Generated", "Audio", "Sound/Loop", "Vocal"]) {
+      expect(
+        screen.getByRole("menuitem", { name: new RegExp(label) })
+      ).toBeInTheDocument()
+    }
+    await user.click(screen.getByRole("menuitem", { name: /Sound\/Loop/ }))
+    expect(screen.getByTestId("track-probe")).toHaveTextContent("loop")
+  })
+
+  it("can create every track type (US-19.2 acceptance)", async () => {
+    const user = userEvent.setup()
+    render(<MenuHarness />)
+    for (const label of ["AI-Generated", "Audio", "Sound/Loop", "Vocal"]) {
+      await user.click(screen.getByRole("button", { name: /Add Track/i }))
+      await user.click(
+        screen.getByRole("menuitem", { name: new RegExp(label) })
+      )
+    }
+    expect(screen.getByTestId("track-probe")).toHaveTextContent(
+      "ai,audio,loop,vocal"
     )
   })
 })
@@ -217,6 +298,72 @@ describe("TrackLane drop zone — adding a new clip", () => {
       region.dispatchEvent(dragLeaveEventWithRelatedTarget(document.body))
     })
     expect(region.className).not.toMatch(/bg-accent/)
+  })
+
+  it("rejects a drop whose clip type mismatches the track type (US-19.2)", () => {
+    render(<Harness trackType="vocal" />)
+    const region = screen.getByRole("region", { name: "Track 1 timeline" })
+    vi.spyOn(region, "getBoundingClientRect").mockReturnValue(zeroRect())
+
+    fireEvent.drop(region, {
+      dataTransfer: {
+        getData: () =>
+          JSON.stringify({
+            kind: "add",
+            clipId: "c1",
+            title: "AI song",
+            duration: 10,
+            generationMode: "song",
+          }),
+      },
+    })
+
+    expect(screen.queryAllByTestId("clip-block")).toHaveLength(0)
+  })
+
+  it("marks the lane invalid during dragover of a mismatched clip type", () => {
+    render(<Harness trackType="vocal" />)
+    const region = screen.getByRole("region", { name: "Track 1 timeline" })
+    fireEvent.dragEnter(region, {
+      dataTransfer: { types: ["application/x-ams-track-type-ai"] },
+    })
+    expect(region.className).toMatch(/destructive/)
+    expect(region.className).not.toMatch(/bg-accent/)
+  })
+
+  it("keeps the normal highlight during dragover of a matching clip type", () => {
+    render(<Harness trackType="vocal" />)
+    const region = screen.getByRole("region", { name: "Track 1 timeline" })
+    fireEvent.dragEnter(region, {
+      dataTransfer: { types: ["application/x-ams-track-type-vocal"] },
+    })
+    expect(region.className).toMatch(/bg-accent/)
+    expect(region.className).not.toMatch(/destructive/)
+  })
+
+  it("stretches a dropped loop clip to the project tempo (width from playbackRate)", async () => {
+    // 90 BPM, 8s loop in a 120 BPM project → 4/3 rate → 6s × 20px = 120px.
+    render(<Harness trackType="loop" />)
+    const region = screen.getByRole("region", { name: "Track 1 timeline" })
+    vi.spyOn(region, "getBoundingClientRect").mockReturnValue(zeroRect())
+
+    fireEvent.drop(region, {
+      dataTransfer: {
+        getData: () =>
+          JSON.stringify({
+            kind: "add",
+            clipId: "c1",
+            title: "Loop",
+            duration: 8,
+            generationMode: "sound",
+            bpm: 90,
+          }),
+      },
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId("clip-block").style.width).toBe("120px")
+    )
   })
 
   it("clamps a drop left of the lane's origin to startSec 0", async () => {

--- a/web/components/studio/TrackLane.tsx
+++ b/web/components/studio/TrackLane.tsx
@@ -123,6 +123,9 @@ export function TrackLane({
         }}
       >
         <span
+          // aria-label is prohibited on role=generic (a bare span); role="img"
+          // makes the accessible name spec-valid for screenreaders.
+          role="img"
           aria-label={`${typeConfig.label} track`}
           className="shrink-0"
           style={{ color: track.color }}

--- a/web/components/studio/TrackLane.tsx
+++ b/web/components/studio/TrackLane.tsx
@@ -5,11 +5,22 @@ import { HugeiconsIcon } from "@hugeicons/react"
 import { Add01Icon } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { ClipBlock } from "@/components/studio/ClipBlock"
 import { useStudio, type StudioTrack } from "@/contexts/studio-context"
-import { parseClipDragData } from "@/lib/clip-drag"
+import { parseClipDragData, readDragTrackType } from "@/lib/clip-drag"
 import { TRACK_STRIP_PX, xToSec } from "@/lib/timeline"
+import {
+  TRACK_TYPES,
+  TRACK_TYPE_ORDER,
+  placementPlaybackRate,
+} from "@/lib/track-types"
 import { cn } from "@/lib/utils"
 
 // A track row: an editable-name control strip on the left, and a drop-target
@@ -17,7 +28,14 @@ import { cn } from "@/lib/utils"
 // drop kinds (lib/clip-drag.ts): a fresh clip dragged in from the workspace
 // panel ("add") or an existing placement being repositioned from this or
 // another lane ("move") — the x position of the drop converts to a start time
-// via xToSec either way.
+// via xToSec either way. Tracks are typed (US-19.2): mismatched clips get
+// invalid-drop feedback during dragover, and the reducer rejects them
+// authoritatively on drop.
+
+/** Valid/invalid drop feedback while a drag hovers the lane. A drag with no
+ * track-type entry (external files, unit tests) reads as valid — the drop
+ * handler and reducer still validate the actual payload. */
+type DragOverState = null | "valid" | "invalid"
 
 export function TrackLane({
   track,
@@ -28,10 +46,11 @@ export function TrackLane({
   pxPerSec: number
   token: string | null
 }) {
-  const { dispatch } = useStudio()
+  const { state, dispatch } = useStudio()
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(track.name)
-  const [dragOver, setDragOver] = useState(false)
+  const [dragOver, setDragOver] = useState<DragOverState>(null)
+  const typeConfig = TRACK_TYPES[track.trackType]
 
   function startEdit() {
     setDraft(track.name)
@@ -46,9 +65,23 @@ export function TrackLane({
     }
   }
 
+  function dragValidity(e: DragEvent<HTMLDivElement>): DragOverState {
+    const dragType = e.dataTransfer ? readDragTrackType(e.dataTransfer) : null
+    return dragType && dragType !== track.trackType ? "invalid" : "valid"
+  }
+
+  function onDragOver(e: DragEvent<HTMLDivElement>) {
+    if (dragValidity(e) === "invalid") {
+      // No preventDefault → the browser disallows the drop and shows the
+      // platform's no-drop cursor; the tinted lane says why.
+      return
+    }
+    e.preventDefault()
+  }
+
   function onDrop(e: DragEvent<HTMLDivElement>) {
     e.preventDefault()
-    setDragOver(false)
+    setDragOver(null)
     const payload = parseClipDragData(e.dataTransfer)
     if (!payload) return
 
@@ -64,6 +97,8 @@ export function TrackLane({
         startSec: Math.max(0, cursorSec),
         title: payload.title,
         durationSec: payload.duration,
+        generationMode: payload.generationMode,
+        clipBpm: payload.bpm,
       })
     } else {
       dispatch({
@@ -81,12 +116,19 @@ export function TrackLane({
     <div data-testid="track-lane" className="flex border-b border-border">
       <div
         data-testid="track-strip"
-        className="flex shrink-0 items-center p-2"
+        className="flex shrink-0 items-center gap-1.5 p-2"
         style={{
           width: TRACK_STRIP_PX,
           borderLeft: `4px solid ${track.color}`,
         }}
       >
+        <span
+          aria-label={`${typeConfig.label} track`}
+          className="shrink-0"
+          style={{ color: track.color }}
+        >
+          <HugeiconsIcon icon={typeConfig.icon} size={16} />
+        </span>
         {editing ? (
           <Input
             aria-label="Track name"
@@ -118,16 +160,20 @@ export function TrackLane({
       <div
         role="region"
         aria-label={`${track.name} timeline`}
-        className={cn("relative min-h-16 flex-1", dragOver && "bg-accent/40")}
-        onDragOver={(e) => e.preventDefault()}
-        onDragEnter={() => setDragOver(true)}
+        className={cn(
+          "relative min-h-16 flex-1",
+          dragOver === "valid" && "bg-accent/40",
+          dragOver === "invalid" && "bg-destructive/10"
+        )}
+        onDragOver={onDragOver}
+        onDragEnter={(e) => setDragOver(dragValidity(e))}
         onDragLeave={(e) => {
           // A dragLeave also fires when the pointer moves onto a child
           // ClipBlock (still within this lane) — only clear once it's truly
           // left the lane's own box, or the highlight flickers on every clip
           // it drags over.
           if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-            setDragOver(false)
+            setDragOver(null)
           }
         }}
         onDrop={onDrop}
@@ -139,6 +185,12 @@ export function TrackLane({
             pxPerSec={pxPerSec}
             color={track.color}
             token={token}
+            trackType={track.trackType}
+            playbackRate={placementPlaybackRate(
+              placement.clipBpm,
+              track.trackType,
+              state.bpm
+            )}
           />
         ))}
       </div>
@@ -146,18 +198,44 @@ export function TrackLane({
   )
 }
 
-/** Appends a new track to the studio (US-19.1). */
+/** Appends a new track of the chosen type to the studio (US-19.1, US-19.2). */
 export function AddTrackButton() {
   const { dispatch } = useStudio()
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      onClick={() => dispatch({ type: "ADD_TRACK", id: crypto.randomUUID() })}
-    >
-      <HugeiconsIcon icon={Add01Icon} data-icon="inline-start" />
-      Add Track
-    </Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          <HugeiconsIcon icon={Add01Icon} data-icon="inline-start" />
+          Add Track
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {TRACK_TYPE_ORDER.map((type) => {
+          const cfg = TRACK_TYPES[type]
+          return (
+            <DropdownMenuItem
+              key={type}
+              onSelect={() =>
+                dispatch({
+                  type: "ADD_TRACK",
+                  id: crypto.randomUUID(),
+                  trackType: type,
+                })
+              }
+            >
+              <span style={{ color: cfg.color }}>
+                <HugeiconsIcon icon={cfg.icon} size={16} />
+              </span>
+              <span className="flex flex-col">
+                <span>{cfg.label}</span>
+                <span className="text-xs text-muted-foreground">
+                  {cfg.description}
+                </span>
+              </span>
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/web/components/workspace/ClipCard.test.tsx
+++ b/web/components/workspace/ClipCard.test.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react"
 import { ClipCard, type ClipCardProps } from "@/components/workspace/ClipCard"
 import { AuthContext } from "@/contexts/auth-context"
 import { PlayerProvider, usePlayer } from "@/contexts/player-context"
-import { parseClipDragData } from "@/lib/clip-drag"
+import { parseClipDragData, readDragTrackType } from "@/lib/clip-drag"
 import type { Clip } from "@/lib/workspace-clips"
 
 // The ⋯ menu now dispatches through useSongActions (US-17.5): navigation uses the
@@ -398,7 +398,15 @@ describe("ClipCard", () => {
   })
 
   it("is draggable, carrying an 'add' payload for the Studio timeline (US-19.1)", () => {
-    renderCard({ clip: clip({ id: "c1", title: "Midnight", duration: 95 }) })
+    renderCard({
+      clip: clip({
+        id: "c1",
+        title: "Midnight",
+        duration: 95,
+        generation_mode: "sound",
+        bpm: 90,
+      }),
+    })
     const card = screen.getByTestId("clip-card")
     expect(card).toHaveAttribute("draggable", "true")
 
@@ -406,6 +414,9 @@ describe("ClipCard", () => {
     const dataTransfer = {
       setData: (type: string, value: string) => store.set(type, value),
       getData: (type: string) => store.get(type) ?? "",
+      get types() {
+        return [...store.keys()]
+      },
     } as unknown as DataTransfer
     fireEvent.dragStart(card, { dataTransfer })
 
@@ -414,6 +425,11 @@ describe("ClipCard", () => {
       clipId: "c1",
       title: "Midnight",
       duration: 95,
+      generationMode: "sound",
+      bpm: 90,
     })
+    // Track type entry, readable during dragover for drop-target validation
+    // (US-19.2): a "sound" clip belongs on Sound/Loop tracks.
+    expect(readDragTrackType(dataTransfer)).toBe("loop")
   })
 })

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -35,7 +35,8 @@ import { ShareModal } from "@/components/song/ShareModal"
 import { SongActionModal } from "@/components/song/SongActionModal"
 import { usePlayer } from "@/contexts/player-context"
 import { useSongActions } from "@/hooks/use-song-actions"
-import { setClipDragData } from "@/lib/clip-drag"
+import { setClipDragData, setDragTrackType } from "@/lib/clip-drag"
+import { inferTrackType } from "@/lib/track-types"
 import { modeLabel, versionLabel } from "@/lib/clip-labels"
 import { formatTime, trackFromClip } from "@/lib/clips"
 import { isFullSongEligible } from "@/lib/song-structure"
@@ -204,14 +205,19 @@ export function ClipCard({
     <div
       data-testid="clip-card"
       draggable
-      onDragStart={(e) =>
+      onDragStart={(e) => {
         setClipDragData(e.dataTransfer, {
           kind: "add",
           clipId: clip.id,
           title: title ?? null,
           duration: clip.duration,
+          generationMode: clip.generation_mode,
+          bpm: clip.bpm,
         })
-      }
+        // Track type entry, readable during dragover so studio lanes can show
+        // valid/invalid drop feedback (US-19.2).
+        setDragTrackType(e.dataTransfer, inferTrackType(clip.generation_mode))
+      }}
       className="flex gap-3 rounded-lg border border-border bg-card p-2"
     >
       {/* Thumbnail with duration overlay + hover play. */}

--- a/web/contexts/studio-context.test.ts
+++ b/web/contexts/studio-context.test.ts
@@ -359,6 +359,13 @@ describe("studioReducer project tempo (US-19.2)", () => {
   it("SET_BPM ignores a non-finite value", () => {
     expect(studioReducer(base(), { type: "SET_BPM", bpm: NaN }).bpm).toBe(120)
   })
+
+  it("SET_BPM bumps seekEpoch so an in-flight playback reschedules at the new rates", () => {
+    const s = studioReducer(base(), { type: "SET_BPM", bpm: 150 })
+    expect(s.seekEpoch).toBe(1)
+    // An ignored non-finite value must not force a pointless reschedule.
+    expect(studioReducer(base(), { type: "SET_BPM", bpm: NaN }).seekEpoch).toBe(0)
+  })
 })
 
 describe("studioReducer transport + view state", () => {

--- a/web/contexts/studio-context.test.ts
+++ b/web/contexts/studio-context.test.ts
@@ -370,8 +370,8 @@ describe("studioReducer project tempo (US-19.2)", () => {
   it("SET_BPM is a full no-op when the clamped value equals the current tempo", () => {
     // Re-committing the same value (or clamping into the same value) must not
     // bump seekEpoch — that would audibly restart an in-flight playback.
-    const same = studioReducer(base(), { type: "SET_BPM", bpm: 120 })
-    expect(same).toBe(initialStudioState)
+    const s0 = base()
+    expect(studioReducer(s0, { type: "SET_BPM", bpm: 120 })).toBe(s0)
 
     const atCeiling = studioReducer(base({ bpm: 180 }), {
       type: "SET_BPM",

--- a/web/contexts/studio-context.test.ts
+++ b/web/contexts/studio-context.test.ts
@@ -5,6 +5,7 @@ import {
   studioReducer,
   type StudioState,
 } from "@/contexts/studio-context"
+import { TRACK_TYPES, TRACK_TYPE_ORDER } from "@/lib/track-types"
 
 const base = (over: Partial<StudioState> = {}): StudioState => ({
   ...initialStudioState,
@@ -12,23 +13,47 @@ const base = (over: Partial<StudioState> = {}): StudioState => ({
 })
 
 describe("studioReducer tracks", () => {
-  it("ADD_TRACK appends a track with a generated name and cycling color", () => {
-    const s1 = studioReducer(base(), { type: "ADD_TRACK", id: "t1" })
+  it("ADD_TRACK appends a track typed with the requested track type and its color", () => {
+    const s1 = studioReducer(base(), {
+      type: "ADD_TRACK",
+      id: "t1",
+      trackType: "ai",
+    })
     expect(s1.tracks).toHaveLength(1)
-    expect(s1.tracks[0]).toMatchObject({ id: "t1", name: "Track 1", clips: [] })
-    expect(s1.tracks[0].color).toBeTruthy()
+    expect(s1.tracks[0]).toMatchObject({
+      id: "t1",
+      name: "Track 1",
+      trackType: "ai",
+      color: TRACK_TYPES.ai.color,
+      clips: [],
+    })
 
-    const s2 = studioReducer(s1, { type: "ADD_TRACK", id: "t2" })
+    const s2 = studioReducer(s1, {
+      type: "ADD_TRACK",
+      id: "t2",
+      trackType: "loop",
+    })
     expect(s2.tracks).toHaveLength(2)
     expect(s2.tracks[1].name).toBe("Track 2")
-    // Distinct per-track colors (plan requirement).
-    expect(s2.tracks[1].color).not.toBe(s2.tracks[0].color)
+    expect(s2.tracks[1]).toMatchObject({
+      trackType: "loop",
+      color: TRACK_TYPES.loop.color,
+    })
+  })
+
+  it("all four track types can be created (US-19.2 acceptance)", () => {
+    let s = base()
+    for (const [i, trackType] of TRACK_TYPE_ORDER.entries()) {
+      s = studioReducer(s, { type: "ADD_TRACK", id: `t${i}`, trackType })
+    }
+    expect(s.tracks.map((t) => t.trackType)).toEqual(TRACK_TYPE_ORDER)
   })
 
   it("ADD_TRACK honors an explicit name/color", () => {
     const s = studioReducer(base(), {
       type: "ADD_TRACK",
       id: "t1",
+      trackType: "audio",
       name: "Drums",
       color: "#ff0000",
     })
@@ -36,22 +61,26 @@ describe("studioReducer tracks", () => {
   })
 
   it("REMOVE_TRACK drops the matching track", () => {
-    let s = studioReducer(base(), { type: "ADD_TRACK", id: "t1" })
-    s = studioReducer(s, { type: "ADD_TRACK", id: "t2" })
+    let s = studioReducer(base(), { type: "ADD_TRACK", id: "t1", trackType: "ai" })
+    s = studioReducer(s, { type: "ADD_TRACK", id: "t2", trackType: "ai" })
     s = studioReducer(s, { type: "REMOVE_TRACK", trackId: "t1" })
     expect(s.tracks.map((t) => t.id)).toEqual(["t2"])
   })
 
   it("RENAME_TRACK updates the matching track's name", () => {
-    let s = studioReducer(base(), { type: "ADD_TRACK", id: "t1" })
-    s = studioReducer(s, { type: "ADD_TRACK", id: "t2" })
+    let s = studioReducer(base(), { type: "ADD_TRACK", id: "t1", trackType: "ai" })
+    s = studioReducer(s, { type: "ADD_TRACK", id: "t2", trackType: "ai" })
     s = studioReducer(s, { type: "RENAME_TRACK", trackId: "t1", name: "Drums" })
     expect(s.tracks[0].name).toBe("Drums")
     expect(s.tracks[1].name).toBe("Track 2")
   })
 
   it("RENAME_TRACK on an unknown track is a no-op", () => {
-    const s = studioReducer(base(), { type: "ADD_TRACK", id: "t1" })
+    const s = studioReducer(base(), {
+      type: "ADD_TRACK",
+      id: "t1",
+      trackType: "ai",
+    })
     expect(
       studioReducer(s, { type: "RENAME_TRACK", trackId: "missing", name: "X" })
     ).toBe(s)
@@ -63,6 +92,7 @@ describe("studioReducer clips", () => {
     return studioReducer(base(), {
       type: "ADD_TRACK",
       id: "t1",
+      trackType: "ai",
       name: "Track 1",
     })
   }
@@ -84,8 +114,69 @@ describe("studioReducer clips", () => {
         startSec: 4,
         title: "My Clip",
         durationSec: 12,
+        clipBpm: null,
       },
     ])
+  })
+
+  it("ADD_CLIP accepts a clip whose inferred type matches the track and stores its BPM", () => {
+    let s = studioReducer(base(), {
+      type: "ADD_TRACK",
+      id: "loop1",
+      trackType: "loop",
+    })
+    s = studioReducer(s, {
+      type: "ADD_CLIP",
+      id: "p1",
+      trackId: "loop1",
+      clipId: "clip-a",
+      startSec: 0,
+      title: "Loop",
+      durationSec: 8,
+      generationMode: "sound",
+      clipBpm: 90,
+    })
+    expect(s.tracks[0].clips).toHaveLength(1)
+    expect(s.tracks[0].clips[0].clipBpm).toBe(90)
+  })
+
+  it("ADD_CLIP rejects a clip whose inferred type mismatches the track (US-19.2 strict typing)", () => {
+    let s = studioReducer(base(), {
+      type: "ADD_TRACK",
+      id: "vocal1",
+      trackType: "vocal",
+    })
+    const before = s
+    s = studioReducer(s, {
+      type: "ADD_CLIP",
+      id: "p1",
+      trackId: "vocal1",
+      clipId: "clip-a",
+      startSec: 0,
+      title: "AI song",
+      durationSec: 8,
+      generationMode: "song",
+    })
+    expect(s).toBe(before)
+    expect(s.tracks[0].clips).toEqual([])
+  })
+
+  it("ADD_CLIP with no generationMode is treated as AI-generated (only ai tracks accept it)", () => {
+    let s = studioReducer(base(), {
+      type: "ADD_TRACK",
+      id: "audio1",
+      trackType: "audio",
+    })
+    s = studioReducer(s, {
+      type: "ADD_CLIP",
+      id: "p1",
+      trackId: "audio1",
+      clipId: "clip-a",
+      startSec: 0,
+      title: null,
+      durationSec: null,
+    })
+    expect(s.tracks[0].clips).toEqual([])
   })
 
   it("ADD_CLIP on an unknown track is a no-op", () => {
@@ -119,7 +210,14 @@ describe("studioReducer clips", () => {
       startSec: 10,
     })
     expect(s.tracks[0].clips).toEqual([
-      { id: "p1", clipId: "clip-a", startSec: 10, title: "A", durationSec: 5 },
+      {
+        id: "p1",
+        clipId: "clip-a",
+        startSec: 10,
+        title: "A",
+        durationSec: 5,
+        clipBpm: null,
+      },
     ])
   })
 
@@ -142,10 +240,11 @@ describe("studioReducer clips", () => {
     expect(s.tracks[0].clips[0].startSec).toBe(0)
   })
 
-  it("MOVE_CLIP across tracks removes from the source and adds to the destination", () => {
+  it("MOVE_CLIP across same-type tracks removes from the source and adds to the destination", () => {
     let s = studioReducer(withTrack(), {
       type: "ADD_TRACK",
       id: "t2",
+      trackType: "ai",
       name: "Track 2",
     })
     s = studioReducer(s, {
@@ -165,8 +264,42 @@ describe("studioReducer clips", () => {
     })
     expect(s.tracks[0].clips).toEqual([])
     expect(s.tracks[1].clips).toEqual([
-      { id: "p1", clipId: "clip-a", startSec: 3, title: "A", durationSec: 5 },
+      {
+        id: "p1",
+        clipId: "clip-a",
+        startSec: 3,
+        title: "A",
+        durationSec: 5,
+        clipBpm: null,
+      },
     ])
+  })
+
+  it("MOVE_CLIP to a different-type track is a no-op (US-19.2 strict typing)", () => {
+    let s = studioReducer(withTrack(), {
+      type: "ADD_TRACK",
+      id: "vocal1",
+      trackType: "vocal",
+    })
+    s = studioReducer(s, {
+      type: "ADD_CLIP",
+      id: "p1",
+      trackId: "t1",
+      clipId: "clip-a",
+      startSec: 0,
+      title: "A",
+      durationSec: 5,
+    })
+    const before = s
+    s = studioReducer(s, {
+      type: "MOVE_CLIP",
+      trackId: "vocal1",
+      placementId: "p1",
+      startSec: 3,
+    })
+    expect(s).toBe(before)
+    expect(s.tracks[0].clips).toHaveLength(1)
+    expect(s.tracks[1].clips).toEqual([])
   })
 
   it("MOVE_CLIP with an unknown placement id is a no-op", () => {
@@ -200,8 +333,31 @@ describe("studioReducer clips", () => {
     })
     expect(s).toBe(before)
     expect(s.tracks[0].clips).toEqual([
-      { id: "p1", clipId: "clip-a", startSec: 0, title: "A", durationSec: 5 },
+      {
+        id: "p1",
+        clipId: "clip-a",
+        startSec: 0,
+        title: "A",
+        durationSec: 5,
+        clipBpm: null,
+      },
     ])
+  })
+})
+
+describe("studioReducer project tempo (US-19.2)", () => {
+  it("defaults the project tempo to 120 BPM", () => {
+    expect(initialStudioState.bpm).toBe(120)
+  })
+
+  it("SET_BPM updates the tempo and clamps to the supported range", () => {
+    expect(studioReducer(base(), { type: "SET_BPM", bpm: 90 }).bpm).toBe(90)
+    expect(studioReducer(base(), { type: "SET_BPM", bpm: 500 }).bpm).toBe(180)
+    expect(studioReducer(base(), { type: "SET_BPM", bpm: 10 }).bpm).toBe(60)
+  })
+
+  it("SET_BPM ignores a non-finite value", () => {
+    expect(studioReducer(base(), { type: "SET_BPM", bpm: NaN }).bpm).toBe(120)
   })
 })
 

--- a/web/contexts/studio-context.test.ts
+++ b/web/contexts/studio-context.test.ts
@@ -366,6 +366,20 @@ describe("studioReducer project tempo (US-19.2)", () => {
     // An ignored non-finite value must not force a pointless reschedule.
     expect(studioReducer(base(), { type: "SET_BPM", bpm: NaN }).seekEpoch).toBe(0)
   })
+
+  it("SET_BPM is a full no-op when the clamped value equals the current tempo", () => {
+    // Re-committing the same value (or clamping into the same value) must not
+    // bump seekEpoch — that would audibly restart an in-flight playback.
+    const same = studioReducer(base(), { type: "SET_BPM", bpm: 120 })
+    expect(same).toBe(initialStudioState)
+
+    const atCeiling = studioReducer(base({ bpm: 180 }), {
+      type: "SET_BPM",
+      bpm: 999,
+    })
+    expect(atCeiling.seekEpoch).toBe(0)
+    expect(atCeiling.bpm).toBe(180)
+  })
 })
 
 describe("studioReducer transport + view state", () => {

--- a/web/contexts/studio-context.tsx
+++ b/web/contexts/studio-context.tsx
@@ -8,11 +8,20 @@ import {
   type ReactNode,
 } from "react"
 
-import { clampZoom, type DisplayMode, type Placement } from "@/lib/timeline"
+import { clampZoom, DEFAULT_BPM, type DisplayMode, type Placement } from "@/lib/timeline"
+import {
+  BPM_MAX,
+  BPM_MIN,
+  TRACK_TYPES,
+  inferTrackType,
+  type TrackType,
+} from "@/lib/track-types"
 
 export type StudioTrack = {
   id: string
   name: string
+  /** Which clip category this track accepts (US-19.2). */
+  trackType: TrackType
   color: string
   clips: Placement[]
 }
@@ -23,6 +32,8 @@ export type StudioState = {
   isPlaying: boolean
   zoom: number
   displayMode: DisplayMode
+  /** Project tempo — loop-track clips stretch to match it (US-19.2). */
+  bpm: number
   // Bumped only by a user-initiated SEEK (never by the rAF loop's own
   // SET_PLAYHEAD ticks) — the playback engine watches this to reschedule
   // audio from the new position instead of stomping it on the next frame.
@@ -35,21 +46,18 @@ export const initialStudioState: StudioState = {
   isPlaying: false,
   zoom: 1,
   displayMode: "bars-beats",
+  bpm: DEFAULT_BPM,
   seekEpoch: 0,
 }
 
-// Distinct per-track colors (plan requirement), cycled by track index.
-const TRACK_COLORS = [
-  "#6d28d9",
-  "#0ea5e9",
-  "#f97316",
-  "#22c55e",
-  "#ec4899",
-  "#eab308",
-]
-
 export type StudioAction =
-  | { type: "ADD_TRACK"; id: string; name?: string; color?: string }
+  | {
+      type: "ADD_TRACK"
+      id: string
+      trackType: TrackType
+      name?: string
+      color?: string
+    }
   | { type: "REMOVE_TRACK"; trackId: string }
   | { type: "RENAME_TRACK"; trackId: string; name: string }
   | {
@@ -60,6 +68,10 @@ export type StudioAction =
       startSec: number
       title: string | null
       durationSec: number | null
+      /** For track-type matching; undefined/null infers as AI-generated. */
+      generationMode?: string | null
+      /** For loop-track tempo inheritance. */
+      clipBpm?: number | null
     }
   | {
       type: "MOVE_CLIP"
@@ -71,6 +83,7 @@ export type StudioAction =
   | { type: "SEEK"; sec: number }
   | { type: "SET_PLAYING"; playing: boolean }
   | { type: "SET_ZOOM"; zoom: number }
+  | { type: "SET_BPM"; bpm: number }
   | { type: "TOGGLE_DISPLAY_MODE" }
 
 export function studioReducer(
@@ -82,9 +95,9 @@ export function studioReducer(
       const track: StudioTrack = {
         id: action.id,
         name: action.name ?? `Track ${state.tracks.length + 1}`,
-        color:
-          action.color ??
-          TRACK_COLORS[state.tracks.length % TRACK_COLORS.length],
+        trackType: action.trackType,
+        // Type color by default — the type IS the visual identity (US-19.2).
+        color: action.color ?? TRACK_TYPES[action.trackType].color,
         clips: [],
       }
       return { ...state, tracks: [...state.tracks, track] }
@@ -104,12 +117,21 @@ export function studioReducer(
       }
     }
     case "ADD_CLIP": {
+      const track = state.tracks.find((t) => t.id === action.trackId)
+      if (!track) return state
+      // Strict type matching (US-19.2): a clip only lands on a track of its
+      // inferred type. The drop target gives visual feedback during the drag;
+      // this is the authoritative check.
+      if (inferTrackType(action.generationMode) !== track.trackType) {
+        return state
+      }
       const placement: Placement = {
         id: action.id,
         clipId: action.clipId,
         startSec: action.startSec,
         title: action.title,
         durationSec: action.durationSec,
+        clipBpm: action.clipBpm ?? null,
       }
       return {
         ...state,
@@ -119,12 +141,16 @@ export function studioReducer(
       }
     }
     case "MOVE_CLIP": {
-      if (!state.tracks.some((t) => t.id === action.trackId)) return state
+      const dest = state.tracks.find((t) => t.id === action.trackId)
+      if (!dest) return state
       const source = state.tracks.find((t) =>
         t.clips.some((c) => c.id === action.placementId)
       )
       const original = source?.clips.find((c) => c.id === action.placementId)
       if (!source || !original) return state
+      // A clip was validated against its track's type on entry, so same-type
+      // moves are always safe; cross-type moves are rejected (US-19.2).
+      if (source.trackType !== dest.trackType) return state
       const relocated: Placement = {
         ...original,
         startSec: Math.max(0, action.startSec),
@@ -154,6 +180,10 @@ export function studioReducer(
       return { ...state, isPlaying: action.playing }
     case "SET_ZOOM":
       return { ...state, zoom: clampZoom(action.zoom) }
+    case "SET_BPM": {
+      if (!Number.isFinite(action.bpm)) return state
+      return { ...state, bpm: Math.min(BPM_MAX, Math.max(BPM_MIN, action.bpm)) }
+    }
     case "TOGGLE_DISPLAY_MODE":
       return {
         ...state,

--- a/web/contexts/studio-context.tsx
+++ b/web/contexts/studio-context.tsx
@@ -182,7 +182,14 @@ export function studioReducer(
       return { ...state, zoom: clampZoom(action.zoom) }
     case "SET_BPM": {
       if (!Number.isFinite(action.bpm)) return state
-      return { ...state, bpm: Math.min(BPM_MAX, Math.max(BPM_MIN, action.bpm)) }
+      return {
+        ...state,
+        bpm: Math.min(BPM_MAX, Math.max(BPM_MIN, action.bpm)),
+        // A tempo change re-rates loop-track clips; treat it like a seek so a
+        // playback already in flight reschedules its sources at the new rates
+        // (the engine only watches isPlaying/seekEpoch).
+        seekEpoch: state.seekEpoch + 1,
+      }
     }
     case "TOGGLE_DISPLAY_MODE":
       return {

--- a/web/contexts/studio-context.tsx
+++ b/web/contexts/studio-context.tsx
@@ -34,9 +34,10 @@ export type StudioState = {
   displayMode: DisplayMode
   /** Project tempo — loop-track clips stretch to match it (US-19.2). */
   bpm: number
-  // Bumped only by a user-initiated SEEK (never by the rAF loop's own
-  // SET_PLAYHEAD ticks) — the playback engine watches this to reschedule
-  // audio from the new position instead of stomping it on the next frame.
+  // Bumped by user-initiated SEEKs and effective BPM changes (never by the
+  // rAF loop's own SET_PLAYHEAD ticks) — the playback engine watches this to
+  // reschedule audio from the new position/rates instead of stomping it on
+  // the next frame.
   seekEpoch: number
 }
 
@@ -182,9 +183,13 @@ export function studioReducer(
       return { ...state, zoom: clampZoom(action.zoom) }
     case "SET_BPM": {
       if (!Number.isFinite(action.bpm)) return state
+      const bpm = Math.min(BPM_MAX, Math.max(BPM_MIN, action.bpm))
+      // No-op commits (same value, or clamped into the same value) must not
+      // bump seekEpoch — that would audibly restart an in-flight playback.
+      if (bpm === state.bpm) return state
       return {
         ...state,
-        bpm: Math.min(BPM_MAX, Math.max(BPM_MIN, action.bpm)),
+        bpm,
         // A tempo change re-rates loop-track clips; treat it like a seek so a
         // playback already in flight reschedules its sources at the new rates
         // (the engine only watches isPlaying/seekEpoch).

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from "react"
 import { useStudioPlayback } from "./use-studio-playback"
 import { PlayerProvider, usePlayer } from "@/contexts/player-context"
 import { StudioProvider, useStudio } from "@/contexts/studio-context"
+import type { TrackType } from "@/lib/track-types"
 
 const { getClipAudioMock } = vi.hoisted(() => ({
   getClipAudioMock: vi.fn(),
@@ -28,6 +29,7 @@ class FakeGainNode {
 
 class FakeSourceNode {
   buffer: AudioBuffer | null = null
+  playbackRate = { value: 1 }
   connect = vi.fn()
   disconnect = vi.fn()
   start = vi.fn()
@@ -104,21 +106,30 @@ type SeedClip = {
   title: string
   duration: number
   startSec: number
+  trackId?: string
+  generationMode?: string | null
+  clipBpm?: number | null
 }
+
+type SeedTrack = { id: string; trackType: TrackType }
+
+const DEFAULT_TRACKS: SeedTrack[] = [{ id: "t1", trackType: "ai" }]
 
 function Harness({
   token = "tok",
   clips = [],
+  tracks = DEFAULT_TRACKS,
   autoplay = false,
 }: {
   token?: string | null
   clips?: SeedClip[]
+  tracks?: SeedTrack[]
   autoplay?: boolean
 }) {
   return (
     <PlayerProvider>
       <StudioProvider>
-        <Seed token={token} clips={clips} autoplay={autoplay} />
+        <Seed token={token} clips={clips} tracks={tracks} autoplay={autoplay} />
       </StudioProvider>
     </PlayerProvider>
   )
@@ -127,10 +138,12 @@ function Harness({
 function Seed({
   token,
   clips,
+  tracks,
   autoplay,
 }: {
   token: string | null
   clips: SeedClip[]
+  tracks: SeedTrack[]
   autoplay: boolean
 }) {
   const { state: studioState, dispatch } = useStudio()
@@ -140,16 +153,20 @@ function Seed({
   useEffect(() => {
     if (seededRef.current) return
     seededRef.current = true
-    dispatch({ type: "ADD_TRACK", id: "t1" })
+    for (const t of tracks) {
+      dispatch({ type: "ADD_TRACK", id: t.id, trackType: t.trackType })
+    }
     clips.forEach((c, i) => {
       dispatch({
         type: "ADD_CLIP",
         id: `p${i}`,
-        trackId: "t1",
+        trackId: c.trackId ?? "t1",
         clipId: c.clipId,
         startSec: c.startSec,
         title: c.title,
         durationSec: c.duration,
+        generationMode: c.generationMode,
+        clipBpm: c.clipBpm,
       })
     })
     if (autoplay) dispatch({ type: "SET_PLAYING", playing: true })
@@ -223,6 +240,105 @@ describe("useStudioPlayback scheduling", () => {
     })
 
     expect(getClipAudioMock).not.toHaveBeenCalled()
+  })
+
+  it("plays clips on the same track sequentially by timeline position (US-19.2 acceptance)", async () => {
+    const { sources, box } = stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue({
+      buffer: fakeBuffer(),
+      peaks: new Float32Array(),
+      duration: 4,
+    })
+
+    await act(async () => {
+      render(
+        <Harness
+          clips={[
+            { clipId: "c1", title: "A", duration: 4, startSec: 0 },
+            { clipId: "c2", title: "B", duration: 4, startSec: 4 },
+          ]}
+          autoplay
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const now = box.instance!.currentTime
+    expect(sources).toHaveLength(2)
+    // One after the other: the second starts exactly when the first ends.
+    expect(sources[0].start).toHaveBeenCalledWith(now, 0)
+    expect(sources[1].start).toHaveBeenCalledWith(now + 4, 0)
+  })
+
+  it("plays clips on different tracks simultaneously (US-19.2 acceptance)", async () => {
+    const { sources, box } = stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue({
+      buffer: fakeBuffer(),
+      peaks: new Float32Array(),
+      duration: 4,
+    })
+
+    await act(async () => {
+      render(
+        <Harness
+          tracks={[
+            { id: "t1", trackType: "ai" },
+            { id: "t2", trackType: "ai" },
+          ]}
+          clips={[
+            { clipId: "c1", title: "A", duration: 4, startSec: 0, trackId: "t1" },
+            { clipId: "c2", title: "B", duration: 4, startSec: 0, trackId: "t2" },
+          ]}
+          autoplay
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const now = box.instance!.currentTime
+    expect(sources).toHaveLength(2)
+    // Same start time on both sources: layered playback.
+    expect(sources[0].start).toHaveBeenCalledWith(now, 0)
+    expect(sources[1].start).toHaveBeenCalledWith(now, 0)
+  })
+
+  it("applies the loop track's tempo-derived playback rate to the source (US-19.2)", async () => {
+    const { sources } = stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue({
+      buffer: fakeBuffer(),
+      peaks: new Float32Array(),
+      duration: 8,
+    })
+
+    await act(async () => {
+      render(
+        <Harness
+          tracks={[{ id: "t1", trackType: "loop" }]}
+          clips={[
+            {
+              clipId: "c1",
+              title: "Loop",
+              duration: 8,
+              startSec: 0,
+              generationMode: "sound",
+              clipBpm: 90,
+            },
+          ]}
+          autoplay
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(sources).toHaveLength(1)
+    // 90 BPM loop in the default 120 BPM project → 4/3 rate.
+    expect(sources[0].playbackRate.value).toBeCloseTo(4 / 3)
   })
 })
 
@@ -459,7 +575,7 @@ describe("useStudioPlayback seek during playback", () => {
     function SeekHarness() {
       const { dispatch } = useStudio()
       useEffect(() => {
-        dispatch({ type: "ADD_TRACK", id: "t1" })
+        dispatch({ type: "ADD_TRACK", id: "t1", trackType: "ai" })
         dispatch({
           type: "ADD_CLIP",
           id: "p0",
@@ -549,7 +665,7 @@ describe("useStudioPlayback cleanup", () => {
     function ToggleHarness() {
       const { dispatch } = useStudio()
       useEffect(() => {
-        dispatch({ type: "ADD_TRACK", id: "t1" })
+        dispatch({ type: "ADD_TRACK", id: "t1", trackType: "ai" })
         dispatch({
           type: "ADD_CLIP",
           id: "p0",

--- a/web/hooks/use-studio-playback.ts
+++ b/web/hooks/use-studio-playback.ts
@@ -7,6 +7,7 @@ import { useStudio } from "@/contexts/studio-context"
 import { getAudioContextCtor } from "@/lib/audio-context"
 import { getClipAudio } from "@/lib/clip-audio-cache"
 import { computePlaybackSchedule, type Placement } from "@/lib/timeline"
+import { placementPlaybackRate } from "@/lib/track-types"
 
 // Studio-owned playback engine (US-19.1). Schedules every placement across
 // every track through a dedicated AudioContext + master gain node, keyed off
@@ -103,6 +104,16 @@ export function useStudioPlayback(token: string | null): void {
     if (ctx.state === "suspended") void ctx.resume()
     const master = masterGainRef.current!
     const placements: Placement[] = state.tracks.flatMap((t) => t.clips)
+    // Loop-track clips stretch to the project tempo (US-19.2) — derived here,
+    // per placement, from its track's type + the tempo at play time.
+    const rateByPlacementId = new Map(
+      state.tracks.flatMap((t) =>
+        t.clips.map((c) => [
+          c.id,
+          placementPlaybackRate(c.clipBpm, t.trackType, state.bpm),
+        ])
+      )
+    )
     const playheadAtStart = state.playheadSec
 
     let cancelled = false
@@ -126,13 +137,15 @@ export function useStudioPlayback(token: string | null): void {
         const schedule = computePlaybackSchedule(
           placements,
           playheadAtStart,
-          now
+          now,
+          (p) => rateByPlacementId.get(p.id) ?? 1
         )
         for (const item of schedule) {
           const buffer = bufferByClipId.get(item.clipId)
           if (!buffer) continue
           const source = ctx.createBufferSource()
           source.buffer = buffer
+          source.playbackRate.value = item.playbackRate
           source.connect(master)
           source.start(item.when, item.offset)
           sourcesRef.current.push({ source })

--- a/web/lib/clip-drag.test.ts
+++ b/web/lib/clip-drag.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest"
 
 import {
   parseClipDragData,
+  readDragTrackType,
   setClipDragData,
+  setDragTrackType,
   type ClipDragPayload,
 } from "./clip-drag"
 
@@ -13,6 +15,9 @@ function fakeDataTransfer(): DataTransfer {
   return {
     setData: (type: string, value: string) => store.set(type, value),
     getData: (type: string) => store.get(type) ?? "",
+    get types() {
+      return [...store.keys()]
+    },
   } as unknown as DataTransfer
 }
 
@@ -24,9 +29,27 @@ describe("setClipDragData / parseClipDragData round-trip", () => {
       clipId: "clip-a",
       title: "My Clip",
       duration: 12,
+      generationMode: "sound",
+      bpm: 90,
     }
     setClipDragData(dt, payload)
     expect(parseClipDragData(dt)).toEqual(payload)
+  })
+
+  it("defaults missing generationMode/bpm to null on an 'add' payload", () => {
+    const dt = fakeDataTransfer()
+    dt.setData(
+      "application/json",
+      JSON.stringify({ kind: "add", clipId: "clip-a", title: "A", duration: 3 })
+    )
+    expect(parseClipDragData(dt)).toEqual({
+      kind: "add",
+      clipId: "clip-a",
+      title: "A",
+      duration: 3,
+      generationMode: null,
+      bpm: null,
+    })
   })
 
   it("round-trips a 'move' payload (existing placement being repositioned)", () => {
@@ -75,5 +98,34 @@ describe("parseClipDragData validation", () => {
     const dt = fakeDataTransfer()
     dt.setData("application/json", JSON.stringify({ kind: "delete" }))
     expect(parseClipDragData(dt)).toBeNull()
+  })
+})
+
+describe("drag track-type entry (readable during dragover, unlike getData)", () => {
+  it("round-trips the dragged clip's track type via the dataTransfer type list", () => {
+    const dt = fakeDataTransfer()
+    setDragTrackType(dt, "loop")
+    expect(readDragTrackType(dt)).toBe("loop")
+  })
+
+  it("coexists with the JSON payload entry", () => {
+    const dt = fakeDataTransfer()
+    setClipDragData(dt, {
+      kind: "add",
+      clipId: "c1",
+      title: null,
+      duration: null,
+      generationMode: "upload",
+      bpm: null,
+    })
+    setDragTrackType(dt, "audio")
+    expect(readDragTrackType(dt)).toBe("audio")
+    expect(parseClipDragData(dt)?.kind).toBe("add")
+  })
+
+  it("returns null when no track-type entry is present (external drags)", () => {
+    const dt = fakeDataTransfer()
+    dt.setData("text/plain", "whatever")
+    expect(readDragTrackType(dt)).toBeNull()
   })
 })

--- a/web/lib/clip-drag.ts
+++ b/web/lib/clip-drag.ts
@@ -8,7 +8,18 @@
 // sources (ClipCard, ClipBlock) and the drop target (TrackLane) can't drift
 // on the wire shape.
 
+import {
+  TRACK_TYPE_ORDER,
+  type TrackType,
+} from "@/lib/track-types"
+
 const MIME_TYPE = "application/json"
+
+// The dragged clip's track type, encoded into the dataTransfer *type* string
+// (one entry per drag, empty value). Unlike getData() — which browsers only
+// expose on drop — dataTransfer.types is readable during dragover, which is
+// where TrackLane needs it to show valid/invalid drop feedback (US-19.2).
+const TRACK_TYPE_PREFIX = "application/x-ams-track-type-"
 
 export type ClipDragPayload =
   | {
@@ -16,6 +27,10 @@ export type ClipDragPayload =
       clipId: string
       title: string | null
       duration: number | null
+      /** The clip's generation_mode, for track-type matching (US-19.2). */
+      generationMode: string | null
+      /** The clip's own BPM, for loop-track tempo inheritance (US-19.2). */
+      bpm: number | null
     }
   | {
       kind: "move"
@@ -24,6 +39,28 @@ export type ClipDragPayload =
        * so a drop places the grab point (not the left edge) at the cursor. */
       grabOffsetSec: number
     }
+
+/** Marks the drag with the clip's track type, readable during dragover. */
+export function setDragTrackType(
+  dataTransfer: DataTransfer,
+  trackType: TrackType
+): void {
+  dataTransfer.setData(TRACK_TYPE_PREFIX + trackType, "")
+}
+
+/** The dragged clip's track type, or null for drags without one (e.g. files). */
+export function readDragTrackType(
+  dataTransfer: DataTransfer
+): TrackType | null {
+  for (const entry of dataTransfer.types) {
+    if (!entry.startsWith(TRACK_TYPE_PREFIX)) continue
+    const type = entry.slice(TRACK_TYPE_PREFIX.length)
+    if ((TRACK_TYPE_ORDER as readonly string[]).includes(type)) {
+      return type as TrackType
+    }
+  }
+  return null
+}
 
 export function setClipDragData(
   dataTransfer: DataTransfer,
@@ -52,6 +89,9 @@ export function parseClipDragData(
       clipId: p.clipId,
       title: typeof p.title === "string" ? p.title : null,
       duration: typeof p.duration === "number" ? p.duration : null,
+      generationMode:
+        typeof p.generationMode === "string" ? p.generationMode : null,
+      bpm: typeof p.bpm === "number" ? p.bpm : null,
     }
   }
   if (p.kind === "move" && typeof p.placementId === "string") {

--- a/web/lib/timeline.test.ts
+++ b/web/lib/timeline.test.ts
@@ -121,9 +121,9 @@ describe("computePlaybackSchedule", () => {
   it("schedules a future placement at its absolute offset from now", () => {
     const schedule = computePlaybackSchedule(placements, 0, 100)
     expect(schedule).toEqual([
-      { clipId: "c1", when: 100, offset: 0 },
-      { clipId: "c2", when: 104, offset: 0 },
-      { clipId: "c3", when: 110, offset: 0 },
+      { clipId: "c1", when: 100, offset: 0, playbackRate: 1 },
+      { clipId: "c2", when: 104, offset: 0, playbackRate: 1 },
+      { clipId: "c3", when: 110, offset: 0, playbackRate: 1 },
     ])
   })
 
@@ -131,8 +131,8 @@ describe("computePlaybackSchedule", () => {
     // Playhead at 6s: c1 already ended (0-4), c2 (4-8) is mid-playback.
     const schedule = computePlaybackSchedule(placements, 6, 50)
     expect(schedule).toEqual([
-      { clipId: "c2", when: 50, offset: 2 },
-      { clipId: "c3", when: 54, offset: 0 },
+      { clipId: "c2", when: 50, offset: 2, playbackRate: 1 },
+      { clipId: "c3", when: 54, offset: 0, playbackRate: 1 },
     ])
   })
 
@@ -157,6 +157,44 @@ describe("computePlaybackSchedule", () => {
     // Even at a playhead far past any "reasonable" clip length, a null
     // duration must not be treated as already-finished.
     const schedule = computePlaybackSchedule(unknownDuration, 10_000, 0)
-    expect(schedule).toEqual([{ clipId: "c1", when: 0, offset: 10_000 }])
+    expect(schedule).toEqual([
+      { clipId: "c1", when: 0, offset: 10_000, playbackRate: 1 },
+    ])
+  })
+})
+
+describe("computePlaybackSchedule with per-placement playback rates (US-19.2)", () => {
+  // A 90 BPM loop in a 120 BPM project plays at 4/3 speed: its 8s of audio
+  // occupy 6s of timeline.
+  const RATE = 4 / 3
+  const loop: Placement = {
+    id: "p1",
+    clipId: "c1",
+    startSec: 0,
+    title: "loop",
+    durationSec: 8,
+  }
+  const rateFor = () => RATE
+
+  it("carries the rate onto the scheduled clip", () => {
+    const schedule = computePlaybackSchedule([loop], 0, 100, rateFor)
+    expect(schedule).toEqual([
+      { clipId: "c1", when: 100, offset: 0, playbackRate: RATE },
+    ])
+  })
+
+  it("scales the buffer offset for an in-progress sped-up clip", () => {
+    // Playhead 3s into the timeline = 3 * RATE = 4s into the buffer.
+    const schedule = computePlaybackSchedule([loop], 3, 50, rateFor)
+    expect(schedule).toHaveLength(1)
+    expect(schedule[0].when).toBe(50)
+    expect(schedule[0].offset).toBeCloseTo(4)
+  })
+
+  it("uses the rate-compressed duration to decide when a clip has finished", () => {
+    // 8s of audio at 4/3 speed ends at 6s on the timeline: playhead 7s → done.
+    expect(computePlaybackSchedule([loop], 7, 0, rateFor)).toEqual([])
+    // But at 1x it would still be playing at 7s.
+    expect(computePlaybackSchedule([loop], 7, 0)).toHaveLength(1)
   })
 })

--- a/web/lib/timeline.ts
+++ b/web/lib/timeline.ts
@@ -113,6 +113,10 @@ export type Placement = {
   startSec: number
   title: string | null
   durationSec: number | null
+  /** The source clip's own BPM (US-19.2) — kept on the placement so a
+   * loop-track clip's playback rate can be re-derived whenever the project
+   * tempo changes, instead of freezing a multiplier at drop time. */
+  clipBpm?: number | null
 }
 
 /** Timeline never renders shorter than this, even with no clips placed. */
@@ -139,6 +143,8 @@ export type ScheduledClip = {
   when: number
   /** Offset into the clip's buffer to start playback from, in seconds. */
   offset: number
+  /** AudioBufferSourceNode.playbackRate for this clip (US-19.2 loop tempo). */
+  playbackRate: number
 }
 
 /**
@@ -149,20 +155,27 @@ export type ScheduledClip = {
  * with a nonzero buffer offset; future ones are scheduled at their absolute
  * start time. Placements with no known duration are treated as playing
  * through to the end (never pre-emptively excluded).
+ *
+ * `rateFor` supplies each placement's playback rate (loop-track tempo
+ * matching, US-19.2): a rate ≠ 1 compresses/stretches the clip on the
+ * timeline (durationSec/rate) and scales the buffer offset for in-progress
+ * clips, since timeline seconds pass `rate`× faster inside the buffer.
  */
 export function computePlaybackSchedule(
   placements: Placement[],
   playheadSec: number,
-  audioContextNow: number
+  audioContextNow: number,
+  rateFor: (p: Placement) => number = () => 1
 ): ScheduledClip[] {
   const schedule: ScheduledClip[] = []
   for (const p of placements) {
-    const duration = p.durationSec ?? Infinity
+    const rate = rateFor(p)
+    const duration = p.durationSec == null ? Infinity : p.durationSec / rate
     const endSec = p.startSec + duration
     if (endSec <= playheadSec) continue
-    const offset = Math.max(0, playheadSec - p.startSec)
+    const offset = Math.max(0, playheadSec - p.startSec) * rate
     const when = audioContextNow + Math.max(0, p.startSec - playheadSec)
-    schedule.push({ clipId: p.clipId, when, offset })
+    schedule.push({ clipId: p.clipId, when, offset, playbackRate: rate })
   }
   return schedule.sort((a, b) => a.when - b.when)
 }

--- a/web/lib/track-types.test.ts
+++ b/web/lib/track-types.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  BPM_MAX,
+  BPM_MIN,
+  TRACK_TYPES,
+  TRACK_TYPE_ORDER,
+  inferTrackType,
+  placementPlaybackRate,
+  type TrackType,
+} from "./track-types"
+
+describe("TRACK_TYPES config", () => {
+  it("defines all four track types, each with a label, description, color, and icon", () => {
+    expect(TRACK_TYPE_ORDER).toEqual(["ai", "audio", "loop", "vocal"])
+    for (const type of TRACK_TYPE_ORDER) {
+      const cfg = TRACK_TYPES[type]
+      expect(cfg.label).toBeTruthy()
+      expect(cfg.description).toBeTruthy()
+      expect(cfg.color).toMatch(/^#[0-9a-f]{6}$/i)
+      expect(cfg.icon).toBeTruthy()
+    }
+  })
+
+  it("gives each type a distinct color (visual distinction requirement)", () => {
+    const colors = TRACK_TYPE_ORDER.map((t) => TRACK_TYPES[t].color)
+    expect(new Set(colors).size).toBe(colors.length)
+  })
+})
+
+describe("inferTrackType", () => {
+  it.each([
+    ["upload", "audio"],
+    ["stems", "vocal"],
+    ["sound", "loop"],
+    ["song", "ai"],
+    ["generate", "ai"],
+    ["compose", "ai"],
+    ["cover", "ai"],
+    ["extend", "ai"],
+    ["remix", "ai"],
+    ["mashup", "ai"],
+    ["sample", "ai"],
+    ["full_song", "ai"],
+    ["mastering", "ai"],
+  ] as [string, TrackType][])("maps generation_mode %j → %j", (mode, expected) => {
+    expect(inferTrackType(mode)).toBe(expected)
+  })
+
+  it("defaults null/undefined/unknown modes to ai", () => {
+    expect(inferTrackType(null)).toBe("ai")
+    expect(inferTrackType(undefined)).toBe("ai")
+    expect(inferTrackType("some-future-mode")).toBe("ai")
+  })
+})
+
+describe("placementPlaybackRate", () => {
+  it("scales a loop-track clip's rate to the project tempo", () => {
+    // 90 BPM loop in a 120 BPM project plays at 4/3 speed.
+    expect(placementPlaybackRate(90, "loop", 120)).toBeCloseTo(4 / 3)
+    expect(placementPlaybackRate(120, "loop", 120)).toBe(1)
+  })
+
+  it("returns 1 on non-loop tracks regardless of BPM", () => {
+    expect(placementPlaybackRate(90, "ai", 120)).toBe(1)
+    expect(placementPlaybackRate(90, "audio", 120)).toBe(1)
+    expect(placementPlaybackRate(90, "vocal", 120)).toBe(1)
+  })
+
+  it("returns 1 when the clip has no usable BPM", () => {
+    expect(placementPlaybackRate(null, "loop", 120)).toBe(1)
+    expect(placementPlaybackRate(undefined, "loop", 120)).toBe(1)
+    expect(placementPlaybackRate(0, "loop", 120)).toBe(1)
+    expect(placementPlaybackRate(-4, "loop", 120)).toBe(1)
+  })
+
+  it("exports the project tempo bounds mirroring the backend", () => {
+    expect(BPM_MIN).toBe(60)
+    expect(BPM_MAX).toBe(180)
+  })
+})

--- a/web/lib/track-types.ts
+++ b/web/lib/track-types.ts
@@ -1,0 +1,94 @@
+// Track types for the Studio multi-track editor (US-19.2, spec §24.2). Each
+// track accepts only clips whose category matches: the category is inferred
+// from the clip's persisted generation_mode (the API stores the generation
+// request's mode — "song"/"sound" — or the operation that produced the clip:
+// "upload", "stems", "cover", "extend", …). Everything that isn't an upload,
+// a stem extraction, or a sound/loop generation is an AI-generated clip, so
+// unknown/null modes default to "ai" rather than being unplaceable.
+
+import {
+  AiMagicIcon,
+  Mic01Icon,
+  RepeatIcon,
+  Upload01Icon,
+} from "@hugeicons/core-free-icons"
+
+export type TrackType = "ai" | "audio" | "loop" | "vocal"
+
+export const TRACK_TYPE_ORDER: readonly TrackType[] = [
+  "ai",
+  "audio",
+  "loop",
+  "vocal",
+]
+
+export type TrackTypeConfig = {
+  label: string
+  description: string
+  /** Lane strip / clip block accent color. */
+  color: string
+  /** @hugeicons/core-free-icons icon for HugeiconsIcon. */
+  icon: typeof AiMagicIcon
+}
+
+export const TRACK_TYPES: Record<TrackType, TrackTypeConfig> = {
+  ai: {
+    label: "AI-Generated",
+    description: "Generated songs, covers, extensions, and remixes",
+    color: "#6d28d9",
+    icon: AiMagicIcon,
+  },
+  audio: {
+    label: "Audio",
+    description: "Uploaded audio files",
+    color: "#0ea5e9",
+    icon: Upload01Icon,
+  },
+  loop: {
+    label: "Sound/Loop",
+    description: "Sounds and loops, tempo-matched to the project",
+    color: "#22c55e",
+    icon: RepeatIcon,
+  },
+  vocal: {
+    label: "Vocal",
+    description: "Extracted vocal stems",
+    color: "#f97316",
+    icon: Mic01Icon,
+  },
+}
+
+/** Project tempo bounds, mirroring the backend's BPM_MIN/BPM_MAX (constants.py). */
+export const BPM_MIN = 60
+export const BPM_MAX = 180
+
+/** The track type a clip belongs on, inferred from its generation_mode. */
+export function inferTrackType(
+  generationMode: string | null | undefined
+): TrackType {
+  switch (generationMode) {
+    case "upload":
+      return "audio"
+    case "stems":
+      return "vocal"
+    case "sound":
+      return "loop"
+    default:
+      return "ai"
+  }
+}
+
+/**
+ * Playback rate for a placement: loop-track clips stretch to the project
+ * tempo (rate = projectBpm / clipBpm); everything else — including loops with
+ * no usable BPM metadata — plays at 1x.
+ */
+export function placementPlaybackRate(
+  clipBpm: number | null | undefined,
+  trackType: TrackType,
+  projectBpm: number
+): number {
+  if (trackType !== "loop") return 1
+  if (!clipBpm || clipBpm <= 0) return 1
+  return projectBpm / clipBpm
+}


### PR DESCRIPTION
## Summary
Implements #208: US-19.2 Track Types and Clip Import

- Four typed studio tracks — AI-Generated (purple, `AiMagicIcon`), Audio (blue, `Upload01Icon`), Sound/Loop (green, `RepeatIcon`), Vocal (orange, `Mic01Icon`) — defined in a new `web/lib/track-types.ts` config; the Add Track button opens a dropdown selector with icon + name + description per type
- Track lanes show the type's icon (accessible label `"<Type> track"`) and use the type color for the strip border and clip blocks
- Clip category is inferred from the clip's persisted `generation_mode` (`"upload"` → Audio, `"stems"` → Vocal, `"sound"` → Sound/Loop, everything else incl. null → AI-Generated); no backend change needed — the API already persists the generation request's `mode`
- Strict type matching enforced authoritatively in the reducer for both drops (`ADD_CLIP`) and cross-track moves (`MOVE_CLIP`); dragover shows valid (`bg-accent`) / invalid (`bg-destructive` tint + native no-drop, via not calling `preventDefault`) feedback using a dataTransfer *type* entry, since `getData()` is unavailable during dragover
- Loop-track tempo inheritance: project `bpm` in studio state (default 120, clamped 60–180 matching backend bounds) editable via a header BPM input; playback rate = `projectBpm / clipBpm` is derived per placement at render/schedule time (stored `clipBpm`, not a frozen multiplier — so changing the project tempo re-stretches placed loops), applied to `AudioBufferSourceNode.playbackRate` and clip-block width
- `?song=` preload creates the track with the clip's inferred type so the preloaded clip always lands

## Acceptance Criteria
- [x] All four track types can be created
- [x] Each type is visually distinguished by color and icon
- [x] Clips from the workspace can be dragged onto tracks (matching types only)
- [x] Multiple clips on one track play sequentially
- [x] Clips on different tracks play simultaneously

## Test Plan
- [x] Unit tests written (TDD approach) — 904 tests passing (`npx vitest run`)
- [x] Diff coverage 95% on changed lines (diff-cover, ≥85% gate)
- [x] Linting + typecheck + `next build` clean (web is not in CI — run locally)
- [x] Internal code review (advisory) completed
- [x] Cross-family review pass: opencode (GLM) — verdict APPROVE, no Critical/Major findings
- [x] Test mutation sanity check completed — 6 targeted mutations (type mapping, rate derivation, reducer validation, offset scaling, dragover validity, source rate application) all killed by tests

## Known Limitations / Intentionally Deferred
- Loop tempo inheritance requires the clip to carry BPM metadata; clips without `bpm` play at 1x on loop tracks (no prompt-for-BPM flow — deferred)
- No time-stretching DSP: rate change via `playbackRate` shifts pitch as well as tempo (standard Web Audio behavior; pitch-preserving stretch is out of scope)
- All stem kinds (vocals/drums/bass/other) classify as Vocal: the backend stores every stem as `generation_mode="stems"` with the kind only in the renamable title; finer stem typing needs a backend schema field (follow-up candidate)
- Sound/loop clips generated before the API began persisting `generation_mode` (or via CLI paths that store other values) classify as AI-Generated; reclassification/manual tagging is not in scope
- Track type is fixed at creation — no type change on an existing track (create a new track instead)
- `REMOVE_TRACK` still has no UI affordance (pre-existing from US-19.1)

## Implementation Notes
- The CodeRabbit issue plan predated the US-19.1 studio code and assumed `generation_mode` values that don't exist; the mapping was corrected to the actually-persisted values (`processor.py` stores the request `mode`, so `"song"`/`"sound"` are real values)
- Deviation from the plan's "store a tempoMultiplier on the placed clip": the placement stores `clipBpm` and the rate is derived, which keeps placed loops in sync with later project-tempo changes

Closes #208
