### PR TITLE
fix(web): P1.1 private clips play via httpOnly access cookie in stream proxy (#282)

### DIFF
--- a/web/app/api/auth/callback/[provider]/route.test.ts
+++ b/web/app/api/auth/callback/[provider]/route.test.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from "next/server"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ACCESS_COOKIE, REFRESH_COOKIE } from "@/lib/auth"
+import { POST } from "./route"
+
+function request(body: unknown): NextRequest {
+  return new NextRequest(
+    new URL("http://localhost:3000/api/auth/callback/google"),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  )
+}
+
+const ctx = { params: Promise.resolve({ provider: "google" }) }
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("callback route", () => {
+  it("sets both the refresh and clip-scoped access cookie on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "a",
+          refresh_token: "r",
+          expires_in: 900,
+        }),
+      }))
+    )
+
+    const res = await POST(request({ code: "c", state: "s" }), ctx)
+    expect(res.status).toBe(200)
+    const setCookie = res.headers.get("set-cookie") ?? ""
+    expect(setCookie).toContain(`${REFRESH_COOKIE}=r`)
+    expect(setCookie).toContain(`${ACCESS_COOKIE}=a`)
+    expect(setCookie).toContain("Path=/api/clips")
+    expect(await res.json()).toEqual({ access_token: "a", expires_in: 900 })
+  })
+
+  it("400s for an unknown provider without calling the backend", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    const res = await POST(request({ code: "c", state: "s" }), {
+      params: Promise.resolve({ provider: "nope" }),
+    })
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/api/auth/callback/[provider]/route.ts
+++ b/web/app/api/auth/callback/[provider]/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server"
 
-import { REFRESH_COOKIE, isSupportedProvider } from "@/lib/auth"
+import { ACCESS_COOKIE, REFRESH_COOKIE, isSupportedProvider } from "@/lib/auth"
 import {
   BACKEND_URL,
   REFRESH_MAX_AGE,
+  accessCookieOptions,
   clearStateCookies,
   collectStateCookies,
   cookieOptions,
@@ -50,6 +51,8 @@ export async function POST(
     expires_in: body.expires_in,
   })
   out.cookies.set(REFRESH_COOKIE, body.refresh_token, cookieOptions(REFRESH_MAX_AGE))
+  // Clip-scoped access cookie so <audio> can stream private clips (issue #282).
+  out.cookies.set(ACCESS_COOKIE, body.access_token, accessCookieOptions(body.expires_in))
   clearStateCookies(request, out)
   return out
 }

--- a/web/app/api/auth/logout/route.test.ts
+++ b/web/app/api/auth/logout/route.test.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ACCESS_COOKIE, REFRESH_COOKIE } from "@/lib/auth"
+import { POST } from "./route"
+
+function request(cookie?: string): NextRequest {
+  const req = new NextRequest(new URL("http://localhost:3000/api/auth/logout"), {
+    method: "POST",
+  })
+  if (cookie) req.cookies.set(REFRESH_COOKIE, cookie)
+  return req
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("logout route", () => {
+  it("clears both the refresh and the access cookie", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 204 })))
+    const res = await POST(request("some-token"))
+    expect(res.status).toBe(204)
+    const setCookie = res.headers.get("set-cookie") ?? ""
+    expect(setCookie).toContain(`${REFRESH_COOKIE}=;`)
+    expect(setCookie).toContain(`${ACCESS_COOKIE}=;`)
+    // Both expire immediately.
+    expect(setCookie.match(/Max-Age=0/g)?.length).toBe(2)
+  })
+})

--- a/web/app/api/auth/logout/route.ts
+++ b/web/app/api/auth/logout/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 
-import { REFRESH_COOKIE } from "@/lib/auth"
-import { BACKEND_URL, cookieOptions } from "@/lib/auth-server"
+import { ACCESS_COOKIE, REFRESH_COOKIE } from "@/lib/auth"
+import { BACKEND_URL, accessCookieOptions, cookieOptions } from "@/lib/auth-server"
 
 // Revoke the refresh token on the backend (best-effort) and clear the cookie.
 export async function POST(request: NextRequest) {
@@ -15,5 +15,6 @@ export async function POST(request: NextRequest) {
   }
   const out = new NextResponse(null, { status: 204 })
   out.cookies.set(REFRESH_COOKIE, "", cookieOptions(0))
+  out.cookies.set(ACCESS_COOKIE, "", accessCookieOptions(0))
   return out
 }

