### PR TITLE
feat(web): US-19.5 master bus controls (volume, EQ, compressor, limiter, metering)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -274,6 +274,36 @@ action, on top of the name edit from US-19.1:
   the finished clip to the end of the track once generation completes;
   regeneration is additive, never a replacement.
 
+## Master Bus Controls (US-19.5)
+
+The studio's right aside is now tabbed **Workspace | Master**
+(`app/studio/page.tsx`); the Master tab holds `MasterBusPanel` with a live
+`StereoMeter` on top. The playback engine is owned by `StudioView` (called
+once) so both the timeline and the panel observe the same `AudioContext`.
+
+- **Audio chain** — `hooks/use-studio-playback.ts` splices the bus between
+  the track sum and the destination: sum → low shelf → mid peak → high shelf
+  (BiquadFilters) → compressor → master volume → limiter
+  (`DynamicsCompressorNode`, fixed 20:1 / 1ms attack / 50ms release / hard
+  knee) → destination, with a `ChannelSplitter` → dual `AnalyserNode` (L/R)
+  metering tap on the final output. Built once per `AudioContext`; survives
+  play/stop. Master volume sits *before* the limiter so the configured
+  ceiling stays a real output cap, and *after* the compressor so fader moves
+  don't change compression amount.
+- **State** — `masterBus: MasterBusState` on `StudioState`
+  (`lib/master-bus.ts` has the types, defaults, and ranges), set via
+  `SET_MASTER_VOLUME` / `SET_MASTER_EQ` / `SET_MASTER_COMPRESSOR` /
+  `SET_MASTER_LIMITER_CEILING` (clamped + NaN-guarded in the reducer). A
+  dedicated effect retunes the live nodes on change — same
+  never-restart-the-run ref pattern as the per-track controls.
+- **Metering** — `lib/metering.ts` (pure peak/RMS dBFS math + peak-hold
+  decay) drives `components/studio/StereoMeter.tsx`'s rAF loop: peak + RMS
+  bars, 1.5s peak-hold, clip indicators, -60 dBFS floor.
+- **Limiter caveat** — the ceiling is a soft limiter built on
+  `DynamicsCompressorNode`; Chromium's fixed internal makeup gain means a
+  -6 dB ceiling caps a near-0 dBFS tone at ≈ -2 dBFS rather than exactly -6.
+  Exact adherence needs an AudioWorklet limiter (deferred by design).
+
 ## Adding components
 
 To add components to your app, run the following command:

--- a/web/app/studio/page.test.tsx
+++ b/web/app/studio/page.test.tsx
@@ -26,8 +26,15 @@ import StudioPage from "@/app/studio/page"
 import { AuthContext } from "@/contexts/auth-context"
 import { PlayerProvider } from "@/contexts/player-context"
 import { TRACK_STRIP_PX } from "@/lib/timeline"
+import {
+  FakeAnalyserNode,
+  FakeBiquadFilterNode,
+  FakeChannelSplitterNode,
+  FakeDynamicsCompressorNode,
+} from "@/test/audio-stubs"
+import { stubRaf } from "@/test/raf-stub"
 