--- a/web/app/api/auth/refresh/route.test.ts
+++ b/web/app/api/auth/refresh/route.test.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { REFRESH_COOKIE } from "@/lib/auth"
+import { ACCESS_COOKIE, REFRESH_COOKIE } from "@/lib/auth"
 import { POST } from "./route"
 
 function request(cookie?: string): NextRequest {
@@ -50,7 +50,11 @@ describe("refresh route", () => {
     )
     const res = await POST(request("old-token"))
     expect(res.status).toBe(200)
-    expect(res.headers.get("set-cookie")).toContain(`${REFRESH_COOKIE}=newR`)
+    const setCookie = res.headers.get("set-cookie") ?? ""
+    expect(setCookie).toContain(`${REFRESH_COOKIE}=newR`)
+    // The access token is mirrored into a clip-scoped httpOnly cookie (#282).
+    expect(setCookie).toContain(`${ACCESS_COOKIE}=a`)
+    expect(setCookie).toContain("Path=/api/clips")
     expect(await res.json()).toEqual({ access_token: "a", expires_in: 900 })
   })
 })

--- a/web/app/api/auth/refresh/route.ts
+++ b/web/app/api/auth/refresh/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server"
 
-import { REFRESH_COOKIE } from "@/lib/auth"
+import { ACCESS_COOKIE, REFRESH_COOKIE } from "@/lib/auth"
 import {
   BACKEND_URL,
   REFRESH_MAX_AGE,
+  accessCookieOptions,
   cookieOptions,
 } from "@/lib/auth-server"
 
@@ -40,5 +41,8 @@ export async function POST(request: NextRequest) {
     expires_in: body.expires_in,
   })
   out.cookies.set(REFRESH_COOKIE, body.refresh_token, cookieOptions(REFRESH_MAX_AGE))
+  // Mirror the access token into a clip-scoped httpOnly cookie so an <audio src>
+  // can authenticate to the stream proxy for a private clip (issue #282).
+  out.cookies.set(ACCESS_COOKIE, body.access_token, accessCookieOptions(body.expires_in))
   return out
 }

--- a/web/app/api/clips/[id]/stream/route.test.ts
+++ b/web/app/api/clips/[id]/stream/route.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import type { NextRequest } from "next/server"
+import { NextRequest } from "next/server"
 
+import { ACCESS_COOKIE } from "@/lib/auth"
 import { GET } from "@/app/api/clips/[id]/stream/route"
 
-function req(url: string, init: RequestInit = {}): NextRequest {
-  return new Request(url, init) as unknown as NextRequest
+function req(
+  url: string,
+  init: { headers?: Record<string, string>; cookie?: string } = {}
+): NextRequest {
+  const r = new NextRequest(new URL(url), { headers: init.headers })
+  if (init.cookie) r.cookies.set(ACCESS_COOKIE, init.cookie)
+  return r
 }
 
 const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
@@ -41,6 +47,43 @@ describe("GET /api/clips/[id]/stream", () => {
 
     const [, opts] = fetchMock.mock.calls[0]
     expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+  })
+
+  it("falls back to the access cookie as a Bearer token when no header is present (private clip)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("audio", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await GET(
+      req("http://localhost/api/clips/c1/stream", { cookie: "cookieTok" }),
+      ctx("c1")
+    )
+
+    const [, opts] = fetchMock.mock.calls[0]
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer cookieTok"
+    )
+  })
+
+  it("prefers an explicit Authorization header over the access cookie", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("audio", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await GET(
+      req("http://localhost/api/clips/c1/stream", {
+        headers: { authorization: "Bearer headerTok" },
+        cookie: "cookieTok",
+      }),
+      ctx("c1")
+    )
+
+    const [, opts] = fetchMock.mock.calls[0]
+    expect((opts.headers as Record<string, string>).authorization).toBe(
+      "Bearer headerTok"
+    )
   })
 
   it("forwards the Range header and passes a 206 through with its range headers", async () => {

--- a/web/app/api/clips/[id]/stream/route.ts
+++ b/web/app/api/clips/[id]/stream/route.ts
@@ -1,15 +1,20 @@
 import { NextResponse, type NextRequest } from "next/server"
 
+import { ACCESS_COOKIE } from "@/lib/auth"
 import { BACKEND_URL } from "@/lib/auth-server"
 import { fetchWithTimeout } from "@/lib/proxy-fetch"
 
 // Same-origin proxy for GET /api/v1/clips/{clip_id}/stream (US-20.0), the
 // URL an <audio> element points at. Distinct from the sibling /audio route,
 // which this deliberately leaves alone: /audio requires a token and buffers a
-// whole body for the Download items, whereas an <audio src> cannot attach an
-// Authorization header at all — so playback has to reach an endpoint that
-// serves public clips anonymously. Auth is forwarded when present (fetch-based
-// callers), absent for <audio>; the backend resolves visibility either way.
+// whole body for the Download items.
+//
+// An <audio src> cannot attach an Authorization header, so to play a *private*
+// clip it falls back to the httpOnly `ams_access_token` cookie the browser
+// sends automatically (issue #282): if no header is present, that cookie is
+// forwarded as the Bearer token. Explicit header (fetch callers) wins; with
+// neither, the request reaches the backend anonymously and only public clips
+// resolve. The backend enforces visibility either way.
 //
 // Range is forwarded and the range/caching headers are copied back so seeking
 // keeps working — a 206 must arrive at the browser as a 206 with its
@@ -29,7 +34,12 @@ export async function GET(
   request: NextRequest,
   ctx: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
-  const auth = request.headers.get("authorization")
+  // Prefer an explicit Bearer header (fetch callers); fall back to the
+  // clip-scoped access cookie so an <audio src> can authenticate (issue #282).
+  const cookieToken = request.cookies.get(ACCESS_COOKIE)?.value
+  const auth =
+    request.headers.get("authorization") ??
+    (cookieToken ? `Bearer ${cookieToken}` : null)
   const range = request.headers.get("range")
   const { id } = await ctx.params
 

--- a/web/lib/auth-server.ts
+++ b/web/lib/auth-server.ts
@@ -23,6 +23,24 @@ export function cookieOptions(maxAge: number) {
   }
 }
 
+/** Fallback access-cookie lifetime (15 min) when the backend omits `expires_in`. */
+const ACCESS_COOKIE_FALLBACK_MAX_AGE = 15 * 60
+
+/**
+ * Cookie options for the access token, scoped to `/api/clips` so the token is
+ * only sent on clip media requests (the `<audio>` stream proxy) rather than
+ * every request to the app. `maxAge` mirrors the token's `expires_in`.
+ */
+export function accessCookieOptions(maxAge: number | undefined) {
+  // A finite number (including 0, used to clear the cookie) is honoured as-is;
+  // only a missing/malformed `expires_in` falls back to the default lifetime.
+  const resolved =
+    typeof maxAge === "number" && Number.isFinite(maxAge)
+      ? maxAge
+      : ACCESS_COOKIE_FALLBACK_MAX_AGE
+  return { ...cookieOptions(resolved), path: "/api/clips" }
+}
+
 /** Build a `Cookie` header of the `oauth_state_*` cookies to forward to the backend. */
 export function collectStateCookies(request: NextRequest): string {
   return request.cookies

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -4,6 +4,15 @@
 /** httpOnly cookie the BFF uses to hold the backend refresh token. */
 export const REFRESH_COOKIE = "ams_refresh_token"
 
+/**
+ * httpOnly cookie holding the short-lived access token, scoped to `/api/clips`.
+ * Exists so an `<audio src>` (which cannot attach an Authorization header) can
+ * still authenticate to the stream proxy for a private clip: the browser sends
+ * this cookie automatically. httpOnly keeps it out of client JS; the `/api/clips`
+ * path keeps it off every other request. Mirrors the access token's lifetime.
+ */
+export const ACCESS_COOKIE = "ams_access_token"
+
 /** Prefix of the backend's per-flow OAuth state cookie (`oauth_state_<flow_id>`). */
 export const OAUTH_STATE_PREFIX = "oauth_state_"
 

--- a/web/lib/clips.ts
+++ b/web/lib/clips.ts
@@ -43,10 +43,10 @@ export function trackFromClip(clip: {
  * Same-origin stream path for a clip's audio (US-20.0).
  *
  * Targets the `/stream` proxy, not `/audio`: this URL is consumed as an
- * `<audio src>`, which cannot attach a Bearer token, so it has to reach the
- * endpoint that serves public clips anonymously (and supports seeking). A
- * private clip therefore does not play through this path — see the route's
- * comment.
+ * `<audio src>`, which cannot attach a Bearer token. The proxy falls back to
+ * the httpOnly `ams_access_token` cookie the browser sends automatically, so a
+ * signed-in owner's *private* clip plays too (issue #282); public clips still
+ * resolve anonymously. Seeking is supported. See the route's comment.
  */
 export function clipAudioUrl(id: string): string {
   return `/api/clips/${encodeURIComponent(id)}/stream`


### PR DESCRIPTION
Closes #282

## Problem
`<audio src>` cannot attach an `Authorization` header, so a signed-in user could not play their **own private/unpublished clip** anywhere (workspace cards, waveform editor, song page, section preview). All go through `trackFromClip → clipAudioUrl → GET /api/clips/{id}/stream`, which reached the backend with no credentials → resolved as anonymous → `404` for a private clip. Since unpublished is the default state of everything a user creates, this broke the primary creation loop.

## Approach
The browser already *is* a per-user token store. Mint a short-lived **httpOnly** access-token cookie (`ams_access_token`, scoped `Path=/api/clips`) wherever the session already mints an access token — the auth **refresh** and OAuth **callback** routes — and have the `/api/clips/[id]/stream` proxy fall back to it as a Bearer token when no `Authorization` header is present. The browser sends it automatically for the same-origin `<audio>` request; `httpOnly` keeps it out of client JS and it never appears in a URL. Cleared on logout.

### Why not a server-side token cache
The backend refresh token is **single-use rotating** (`consume_refresh_token` atomically revokes + reissues). `<audio>` fires many `Range` requests per playback, so refreshing per request — as the issue warns — would race the single-use token and strand the session. This approach adds **zero server state** and triggers **no extra rotation**: the cookie is only (re)set during the refresh/callback cycle that already runs.

## Acceptance criteria
- [x] Signed-in owner can play their own **private** clip (cookie → Bearer → backend authorizes owner).
- [x] Public clip still plays for a signed-out visitor — no cookie → anonymous → backend serves public (US-20.0 path unchanged).
- [x] Non-owner still cannot stream someone else's private clip — the cookie authenticates as *its own* user; backend returns 403/404, passed through.
- [x] Seeking works — `Range` forwarding and `206`/`Content-Range` passthrough are unchanged (covered by tests).
- [x] No access/refresh token in a URL or exposed to client JS — `httpOnly` cookie, never JS-readable, never in a URL.

## Tests
16 tests across the touched routes (all green locally; web is not in CI):
- `stream/route.test.ts` — cookie→Bearer fallback, header-over-cookie precedence, anonymous passthrough, Range/206, 404/416/502.
- `refresh` / `callback` — assert the clip-scoped access cookie is set (`Path=/api/clips`).
- `logout` — asserts both cookies are cleared.

`tsc --noEmit` clean · `eslint` clean.

## Known limitations
- The access cookie's lifetime mirrors `expires_in` (~15 min). Between session refreshes it can lapse, after which a private clip 404s until the next page load re-runs mount-refresh — **the same degradation the rest of the app already has** (there is no proactive token renewal today). Playback works on every fresh page load.
- The cookie is sent on all `/api/clips/*` requests (path scope). Other clip routes read the explicit Bearer header and ignore it — harmless, negligible header size.

## Review disclosure
Cross-family review (opencode/GLM, then codex) could not complete in this environment — both hung with no output under heavy local load (vitest workers and eslint were also resource-starved). This PR carries a **Claude internal adversarial review** (advisory) instead. Given the change touches auth-cookie handling, `/code-review ultra` is recommended as a manual escalation before merge.