-// --- Minimal Web Audio + rAF stand-ins (jsdom has neither), mirroring
+// --- Minimal Web Audio stand-ins (jsdom has none), mirroring
 // hooks/use-studio-playback.test.tsx's stubs. ---
 
 class FakeGainNode {
@@ -51,41 +58,6 @@ class FakeSourceNode {
   stop = vi.fn()
 }
 
-// US-19.5's master bus chain runs on every play, so this page-level harness
-// needs the same node stand-ins as hooks/use-studio-playback.test.tsx even
-// though this file doesn't assert on them directly.
-class FakeBiquadFilterNode {
-  type: BiquadFilterType = "lowpass"
-  connect = vi.fn()
-  disconnect = vi.fn()
-  frequency = { value: 350 }
-  gain = { value: 0 }
-  Q = { value: 1 }
-}
-
-class FakeDynamicsCompressorNode {
-  connect = vi.fn()
-  disconnect = vi.fn()
-  threshold = { value: -24 }
-  knee = { value: 30 }
-  ratio = { value: 12 }
-  attack = { value: 0.003 }
-  release = { value: 0.25 }
-  reduction = 0
-}
-
-class FakeChannelSplitterNode {
-  connect = vi.fn()
-  disconnect = vi.fn()
-}
-
-class FakeAnalyserNode {
-  connect = vi.fn()
-  disconnect = vi.fn()
-  fftSize = 2048
-  getFloatTimeDomainData = vi.fn()
-}
-
 function stubAudioContext() {
   const box: { instance: { currentTime: number } | null } = { instance: null }
   class FakeAudioContext {
@@ -105,33 +77,6 @@ function stubAudioContext() {
   }
   vi.stubGlobal("AudioContext", FakeAudioContext)
   return box
-}
-
-function stubRaf() {
-  let nextId = 1
-  const callbacks = new Map<number, FrameRequestCallback>()
-  vi.stubGlobal(
-    "requestAnimationFrame",
-    vi.fn((cb: FrameRequestCallback) => {
-      const id = nextId++
-      callbacks.set(id, cb)
-      return id
-    })
-  )
-  vi.stubGlobal(
-    "cancelAnimationFrame",
-    vi.fn((id: number) => {
-      callbacks.delete(id)
-    })
-  )
-  return {
-    /** Invoke every currently-scheduled rAF callback once, at time `t`. */
-    tick(t: number) {
-      const due = [...callbacks.entries()]
-      callbacks.clear()
-      for (const [, cb] of due) cb(t)
-    },
-  }
 }
 
 const authValue = {

--- a/web/app/studio/page.test.tsx
+++ b/web/app/studio/page.test.tsx
@@ -51,6 +51,41 @@ class FakeSourceNode {
   stop = vi.fn()
 }
 
+// US-19.5's master bus chain runs on every play, so this page-level harness
+// needs the same node stand-ins as hooks/use-studio-playback.test.tsx even
+// though this file doesn't assert on them directly.
+class FakeBiquadFilterNode {
+  type: BiquadFilterType = "lowpass"
+  connect = vi.fn()
+  disconnect = vi.fn()
+  frequency = { value: 350 }
+  gain = { value: 0 }
+  Q = { value: 1 }
+}
+
+class FakeDynamicsCompressorNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+  threshold = { value: -24 }
+  knee = { value: 30 }
+  ratio = { value: 12 }
+  attack = { value: 0.003 }
+  release = { value: 0.25 }
+  reduction = 0
+}
+
+class FakeChannelSplitterNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+}
+
+class FakeAnalyserNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+  fftSize = 2048
+  getFloatTimeDomainData = vi.fn()
+}
+
 function stubAudioContext() {
   const box: { instance: { currentTime: number } | null } = { instance: null }
   class FakeAudioContext {
@@ -59,6 +94,10 @@ function stubAudioContext() {
     createGain = vi.fn(() => new FakeGainNode())
     createStereoPanner = vi.fn(() => new FakePannerNode())
     createBufferSource = vi.fn(() => new FakeSourceNode())
+    createBiquadFilter = vi.fn(() => new FakeBiquadFilterNode())
+    createDynamicsCompressor = vi.fn(() => new FakeDynamicsCompressorNode())
+    createChannelSplitter = vi.fn(() => new FakeChannelSplitterNode())
+    createAnalyser = vi.fn(() => new FakeAnalyserNode())
     close = vi.fn().mockResolvedValue(undefined)
     constructor() {
       box.instance = this

--- a/web/app/studio/page.test.tsx
+++ b/web/app/studio/page.test.tsx
@@ -246,7 +246,9 @@ describe("StudioPage header", () => {
     const tick = () => screen.getByText("2.1").parentElement as HTMLElement
     expect(tick().style.left).toBe("200px")
 
-    const input = screen.getByRole("spinbutton", { name: "Project tempo (BPM)" })
+    const input = screen.getByRole("spinbutton", {
+      name: "Project tempo (BPM)",
+    })
     await user.clear(input)
     await user.type(input, "60")
     await user.tab()
@@ -569,5 +571,52 @@ describe("StudioPage clip library aside", () => {
     stubStudioFetch()
     renderPage()
     expect(screen.getByTestId("workspace-panel")).toBeInTheDocument()
+  })
+})
+
+describe("StudioPage master bus tab (US-19.5)", () => {
+  it("defaults to the Workspace tab, hiding the master bus controls", () => {
+    stubAudioContext()
+    stubRaf()
+    stubStudioFetch()
+    renderPage()
+    expect(screen.getByTestId("workspace-panel")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("slider", { name: "Master volume" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("switching to the Master tab reveals the master bus controls and meter, hiding the workspace panel", async () => {
+    stubAudioContext()
+    stubRaf()
+    stubStudioFetch()
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.click(screen.getByRole("tab", { name: "Master" }))
+
+    expect(
+      screen.getByRole("slider", { name: "Master volume" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("meter", { name: "L channel level" })
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId("workspace-panel")).not.toBeInTheDocument()
+  })
+
+  it("switching back to Workspace restores the clip library", async () => {
+    stubAudioContext()
+    stubRaf()
+    stubStudioFetch()
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.click(screen.getByRole("tab", { name: "Master" }))
+    await user.click(screen.getByRole("tab", { name: "Workspace" }))
+
+    expect(screen.getByTestId("workspace-panel")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("slider", { name: "Master volume" })
+    ).not.toBeInTheDocument()
   })
 })

--- a/web/app/studio/page.tsx
+++ b/web/app/studio/page.tsx
@@ -7,7 +7,9 @@ import { ZoomInAreaIcon, ZoomOutAreaIcon } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { AddTrackButton, TrackLane } from "@/components/studio/TrackLane"
+import { MasterBusPanel } from "@/components/studio/MasterBusPanel"
 import { Playhead } from "@/components/studio/Playhead"
 import { RulerArea } from "@/components/studio/RulerArea"
 import { SnapControls } from "@/components/studio/SnapControls"
@@ -158,7 +160,6 @@ function StudioHeader() {
 function StudioTimeline() {
   const { state, dispatch } = useStudio()
   const { accessToken } = useAuth()
-  useStudioPlayback(accessToken)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   // Latest zoom read through a ref so the non-passive wheel listener (needed
@@ -222,20 +223,42 @@ function StudioTimeline() {
 
 function StudioView() {
   useSongPreload()
+  const { accessToken } = useAuth()
+  // The playback engine is owned by this shared ancestor, not by the
+  // timeline or the side panel individually — both StudioTimeline (via
+  // context/props) and the Master tab (via these refs) need to observe the
+  // one AudioContext it builds, and calling the hook twice would build two.
+  const { analyserLeft, analyserRight, limiter } =
+    useStudioPlayback(accessToken)
   return (
     <div className="flex h-full">
       <div className="flex min-w-0 flex-1 flex-col">
         <StudioHeader />
         <StudioTimeline />
       </div>
-      {/* Clip library, dragged onto lanes to add clips (US-19.1). Hidden below
-          lg to keep the timeline usable at the minimum supported width,
+      {/* Clip library / master bus, tabbed (US-19.1, US-19.5). Hidden below lg
+          to keep the timeline usable at the minimum supported width,
           mirroring the app shell's RightPanel (see app/create/page.tsx). */}
       <aside
-        aria-label="Clip library"
+        aria-label="Studio side panel"
         className="hidden w-80 shrink-0 flex-col border-l border-border p-4 lg:flex"
       >
-        <WorkspacePanel />
+        <Tabs defaultValue="workspace" className="h-full min-h-0">
+          <TabsList>
+            <TabsTrigger value="workspace">Workspace</TabsTrigger>
+            <TabsTrigger value="master">Master</TabsTrigger>
+          </TabsList>
+          <TabsContent value="workspace" className="min-h-0 overflow-y-auto">
+            <WorkspacePanel />
+          </TabsContent>
+          <TabsContent value="master" className="min-h-0 overflow-y-auto">
+            <MasterBusPanel
+              analyserLeft={analyserLeft}
+              analyserRight={analyserRight}
+              limiter={limiter}
+            />
+          </TabsContent>
+        </Tabs>
       </aside>
     </div>
   )

--- a/web/components/studio/MasterBusPanel.test.tsx
+++ b/web/components/studio/MasterBusPanel.test.tsx
@@ -1,0 +1,271 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { act, useRef } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { MasterBusPanel } from "./MasterBusPanel"
+import { StudioProvider, useStudio } from "@/contexts/studio-context"
+import { DEFAULT_MASTER_BUS } from "@/lib/master-bus"
+
+function stubRaf() {
+  let nextId = 1
+  const callbacks = new Map<number, FrameRequestCallback>()
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((cb: FrameRequestCallback) => {
+      const id = nextId++
+      callbacks.set(id, cb)
+      return id
+    })
+  )
+  vi.stubGlobal(
+    "cancelAnimationFrame",
+    vi.fn((id: number) => {
+      callbacks.delete(id)
+    })
+  )
+  return {
+    tick(t: number) {
+      const due = [...callbacks.entries()]
+      callbacks.clear()
+      for (const [, cb] of due) cb(t)
+    },
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** A null-analyser / null-limiter panel is the common case in these tests —
+ * the panel must render fine before playback ever starts (US-19.5). */
+function Harness({
+  limiter = { current: null },
+}: {
+  limiter?: { current: DynamicsCompressorNode | null }
+}) {
+  return (
+    <StudioProvider>
+      <Seed limiter={limiter} />
+    </StudioProvider>
+  )
+}
+
+function Seed({
+  limiter,
+}: {
+  limiter: { current: DynamicsCompressorNode | null }
+}) {
+  const { state } = useStudio()
+  const analyserLeft = useRef<AnalyserNode | null>(null)
+  const analyserRight = useRef<AnalyserNode | null>(null)
+  return (
+    <>
+      <MasterBusPanel
+        analyserLeft={analyserLeft}
+        analyserRight={analyserRight}
+        limiter={limiter}
+      />
+      <div data-testid="master-bus-probe">{JSON.stringify(state.masterBus)}</div>
+    </>
+  )
+}
+
+function probe() {
+  return JSON.parse(screen.getByTestId("master-bus-probe").textContent!)
+}
+
+describe("MasterBusPanel rendering", () => {
+  it("renders the stereo meter", () => {
+    stubRaf()
+    render(<Harness />)
+    expect(screen.getByRole("meter", { name: "L channel level" })).toBeInTheDocument()
+    expect(screen.getByRole("meter", { name: "R channel level" })).toBeInTheDocument()
+  })
+
+  it("renders every fader at its default value and range", () => {
+    stubRaf()
+    render(<Harness />)
+
+    const volume = screen.getByRole("slider", { name: "Master volume" })
+    expect(volume).toHaveAttribute("aria-valuenow", "0")
+    expect(volume).toHaveAttribute("aria-valuemin", "-60")
+    expect(volume).toHaveAttribute("aria-valuemax", "6")
+
+    const lowFreq = screen.getByRole("slider", { name: "Low shelf frequency" })
+    expect(lowFreq).toHaveAttribute(
+      "aria-valuenow",
+      String(DEFAULT_MASTER_BUS.eq.lowShelf.freqHz)
+    )
+    const midQ = screen.getByRole("slider", { name: "Mid Q" })
+    expect(midQ).toHaveAttribute("aria-valuenow", String(DEFAULT_MASTER_BUS.eq.midPeak.q))
+    const threshold = screen.getByRole("slider", { name: "Threshold" })
+    expect(threshold).toHaveAttribute(
+      "aria-valuenow",
+      String(DEFAULT_MASTER_BUS.compressor.thresholdDb)
+    )
+    const ceiling = screen.getByRole("slider", { name: "Ceiling" })
+    expect(ceiling).toHaveAttribute(
+      "aria-valuenow",
+      String(DEFAULT_MASTER_BUS.limiterCeilingDb)
+    )
+  })
+})
+
+describe("MasterBusPanel dispatch (US-19.5)", () => {
+  it("changes master volume from the fader keyboard", async () => {
+    stubRaf()
+    const user = userEvent.setup()
+    render(<Harness />)
+    const fader = screen.getByRole("slider", { name: "Master volume" })
+    fader.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().masterVolumeDb).toBe(1)
+  })
+
+  it("changes the low shelf frequency and gain independently", async () => {
+    stubRaf()
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const freq = screen.getByRole("slider", { name: "Low shelf frequency" })
+    freq.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().eq.lowShelf.freqHz).toBe(
+      DEFAULT_MASTER_BUS.eq.lowShelf.freqHz + 5
+    )
+    // Untouched sibling field on the same band stays at its default.
+    expect(probe().eq.lowShelf.gainDb).toBe(DEFAULT_MASTER_BUS.eq.lowShelf.gainDb)
+
+    const gain = screen.getByRole("slider", { name: "Low shelf gain" })
+    gain.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().eq.lowShelf.gainDb).toBe(1)
+  })
+
+  it("changes the mid band's frequency, gain, and Q", async () => {
+    stubRaf()
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const freq = screen.getByRole("slider", { name: "Mid frequency" })
+    freq.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().eq.midPeak.freqHz).toBe(
+      DEFAULT_MASTER_BUS.eq.midPeak.freqHz + 10
+    )
+
+    const gain = screen.getByRole("slider", { name: "Mid gain" })
+    gain.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().eq.midPeak.gainDb).toBe(1)
+
+    const q = screen.getByRole("slider", { name: "Mid Q" })
+    q.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().eq.midPeak.q).toBeCloseTo(DEFAULT_MASTER_BUS.eq.midPeak.q + 0.1)
+  })
+
+  it("changes the high shelf frequency and gain", async () => {
+    stubRaf()
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const freq = screen.getByRole("slider", { name: "High shelf frequency" })
+    freq.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().eq.highShelf.freqHz).toBe(
+      DEFAULT_MASTER_BUS.eq.highShelf.freqHz + 50
+    )
+  })
+
+  it("changes compressor threshold, ratio, attack, and release", async () => {
+    stubRaf()
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const threshold = screen.getByRole("slider", { name: "Threshold" })
+    threshold.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().compressor.thresholdDb).toBe(
+      DEFAULT_MASTER_BUS.compressor.thresholdDb + 1
+    )
+
+    const ratio = screen.getByRole("slider", { name: "Ratio" })
+    ratio.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().compressor.ratio).toBe(DEFAULT_MASTER_BUS.compressor.ratio + 1)
+
+    const attack = screen.getByRole("slider", { name: "Attack" })
+    attack.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().compressor.attackSec).toBeCloseTo(
+      DEFAULT_MASTER_BUS.compressor.attackSec + 0.001
+    )
+
+    const release = screen.getByRole("slider", { name: "Release" })
+    release.focus()
+    await user.keyboard("{ArrowUp}")
+    expect(probe().compressor.releaseSec).toBeCloseTo(
+      DEFAULT_MASTER_BUS.compressor.releaseSec + 0.01
+    )
+  })
+
+  it("changes the limiter ceiling", async () => {
+    stubRaf()
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const ceiling = screen.getByRole("slider", { name: "Ceiling" })
+    ceiling.focus()
+    await user.keyboard("{ArrowDown}")
+    expect(probe().limiterCeilingDb).toBeCloseTo(
+      DEFAULT_MASTER_BUS.limiterCeilingDb - 0.1
+    )
+  })
+})
+
+describe("MasterBusPanel limiter-active indicator (US-19.5)", () => {
+  it("reads inactive when the limiter node is absent (playback hasn't started)", () => {
+    stubRaf()
+    render(<Harness />)
+    expect(screen.getByTestId("limiter-active-indicator")).toHaveAttribute(
+      "data-active",
+      "false"
+    )
+  })
+
+  it("goes active once the live limiter node reports gain reduction", () => {
+    const raf = stubRaf()
+    const limiter = { current: { reduction: -6 } as DynamicsCompressorNode }
+    render(<Harness limiter={limiter} />)
+    expect(screen.getByTestId("limiter-active-indicator")).toHaveAttribute(
+      "data-active",
+      "false"
+    )
+
+    act(() => raf.tick(16))
+    expect(screen.getByTestId("limiter-active-indicator")).toHaveAttribute(
+      "data-active",
+      "true"
+    )
+  })
+
+  it("goes back to inactive once gain reduction returns to zero", () => {
+    const raf = stubRaf()
+    const limiter = { current: { reduction: -6 } as DynamicsCompressorNode }
+    render(<Harness limiter={limiter} />)
+    act(() => raf.tick(16))
+    expect(screen.getByTestId("limiter-active-indicator")).toHaveAttribute(
+      "data-active",
+      "true"
+    )
+
+    limiter.current = { reduction: 0 } as DynamicsCompressorNode
+    act(() => raf.tick(32))
+    expect(screen.getByTestId("limiter-active-indicator")).toHaveAttribute(
+      "data-active",
+      "false"
+    )
+  })
+})

--- a/web/components/studio/MasterBusPanel.test.tsx
+++ b/web/components/studio/MasterBusPanel.test.tsx
@@ -6,32 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { MasterBusPanel } from "./MasterBusPanel"
 import { StudioProvider, useStudio } from "@/contexts/studio-context"
 import { DEFAULT_MASTER_BUS } from "@/lib/master-bus"
-
-function stubRaf() {
-  let nextId = 1
-  const callbacks = new Map<number, FrameRequestCallback>()
-  vi.stubGlobal(
-    "requestAnimationFrame",
-    vi.fn((cb: FrameRequestCallback) => {
-      const id = nextId++
-      callbacks.set(id, cb)
-      return id
-    })
-  )
-  vi.stubGlobal(
-    "cancelAnimationFrame",
-    vi.fn((id: number) => {
-      callbacks.delete(id)
-    })
-  )
-  return {
-    tick(t: number) {
-      const due = [...callbacks.entries()]
-      callbacks.clear()
-      for (const [, cb] of due) cb(t)
-    },
-  }
-}
+import { stubRaf } from "@/test/raf-stub"
 
 afterEach(() => {
   vi.unstubAllGlobals()

--- a/web/components/studio/MasterBusPanel.test.tsx
+++ b/web/components/studio/MasterBusPanel.test.tsx
@@ -66,7 +66,9 @@ function Seed({
         analyserRight={analyserRight}
         limiter={limiter}
       />
-      <div data-testid="master-bus-probe">{JSON.stringify(state.masterBus)}</div>
+      <div data-testid="master-bus-probe">
+        {JSON.stringify(state.masterBus)}
+      </div>
     </>
   )
 }
@@ -79,8 +81,12 @@ describe("MasterBusPanel rendering", () => {
   it("renders the stereo meter", () => {
     stubRaf()
     render(<Harness />)
-    expect(screen.getByRole("meter", { name: "L channel level" })).toBeInTheDocument()
-    expect(screen.getByRole("meter", { name: "R channel level" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("meter", { name: "L channel level" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("meter", { name: "R channel level" })
+    ).toBeInTheDocument()
   })
 
   it("renders every fader at its default value and range", () => {
@@ -98,7 +104,10 @@ describe("MasterBusPanel rendering", () => {
       String(DEFAULT_MASTER_BUS.eq.lowShelf.freqHz)
     )
     const midQ = screen.getByRole("slider", { name: "Mid Q" })
-    expect(midQ).toHaveAttribute("aria-valuenow", String(DEFAULT_MASTER_BUS.eq.midPeak.q))
+    expect(midQ).toHaveAttribute(
+      "aria-valuenow",
+      String(DEFAULT_MASTER_BUS.eq.midPeak.q)
+    )
     const threshold = screen.getByRole("slider", { name: "Threshold" })
     expect(threshold).toHaveAttribute(
       "aria-valuenow",
@@ -135,7 +144,9 @@ describe("MasterBusPanel dispatch (US-19.5)", () => {
       DEFAULT_MASTER_BUS.eq.lowShelf.freqHz + 5
     )
     // Untouched sibling field on the same band stays at its default.
-    expect(probe().eq.lowShelf.gainDb).toBe(DEFAULT_MASTER_BUS.eq.lowShelf.gainDb)
+    expect(probe().eq.lowShelf.gainDb).toBe(
+      DEFAULT_MASTER_BUS.eq.lowShelf.gainDb
+    )
 
     const gain = screen.getByRole("slider", { name: "Low shelf gain" })
     gain.focus()
@@ -163,7 +174,9 @@ describe("MasterBusPanel dispatch (US-19.5)", () => {
     const q = screen.getByRole("slider", { name: "Mid Q" })
     q.focus()
     await user.keyboard("{ArrowUp}")
-    expect(probe().eq.midPeak.q).toBeCloseTo(DEFAULT_MASTER_BUS.eq.midPeak.q + 0.1)
+    expect(probe().eq.midPeak.q).toBeCloseTo(
+      DEFAULT_MASTER_BUS.eq.midPeak.q + 0.1
+    )
   })
 
   it("changes the high shelf frequency and gain", async () => {
@@ -194,7 +207,9 @@ describe("MasterBusPanel dispatch (US-19.5)", () => {
     const ratio = screen.getByRole("slider", { name: "Ratio" })
     ratio.focus()
     await user.keyboard("{ArrowUp}")
-    expect(probe().compressor.ratio).toBe(DEFAULT_MASTER_BUS.compressor.ratio + 1)
+    expect(probe().compressor.ratio).toBe(
+      DEFAULT_MASTER_BUS.compressor.ratio + 1
+    )
 
     const attack = screen.getByRole("slider", { name: "Attack" })
     attack.focus()

--- a/web/components/studio/MasterBusPanel.tsx
+++ b/web/components/studio/MasterBusPanel.tsx
@@ -163,7 +163,9 @@ export function MasterBusPanel({
         max={MASTER_VOLUME_DB_MAX}
         step={1}
         format={formatVolumeDb}
-        onValueChange={(v) => dispatch({ type: "SET_MASTER_VOLUME", volumeDb: v })}
+        onValueChange={(v) =>
+          dispatch({ type: "SET_MASTER_VOLUME", volumeDb: v })
+        }
       />
 
       <div className="flex flex-col gap-2">

--- a/web/components/studio/MasterBusPanel.tsx
+++ b/web/components/studio/MasterBusPanel.tsx
@@ -1,0 +1,317 @@
+"use client"
+
+import { useEffect, useRef, useState, type RefObject } from "react"
+
+import { Slider } from "@/components/ui/slider"
+import { StereoMeter } from "@/components/studio/StereoMeter"
+import { useStudio } from "@/contexts/studio-context"
+import {
+  COMPRESSOR_ATTACK_SEC_MAX,
+  COMPRESSOR_ATTACK_SEC_MIN,
+  COMPRESSOR_RATIO_MAX,
+  COMPRESSOR_RATIO_MIN,
+  COMPRESSOR_RELEASE_SEC_MAX,
+  COMPRESSOR_RELEASE_SEC_MIN,
+  COMPRESSOR_THRESHOLD_DB_MAX,
+  COMPRESSOR_THRESHOLD_DB_MIN,
+  EQ_GAIN_DB_MAX,
+  EQ_GAIN_DB_MIN,
+  EQ_HIGH_SHELF_FREQ_MAX,
+  EQ_HIGH_SHELF_FREQ_MIN,
+  EQ_LOW_SHELF_FREQ_MAX,
+  EQ_LOW_SHELF_FREQ_MIN,
+  EQ_MID_FREQ_MAX,
+  EQ_MID_FREQ_MIN,
+  EQ_Q_MAX,
+  EQ_Q_MIN,
+  LIMITER_CEILING_DB_MAX,
+  LIMITER_CEILING_DB_MIN,
+  MASTER_VOLUME_DB_MAX,
+  MASTER_VOLUME_DB_MIN,
+} from "@/lib/master-bus"
+import { formatVolumeDb } from "@/lib/track-audio"
+import { cn } from "@/lib/utils"
+
+// Master bus settings panel (US-19.5): a meter plus four dispatch-only
+// sections (volume, EQ, compressor, limiter) — every slider dispatches a
+// masterBus action directly, mirroring TrackLane's per-track controls.
+// Values/labels come from state.masterBus, never from an AudioNode; the
+// limiter-active indicator is the one exception (see LimiterIndicator).
+
+function formatHz(hz: number): string {
+  return hz >= 1000 ? `${(hz / 1000).toFixed(1)}kHz` : `${Math.round(hz)}Hz`
+}
+function formatDb(db: number): string {
+  return db > 0 ? `+${db.toFixed(1)}dB` : `${db.toFixed(1)}dB`
+}
+function formatMs(sec: number): string {
+  return `${Math.round(sec * 1000)}ms`
+}
+function formatRatio(ratio: number): string {
+  return `${ratio.toFixed(1)}:1`
+}
+function formatQ(q: number): string {
+  return q.toFixed(1)
+}
+
+function LabeledSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  format,
+  onValueChange,
+}: {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  format: (v: number) => string
+  onValueChange: (v: number) => void
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs">
+      <span className="flex items-center justify-between text-muted-foreground">
+        <span>{label}</span>
+        <span className="tabular-nums">{format(value)}</span>
+      </span>
+      <Slider
+        aria-label={label}
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={([v]) => onValueChange(v)}
+      />
+    </label>
+  )
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+      {children}
+    </h3>
+  )
+}
+
+/** Polls the live limiter node's `.reduction` (dB of gain currently being
+ * pulled) to light an "active" indicator — a genuinely live audio-domain
+ * reading with no state-slice equivalent, same as the meter itself. */
+function LimiterIndicator({
+  limiter,
+}: {
+  limiter: RefObject<DynamicsCompressorNode | null>
+}) {
+  const [active, setActive] = useState(false)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    function tick() {
+      setActive((limiter.current?.reduction ?? 0) < -0.1)
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [limiter])
+
+  return (
+    <span
+      data-testid="limiter-active-indicator"
+      data-active={active}
+      className={cn(
+        "inline-flex items-center gap-1.5 text-xs",
+        active ? "text-destructive" : "text-muted-foreground"
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "size-1.5 rounded-full",
+          active ? "bg-destructive" : "bg-muted"
+        )}
+      />
+      Limiting
+    </span>
+  )
+}
+
+export function MasterBusPanel({
+  analyserLeft,
+  analyserRight,
+  limiter,
+}: {
+  analyserLeft: RefObject<AnalyserNode | null>
+  analyserRight: RefObject<AnalyserNode | null>
+  limiter: RefObject<DynamicsCompressorNode | null>
+}) {
+  const { state, dispatch } = useStudio()
+  const bus = state.masterBus
+
+  return (
+    <div className="flex flex-col gap-4">
+      <StereoMeter analyserLeft={analyserLeft} analyserRight={analyserRight} />
+
+      <LabeledSlider
+        label="Master volume"
+        value={bus.masterVolumeDb}
+        min={MASTER_VOLUME_DB_MIN}
+        max={MASTER_VOLUME_DB_MAX}
+        step={1}
+        format={formatVolumeDb}
+        onValueChange={(v) => dispatch({ type: "SET_MASTER_VOLUME", volumeDb: v })}
+      />
+
+      <div className="flex flex-col gap-2">
+        <SectionHeading>EQ</SectionHeading>
+        <LabeledSlider
+          label="Low shelf frequency"
+          value={bus.eq.lowShelf.freqHz}
+          min={EQ_LOW_SHELF_FREQ_MIN}
+          max={EQ_LOW_SHELF_FREQ_MAX}
+          step={5}
+          format={formatHz}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_EQ", band: "low", freqHz: v })
+          }
+        />
+        <LabeledSlider
+          label="Low shelf gain"
+          value={bus.eq.lowShelf.gainDb}
+          min={EQ_GAIN_DB_MIN}
+          max={EQ_GAIN_DB_MAX}
+          step={1}
+          format={formatDb}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_EQ", band: "low", gainDb: v })
+          }
+        />
+        <LabeledSlider
+          label="Mid frequency"
+          value={bus.eq.midPeak.freqHz}
+          min={EQ_MID_FREQ_MIN}
+          max={EQ_MID_FREQ_MAX}
+          step={10}
+          format={formatHz}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_EQ", band: "mid", freqHz: v })
+          }
+        />
+        <LabeledSlider
+          label="Mid gain"
+          value={bus.eq.midPeak.gainDb}
+          min={EQ_GAIN_DB_MIN}
+          max={EQ_GAIN_DB_MAX}
+          step={1}
+          format={formatDb}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_EQ", band: "mid", gainDb: v })
+          }
+        />
+        <LabeledSlider
+          label="Mid Q"
+          value={bus.eq.midPeak.q}
+          min={EQ_Q_MIN}
+          max={EQ_Q_MAX}
+          step={0.1}
+          format={formatQ}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_EQ", band: "mid", q: v })
+          }
+        />
+        <LabeledSlider
+          label="High shelf frequency"
+          value={bus.eq.highShelf.freqHz}
+          min={EQ_HIGH_SHELF_FREQ_MIN}
+          max={EQ_HIGH_SHELF_FREQ_MAX}
+          step={50}
+          format={formatHz}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_EQ", band: "high", freqHz: v })
+          }
+        />
+        <LabeledSlider
+          label="High shelf gain"
+          value={bus.eq.highShelf.gainDb}
+          min={EQ_GAIN_DB_MIN}
+          max={EQ_GAIN_DB_MAX}
+          step={1}
+          format={formatDb}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_EQ", band: "high", gainDb: v })
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <SectionHeading>Compressor</SectionHeading>
+        <LabeledSlider
+          label="Threshold"
+          value={bus.compressor.thresholdDb}
+          min={COMPRESSOR_THRESHOLD_DB_MIN}
+          max={COMPRESSOR_THRESHOLD_DB_MAX}
+          step={1}
+          format={formatDb}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_COMPRESSOR", thresholdDb: v })
+          }
+        />
+        <LabeledSlider
+          label="Ratio"
+          value={bus.compressor.ratio}
+          min={COMPRESSOR_RATIO_MIN}
+          max={COMPRESSOR_RATIO_MAX}
+          step={1}
+          format={formatRatio}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_COMPRESSOR", ratio: v })
+          }
+        />
+        <LabeledSlider
+          label="Attack"
+          value={bus.compressor.attackSec}
+          min={COMPRESSOR_ATTACK_SEC_MIN}
+          max={COMPRESSOR_ATTACK_SEC_MAX}
+          step={0.001}
+          format={formatMs}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_COMPRESSOR", attackSec: v })
+          }
+        />
+        <LabeledSlider
+          label="Release"
+          value={bus.compressor.releaseSec}
+          min={COMPRESSOR_RELEASE_SEC_MIN}
+          max={COMPRESSOR_RELEASE_SEC_MAX}
+          step={0.01}
+          format={formatMs}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_COMPRESSOR", releaseSec: v })
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <SectionHeading>Limiter</SectionHeading>
+          <LimiterIndicator limiter={limiter} />
+        </div>
+        <LabeledSlider
+          label="Ceiling"
+          value={bus.limiterCeilingDb}
+          min={LIMITER_CEILING_DB_MIN}
+          max={LIMITER_CEILING_DB_MAX}
+          step={0.1}
+          format={formatDb}
+          onValueChange={(v) =>
+            dispatch({ type: "SET_MASTER_LIMITER_CEILING", ceilingDb: v })
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/components/studio/StereoMeter.test.tsx
+++ b/web/components/studio/StereoMeter.test.tsx
@@ -1,0 +1,157 @@
+import { render } from "@testing-library/react"
+import { act, createRef } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { StereoMeter } from "./StereoMeter"
+
+/** A fake AnalyserNode whose `getFloatTimeDomainData` fills the caller's
+ * buffer with a fixed sample window — swappable mid-test via `.samples`. */
+function fakeAnalyser(initial: number[] = [0]) {
+  const state = { samples: initial }
+  return {
+    node: {
+      fftSize: 8,
+      getFloatTimeDomainData: vi.fn((buf: Float32Array) => {
+        for (let i = 0; i < buf.length; i++) {
+          buf[i] = state.samples[i % state.samples.length]
+        }
+      }),
+    } as unknown as AnalyserNode,
+    setSamples(samples: number[]) {
+      state.samples = samples
+    },
+  }
+}
+
+function stubRaf() {
+  let nextId = 1
+  const callbacks = new Map<number, FrameRequestCallback>()
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((cb: FrameRequestCallback) => {
+      const id = nextId++
+      callbacks.set(id, cb)
+      return id
+    })
+  )
+  vi.stubGlobal(
+    "cancelAnimationFrame",
+    vi.fn((id: number) => {
+      callbacks.delete(id)
+    })
+  )
+  return {
+    tick(t: number) {
+      const due = [...callbacks.entries()]
+      callbacks.clear()
+      for (const [, cb] of due) cb(t)
+    },
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("StereoMeter", () => {
+  it("renders an L and R meter, silent by default", () => {
+    stubRaf()
+    const left = createRef<AnalyserNode | null>()
+    const right = createRef<AnalyserNode | null>()
+    const { getByRole } = render(
+      <StereoMeter analyserLeft={left} analyserRight={right} />
+    )
+    expect(
+      getByRole("meter", { name: "L channel level" })
+    ).toBeInTheDocument()
+    expect(
+      getByRole("meter", { name: "R channel level" })
+    ).toBeInTheDocument()
+  })
+
+  it("reflects a loud left-channel signal in its meter value, distinct from a silent right channel", () => {
+    const raf = stubRaf()
+    const l = fakeAnalyser([1, -1, 1, -1])
+    const r = fakeAnalyser([0])
+    const left = { current: l.node }
+    const right = { current: r.node }
+
+    const { getByRole } = render(
+      <StereoMeter analyserLeft={left} analyserRight={right} />
+    )
+    act(() => raf.tick(16))
+
+    const leftMeter = getByRole("meter", { name: "L channel level" })
+    const rightMeter = getByRole("meter", { name: "R channel level" })
+    expect(Number(leftMeter.getAttribute("aria-valuenow"))).toBeCloseTo(0, 0)
+    expect(Number(rightMeter.getAttribute("aria-valuenow"))).toBeLessThan(-40)
+  })
+
+  it("shows a clip indicator once a channel's peak exceeds 0 dBFS", () => {
+    const raf = stubRaf()
+    const l = fakeAnalyser([2, -2]) // amplitude > 1 → clips
+    const left = { current: l.node }
+    const right = { current: null }
+
+    const { getByTestId } = render(
+      <StereoMeter analyserLeft={left} analyserRight={right} />
+    )
+    expect(getByTestId("clip-indicator-l")).toHaveAttribute(
+      "data-clipping",
+      "false"
+    )
+
+    act(() => raf.tick(16))
+    expect(getByTestId("clip-indicator-l")).toHaveAttribute(
+      "data-clipping",
+      "true"
+    )
+  })
+
+  it("holds the peak marker after a loud transient drops to silence, within the hold window", () => {
+    const raf = stubRaf()
+    const l = fakeAnalyser([1, -1])
+    const left = { current: l.node }
+    const right = { current: null }
+
+    const { getByRole } = render(
+      <StereoMeter analyserLeft={left} analyserRight={right} />
+    )
+    act(() => raf.tick(0))
+    const leftMeter = getByRole("meter", { name: "L channel level" })
+    expect(Number(leftMeter.getAttribute("aria-valuenow"))).toBeCloseTo(0, 0)
+
+    l.setSamples([0])
+    act(() => raf.tick(50)) // well within the hold window
+    // The instantaneous peak dropped to silence, but the held marker must
+    // still read near 0 dBFS.
+    const holdEl = getByRole("meter", { name: "L channel level" }).querySelector(
+      '[data-role="peak-hold"]'
+    )
+    expect(holdEl).not.toBeNull()
+    const holdPercent = parseFloat((holdEl as HTMLElement).style.bottom)
+    expect(holdPercent).toBeGreaterThan(90)
+  })
+
+  it("cancels the animation frame loop on unmount", () => {
+    stubRaf()
+    const left = { current: null }
+    const right = { current: null }
+    const { unmount } = render(
+      <StereoMeter analyserLeft={left} analyserRight={right} />
+    )
+    unmount()
+    expect(cancelAnimationFrame).toHaveBeenCalled()
+  })
+
+  it("renders at the floor with no error when analysers are not yet built (null refs)", () => {
+    stubRaf()
+    const left = { current: null }
+    const right = { current: null }
+    const { getByRole } = render(
+      <StereoMeter analyserLeft={left} analyserRight={right} />
+    )
+    const leftMeter = getByRole("meter", { name: "L channel level" })
+    expect(leftMeter).toBeInTheDocument()
+  })
+})

--- a/web/components/studio/StereoMeter.test.tsx
+++ b/web/components/studio/StereoMeter.test.tsx
@@ -3,6 +3,7 @@ import { act, createRef } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { StereoMeter } from "./StereoMeter"
+import { stubRaf } from "@/test/raf-stub"
 
 /** A fake AnalyserNode whose `getFloatTimeDomainData` fills the caller's
  * buffer with a fixed sample window — swappable mid-test via `.samples`. */
@@ -19,32 +20,6 @@ function fakeAnalyser(initial: number[] = [0]) {
     } as unknown as AnalyserNode,
     setSamples(samples: number[]) {
       state.samples = samples
-    },
-  }
-}
-
-function stubRaf() {
-  let nextId = 1
-  const callbacks = new Map<number, FrameRequestCallback>()
-  vi.stubGlobal(
-    "requestAnimationFrame",
-    vi.fn((cb: FrameRequestCallback) => {
-      const id = nextId++
-      callbacks.set(id, cb)
-      return id
-    })
-  )
-  vi.stubGlobal(
-    "cancelAnimationFrame",
-    vi.fn((id: number) => {
-      callbacks.delete(id)
-    })
-  )
-  return {
-    tick(t: number) {
-      const due = [...callbacks.entries()]
-      callbacks.clear()
-      for (const [, cb] of due) cb(t)
     },
   }
 }

--- a/web/components/studio/StereoMeter.test.tsx
+++ b/web/components/studio/StereoMeter.test.tsx
@@ -61,12 +61,8 @@ describe("StereoMeter", () => {
     const { getByRole } = render(
       <StereoMeter analyserLeft={left} analyserRight={right} />
     )
-    expect(
-      getByRole("meter", { name: "L channel level" })
-    ).toBeInTheDocument()
-    expect(
-      getByRole("meter", { name: "R channel level" })
-    ).toBeInTheDocument()
+    expect(getByRole("meter", { name: "L channel level" })).toBeInTheDocument()
+    expect(getByRole("meter", { name: "R channel level" })).toBeInTheDocument()
   })
 
   it("reflects a loud left-channel signal in its meter value, distinct from a silent right channel", () => {
@@ -125,9 +121,9 @@ describe("StereoMeter", () => {
     act(() => raf.tick(50)) // well within the hold window
     // The instantaneous peak dropped to silence, but the held marker must
     // still read near 0 dBFS.
-    const holdEl = getByRole("meter", { name: "L channel level" }).querySelector(
-      '[data-role="peak-hold"]'
-    )
+    const holdEl = getByRole("meter", {
+      name: "L channel level",
+    }).querySelector('[data-role="peak-hold"]')
     expect(holdEl).not.toBeNull()
     const holdPercent = parseFloat((holdEl as HTMLElement).style.bottom)
     expect(holdPercent).toBeGreaterThan(90)

--- a/web/components/studio/StereoMeter.tsx
+++ b/web/components/studio/StereoMeter.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useEffect, useRef, useState, type RefObject } from "react"
+
+import {
+  METER_FLOOR_DB,
+  peakDbfs,
+  rmsDbfs,
+  stepPeakHold,
+  type PeakHoldState,
+} from "@/lib/metering"
+import { cn } from "@/lib/utils"
+
+// Real-time peak/RMS metering for the master bus (US-19.5): a rAF loop reads
+// both analysers' time-domain data each frame, computes levels via the pure
+// math in lib/metering.ts, and setState's the result — setState here runs
+// inside the rAF callback (an async-context callback), not synchronously in
+// the effect body, so it doesn't trip react-hooks/set-state-in-effect.
+
+const METER_TICKS_DB = [0, -6, -12, -24, -48] as const
+
+function dbToPercent(db: number): number {
+  const clamped = Math.max(METER_FLOOR_DB, Math.min(0, db))
+  return ((clamped - METER_FLOOR_DB) / -METER_FLOOR_DB) * 100
+}
+
+function levelColorClass(db: number): string {
+  if (db > 0) return "bg-destructive"
+  if (db > -6) return "bg-amber-500"
+  return "bg-emerald-500"
+}
+
+type ChannelLevels = { peakDb: number; rmsDb: number; holdDb: number }
+
+const SILENT_LEVELS: ChannelLevels = {
+  peakDb: METER_FLOOR_DB,
+  rmsDb: METER_FLOOR_DB,
+  holdDb: METER_FLOOR_DB,
+}
+
+function ChannelBar({
+  label,
+  levels,
+}: {
+  label: "L" | "R"
+  levels: ChannelLevels
+}) {
+  const clipping = levels.peakDb > 0
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div
+        role="meter"
+        aria-label={`${label} channel level`}
+        aria-valuemin={METER_FLOOR_DB}
+        aria-valuemax={0}
+        aria-valuenow={Math.round(levels.peakDb)}
+        className="relative h-32 w-3 overflow-hidden rounded-sm bg-muted"
+      >
+        <div
+          className={cn(
+            "absolute inset-x-0 bottom-0",
+            levelColorClass(levels.rmsDb)
+          )}
+          style={{ height: `${dbToPercent(levels.rmsDb)}%` }}
+        />
+        <div
+          data-role="peak-hold"
+          className={cn("absolute inset-x-0 h-0.5", levelColorClass(levels.holdDb))}
+          style={{ bottom: `${dbToPercent(levels.holdDb)}%` }}
+        />
+      </div>
+      <span
+        data-testid={`clip-indicator-${label.toLowerCase()}`}
+        data-clipping={clipping}
+        aria-hidden="true"
+        className={cn(
+          "size-1.5 rounded-full",
+          clipping ? "bg-destructive" : "bg-muted"
+        )}
+      />
+    </div>
+  )
+}
+
+export function StereoMeter({
+  analyserLeft,
+  analyserRight,
+}: {
+  analyserLeft: RefObject<AnalyserNode | null>
+  analyserRight: RefObject<AnalyserNode | null>
+}) {
+  const [left, setLeft] = useState<ChannelLevels>(SILENT_LEVELS)
+  const [right, setRight] = useState<ChannelLevels>(SILENT_LEVELS)
+
+  const leftHoldRef = useRef<PeakHoldState | null>(null)
+  const rightHoldRef = useRef<PeakHoldState | null>(null)
+  const buffersRef = useRef(new WeakMap<AnalyserNode, Float32Array<ArrayBuffer>>())
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    function bufferFor(analyser: AnalyserNode): Float32Array<ArrayBuffer> {
+      const cached = buffersRef.current.get(analyser)
+      if (cached && cached.length === analyser.fftSize) return cached
+      const fresh = new Float32Array(analyser.fftSize)
+      buffersRef.current.set(analyser, fresh)
+      return fresh
+    }
+
+    function readChannel(
+      analyser: AnalyserNode | null,
+      holdRef: RefObject<PeakHoldState | null>,
+      nowMs: number
+    ): ChannelLevels {
+      if (!analyser) return SILENT_LEVELS
+      const buffer = bufferFor(analyser)
+      analyser.getFloatTimeDomainData(buffer)
+      const peakDb = peakDbfs(buffer)
+      const rmsDb = rmsDbfs(buffer)
+      holdRef.current = stepPeakHold(holdRef.current, peakDb, nowMs)
+      return { peakDb, rmsDb, holdDb: holdRef.current.db }
+    }
+
+    function tick(nowMs: number) {
+      setLeft(readChannel(analyserLeft.current, leftHoldRef, nowMs))
+      setRight(readChannel(analyserRight.current, rightHoldRef, nowMs))
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [analyserLeft, analyserRight])
+
+  return (
+    <div className="flex items-end gap-3">
+      <div className="relative h-32 w-5 text-[10px] text-muted-foreground">
+        {METER_TICKS_DB.map((db) => (
+          <span
+            key={db}
+            className="absolute right-0 -translate-y-1/2 tabular-nums"
+            style={{ bottom: `${dbToPercent(db)}%` }}
+          >
+            {db}
+          </span>
+        ))}
+      </div>
+      <ChannelBar label="L" levels={left} />
+      <ChannelBar label="R" levels={right} />
+    </div>
+  )
+}

--- a/web/components/studio/StereoMeter.tsx
+++ b/web/components/studio/StereoMeter.tsx
@@ -53,7 +53,7 @@ function ChannelBar({
         aria-label={`${label} channel level`}
         aria-valuemin={METER_FLOOR_DB}
         aria-valuemax={0}
-        aria-valuenow={Math.round(levels.peakDb)}
+        aria-valuenow={Math.round(Math.min(0, levels.peakDb))}
         className="relative h-32 w-3 overflow-hidden rounded-sm bg-muted"
       >
         <div
@@ -125,9 +125,22 @@ export function StereoMeter({
       return { peakDb, rmsDb, holdDb: holdRef.current.db }
     }
 
+    // Returning the previous object when levels are unchanged lets React
+    // bail out of the re-render — during silence/pause the loop keeps
+    // ticking but stops repainting.
+    function replaceIfChanged(prev: ChannelLevels, next: ChannelLevels) {
+      return prev.peakDb === next.peakDb &&
+        prev.rmsDb === next.rmsDb &&
+        prev.holdDb === next.holdDb
+        ? prev
+        : next
+    }
+
     function tick(nowMs: number) {
-      setLeft(readChannel(analyserLeft.current, leftHoldRef, nowMs))
-      setRight(readChannel(analyserRight.current, rightHoldRef, nowMs))
+      const nextLeft = readChannel(analyserLeft.current, leftHoldRef, nowMs)
+      const nextRight = readChannel(analyserRight.current, rightHoldRef, nowMs)
+      setLeft((prev) => replaceIfChanged(prev, nextLeft))
+      setRight((prev) => replaceIfChanged(prev, nextRight))
       rafRef.current = requestAnimationFrame(tick)
     }
     rafRef.current = requestAnimationFrame(tick)

--- a/web/components/studio/StereoMeter.tsx
+++ b/web/components/studio/StereoMeter.tsx
@@ -65,7 +65,10 @@ function ChannelBar({
         />
         <div
           data-role="peak-hold"
-          className={cn("absolute inset-x-0 h-0.5", levelColorClass(levels.holdDb))}
+          className={cn(
+            "absolute inset-x-0 h-0.5",
+            levelColorClass(levels.holdDb)
+          )}
           style={{ bottom: `${dbToPercent(levels.holdDb)}%` }}
         />
       </div>
@@ -94,7 +97,9 @@ export function StereoMeter({
 
   const leftHoldRef = useRef<PeakHoldState | null>(null)
   const rightHoldRef = useRef<PeakHoldState | null>(null)
-  const buffersRef = useRef(new WeakMap<AnalyserNode, Float32Array<ArrayBuffer>>())
+  const buffersRef = useRef(
+    new WeakMap<AnalyserNode, Float32Array<ArrayBuffer>>()
+  )
   const rafRef = useRef<number | null>(null)
 
   useEffect(() => {

--- a/web/contexts/studio-context.test.ts
+++ b/web/contexts/studio-context.test.ts
@@ -848,6 +848,11 @@ describe("studioReducer masterBus (US-19.5)", () => {
     })
   })
 
+  it("SET_MASTER_COMPRESSOR with no fields returns the same state object", () => {
+    const s = base()
+    expect(studioReducer(s, { type: "SET_MASTER_COMPRESSOR" })).toBe(s)
+  })
+
   it("SET_MASTER_COMPRESSOR ignores non-finite fields", () => {
     const s = base()
     expect(

--- a/web/contexts/studio-context.test.ts
+++ b/web/contexts/studio-context.test.ts
@@ -5,6 +5,22 @@ import {
   studioReducer,
   type StudioState,
 } from "@/contexts/studio-context"
+import {
+  COMPRESSOR_ATTACK_SEC_MAX,
+  COMPRESSOR_RATIO_MAX,
+  COMPRESSOR_RELEASE_SEC_MAX,
+  COMPRESSOR_THRESHOLD_DB_MIN,
+  DEFAULT_MASTER_BUS,
+  EQ_GAIN_DB_MAX,
+  EQ_GAIN_DB_MIN,
+  EQ_HIGH_SHELF_FREQ_MAX,
+  EQ_LOW_SHELF_FREQ_MAX,
+  EQ_Q_MAX,
+  LIMITER_CEILING_DB_MAX,
+  LIMITER_CEILING_DB_MIN,
+  MASTER_VOLUME_DB_MAX,
+  MASTER_VOLUME_DB_MIN,
+} from "@/lib/master-bus"
 import { TRACK_TYPES, TRACK_TYPE_ORDER } from "@/lib/track-types"
 
 const base = (over: Partial<StudioState> = {}): StudioState => ({
@@ -677,5 +693,147 @@ describe("studioReducer markers (US-19.3)", () => {
     })
     const s = studioReducer(seeded, { type: "DELETE_MARKER", markerId: "m1" })
     expect(s.markers).toEqual([])
+  })
+})
+
+describe("studioReducer masterBus (US-19.5)", () => {
+  it("initializes to DEFAULT_MASTER_BUS", () => {
+    expect(initialStudioState.masterBus).toEqual(DEFAULT_MASTER_BUS)
+  })
+
+  it("SET_MASTER_VOLUME updates masterVolumeDb, clamped to the fader range", () => {
+    const s1 = studioReducer(base(), {
+      type: "SET_MASTER_VOLUME",
+      volumeDb: -12,
+    })
+    expect(s1.masterBus.masterVolumeDb).toBe(-12)
+    const s2 = studioReducer(base(), {
+      type: "SET_MASTER_VOLUME",
+      volumeDb: 100,
+    })
+    expect(s2.masterBus.masterVolumeDb).toBe(MASTER_VOLUME_DB_MAX)
+    const s3 = studioReducer(base(), {
+      type: "SET_MASTER_VOLUME",
+      volumeDb: -100,
+    })
+    expect(s3.masterBus.masterVolumeDb).toBe(MASTER_VOLUME_DB_MIN)
+  })
+
+  it("SET_MASTER_VOLUME ignores non-finite input", () => {
+    const s = base()
+    expect(
+      studioReducer(s, { type: "SET_MASTER_VOLUME", volumeDb: NaN })
+    ).toBe(s)
+  })
+
+  it("SET_MASTER_EQ updates only the targeted band, clamping freq/gain", () => {
+    const s1 = studioReducer(base(), {
+      type: "SET_MASTER_EQ",
+      band: "low",
+      freqHz: 50,
+      gainDb: 6,
+    })
+    expect(s1.masterBus.eq.lowShelf).toEqual({ freqHz: 50, gainDb: 6 })
+    expect(s1.masterBus.eq.midPeak).toEqual(DEFAULT_MASTER_BUS.eq.midPeak)
+    expect(s1.masterBus.eq.highShelf).toEqual(DEFAULT_MASTER_BUS.eq.highShelf)
+
+    const s2 = studioReducer(base(), {
+      type: "SET_MASTER_EQ",
+      band: "mid",
+      gainDb: 999,
+      q: 999,
+    })
+    expect(s2.masterBus.eq.midPeak.gainDb).toBe(EQ_GAIN_DB_MAX)
+    expect(s2.masterBus.eq.midPeak.q).toBe(EQ_Q_MAX)
+    // freqHz not passed — stays at the default.
+    expect(s2.masterBus.eq.midPeak.freqHz).toBe(
+      DEFAULT_MASTER_BUS.eq.midPeak.freqHz
+    )
+
+    const s3 = studioReducer(base(), {
+      type: "SET_MASTER_EQ",
+      band: "high",
+      freqHz: 999999,
+      gainDb: -999,
+    })
+    expect(s3.masterBus.eq.highShelf.freqHz).toBe(EQ_HIGH_SHELF_FREQ_MAX)
+    expect(s3.masterBus.eq.highShelf.gainDb).toBe(EQ_GAIN_DB_MIN)
+  })
+
+  it("SET_MASTER_EQ clamps each band's frequency to its own range", () => {
+    const s = studioReducer(base(), {
+      type: "SET_MASTER_EQ",
+      band: "low",
+      freqHz: 999999,
+    })
+    expect(s.masterBus.eq.lowShelf.freqHz).toBe(EQ_LOW_SHELF_FREQ_MAX)
+  })
+
+  it("SET_MASTER_EQ ignores non-finite fields", () => {
+    const s = base()
+    expect(
+      studioReducer(s, {
+        type: "SET_MASTER_EQ",
+        band: "low",
+        freqHz: NaN,
+      })
+    ).toBe(s)
+  })
+
+  it("SET_MASTER_COMPRESSOR patches only the provided fields, clamped", () => {
+    const s1 = studioReducer(base(), {
+      type: "SET_MASTER_COMPRESSOR",
+      thresholdDb: -30,
+    })
+    expect(s1.masterBus.compressor).toEqual({
+      ...DEFAULT_MASTER_BUS.compressor,
+      thresholdDb: -30,
+    })
+
+    const s2 = studioReducer(base(), {
+      type: "SET_MASTER_COMPRESSOR",
+      ratio: 999,
+      attackSec: 999,
+      releaseSec: 999,
+      thresholdDb: -999,
+    })
+    expect(s2.masterBus.compressor).toEqual({
+      thresholdDb: COMPRESSOR_THRESHOLD_DB_MIN,
+      ratio: COMPRESSOR_RATIO_MAX,
+      attackSec: COMPRESSOR_ATTACK_SEC_MAX,
+      releaseSec: COMPRESSOR_RELEASE_SEC_MAX,
+    })
+  })
+
+  it("SET_MASTER_COMPRESSOR ignores non-finite fields", () => {
+    const s = base()
+    expect(
+      studioReducer(s, { type: "SET_MASTER_COMPRESSOR", ratio: NaN })
+    ).toBe(s)
+  })
+
+  it("SET_MASTER_LIMITER_CEILING updates limiterCeilingDb, clamped", () => {
+    const s1 = studioReducer(base(), {
+      type: "SET_MASTER_LIMITER_CEILING",
+      ceilingDb: -1,
+    })
+    expect(s1.masterBus.limiterCeilingDb).toBe(-1)
+    const s2 = studioReducer(base(), {
+      type: "SET_MASTER_LIMITER_CEILING",
+      ceilingDb: 10,
+    })
+    expect(s2.masterBus.limiterCeilingDb).toBe(LIMITER_CEILING_DB_MAX)
+    const s3 = studioReducer(base(), {
+      type: "SET_MASTER_LIMITER_CEILING",
+      ceilingDb: -100,
+    })
+    expect(s3.masterBus.limiterCeilingDb).toBe(LIMITER_CEILING_DB_MIN)
+  })
+
+  it("SET_MASTER_LIMITER_CEILING ignores non-finite input", () => {
+    const s = base()
+    expect(
+      studioReducer(s, { type: "SET_MASTER_LIMITER_CEILING", ceilingDb: NaN })
+    ).toBe(s)
   })
 })

--- a/web/contexts/studio-context.test.ts
+++ b/web/contexts/studio-context.test.ts
@@ -77,14 +77,22 @@ describe("studioReducer tracks", () => {
   })
 
   it("REMOVE_TRACK drops the matching track", () => {
-    let s = studioReducer(base(), { type: "ADD_TRACK", id: "t1", trackType: "ai" })
+    let s = studioReducer(base(), {
+      type: "ADD_TRACK",
+      id: "t1",
+      trackType: "ai",
+    })
     s = studioReducer(s, { type: "ADD_TRACK", id: "t2", trackType: "ai" })
     s = studioReducer(s, { type: "REMOVE_TRACK", trackId: "t1" })
     expect(s.tracks.map((t) => t.id)).toEqual(["t2"])
   })
 
   it("RENAME_TRACK updates the matching track's name", () => {
-    let s = studioReducer(base(), { type: "ADD_TRACK", id: "t1", trackType: "ai" })
+    let s = studioReducer(base(), {
+      type: "ADD_TRACK",
+      id: "t1",
+      trackType: "ai",
+    })
     s = studioReducer(s, { type: "ADD_TRACK", id: "t2", trackType: "ai" })
     s = studioReducer(s, { type: "RENAME_TRACK", trackId: "t1", name: "Drums" })
     expect(s.tracks[0].name).toBe("Drums")
@@ -380,7 +388,9 @@ describe("studioReducer project tempo (US-19.2)", () => {
     const s = studioReducer(base(), { type: "SET_BPM", bpm: 150 })
     expect(s.seekEpoch).toBe(1)
     // An ignored non-finite value must not force a pointless reschedule.
-    expect(studioReducer(base(), { type: "SET_BPM", bpm: NaN }).seekEpoch).toBe(0)
+    expect(studioReducer(base(), { type: "SET_BPM", bpm: NaN }).seekEpoch).toBe(
+      0
+    )
   })
 
   it("SET_BPM is a full no-op when the clamped value equals the current tempo", () => {
@@ -509,7 +519,11 @@ describe("studioReducer loop region (US-19.3)", () => {
 
 describe("studioReducer per-track controls (US-19.4)", () => {
   function withTrack(): StudioState {
-    return studioReducer(base(), { type: "ADD_TRACK", id: "t1", trackType: "ai" })
+    return studioReducer(base(), {
+      type: "ADD_TRACK",
+      id: "t1",
+      trackType: "ai",
+    })
   }
 
   it("ADD_TRACK defaults volume to 0 dB, pan centered, not muted, not soloed", () => {
@@ -529,19 +543,35 @@ describe("studioReducer per-track controls (US-19.4)", () => {
       volumeDb: -12,
     })
     expect(s.tracks[0].volumeDb).toBe(-12)
-    s = studioReducer(s, { type: "SET_TRACK_VOLUME", trackId: "t1", volumeDb: 20 })
+    s = studioReducer(s, {
+      type: "SET_TRACK_VOLUME",
+      trackId: "t1",
+      volumeDb: 20,
+    })
     expect(s.tracks[0].volumeDb).toBe(6)
-    s = studioReducer(s, { type: "SET_TRACK_VOLUME", trackId: "t1", volumeDb: -99 })
+    s = studioReducer(s, {
+      type: "SET_TRACK_VOLUME",
+      trackId: "t1",
+      volumeDb: -99,
+    })
     expect(s.tracks[0].volumeDb).toBe(-60)
   })
 
   it("SET_TRACK_VOLUME ignores a non-finite value and unknown tracks", () => {
     const s = withTrack()
     expect(
-      studioReducer(s, { type: "SET_TRACK_VOLUME", trackId: "t1", volumeDb: NaN })
+      studioReducer(s, {
+        type: "SET_TRACK_VOLUME",
+        trackId: "t1",
+        volumeDb: NaN,
+      })
     ).toBe(s)
     expect(
-      studioReducer(s, { type: "SET_TRACK_VOLUME", trackId: "nope", volumeDb: -6 })
+      studioReducer(s, {
+        type: "SET_TRACK_VOLUME",
+        trackId: "nope",
+        volumeDb: -6,
+      })
     ).toBe(s)
   })
 
@@ -563,9 +593,9 @@ describe("studioReducer per-track controls (US-19.4)", () => {
     expect(
       studioReducer(s, { type: "SET_TRACK_PAN", trackId: "t1", pan: NaN })
     ).toBe(s)
-    expect(studioReducer(s, { type: "SET_TRACK_PAN", trackId: "nope", pan: 10 })).toBe(
-      s
-    )
+    expect(
+      studioReducer(s, { type: "SET_TRACK_PAN", trackId: "nope", pan: 10 })
+    ).toBe(s)
   })
 
   it("TOGGLE_TRACK_MUTE flips only the targeted track", () => {
@@ -596,8 +626,12 @@ describe("studioReducer per-track controls (US-19.4)", () => {
 
   it("TOGGLE_TRACK_MUTE / TOGGLE_TRACK_SOLO on unknown tracks are no-ops", () => {
     const s = withTrack()
-    expect(studioReducer(s, { type: "TOGGLE_TRACK_MUTE", trackId: "nope" })).toBe(s)
-    expect(studioReducer(s, { type: "TOGGLE_TRACK_SOLO", trackId: "nope" })).toBe(s)
+    expect(
+      studioReducer(s, { type: "TOGGLE_TRACK_MUTE", trackId: "nope" })
+    ).toBe(s)
+    expect(
+      studioReducer(s, { type: "TOGGLE_TRACK_SOLO", trackId: "nope" })
+    ).toBe(s)
   })
 
   it("SET_TRACK_COLOR recolors only the targeted track", () => {
@@ -614,7 +648,11 @@ describe("studioReducer per-track controls (US-19.4)", () => {
     expect(s.tracks[0].color).toBe("#f43f5e")
     expect(s.tracks[1].color).toBe(TRACK_TYPES.loop.color)
     expect(
-      studioReducer(s, { type: "SET_TRACK_COLOR", trackId: "nope", color: "#000" })
+      studioReducer(s, {
+        type: "SET_TRACK_COLOR",
+        trackId: "nope",
+        color: "#000",
+      })
     ).toBe(s)
   })
 
@@ -721,9 +759,9 @@ describe("studioReducer masterBus (US-19.5)", () => {
 
   it("SET_MASTER_VOLUME ignores non-finite input", () => {
     const s = base()
-    expect(
-      studioReducer(s, { type: "SET_MASTER_VOLUME", volumeDb: NaN })
-    ).toBe(s)
+    expect(studioReducer(s, { type: "SET_MASTER_VOLUME", volumeDb: NaN })).toBe(
+      s
+    )
   })
 
   it("SET_MASTER_EQ updates only the targeted band, clamping freq/gain", () => {

--- a/web/contexts/studio-context.test.ts
+++ b/web/contexts/studio-context.test.ts
@@ -807,6 +807,11 @@ describe("studioReducer masterBus (US-19.5)", () => {
     expect(s.masterBus.eq.lowShelf.freqHz).toBe(EQ_LOW_SHELF_FREQ_MAX)
   })
 
+  it("SET_MASTER_EQ with no fields returns the same state object", () => {
+    const s = base()
+    expect(studioReducer(s, { type: "SET_MASTER_EQ", band: "mid" })).toBe(s)
+  })
+
   it("SET_MASTER_EQ ignores non-finite fields", () => {
     const s = base()
     expect(

--- a/web/contexts/studio-context.tsx
+++ b/web/contexts/studio-context.tsx
@@ -488,6 +488,15 @@ export function studioReducer(
     }
     case "SET_MASTER_COMPRESSOR": {
       const { thresholdDb, ratio, attackSec, releaseSec } = action
+      // No fields → keep state identity (same rationale as SET_MASTER_EQ).
+      if (
+        thresholdDb === undefined &&
+        ratio === undefined &&
+        attackSec === undefined &&
+        releaseSec === undefined
+      ) {
+        return state
+      }
       if (
         (thresholdDb !== undefined && !Number.isFinite(thresholdDb)) ||
         (ratio !== undefined && !Number.isFinite(ratio)) ||

--- a/web/contexts/studio-context.tsx
+++ b/web/contexts/studio-context.tsx
@@ -9,6 +9,33 @@ import {
 } from "react"
 
 import {
+  clamp,
+  COMPRESSOR_ATTACK_SEC_MAX,
+  COMPRESSOR_ATTACK_SEC_MIN,
+  COMPRESSOR_RATIO_MAX,
+  COMPRESSOR_RATIO_MIN,
+  COMPRESSOR_RELEASE_SEC_MAX,
+  COMPRESSOR_RELEASE_SEC_MIN,
+  COMPRESSOR_THRESHOLD_DB_MAX,
+  COMPRESSOR_THRESHOLD_DB_MIN,
+  DEFAULT_MASTER_BUS,
+  EQ_GAIN_DB_MAX,
+  EQ_GAIN_DB_MIN,
+  EQ_HIGH_SHELF_FREQ_MAX,
+  EQ_HIGH_SHELF_FREQ_MIN,
+  EQ_LOW_SHELF_FREQ_MAX,
+  EQ_LOW_SHELF_FREQ_MIN,
+  EQ_MID_FREQ_MAX,
+  EQ_MID_FREQ_MIN,
+  EQ_Q_MAX,
+  EQ_Q_MIN,
+  LIMITER_CEILING_DB_MAX,
+  LIMITER_CEILING_DB_MIN,
+  MASTER_VOLUME_DB_MAX,
+  MASTER_VOLUME_DB_MIN,
+  type MasterBusState,
+} from "@/lib/master-bus"
+import {
   clampZoom,
   DEFAULT_BPM,
   type DisplayMode,
@@ -67,6 +94,9 @@ export type StudioState = {
   // reschedule audio from the new position/rates instead of stomping it on
   // the next frame.
   seekEpoch: number
+  /** Master bus: EQ/compressor/limiter/volume sitting after the track sum,
+   * before the destination (US-19.5). */
+  masterBus: MasterBusState
 }
 
 export const initialStudioState: StudioState = {
@@ -84,6 +114,7 @@ export const initialStudioState: StudioState = {
   loopEndSec: 8,
   markers: [],
   seekEpoch: 0,
+  masterBus: DEFAULT_MASTER_BUS,
 }
 
 export type StudioAction =
@@ -134,6 +165,23 @@ export type StudioAction =
   | { type: "RENAME_MARKER"; markerId: string; label: string }
   | { type: "MOVE_MARKER"; markerId: string; sec: number }
   | { type: "DELETE_MARKER"; markerId: string }
+  | { type: "SET_MASTER_VOLUME"; volumeDb: number }
+  | {
+      type: "SET_MASTER_EQ"
+      band: "low" | "mid" | "high"
+      freqHz?: number
+      gainDb?: number
+      /** Only meaningful for the mid band's peaking filter. */
+      q?: number
+    }
+  | {
+      type: "SET_MASTER_COMPRESSOR"
+      thresholdDb?: number
+      ratio?: number
+      attackSec?: number
+      releaseSec?: number
+    }
+  | { type: "SET_MASTER_LIMITER_CEILING"; ceilingDb: number }
 
 /** Replace one track via `update`; unknown ids are a strict no-op. */
 function updateTrack(
@@ -335,6 +383,155 @@ export function studioReducer(
         ...state,
         markers: state.markers.filter((m) => m.id !== action.markerId),
       }
+    case "SET_MASTER_VOLUME": {
+      if (!Number.isFinite(action.volumeDb)) return state
+      return {
+        ...state,
+        masterBus: {
+          ...state.masterBus,
+          masterVolumeDb: clamp(
+            action.volumeDb,
+            MASTER_VOLUME_DB_MIN,
+            MASTER_VOLUME_DB_MAX
+          ),
+        },
+      }
+    }
+    case "SET_MASTER_EQ": {
+      const { band, freqHz, gainDb, q } = action
+      if (
+        (freqHz !== undefined && !Number.isFinite(freqHz)) ||
+        (gainDb !== undefined && !Number.isFinite(gainDb)) ||
+        (q !== undefined && !Number.isFinite(q))
+      ) {
+        return state
+      }
+      const eq = state.masterBus.eq
+      if (band === "low") {
+        return {
+          ...state,
+          masterBus: {
+            ...state.masterBus,
+            eq: {
+              ...eq,
+              lowShelf: {
+                freqHz:
+                  freqHz !== undefined
+                    ? clamp(freqHz, EQ_LOW_SHELF_FREQ_MIN, EQ_LOW_SHELF_FREQ_MAX)
+                    : eq.lowShelf.freqHz,
+                gainDb:
+                  gainDb !== undefined
+                    ? clamp(gainDb, EQ_GAIN_DB_MIN, EQ_GAIN_DB_MAX)
+                    : eq.lowShelf.gainDb,
+              },
+            },
+          },
+        }
+      }
+      if (band === "mid") {
+        return {
+          ...state,
+          masterBus: {
+            ...state.masterBus,
+            eq: {
+              ...eq,
+              midPeak: {
+                freqHz:
+                  freqHz !== undefined
+                    ? clamp(freqHz, EQ_MID_FREQ_MIN, EQ_MID_FREQ_MAX)
+                    : eq.midPeak.freqHz,
+                gainDb:
+                  gainDb !== undefined
+                    ? clamp(gainDb, EQ_GAIN_DB_MIN, EQ_GAIN_DB_MAX)
+                    : eq.midPeak.gainDb,
+                q: q !== undefined ? clamp(q, EQ_Q_MIN, EQ_Q_MAX) : eq.midPeak.q,
+              },
+            },
+          },
+        }
+      }
+      return {
+        ...state,
+        masterBus: {
+          ...state.masterBus,
+          eq: {
+            ...eq,
+            highShelf: {
+              freqHz:
+                freqHz !== undefined
+                  ? clamp(freqHz, EQ_HIGH_SHELF_FREQ_MIN, EQ_HIGH_SHELF_FREQ_MAX)
+                  : eq.highShelf.freqHz,
+              gainDb:
+                gainDb !== undefined
+                  ? clamp(gainDb, EQ_GAIN_DB_MIN, EQ_GAIN_DB_MAX)
+                  : eq.highShelf.gainDb,
+            },
+          },
+        },
+      }
+    }
+    case "SET_MASTER_COMPRESSOR": {
+      const { thresholdDb, ratio, attackSec, releaseSec } = action
+      if (
+        (thresholdDb !== undefined && !Number.isFinite(thresholdDb)) ||
+        (ratio !== undefined && !Number.isFinite(ratio)) ||
+        (attackSec !== undefined && !Number.isFinite(attackSec)) ||
+        (releaseSec !== undefined && !Number.isFinite(releaseSec))
+      ) {
+        return state
+      }
+      const compressor = state.masterBus.compressor
+      return {
+        ...state,
+        masterBus: {
+          ...state.masterBus,
+          compressor: {
+            thresholdDb:
+              thresholdDb !== undefined
+                ? clamp(
+                    thresholdDb,
+                    COMPRESSOR_THRESHOLD_DB_MIN,
+                    COMPRESSOR_THRESHOLD_DB_MAX
+                  )
+                : compressor.thresholdDb,
+            ratio:
+              ratio !== undefined
+                ? clamp(ratio, COMPRESSOR_RATIO_MIN, COMPRESSOR_RATIO_MAX)
+                : compressor.ratio,
+            attackSec:
+              attackSec !== undefined
+                ? clamp(
+                    attackSec,
+                    COMPRESSOR_ATTACK_SEC_MIN,
+                    COMPRESSOR_ATTACK_SEC_MAX
+                  )
+                : compressor.attackSec,
+            releaseSec:
+              releaseSec !== undefined
+                ? clamp(
+                    releaseSec,
+                    COMPRESSOR_RELEASE_SEC_MIN,
+                    COMPRESSOR_RELEASE_SEC_MAX
+                  )
+                : compressor.releaseSec,
+          },
+        },
+      }
+    }
+    case "SET_MASTER_LIMITER_CEILING": {
+      if (!Number.isFinite(action.ceilingDb)) return state
+      return {
+        ...state,
+        masterBus: {
+          ...state.masterBus,
+          limiterCeilingDb: clamp(
+            action.ceilingDb,
+            LIMITER_CEILING_DB_MIN,
+            LIMITER_CEILING_DB_MAX
+          ),
+        },
+      }
+    }
     default:
       return state
   }

--- a/web/contexts/studio-context.tsx
+++ b/web/contexts/studio-context.tsx
@@ -402,6 +402,10 @@ export function studioReducer(
     }
     case "SET_MASTER_EQ": {
       const { band, freqHz, gainDb, q } = action
+      // No fields → keep state identity (same rationale as SET_BPM).
+      if (freqHz === undefined && gainDb === undefined && q === undefined) {
+        return state
+      }
       if (
         (freqHz !== undefined && !Number.isFinite(freqHz)) ||
         (gainDb !== undefined && !Number.isFinite(gainDb)) ||

--- a/web/contexts/studio-context.tsx
+++ b/web/contexts/studio-context.tsx
@@ -245,7 +245,10 @@ export function studioReducer(
         muted: !t.muted,
       }))
     case "TOGGLE_TRACK_SOLO":
-      return updateTrack(state, action.trackId, (t) => ({ ...t, solo: !t.solo }))
+      return updateTrack(state, action.trackId, (t) => ({
+        ...t,
+        solo: !t.solo,
+      }))
     case "SET_TRACK_COLOR": {
       // Applied verbatim as CSS (border/background) — an empty value would
       // silently erase the track's visual identity.
@@ -417,7 +420,11 @@ export function studioReducer(
               lowShelf: {
                 freqHz:
                   freqHz !== undefined
-                    ? clamp(freqHz, EQ_LOW_SHELF_FREQ_MIN, EQ_LOW_SHELF_FREQ_MAX)
+                    ? clamp(
+                        freqHz,
+                        EQ_LOW_SHELF_FREQ_MIN,
+                        EQ_LOW_SHELF_FREQ_MAX
+                      )
                     : eq.lowShelf.freqHz,
                 gainDb:
                   gainDb !== undefined
@@ -444,7 +451,8 @@ export function studioReducer(
                   gainDb !== undefined
                     ? clamp(gainDb, EQ_GAIN_DB_MIN, EQ_GAIN_DB_MAX)
                     : eq.midPeak.gainDb,
-                q: q !== undefined ? clamp(q, EQ_Q_MIN, EQ_Q_MAX) : eq.midPeak.q,
+                q:
+                  q !== undefined ? clamp(q, EQ_Q_MIN, EQ_Q_MAX) : eq.midPeak.q,
               },
             },
           },
@@ -459,7 +467,11 @@ export function studioReducer(
             highShelf: {
               freqHz:
                 freqHz !== undefined
-                  ? clamp(freqHz, EQ_HIGH_SHELF_FREQ_MIN, EQ_HIGH_SHELF_FREQ_MAX)
+                  ? clamp(
+                      freqHz,
+                      EQ_HIGH_SHELF_FREQ_MIN,
+                      EQ_HIGH_SHELF_FREQ_MAX
+                    )
                   : eq.highShelf.freqHz,
               gainDb:
                 gainDb !== undefined

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -9,6 +9,7 @@ import { StudioProvider, useStudio } from "@/contexts/studio-context"
 import {
   DEFAULT_MASTER_BUS,
   LIMITER_ATTACK_SEC,
+  LIMITER_RELEASE_SEC,
   LIMITER_RATIO,
 } from "@/lib/master-bus"
 import { dbToGain } from "@/lib/track-audio"
@@ -1346,9 +1347,10 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
       DEFAULT_MASTER_BUS.compressor.releaseSec
     )
 
-    // Limiter ratio/attack are fixed constants, not driven by user state.
+    // Limiter ratio/attack/release are fixed constants, not driven by user state.
     expect(limiter.ratio.value).toBe(LIMITER_RATIO)
     expect(limiter.attack.value).toBeCloseTo(LIMITER_ATTACK_SEC)
+    expect(limiter.release.value).toBeCloseTo(LIMITER_RELEASE_SEC)
     expect(limiter.threshold.value).toBe(DEFAULT_MASTER_BUS.limiterCeilingDb)
 
     const masterVolume = gains[gains.length - 1]

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -101,6 +101,7 @@ function stubAudioContext(initialState: AudioContextState = "running") {
       currentTime: number
       state: AudioContextState
       resume: () => Promise<void>
+      destination: object
     } | null
   } = { instance: null }
   class FakeAudioContext {
@@ -1225,7 +1226,7 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
   }
 
   it("wires the master chain sum → EQ → compressor → masterVolume → limiter → destination + analysers", async () => {
-    const { gains, biquads, compressors, splitters, analysers } =
+    const { gains, biquads, compressors, splitters, analysers, box } =
       stubAudioContext()
     stubRaf()
     getClipAudioMock.mockResolvedValue(audio)
@@ -1261,6 +1262,7 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
     // the limiter's output — the actual signal reaching the destination.
     expect(compressor.connect).toHaveBeenCalledWith(masterVolume)
     expect(masterVolume.connect).toHaveBeenCalledWith(limiter)
+    expect(limiter.connect).toHaveBeenCalledWith(box.instance!.destination)
     expect(limiter.connect).toHaveBeenCalledWith(splitters[0])
     expect(splitters[0].connect).toHaveBeenCalledWith(analyserLeft, 0)
     expect(splitters[0].connect).toHaveBeenCalledWith(analyserRight, 1)

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -150,7 +150,16 @@ function stubAudioContext(initialState: AudioContextState = "running") {
     }
   }
   vi.stubGlobal("AudioContext", FakeAudioContext)
-  return { sources, gains, panners, biquads, compressors, splitters, analysers, box }
+  return {
+    sources,
+    gains,
+    panners,
+    biquads,
+    compressors,
+    splitters,
+    analysers,
+    box,
+  }
 }
 
 function stubRaf() {
@@ -370,8 +379,20 @@ describe("useStudioPlayback scheduling", () => {
             { id: "t2", trackType: "ai" },
           ]}
           clips={[
-            { clipId: "c1", title: "A", duration: 4, startSec: 0, trackId: "t1" },
-            { clipId: "c2", title: "B", duration: 4, startSec: 0, trackId: "t2" },
+            {
+              clipId: "c1",
+              title: "A",
+              duration: 4,
+              startSec: 0,
+              trackId: "t1",
+            },
+            {
+              clipId: "c2",
+              title: "B",
+              duration: 4,
+              startSec: 0,
+              trackId: "t2",
+            },
           ]}
           autoplay
         />
@@ -929,16 +950,28 @@ describe("useStudioPlayback per-track controls (US-19.4)", () => {
     useStudioPlayback("tok")
     return (
       <>
-        <button onClick={() => dispatch({ type: "SET_TRACK_VOLUME", trackId: "t1", volumeDb: -6 })}>
+        <button
+          onClick={() =>
+            dispatch({ type: "SET_TRACK_VOLUME", trackId: "t1", volumeDb: -6 })
+          }
+        >
           duck t1
         </button>
-        <button onClick={() => dispatch({ type: "SET_TRACK_PAN", trackId: "t1", pan: -100 })}>
+        <button
+          onClick={() =>
+            dispatch({ type: "SET_TRACK_PAN", trackId: "t1", pan: -100 })
+          }
+        >
           pan t1 left
         </button>
-        <button onClick={() => dispatch({ type: "TOGGLE_TRACK_MUTE", trackId: "t1" })}>
+        <button
+          onClick={() => dispatch({ type: "TOGGLE_TRACK_MUTE", trackId: "t1" })}
+        >
           mute t1
         </button>
-        <button onClick={() => dispatch({ type: "TOGGLE_TRACK_SOLO", trackId: "t2" })}>
+        <button
+          onClick={() => dispatch({ type: "TOGGLE_TRACK_SOLO", trackId: "t2" })}
+        >
           solo t2
         </button>
       </>
@@ -1108,9 +1141,7 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
           {limiter.current ? "ready" : "null"}
         </div>
         <button
-          onClick={() =>
-            dispatch({ type: "SET_MASTER_VOLUME", volumeDb: -12 })
-          }
+          onClick={() => dispatch({ type: "SET_MASTER_VOLUME", volumeDb: -12 })}
         >
           set master volume
         </button>
@@ -1185,7 +1216,11 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
     )
   }
 
-  const audio = { buffer: fakeBuffer(), peaks: new Float32Array(), duration: 100 }
+  const audio = {
+    buffer: fakeBuffer(),
+    peaks: new Float32Array(),
+    duration: 100,
+  }
 
   it("wires the master chain sum → EQ → compressor → limiter → masterVolume → destination + analysers", async () => {
     const { gains, biquads, compressors, splitters, analysers } =
@@ -1252,9 +1287,7 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
       }, [])
       useStudioPlayback("tok")
       return (
-        <button onClick={() => dispatch({ type: "SEEK", sec: 5 })}>
-          seek
-        </button>
+        <button onClick={() => dispatch({ type: "SEEK", sec: 5 })}>seek</button>
       )
     }
 

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -9,6 +9,7 @@ import { StudioProvider, useStudio } from "@/contexts/studio-context"
 import {
   DEFAULT_MASTER_BUS,
   LIMITER_ATTACK_SEC,
+  LIMITER_KNEE_DB,
   LIMITER_RELEASE_SEC,
   LIMITER_RATIO,
 } from "@/lib/master-bus"
@@ -1354,6 +1355,10 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
     expect(limiter.ratio.value).toBe(LIMITER_RATIO)
     expect(limiter.attack.value).toBeCloseTo(LIMITER_ATTACK_SEC)
     expect(limiter.release.value).toBeCloseTo(LIMITER_RELEASE_SEC)
+    // Hard knee — with the Web Audio default (30 dB) the full 20:1 ratio only
+    // engages 15 dB above threshold, so a -6 dB ceiling would never cap
+    // realistic (non-clipping) material. Live-demo verified.
+    expect(limiter.knee.value).toBe(LIMITER_KNEE_DB)
     expect(limiter.threshold.value).toBe(DEFAULT_MASTER_BUS.limiterCeilingDb)
 
     const masterVolume = gains[gains.length - 1]

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -6,6 +6,12 @@ import { useEffect, useRef } from "react"
 import { useStudioPlayback } from "./use-studio-playback"
 import { PlayerProvider, usePlayer } from "@/contexts/player-context"
 import { StudioProvider, useStudio } from "@/contexts/studio-context"
+import {
+  DEFAULT_MASTER_BUS,
+  LIMITER_ATTACK_SEC,
+  LIMITER_RATIO,
+} from "@/lib/master-bus"
+import { dbToGain } from "@/lib/track-audio"
 import type { TrackType } from "@/lib/track-types"
 
 const { getClipAudioMock } = vi.hoisted(() => ({
@@ -33,6 +39,38 @@ class FakePannerNode {
   pan = { value: 0 }
 }
 
+class FakeBiquadFilterNode {
+  type: BiquadFilterType = "lowpass"
+  connect = vi.fn()
+  disconnect = vi.fn()
+  frequency = { value: 350 }
+  gain = { value: 0 }
+  Q = { value: 1 }
+}
+
+class FakeDynamicsCompressorNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+  threshold = { value: -24 }
+  knee = { value: 30 }
+  ratio = { value: 12 }
+  attack = { value: 0.003 }
+  release = { value: 0.25 }
+  reduction = 0
+}
+
+class FakeChannelSplitterNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+}
+
+class FakeAnalyserNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+  fftSize = 2048
+  getFloatTimeDomainData = vi.fn()
+}
+
 class FakeSourceNode {
   buffer: AudioBuffer | null = null
   playbackRate = { value: 1 }
@@ -48,9 +86,14 @@ class FakeSourceNode {
  * context "suspended" until resumed from a user gesture. */
 function stubAudioContext(initialState: AudioContextState = "running") {
   const sources: FakeSourceNode[] = []
-  // gains[0] is always the master gain; per-track gains follow (US-19.4).
+  // gains[0] is always the master gain; per-track gains follow (US-19.4);
+  // the master bus's own volume gain is appended after them, once (US-19.5).
   const gains: FakeGainNode[] = []
   const panners: FakePannerNode[] = []
+  const biquads: FakeBiquadFilterNode[] = []
+  const compressors: FakeDynamicsCompressorNode[] = []
+  const splitters: FakeChannelSplitterNode[] = []
+  const analysers: FakeAnalyserNode[] = []
   const box: {
     instance: {
       currentTime: number
@@ -77,6 +120,26 @@ function stubAudioContext(initialState: AudioContextState = "running") {
       sources.push(s)
       return s
     })
+    createBiquadFilter = vi.fn(() => {
+      const f = new FakeBiquadFilterNode()
+      biquads.push(f)
+      return f
+    })
+    createDynamicsCompressor = vi.fn(() => {
+      const c = new FakeDynamicsCompressorNode()
+      compressors.push(c)
+      return c
+    })
+    createChannelSplitter = vi.fn(() => {
+      const s = new FakeChannelSplitterNode()
+      splitters.push(s)
+      return s
+    })
+    createAnalyser = vi.fn(() => {
+      const a = new FakeAnalyserNode()
+      analysers.push(a)
+      return a
+    })
     resume = vi.fn(() => {
       this.state = "running"
       return Promise.resolve()
@@ -87,7 +150,7 @@ function stubAudioContext(initialState: AudioContextState = "running") {
     }
   }
   vi.stubGlobal("AudioContext", FakeAudioContext)
-  return { sources, gains, panners, box }
+  return { sources, gains, panners, biquads, compressors, splitters, analysers, box }
 }
 
 function stubRaf() {
@@ -911,8 +974,11 @@ describe("useStudioPlayback per-track controls (US-19.4)", () => {
       await Promise.resolve()
     })
 
-    // gains[0] = master; then one gain+panner per track, in track order.
-    expect(gains).toHaveLength(3)
+    // gains[0] = master sum; then one gain+panner per track, in track order;
+    // gains[3] = the master bus's own volume gain, appended once it's built
+    // after the per-track loop (US-19.5) — appending after preserves every
+    // other index this and sibling tests rely on.
+    expect(gains).toHaveLength(4)
     expect(panners).toHaveLength(2)
     expect(sources).toHaveLength(2)
     expect(sources[0].connect).toHaveBeenCalledWith(gains[1])
@@ -1006,5 +1072,359 @@ describe("useStudioPlayback per-track controls (US-19.4)", () => {
     expect(sources).toHaveLength(2)
     expect(sources[0].stop).not.toHaveBeenCalled()
     expect(sources[1].stop).not.toHaveBeenCalled()
+  })
+})
+
+describe("useStudioPlayback master bus (US-19.5)", () => {
+  function MasterBusSeed() {
+    const { dispatch } = useStudio()
+    const seededRef = useRef(false)
+    useEffect(() => {
+      if (seededRef.current) return
+      seededRef.current = true
+      dispatch({ type: "ADD_TRACK", id: "t1", trackType: "ai" })
+      dispatch({
+        type: "ADD_CLIP",
+        id: "p0",
+        trackId: "t1",
+        clipId: "c1",
+        startSec: 0,
+        title: "A",
+        durationSec: 100,
+      })
+      dispatch({ type: "SET_PLAYING", playing: true })
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+    const { analyserLeft, analyserRight } = useStudioPlayback("tok")
+    return (
+      <>
+        <div data-testid="analyser-left-probe">
+          {analyserLeft.current ? "ready" : "null"}
+        </div>
+        <div data-testid="analyser-right-probe">
+          {analyserRight.current ? "ready" : "null"}
+        </div>
+        <button
+          onClick={() =>
+            dispatch({ type: "SET_MASTER_VOLUME", volumeDb: -12 })
+          }
+        >
+          set master volume
+        </button>
+        <button
+          onClick={() =>
+            dispatch({
+              type: "SET_MASTER_EQ",
+              band: "low",
+              freqHz: 60,
+              gainDb: 4,
+            })
+          }
+        >
+          set low eq
+        </button>
+        <button
+          onClick={() =>
+            dispatch({
+              type: "SET_MASTER_EQ",
+              band: "mid",
+              freqHz: 2000,
+              gainDb: -3,
+              q: 2,
+            })
+          }
+        >
+          set mid eq
+        </button>
+        <button
+          onClick={() =>
+            dispatch({
+              type: "SET_MASTER_EQ",
+              band: "high",
+              freqHz: 6000,
+              gainDb: 5,
+            })
+          }
+        >
+          set high eq
+        </button>
+        <button
+          onClick={() =>
+            dispatch({
+              type: "SET_MASTER_COMPRESSOR",
+              thresholdDb: -10,
+              ratio: 6,
+              attackSec: 0.05,
+              releaseSec: 0.2,
+            })
+          }
+        >
+          set compressor
+        </button>
+        <button
+          onClick={() =>
+            dispatch({ type: "SET_MASTER_LIMITER_CEILING", ceilingDb: -1 })
+          }
+        >
+          set limiter ceiling
+        </button>
+      </>
+    )
+  }
+
+  function MasterBusHarness() {
+    return (
+      <PlayerProvider>
+        <StudioProvider>
+          <MasterBusSeed />
+        </StudioProvider>
+      </PlayerProvider>
+    )
+  }
+
+  const audio = { buffer: fakeBuffer(), peaks: new Float32Array(), duration: 100 }
+
+  it("wires the master chain sum → EQ → compressor → limiter → masterVolume → destination + analysers", async () => {
+    const { gains, biquads, compressors, splitters, analysers } =
+      stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue(audio)
+
+    await act(async () => {
+      render(<MasterBusHarness />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(biquads).toHaveLength(3)
+    const [lowShelf, midPeak, highShelf] = biquads
+    expect(lowShelf.type).toBe("lowshelf")
+    expect(midPeak.type).toBe("peaking")
+    expect(highShelf.type).toBe("highshelf")
+
+    expect(compressors).toHaveLength(2)
+    const [compressor, limiter] = compressors
+
+    expect(splitters).toHaveLength(1)
+    expect(analysers).toHaveLength(2)
+    const [analyserLeft, analyserRight] = analysers
+
+    const sum = gains[0]
+    const masterVolume = gains[gains.length - 1]
+
+    expect(sum.connect).toHaveBeenCalledWith(lowShelf)
+    expect(lowShelf.connect).toHaveBeenCalledWith(midPeak)
+    expect(midPeak.connect).toHaveBeenCalledWith(highShelf)
+    expect(highShelf.connect).toHaveBeenCalledWith(compressor)
+    expect(compressor.connect).toHaveBeenCalledWith(limiter)
+    expect(limiter.connect).toHaveBeenCalledWith(masterVolume)
+    expect(masterVolume.connect).toHaveBeenCalledWith(splitters[0])
+    expect(splitters[0].connect).toHaveBeenCalledWith(analyserLeft, 0)
+    expect(splitters[0].connect).toHaveBeenCalledWith(analyserRight, 1)
+  })
+
+  it("only builds the master chain once across repeated play runs", async () => {
+    const { biquads } = stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue(audio)
+
+    function ReplaySeed() {
+      const { dispatch } = useStudio()
+      const seededRef = useRef(false)
+      useEffect(() => {
+        if (seededRef.current) return
+        seededRef.current = true
+        dispatch({ type: "ADD_TRACK", id: "t1", trackType: "ai" })
+        dispatch({
+          type: "ADD_CLIP",
+          id: "p0",
+          trackId: "t1",
+          clipId: "c1",
+          startSec: 0,
+          title: "A",
+          durationSec: 100,
+        })
+        dispatch({ type: "SET_PLAYING", playing: true })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [])
+      useStudioPlayback("tok")
+      return (
+        <button onClick={() => dispatch({ type: "SEEK", sec: 5 })}>
+          seek
+        </button>
+      )
+    }
+
+    const { getByRole } = render(
+      <PlayerProvider>
+        <StudioProvider>
+          <ReplaySeed />
+        </StudioProvider>
+      </PlayerProvider>
+    )
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(biquads).toHaveLength(3)
+
+    await act(async () => {
+      getByRole("button", { name: "seek" }).click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    // A seek reschedules per-track nodes but must not rebuild the master
+    // chain a second time.
+    expect(biquads).toHaveLength(3)
+  })
+
+  it("initializes chain params from DEFAULT_MASTER_BUS at build time", async () => {
+    const { gains, biquads, compressors } = stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue(audio)
+
+    await act(async () => {
+      render(<MasterBusHarness />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const [lowShelf, midPeak, highShelf] = biquads
+    expect(lowShelf.frequency.value).toBe(DEFAULT_MASTER_BUS.eq.lowShelf.freqHz)
+    expect(lowShelf.gain.value).toBe(DEFAULT_MASTER_BUS.eq.lowShelf.gainDb)
+    expect(midPeak.frequency.value).toBe(DEFAULT_MASTER_BUS.eq.midPeak.freqHz)
+    expect(midPeak.Q.value).toBe(DEFAULT_MASTER_BUS.eq.midPeak.q)
+    expect(highShelf.frequency.value).toBe(
+      DEFAULT_MASTER_BUS.eq.highShelf.freqHz
+    )
+
+    const [compressor, limiter] = compressors
+    expect(compressor.threshold.value).toBe(
+      DEFAULT_MASTER_BUS.compressor.thresholdDb
+    )
+    expect(compressor.ratio.value).toBe(DEFAULT_MASTER_BUS.compressor.ratio)
+    expect(compressor.attack.value).toBe(
+      DEFAULT_MASTER_BUS.compressor.attackSec
+    )
+    expect(compressor.release.value).toBe(
+      DEFAULT_MASTER_BUS.compressor.releaseSec
+    )
+
+    // Limiter ratio/attack are fixed constants, not driven by user state.
+    expect(limiter.ratio.value).toBe(LIMITER_RATIO)
+    expect(limiter.attack.value).toBeCloseTo(LIMITER_ATTACK_SEC)
+    expect(limiter.threshold.value).toBe(DEFAULT_MASTER_BUS.limiterCeilingDb)
+
+    const masterVolume = gains[gains.length - 1]
+    expect(masterVolume.gain.value).toBeCloseTo(
+      dbToGain(DEFAULT_MASTER_BUS.masterVolumeDb)
+    )
+  })
+
+  it("exposes analyser refs once the chain is built", async () => {
+    const { box } = stubAudioContext()
+    const raf = stubRaf()
+    getClipAudioMock.mockResolvedValue(audio)
+
+    const { getByTestId } = render(<MasterBusHarness />)
+    expect(getByTestId("analyser-left-probe")).toHaveTextContent("null")
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // The ref itself is already populated by this point — refs don't trigger
+    // a re-render on mutation, so force one (a rAF tick dispatches
+    // SET_PLAYHEAD) to observe it reflected in the DOM.
+    act(() => {
+      box.instance!.currentTime = 1
+      raf.tick(1000)
+    })
+
+    expect(getByTestId("analyser-left-probe")).toHaveTextContent("ready")
+    expect(getByTestId("analyser-right-probe")).toHaveTextContent("ready")
+  })
+
+  it("live-retunes master volume without rescheduling sources", async () => {
+    const { sources, gains } = stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue(audio)
+
+    const { getByRole } = render(<MasterBusHarness />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(sources).toHaveLength(1)
+    const masterVolume = gains[gains.length - 1]
+    expect(masterVolume.gain.value).toBeCloseTo(1)
+
+    await act(async () => {
+      getByRole("button", { name: "set master volume" }).click()
+    })
+    expect(masterVolume.gain.value).toBeCloseTo(dbToGain(-12))
+    expect(sources).toHaveLength(1)
+    expect(sources[0].stop).not.toHaveBeenCalled()
+  })
+
+  it("live-retunes EQ bands without rescheduling sources", async () => {
+    const { sources, biquads } = stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue(audio)
+
+    const { getByRole } = render(<MasterBusHarness />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    const [lowShelf, midPeak, highShelf] = biquads
+
+    await act(async () => {
+      getByRole("button", { name: "set low eq" }).click()
+      getByRole("button", { name: "set mid eq" }).click()
+      getByRole("button", { name: "set high eq" }).click()
+    })
+
+    expect(lowShelf.frequency.value).toBe(60)
+    expect(lowShelf.gain.value).toBe(4)
+    expect(midPeak.frequency.value).toBe(2000)
+    expect(midPeak.gain.value).toBe(-3)
+    expect(midPeak.Q.value).toBe(2)
+    expect(highShelf.frequency.value).toBe(6000)
+    expect(highShelf.gain.value).toBe(5)
+
+    expect(sources).toHaveLength(1)
+    expect(sources[0].stop).not.toHaveBeenCalled()
+  })
+
+  it("live-retunes the compressor and limiter ceiling without rescheduling sources", async () => {
+    const { sources, compressors } = stubAudioContext()
+    stubRaf()
+    getClipAudioMock.mockResolvedValue(audio)
+
+    const { getByRole } = render(<MasterBusHarness />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    const [compressor, limiter] = compressors
+
+    await act(async () => {
+      getByRole("button", { name: "set compressor" }).click()
+      getByRole("button", { name: "set limiter ceiling" }).click()
+    })
+
+    expect(compressor.threshold.value).toBe(-10)
+    expect(compressor.ratio.value).toBe(6)
+    expect(compressor.attack.value).toBe(0.05)
+    expect(compressor.release.value).toBe(0.2)
+    expect(limiter.threshold.value).toBe(-1)
+    // Ratio/attack remain fixed even after a limiter-ceiling change.
+    expect(limiter.ratio.value).toBe(LIMITER_RATIO)
+    expect(limiter.attack.value).toBeCloseTo(LIMITER_ATTACK_SEC)
+
+    expect(sources).toHaveLength(1)
+    expect(sources[0].stop).not.toHaveBeenCalled()
   })
 })

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -1095,7 +1095,7 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
       dispatch({ type: "SET_PLAYING", playing: true })
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
-    const { analyserLeft, analyserRight } = useStudioPlayback("tok")
+    const { analyserLeft, analyserRight, limiter } = useStudioPlayback("tok")
     return (
       <>
         <div data-testid="analyser-left-probe">
@@ -1103,6 +1103,9 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
         </div>
         <div data-testid="analyser-right-probe">
           {analyserRight.current ? "ready" : "null"}
+        </div>
+        <div data-testid="limiter-probe">
+          {limiter.current ? "ready" : "null"}
         </div>
         <button
           onClick={() =>
@@ -1321,13 +1324,14 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
     )
   })
 
-  it("exposes analyser refs once the chain is built", async () => {
+  it("exposes analyser and limiter refs once the chain is built", async () => {
     const { box } = stubAudioContext()
     const raf = stubRaf()
     getClipAudioMock.mockResolvedValue(audio)
 
     const { getByTestId } = render(<MasterBusHarness />)
     expect(getByTestId("analyser-left-probe")).toHaveTextContent("null")
+    expect(getByTestId("limiter-probe")).toHaveTextContent("null")
 
     await act(async () => {
       await Promise.resolve()
@@ -1344,6 +1348,7 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
 
     expect(getByTestId("analyser-left-probe")).toHaveTextContent("ready")
     expect(getByTestId("analyser-right-probe")).toHaveTextContent("ready")
+    expect(getByTestId("limiter-probe")).toHaveTextContent("ready")
   })
 
   it("live-retunes master volume without rescheduling sources", async () => {

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -1223,7 +1223,7 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
     duration: 100,
   }
 
-  it("wires the master chain sum → EQ → compressor → limiter → masterVolume → destination + analysers", async () => {
+  it("wires the master chain sum → EQ → compressor → masterVolume → limiter → destination + analysers", async () => {
     const { gains, biquads, compressors, splitters, analysers } =
       stubAudioContext()
     stubRaf()
@@ -1255,9 +1255,12 @@ describe("useStudioPlayback master bus (US-19.5)", () => {
     expect(lowShelf.connect).toHaveBeenCalledWith(midPeak)
     expect(midPeak.connect).toHaveBeenCalledWith(highShelf)
     expect(highShelf.connect).toHaveBeenCalledWith(compressor)
-    expect(compressor.connect).toHaveBeenCalledWith(limiter)
-    expect(limiter.connect).toHaveBeenCalledWith(masterVolume)
-    expect(masterVolume.connect).toHaveBeenCalledWith(splitters[0])
+    // Master volume feeds INTO the limiter (not after it) so the configured
+    // ceiling is a true output cap even at +6 dB fader boost; the meter taps
+    // the limiter's output — the actual signal reaching the destination.
+    expect(compressor.connect).toHaveBeenCalledWith(masterVolume)
+    expect(masterVolume.connect).toHaveBeenCalledWith(limiter)
+    expect(limiter.connect).toHaveBeenCalledWith(splitters[0])
     expect(splitters[0].connect).toHaveBeenCalledWith(analyserLeft, 0)
     expect(splitters[0].connect).toHaveBeenCalledWith(analyserRight, 1)
   })

--- a/web/hooks/use-studio-playback.test.tsx
+++ b/web/hooks/use-studio-playback.test.tsx
@@ -15,6 +15,13 @@ import {
 } from "@/lib/master-bus"
 import { dbToGain } from "@/lib/track-audio"
 import type { TrackType } from "@/lib/track-types"
+import {
+  FakeAnalyserNode,
+  FakeBiquadFilterNode,
+  FakeChannelSplitterNode,
+  FakeDynamicsCompressorNode,
+} from "@/test/audio-stubs"
+import { stubRaf } from "@/test/raf-stub"
 
 const { getClipAudioMock } = vi.hoisted(() => ({
   getClipAudioMock: vi.fn(),
@@ -39,38 +46,6 @@ class FakePannerNode {
   connect = vi.fn()
   disconnect = vi.fn()
   pan = { value: 0 }
-}
-
-class FakeBiquadFilterNode {
-  type: BiquadFilterType = "lowpass"
-  connect = vi.fn()
-  disconnect = vi.fn()
-  frequency = { value: 350 }
-  gain = { value: 0 }
-  Q = { value: 1 }
-}
-
-class FakeDynamicsCompressorNode {
-  connect = vi.fn()
-  disconnect = vi.fn()
-  threshold = { value: -24 }
-  knee = { value: 30 }
-  ratio = { value: 12 }
-  attack = { value: 0.003 }
-  release = { value: 0.25 }
-  reduction = 0
-}
-
-class FakeChannelSplitterNode {
-  connect = vi.fn()
-  disconnect = vi.fn()
-}
-
-class FakeAnalyserNode {
-  connect = vi.fn()
-  disconnect = vi.fn()
-  fftSize = 2048
-  getFloatTimeDomainData = vi.fn()
 }
 
 class FakeSourceNode {
@@ -162,33 +137,6 @@ function stubAudioContext(initialState: AudioContextState = "running") {
     splitters,
     analysers,
     box,
-  }
-}
-
-function stubRaf() {
-  let nextId = 1
-  const callbacks = new Map<number, FrameRequestCallback>()
-  vi.stubGlobal(
-    "requestAnimationFrame",
-    vi.fn((cb: FrameRequestCallback) => {
-      const id = nextId++
-      callbacks.set(id, cb)
-      return id
-    })
-  )
-  vi.stubGlobal(
-    "cancelAnimationFrame",
-    vi.fn((id: number) => {
-      callbacks.delete(id)
-    })
-  )
-  return {
-    /** Invoke every currently-scheduled rAF callback once, at time `t`. */
-    tick(t: number) {
-      const due = [...callbacks.entries()]
-      callbacks.clear()
-      for (const [, cb] of due) cb(t)
-    },
   }
 }
 

--- a/web/hooks/use-studio-playback.ts
+++ b/web/hooks/use-studio-playback.ts
@@ -72,12 +72,16 @@ function applyMasterBusParams(nodes: MasterBusNodes, bus: MasterBusState) {
   nodes.masterVolume.gain.value = dbToGain(bus.masterVolumeDb)
 }
 
-export type MasterAnalysers = {
+export type MasterBusRefs = {
   analyserLeft: RefObject<AnalyserNode | null>
   analyserRight: RefObject<AnalyserNode | null>
+  /** Exposed for the limiter-active indicator, which reads the live
+   * `.reduction` value — an audio-domain measurement with no state-slice
+   * equivalent, same rationale as the analysers. */
+  limiter: RefObject<DynamicsCompressorNode | null>
 }
 
-export function useStudioPlayback(token: string | null): MasterAnalysers {
+export function useStudioPlayback(token: string | null): MasterBusRefs {
   const { state, dispatch } = useStudio()
   const { dispatch: playerDispatch } = usePlayer()
 
@@ -131,6 +135,7 @@ export function useStudioPlayback(token: string | null): MasterAnalysers {
   const masterBusNodesRef = useRef<MasterBusNodes | null>(null)
   const analyserLeftRef = useRef<AnalyserNode | null>(null)
   const analyserRightRef = useRef<AnalyserNode | null>(null)
+  const limiterRef = useRef<DynamicsCompressorNode | null>(null)
   // Mirrors state.masterBus (like tracksRef mirrors state.tracks) so a chain
   // built after the user has already tweaked settings still starts in tune.
   const masterBusValuesRef = useRef(state.masterBus)
@@ -197,6 +202,7 @@ export function useStudioPlayback(token: string | null): MasterAnalysers {
     masterBusNodesRef.current = nodes
     analyserLeftRef.current = analyserLeft
     analyserRightRef.current = analyserRight
+    limiterRef.current = limiter
     applyMasterBusParams(nodes, masterBusValuesRef.current)
   }
 
@@ -380,8 +386,12 @@ export function useStudioPlayback(token: string | null): MasterAnalysers {
     }
   }, [])
 
-  // The two ref objects (not their `.current` values) are stable across
+  // The ref objects (not their `.current` values) are stable across
   // renders, so this literal's identity churning each render is harmless —
-  // a consumer's effect can depend on analyserLeft/analyserRight directly.
-  return { analyserLeft: analyserLeftRef, analyserRight: analyserRightRef }
+  // a consumer's effect can depend on the individual refs directly.
+  return {
+    analyserLeft: analyserLeftRef,
+    analyserRight: analyserRightRef,
+    limiter: limiterRef,
+  }
 }

--- a/web/hooks/use-studio-playback.ts
+++ b/web/hooks/use-studio-playback.ts
@@ -48,7 +48,7 @@ type ActiveSource = { source: AudioBufferSourceNode }
 type TrackNodes = { gain: GainNode; panner: StereoPannerNode }
 
 /** The master bus's own post-sum processing chain (US-19.5): sum → EQ →
- * compressor → limiter → masterVolume → [destination, metering splitter]. */
+ * compressor → masterVolume → limiter → [destination, metering splitter]. */
 type MasterBusNodes = {
   lowShelf: BiquadFilterNode
   midPeak: BiquadFilterNode
@@ -186,14 +186,19 @@ export function useStudioPlayback(token: string | null): MasterBusRefs {
     const analyserLeft = ctx.createAnalyser()
     const analyserRight = ctx.createAnalyser()
 
+    // Master volume sits between compressor and limiter: after the compressor
+    // so the fader doesn't change compression amount, but before the limiter
+    // so the configured ceiling is a true output cap even at +6 dB boost.
+    // The metering splitter taps the limiter's output — the actual signal
+    // reaching the destination.
     sum.connect(lowShelf)
     lowShelf.connect(midPeak)
     midPeak.connect(highShelf)
     highShelf.connect(compressor)
-    compressor.connect(limiter)
-    limiter.connect(masterVolume)
-    masterVolume.connect(ctx.destination)
-    masterVolume.connect(splitter)
+    compressor.connect(masterVolume)
+    masterVolume.connect(limiter)
+    limiter.connect(ctx.destination)
+    limiter.connect(splitter)
     splitter.connect(analyserLeft, 0)
     splitter.connect(analyserRight, 1)
 

--- a/web/hooks/use-studio-playback.ts
+++ b/web/hooks/use-studio-playback.ts
@@ -8,6 +8,7 @@ import { getAudioContextCtor } from "@/lib/audio-context"
 import { getClipAudio } from "@/lib/clip-audio-cache"
 import {
   LIMITER_ATTACK_SEC,
+  LIMITER_KNEE_DB,
   LIMITER_RELEASE_SEC,
   LIMITER_RATIO,
   type MasterBusState,
@@ -181,6 +182,7 @@ export function useStudioPlayback(token: string | null): MasterBusRefs {
     limiter.ratio.value = LIMITER_RATIO
     limiter.attack.value = LIMITER_ATTACK_SEC
     limiter.release.value = LIMITER_RELEASE_SEC
+    limiter.knee.value = LIMITER_KNEE_DB
     const masterVolume = ctx.createGain()
     const splitter = ctx.createChannelSplitter(2)
     const analyserLeft = ctx.createAnalyser()

--- a/web/hooks/use-studio-playback.ts
+++ b/web/hooks/use-studio-playback.ts
@@ -12,7 +12,11 @@ import {
   type MasterBusState,
 } from "@/lib/master-bus"
 import { computePlaybackSchedule, type Placement } from "@/lib/timeline"
-import { dbToGain, effectiveTrackGain, panToAudioValue } from "@/lib/track-audio"
+import {
+  dbToGain,
+  effectiveTrackGain,
+  panToAudioValue,
+} from "@/lib/track-audio"
 import { placementPlaybackRate } from "@/lib/track-types"
 
 // Studio-owned playback engine (US-19.1). Schedules every placement across

--- a/web/hooks/use-studio-playback.ts
+++ b/web/hooks/use-studio-playback.ts
@@ -1,13 +1,18 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, type RefObject } from "react"
 
 import { usePlayer } from "@/contexts/player-context"
 import { useStudio } from "@/contexts/studio-context"
 import { getAudioContextCtor } from "@/lib/audio-context"
 import { getClipAudio } from "@/lib/clip-audio-cache"
+import {
+  LIMITER_ATTACK_SEC,
+  LIMITER_RATIO,
+  type MasterBusState,
+} from "@/lib/master-bus"
 import { computePlaybackSchedule, type Placement } from "@/lib/timeline"
-import { effectiveTrackGain, panToAudioValue } from "@/lib/track-audio"
+import { dbToGain, effectiveTrackGain, panToAudioValue } from "@/lib/track-audio"
 import { placementPlaybackRate } from "@/lib/track-types"
 
 // Studio-owned playback engine (US-19.1). Schedules every placement across
@@ -37,7 +42,42 @@ type ActiveSource = { source: AudioBufferSourceNode }
 /** One track's live mixer chain: source → gain → panner → master (US-19.4). */
 type TrackNodes = { gain: GainNode; panner: StereoPannerNode }
 
-export function useStudioPlayback(token: string | null): void {
+/** The master bus's own post-sum processing chain (US-19.5): sum → EQ →
+ * compressor → limiter → masterVolume → [destination, metering splitter]. */
+type MasterBusNodes = {
+  lowShelf: BiquadFilterNode
+  midPeak: BiquadFilterNode
+  highShelf: BiquadFilterNode
+  compressor: DynamicsCompressorNode
+  limiter: DynamicsCompressorNode
+  masterVolume: GainNode
+}
+
+function applyMasterBusParams(nodes: MasterBusNodes, bus: MasterBusState) {
+  nodes.lowShelf.frequency.value = bus.eq.lowShelf.freqHz
+  nodes.lowShelf.gain.value = bus.eq.lowShelf.gainDb
+  nodes.midPeak.frequency.value = bus.eq.midPeak.freqHz
+  nodes.midPeak.gain.value = bus.eq.midPeak.gainDb
+  nodes.midPeak.Q.value = bus.eq.midPeak.q
+  nodes.highShelf.frequency.value = bus.eq.highShelf.freqHz
+  nodes.highShelf.gain.value = bus.eq.highShelf.gainDb
+  nodes.compressor.threshold.value = bus.compressor.thresholdDb
+  nodes.compressor.ratio.value = bus.compressor.ratio
+  nodes.compressor.attack.value = bus.compressor.attackSec
+  nodes.compressor.release.value = bus.compressor.releaseSec
+  // The limiter's ratio/attack are fixed (a high-ratio DynamicsCompressorNode
+  // standing in for a true limiter); only its ceiling is user-adjustable,
+  // modeled as the node's threshold.
+  nodes.limiter.threshold.value = bus.limiterCeilingDb
+  nodes.masterVolume.gain.value = dbToGain(bus.masterVolumeDb)
+}
+
+export type MasterAnalysers = {
+  analyserLeft: RefObject<AnalyserNode | null>
+  analyserRight: RefObject<AnalyserNode | null>
+}
+
+export function useStudioPlayback(token: string | null): MasterAnalysers {
   const { state, dispatch } = useStudio()
   const { dispatch: playerDispatch } = usePlayer()
 
@@ -85,16 +125,79 @@ export function useStudioPlayback(token: string | null): void {
     }
   }, [state.tracks])
 
+  // The master bus's own chain (US-19.5), built once per AudioContext (see
+  // ensureMasterChain below) — unlike per-track nodes, it survives play/pause
+  // cycles rather than being rebuilt on every run.
+  const masterBusNodesRef = useRef<MasterBusNodes | null>(null)
+  const analyserLeftRef = useRef<AnalyserNode | null>(null)
+  const analyserRightRef = useRef<AnalyserNode | null>(null)
+  // Mirrors state.masterBus (like tracksRef mirrors state.tracks) so a chain
+  // built after the user has already tweaked settings still starts in tune.
+  const masterBusValuesRef = useRef(state.masterBus)
+  useEffect(() => {
+    masterBusValuesRef.current = state.masterBus
+    const nodes = masterBusNodesRef.current
+    if (!nodes) return
+    applyMasterBusParams(nodes, state.masterBus)
+  }, [state.masterBus])
+
   function ensureContext(): AudioContext {
     if (!ctxRef.current) {
       const Ctx = getAudioContextCtor()
       const ctx = new Ctx()
       ctxRef.current = ctx
       const gain = ctx.createGain()
-      gain.connect(ctx.destination)
       masterGainRef.current = gain
     }
     return ctxRef.current
+  }
+
+  /** Builds the master bus's post-sum chain the first time playback runs,
+   * splicing it between the summing gain and the destination — see the
+   * per-track gain-creation loop below for why this must run *after* it
+   * (index ordering the wiring tests key off). Idempotent on every later run. */
+  function ensureMasterChain(ctx: AudioContext) {
+    if (masterBusNodesRef.current) return
+    const sum = masterGainRef.current!
+
+    const lowShelf = ctx.createBiquadFilter()
+    lowShelf.type = "lowshelf"
+    const midPeak = ctx.createBiquadFilter()
+    midPeak.type = "peaking"
+    const highShelf = ctx.createBiquadFilter()
+    highShelf.type = "highshelf"
+    const compressor = ctx.createDynamicsCompressor()
+    const limiter = ctx.createDynamicsCompressor()
+    limiter.ratio.value = LIMITER_RATIO
+    limiter.attack.value = LIMITER_ATTACK_SEC
+    const masterVolume = ctx.createGain()
+    const splitter = ctx.createChannelSplitter(2)
+    const analyserLeft = ctx.createAnalyser()
+    const analyserRight = ctx.createAnalyser()
+
+    sum.connect(lowShelf)
+    lowShelf.connect(midPeak)
+    midPeak.connect(highShelf)
+    highShelf.connect(compressor)
+    compressor.connect(limiter)
+    limiter.connect(masterVolume)
+    masterVolume.connect(ctx.destination)
+    masterVolume.connect(splitter)
+    splitter.connect(analyserLeft, 0)
+    splitter.connect(analyserRight, 1)
+
+    const nodes: MasterBusNodes = {
+      lowShelf,
+      midPeak,
+      highShelf,
+      compressor,
+      limiter,
+      masterVolume,
+    }
+    masterBusNodesRef.current = nodes
+    analyserLeftRef.current = analyserLeft
+    analyserRightRef.current = analyserRight
+    applyMasterBusParams(nodes, masterBusValuesRef.current)
   }
 
   function stopAllSources() {
@@ -204,6 +307,11 @@ export function useStudioPlayback(token: string | null): void {
           trackNodesRef.current.set(scheduled.id, { gain, panner })
         }
 
+        // Built after the per-track loop above (see ensureMasterChain's own
+        // note) — its GainNode must not shift indices per-track code already
+        // assumes for the track chains it just created.
+        ensureMasterChain(ctx)
+
         for (const item of schedule) {
           const buffer = bufferByClipId.get(item.clipId)
           if (!buffer) continue
@@ -271,4 +379,9 @@ export function useStudioPlayback(token: string | null): void {
       void ctxRef.current?.close()
     }
   }, [])
+
+  // The two ref objects (not their `.current` values) are stable across
+  // renders, so this literal's identity churning each render is harmless —
+  // a consumer's effect can depend on analyserLeft/analyserRight directly.
+  return { analyserLeft: analyserLeftRef, analyserRight: analyserRightRef }
 }

--- a/web/hooks/use-studio-playback.ts
+++ b/web/hooks/use-studio-playback.ts
@@ -8,6 +8,7 @@ import { getAudioContextCtor } from "@/lib/audio-context"
 import { getClipAudio } from "@/lib/clip-audio-cache"
 import {
   LIMITER_ATTACK_SEC,
+  LIMITER_RELEASE_SEC,
   LIMITER_RATIO,
   type MasterBusState,
 } from "@/lib/master-bus"
@@ -179,6 +180,7 @@ export function useStudioPlayback(token: string | null): MasterBusRefs {
     const limiter = ctx.createDynamicsCompressor()
     limiter.ratio.value = LIMITER_RATIO
     limiter.attack.value = LIMITER_ATTACK_SEC
+    limiter.release.value = LIMITER_RELEASE_SEC
     const masterVolume = ctx.createGain()
     const splitter = ctx.createChannelSplitter(2)
     const analyserLeft = ctx.createAnalyser()

--- a/web/lib/master-bus.test.ts
+++ b/web/lib/master-bus.test.ts
@@ -61,7 +61,7 @@ describe("master-bus defaults", () => {
 
 describe("clamp", () => {
   it("passes values within range through unchanged", () => {
-    expect(clamp(5, 0, 10)) .toBe(5)
+    expect(clamp(5, 0, 10)).toBe(5)
   })
   it("clamps below the minimum", () => {
     expect(clamp(-5, 0, 10)).toBe(0)
@@ -85,7 +85,9 @@ describe("master-bus param ranges", () => {
   })
 
   it("defines compressor param bounds", () => {
-    expect(COMPRESSOR_THRESHOLD_DB_MIN).toBeLessThan(COMPRESSOR_THRESHOLD_DB_MAX)
+    expect(COMPRESSOR_THRESHOLD_DB_MIN).toBeLessThan(
+      COMPRESSOR_THRESHOLD_DB_MAX
+    )
     expect(COMPRESSOR_RATIO_MIN).toBeLessThan(COMPRESSOR_RATIO_MAX)
     expect(COMPRESSOR_ATTACK_SEC_MIN).toBeLessThan(COMPRESSOR_ATTACK_SEC_MAX)
     expect(COMPRESSOR_RELEASE_SEC_MIN).toBeLessThan(COMPRESSOR_RELEASE_SEC_MAX)

--- a/web/lib/master-bus.test.ts
+++ b/web/lib/master-bus.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  clamp,
+  DEFAULT_MASTER_BUS,
+  EQ_GAIN_DB_MAX,
+  EQ_GAIN_DB_MIN,
+  EQ_HIGH_SHELF_FREQ_MAX,
+  EQ_HIGH_SHELF_FREQ_MIN,
+  EQ_LOW_SHELF_FREQ_MAX,
+  EQ_LOW_SHELF_FREQ_MIN,
+  EQ_MID_FREQ_MAX,
+  EQ_MID_FREQ_MIN,
+  EQ_Q_MAX,
+  EQ_Q_MIN,
+  COMPRESSOR_ATTACK_SEC_MAX,
+  COMPRESSOR_ATTACK_SEC_MIN,
+  COMPRESSOR_RATIO_MAX,
+  COMPRESSOR_RATIO_MIN,
+  COMPRESSOR_RELEASE_SEC_MAX,
+  COMPRESSOR_RELEASE_SEC_MIN,
+  COMPRESSOR_THRESHOLD_DB_MAX,
+  COMPRESSOR_THRESHOLD_DB_MIN,
+  LIMITER_ATTACK_SEC,
+  LIMITER_CEILING_DB_MAX,
+  LIMITER_CEILING_DB_MIN,
+  LIMITER_RATIO,
+  MASTER_VOLUME_DB_MAX,
+  MASTER_VOLUME_DB_MIN,
+} from "@/lib/master-bus"
+
+describe("master-bus defaults", () => {
+  it("matches the plan's specified default values", () => {
+    expect(DEFAULT_MASTER_BUS).toEqual({
+      masterVolumeDb: 0,
+      eq: {
+        lowShelf: { freqHz: 100, gainDb: 0 },
+        midPeak: { freqHz: 1000, gainDb: 0, q: 1 },
+        highShelf: { freqHz: 8000, gainDb: 0 },
+      },
+      compressor: {
+        thresholdDb: -20,
+        ratio: 3,
+        attackSec: 0.01,
+        releaseSec: 0.1,
+      },
+      limiterCeilingDb: -0.3,
+    })
+  })
+
+  it("reuses the track fader's volume range for master volume", () => {
+    expect(MASTER_VOLUME_DB_MIN).toBe(-60)
+    expect(MASTER_VOLUME_DB_MAX).toBe(6)
+  })
+
+  it("fixes the limiter ratio and attack as constants, not adjustable ranges", () => {
+    expect(LIMITER_RATIO).toBe(20)
+    expect(LIMITER_ATTACK_SEC).toBeCloseTo(0.001)
+  })
+})
+
+describe("clamp", () => {
+  it("passes values within range through unchanged", () => {
+    expect(clamp(5, 0, 10)) .toBe(5)
+  })
+  it("clamps below the minimum", () => {
+    expect(clamp(-5, 0, 10)).toBe(0)
+  })
+  it("clamps above the maximum", () => {
+    expect(clamp(15, 0, 10)).toBe(10)
+  })
+})
+
+describe("master-bus param ranges", () => {
+  it("defines sane EQ gain bounds", () => {
+    expect(EQ_GAIN_DB_MIN).toBeLessThan(0)
+    expect(EQ_GAIN_DB_MAX).toBeGreaterThan(0)
+  })
+
+  it("defines non-overlapping-order frequency bounds per band", () => {
+    expect(EQ_LOW_SHELF_FREQ_MIN).toBeLessThan(EQ_LOW_SHELF_FREQ_MAX)
+    expect(EQ_MID_FREQ_MIN).toBeLessThan(EQ_MID_FREQ_MAX)
+    expect(EQ_HIGH_SHELF_FREQ_MIN).toBeLessThan(EQ_HIGH_SHELF_FREQ_MAX)
+    expect(EQ_Q_MIN).toBeLessThan(EQ_Q_MAX)
+  })
+
+  it("defines compressor param bounds", () => {
+    expect(COMPRESSOR_THRESHOLD_DB_MIN).toBeLessThan(COMPRESSOR_THRESHOLD_DB_MAX)
+    expect(COMPRESSOR_RATIO_MIN).toBeLessThan(COMPRESSOR_RATIO_MAX)
+    expect(COMPRESSOR_ATTACK_SEC_MIN).toBeLessThan(COMPRESSOR_ATTACK_SEC_MAX)
+    expect(COMPRESSOR_RELEASE_SEC_MIN).toBeLessThan(COMPRESSOR_RELEASE_SEC_MAX)
+  })
+
+  it("defines limiter ceiling bounds at or below 0dB", () => {
+    expect(LIMITER_CEILING_DB_MIN).toBeLessThan(LIMITER_CEILING_DB_MAX)
+    expect(LIMITER_CEILING_DB_MAX).toBeLessThanOrEqual(0)
+  })
+})

--- a/web/lib/master-bus.ts
+++ b/web/lib/master-bus.ts
@@ -47,6 +47,9 @@ export const LIMITER_ATTACK_SEC = 0.001
 // Faster than the Web Audio default (0.25s) so the ceiling lets go quickly
 // instead of audibly pumping on transient-heavy material.
 export const LIMITER_RELEASE_SEC = 0.05
+// Hard knee. The Web Audio default (30 dB) only reaches full ratio 15 dB
+// above threshold, so a -6 dB ceiling would never cap non-clipping material.
+export const LIMITER_KNEE_DB = 0
 
 export type MasterBusState = {
   masterVolumeDb: number

--- a/web/lib/master-bus.ts
+++ b/web/lib/master-bus.ts
@@ -1,0 +1,79 @@
+/**
+ * Master bus state (US-19.5): a 3-band EQ, compressor, limiter, and post
+ * fader sitting between the track sum and the destination. Mirrors the
+ * per-track fader's dB-range convention (see track-audio.ts) — reused
+ * directly for master volume rather than duplicated.
+ */
+
+export { VOLUME_DB_MAX as MASTER_VOLUME_DB_MAX, VOLUME_DB_MIN as MASTER_VOLUME_DB_MIN } from "@/lib/track-audio"
+
+export const EQ_GAIN_DB_MIN = -15
+export const EQ_GAIN_DB_MAX = 15
+
+export const EQ_LOW_SHELF_FREQ_MIN = 20
+export const EQ_LOW_SHELF_FREQ_MAX = 500
+
+export const EQ_MID_FREQ_MIN = 200
+export const EQ_MID_FREQ_MAX = 5000
+
+export const EQ_HIGH_SHELF_FREQ_MIN = 2000
+export const EQ_HIGH_SHELF_FREQ_MAX = 16000
+
+export const EQ_Q_MIN = 0.1
+export const EQ_Q_MAX = 10
+
+export const COMPRESSOR_THRESHOLD_DB_MIN = -60
+export const COMPRESSOR_THRESHOLD_DB_MAX = 0
+
+export const COMPRESSOR_RATIO_MIN = 1
+export const COMPRESSOR_RATIO_MAX = 20
+
+export const COMPRESSOR_ATTACK_SEC_MIN = 0.001
+export const COMPRESSOR_ATTACK_SEC_MAX = 1
+
+export const COMPRESSOR_RELEASE_SEC_MIN = 0.01
+export const COMPRESSOR_RELEASE_SEC_MAX = 1
+
+export const LIMITER_CEILING_DB_MIN = -6
+export const LIMITER_CEILING_DB_MAX = 0
+
+/** Fixed, non-adjustable limiter params (a high-ratio DynamicsCompressorNode
+ * standing in for a true limiter — see the plan's "no AudioWorklet" note). */
+export const LIMITER_RATIO = 20
+export const LIMITER_ATTACK_SEC = 0.001
+
+export type MasterBusState = {
+  masterVolumeDb: number
+  eq: {
+    lowShelf: { freqHz: number; gainDb: number }
+    midPeak: { freqHz: number; gainDb: number; q: number }
+    highShelf: { freqHz: number; gainDb: number }
+  }
+  compressor: {
+    thresholdDb: number
+    ratio: number
+    attackSec: number
+    releaseSec: number
+  }
+  limiterCeilingDb: number
+}
+
+export const DEFAULT_MASTER_BUS: MasterBusState = {
+  masterVolumeDb: 0,
+  eq: {
+    lowShelf: { freqHz: 100, gainDb: 0 },
+    midPeak: { freqHz: 1000, gainDb: 0, q: 1 },
+    highShelf: { freqHz: 8000, gainDb: 0 },
+  },
+  compressor: {
+    thresholdDb: -20,
+    ratio: 3,
+    attackSec: 0.01,
+    releaseSec: 0.1,
+  },
+  limiterCeilingDb: -0.3,
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}

--- a/web/lib/master-bus.ts
+++ b/web/lib/master-bus.ts
@@ -44,6 +44,9 @@ export const LIMITER_CEILING_DB_MAX = 0
  * standing in for a true limiter — see the plan's "no AudioWorklet" note). */
 export const LIMITER_RATIO = 20
 export const LIMITER_ATTACK_SEC = 0.001
+// Faster than the Web Audio default (0.25s) so the ceiling lets go quickly
+// instead of audibly pumping on transient-heavy material.
+export const LIMITER_RELEASE_SEC = 0.05
 
 export type MasterBusState = {
   masterVolumeDb: number

--- a/web/lib/master-bus.ts
+++ b/web/lib/master-bus.ts
@@ -5,7 +5,10 @@
  * directly for master volume rather than duplicated.
  */
 
-export { VOLUME_DB_MAX as MASTER_VOLUME_DB_MAX, VOLUME_DB_MIN as MASTER_VOLUME_DB_MIN } from "@/lib/track-audio"
+export {
+  VOLUME_DB_MAX as MASTER_VOLUME_DB_MAX,
+  VOLUME_DB_MIN as MASTER_VOLUME_DB_MIN,
+} from "@/lib/track-audio"
 
 export const EQ_GAIN_DB_MIN = -15
 export const EQ_GAIN_DB_MAX = 15

--- a/web/lib/metering.test.ts
+++ b/web/lib/metering.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  linearToDbfs,
+  METER_FLOOR_DB,
+  peakDbfs,
+  PEAK_HOLD_MS,
+  rmsDbfs,
+  stepPeakHold,
+} from "@/lib/metering"
+
+describe("linearToDbfs", () => {
+  it("maps full-scale amplitude (1.0) to 0 dBFS", () => {
+    expect(linearToDbfs(1)).toBeCloseTo(0)
+  })
+
+  it("maps half amplitude to about -6 dBFS", () => {
+    expect(linearToDbfs(0.5)).toBeCloseTo(-6.02, 1)
+  })
+
+  it("maps silence (0) to the meter floor, not -Infinity", () => {
+    expect(linearToDbfs(0)).toBe(METER_FLOOR_DB)
+  })
+
+  it("treats negative amplitudes the same as their absolute value", () => {
+    expect(linearToDbfs(-1)).toBeCloseTo(0)
+  })
+
+  it("clamps values quieter than the floor to the floor", () => {
+    expect(linearToDbfs(0.0000001)).toBe(METER_FLOOR_DB)
+  })
+})
+
+describe("peakDbfs", () => {
+  it("returns the loudest absolute sample in the window, in dBFS", () => {
+    const samples = new Float32Array([0.1, -0.9, 0.2, 0.05])
+    expect(peakDbfs(samples)).toBeCloseTo(linearToDbfs(0.9))
+  })
+
+  it("returns the meter floor for an empty window", () => {
+    expect(peakDbfs(new Float32Array())).toBe(METER_FLOOR_DB)
+  })
+
+  it("returns 0 dBFS for a full-scale sample", () => {
+    expect(peakDbfs(new Float32Array([1, -1, 0]))).toBeCloseTo(0)
+  })
+})
+
+describe("rmsDbfs", () => {
+  it("computes the RMS of the window in dBFS", () => {
+    // RMS of a constant 0.5 amplitude is 0.5 itself.
+    const samples = new Float32Array(100).fill(0.5)
+    expect(rmsDbfs(samples)).toBeCloseTo(linearToDbfs(0.5))
+  })
+
+  it("returns the meter floor for an empty window", () => {
+    expect(rmsDbfs(new Float32Array())).toBe(METER_FLOOR_DB)
+  })
+
+  it("is quieter than or equal to the peak for the same window", () => {
+    const samples = new Float32Array([1, 0, -1, 0])
+    expect(rmsDbfs(samples)).toBeLessThanOrEqual(peakDbfs(samples))
+  })
+})
+
+describe("stepPeakHold", () => {
+  it("adopts a new peak immediately when there is no prior hold", () => {
+    const next = stepPeakHold(null, -10, 1000)
+    expect(next).toEqual({ db: -10, heldAtMs: 1000 })
+  })
+
+  it("adopts a louder incoming peak immediately, resetting the hold clock", () => {
+    const prev = { db: -20, heldAtMs: 1000 }
+    const next = stepPeakHold(prev, -5, 1200)
+    expect(next).toEqual({ db: -5, heldAtMs: 1200 })
+  })
+
+  it("holds a quieter reading steady until the hold window elapses", () => {
+    const prev = { db: -5, heldAtMs: 1000 }
+    const next = stepPeakHold(prev, -20, 1000 + PEAK_HOLD_MS - 1)
+    expect(next).toEqual(prev)
+  })
+
+  it("decays the held peak once the hold window has elapsed", () => {
+    const prev = { db: -5, heldAtMs: 1000 }
+    const now = 1000 + PEAK_HOLD_MS + 500 // 0.5s past the hold window
+    const next = stepPeakHold(prev, -40, now)
+    expect(next.db).toBeLessThan(-5)
+    expect(next.db).toBeGreaterThan(-40)
+    expect(next.heldAtMs).toBe(1000) // decay origin unchanged mid-decay
+  })
+
+  it("settles back onto the incoming peak once decay reaches it", () => {
+    const prev = { db: -5, heldAtMs: 1000 }
+    const now = 1000 + PEAK_HOLD_MS + 100_000 // long past full decay
+    const next = stepPeakHold(prev, -40, now)
+    expect(next).toEqual({ db: -40, heldAtMs: now })
+  })
+})

--- a/web/lib/metering.ts
+++ b/web/lib/metering.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure metering math for the StereoMeter (US-19.5): peak/RMS in dBFS from a
+ * time-domain sample window, plus a peak-hold decay step. Kept side-effect
+ * free so the rAF loop that drives the meter can be tested without a real
+ * AnalyserNode.
+ */
+
+/** Floor for the meter display — quieter than this reads as silence rather
+ * than -Infinity, matching the [-48, 0] tick range the meter draws. */
+export const METER_FLOOR_DB = -60
+
+export function linearToDbfs(amplitude: number): number {
+  const abs = Math.abs(amplitude)
+  if (abs <= 0) return METER_FLOOR_DB
+  return Math.max(METER_FLOOR_DB, 20 * Math.log10(abs))
+}
+
+export function peakDbfs(samples: Float32Array): number {
+  let peak = 0
+  for (let i = 0; i < samples.length; i++) {
+    const abs = Math.abs(samples[i])
+    if (abs > peak) peak = abs
+  }
+  return linearToDbfs(peak)
+}
+
+export function rmsDbfs(samples: Float32Array): number {
+  if (samples.length === 0) return METER_FLOOR_DB
+  let sumSquares = 0
+  for (let i = 0; i < samples.length; i++) {
+    sumSquares += samples[i] * samples[i]
+  }
+  return linearToDbfs(Math.sqrt(sumSquares / samples.length))
+}
+
+/** How long a peak-hold marker stays pinned before it starts decaying. */
+export const PEAK_HOLD_MS = 1500
+/** Decay rate once the hold window elapses. */
+export const PEAK_DECAY_DB_PER_SEC = 20
+
+export type PeakHoldState = { db: number; heldAtMs: number }
+
+/** Advances a peak-hold marker by one meter frame. A louder incoming peak is
+ * adopted immediately (and restarts the hold clock); a quieter one is held
+ * steady for PEAK_HOLD_MS, then decays at a fixed rate until the incoming
+ * peak catches up. */
+export function stepPeakHold(
+  prev: PeakHoldState | null,
+  incomingDb: number,
+  nowMs: number
+): PeakHoldState {
+  if (!prev || incomingDb >= prev.db) {
+    return { db: incomingDb, heldAtMs: nowMs }
+  }
+  const elapsed = nowMs - prev.heldAtMs
+  if (elapsed <= PEAK_HOLD_MS) return prev
+  const decayed =
+    prev.db - (PEAK_DECAY_DB_PER_SEC * (elapsed - PEAK_HOLD_MS)) / 1000
+  if (decayed <= incomingDb) return { db: incomingDb, heldAtMs: nowMs }
+  return { db: decayed, heldAtMs: prev.heldAtMs }
+}

--- a/web/test/audio-stubs.ts
+++ b/web/test/audio-stubs.ts
@@ -1,0 +1,38 @@
+import { vi } from "vitest"
+
+// Fake Web Audio node stand-ins (jsdom has none of these) shared by every
+// test that exercises the master bus chain (US-19.5): the playback hook's
+// own AudioContext stub, the studio page's, and the panel/meter component
+// tests that construct nodes directly without a full AudioContext.
+
+export class FakeBiquadFilterNode {
+  type: BiquadFilterType = "lowpass"
+  connect = vi.fn()
+  disconnect = vi.fn()
+  frequency = { value: 350 }
+  gain = { value: 0 }
+  Q = { value: 1 }
+}
+
+export class FakeDynamicsCompressorNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+  threshold = { value: -24 }
+  knee = { value: 30 }
+  ratio = { value: 12 }
+  attack = { value: 0.003 }
+  release = { value: 0.25 }
+  reduction = 0
+}
+
+export class FakeChannelSplitterNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+}
+
+export class FakeAnalyserNode {
+  connect = vi.fn()
+  disconnect = vi.fn()
+  fftSize = 2048
+  getFloatTimeDomainData = vi.fn()
+}

--- a/web/test/raf-stub.ts
+++ b/web/test/raf-stub.ts
@@ -1,0 +1,32 @@
+import { vi } from "vitest"
+
+/** Installs fake `requestAnimationFrame`/`cancelAnimationFrame` globals
+ * (jsdom has neither) and returns a `tick` to fire every currently-scheduled
+ * callback once, at a given time. Shared by every test that drives a rAF
+ * loop (playback scheduling, the studio page, and the master bus meter). */
+export function stubRaf() {
+  let nextId = 1
+  const callbacks = new Map<number, FrameRequestCallback>()
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((cb: FrameRequestCallback) => {
+      const id = nextId++
+      callbacks.set(id, cb)
+      return id
+    })
+  )
+  vi.stubGlobal(
+    "cancelAnimationFrame",
+    vi.fn((id: number) => {
+      callbacks.delete(id)
+    })
+  )
+  return {
+    /** Invoke every currently-scheduled rAF callback once, at time `t`. */
+    tick(t: number) {
+      const due = [...callbacks.entries()]
+      callbacks.clear()
+      for (const [, cb] of due) cb(t)
+    },
+  }
+}


### PR DESCRIPTION
## Summary
Implements #211 (US-19.5): Master Bus Controls for the multi-track studio.

- Master bus Web Audio chain spliced between the track sum and the destination: `sum → low shelf → mid peak → high shelf → compressor → master volume → limiter (fixed 20:1, 1ms attack, 50ms release, hard knee) → destination`, with a `ChannelSplitter → 2× AnalyserNode` metering tap on the final output. Built once per AudioContext; survives play/pause cycles.
- Master volume sits **before** the limiter (but after the compressor) so the configured ceiling is a true output cap even at +6 dB fader boost, while fader moves never change compression amount.
- New `masterBus` state slice in the studio reducer (`SET_MASTER_VOLUME`, `SET_MASTER_EQ`, `SET_MASTER_COMPRESSOR`, `SET_MASTER_LIMITER_CEILING`) with range clamping and NaN guards; live retune effect pushes values onto the running audio graph without rescheduling playback (same ref pattern as US-19.4 track controls).
- `MasterBusPanel` (dispatch-only sliders for volume / 3-band EQ / compressor / limiter ceiling, with a live limiter-active indicator reading the node's `reduction`) and `StereoMeter` (rAF-driven peak + RMS bars, 1.5s peak-hold with decay, clip indicators, dB scale ticks). The studio's right aside is now tabbed: Workspace | Master.
- Pure metering math (`lib/metering.ts`) and master-bus constants/types (`lib/master-bus.ts`) kept side-effect-free and unit-tested.

## Acceptance Criteria
- [x] Master volume controls the overall output level — reducer → `dbToGain` → GainNode, live-retuned without rescheduling
- [x] EQ bands audibly affect the frequency spectrum — three BiquadFilterNodes in the signal path, all params live-wired
- [x] Compressor and limiter respond to dynamics as expected — DynamicsCompressorNodes with user params / fixed high-ratio limiter + ceiling
- [x] Visual metering shows peak and RMS levels in real time — rAF loop over post-limiter stereo analysers

## Test Plan
- [x] Unit tests written (TDD approach) — red confirmed before each implementation step
- [x] All tests passing — 1056/1056 (125 files)
- [x] Diff coverage 98% on changed lines (gate: ≥85%)
- [x] Linting clean (0 errors; 1 pre-existing warning in gitignored coverage artifacts), typecheck clean, production build succeeds — note: web/ is not in CI, verified locally
- [x] Internal code review (advisory) completed — 1 Major finding fixed (see notes)
- [x] Cross-family review pass: opencode (GLM) — verdict APPROVE, 1 suggestion applied
- [x] Test mutation sanity check — 5/5 targeted mutations (dB math, chain wiring, reducer clamp, panel dispatch, meter read) each broke at least one test

## Known Limitations / Intentionally Deferred
- The limiter is a high-ratio `DynamicsCompressorNode` (soft limiter, hard knee), not a true look-ahead brickwall — per the issue plan's chosen design. Live-demo measured behavior: a -6 dB ceiling caps a -0.4 dBFS tone at ≈ -2 dBFS (consistent and reproducible) rather than exactly -6, because Chromium's DynamicsCompressorNode applies fixed internal makeup gain derived from threshold/knee/ratio. Exact ceiling adherence needs the already-deferred AudioWorklet limiter, which can replace the node later without touching the UI contract.
- Master bus params are set via direct `AudioParam.value` assignment (same as US-19.4 track gain/pan); very fast slider drags on EQ could produce zipper artifacts. Matches the existing engine-wide pattern; smoothing ramps would be an engine-wide change.
- Master bus settings are session-only (not persisted), consistent with the rest of the studio arrangement state.
- Compressor knee is left at the Web Audio default (30 dB) and not exposed in the UI.
- Meters are active only after the first playback run creates the AudioContext (browser autoplay policy).

## Implementation Notes
- The CodeRabbit plan on the issue assumed `web/` was greenfield; paths and patterns were adapted to the real US-19.1–19.4 infrastructure (reducer context, playback-hook engine, existing `dbToGain`).
- Sliders instead of rotary knobs — no knob primitive exists in the codebase and the horizontal Shadcn Slider is the established control.
- The internal review caught that an earlier revision placed master volume after the limiter, letting +6 dB of fader boost bypass the ceiling; the chain was corrected and the wiring test's connect-order expectations updated to the corrected contract (commit 3bf4255).
- One pre-existing test assertion updated: master-chain construction adds one GainNode, so a `gains.toHaveLength(3)` count in the US-19.4 wiring test became 4 (commented inline; no assertion weakened).

Closes #211

