### PR TITLE
fix(api): P1.2 rate-limit per visitor behind the BFF proxy (#283)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,14 @@ DATABASE_URL=
 # Leave blank to use local dev defaults (http://localhost:3000, http://localhost:8000).
 ACEMUSIC_API_CORS_ALLOW_ORIGINS=
 
+# Reverse proxies whose forwarded client IP the streaming rate limiter trusts
+# (#283), comma-separated. Set this to the IP(s) the same-origin BFF/Next server
+# reaches the API from, so the per-IP limiter keys on the real visitor (via
+# X-Forwarded-For) instead of collapsing every proxied visitor into one bucket.
+# Leave blank to trust no proxy header — a directly reachable backend then can't
+# be evaded with a spoofed header. Example: ACEMUSIC_API_TRUSTED_PROXIES=127.0.0.1
+ACEMUSIC_API_TRUSTED_PROXIES=
+
 # MongoDB connection (US-8.2).
 # Local dev default is mongodb://localhost:27017. For staging/production set this
 # to your Atlas cluster, e.g.

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -176,6 +176,15 @@ class ApiSettings(BaseSettings):
     # deployments (swap for a shared store if the API runs multiple workers).
     stream_rate_limit_per_minute: int = Field(default=100, ge=1)
 
+    # Reverse proxies whose forwarded client-IP header the limiter trusts (#283).
+    # A same-origin BFF proxy calls the backend server-side, so every visitor
+    # arrives as the proxy's egress IP and the per-IP limiter collapses to one
+    # shared bucket. Listing the proxy's IP here lets the limiter key on the
+    # real client from its X-Forwarded-For instead. Empty by default: trust
+    # nobody, so a directly-reachable backend can't be evaded with a spoofed
+    # header (the header is only honored when the peer is a listed proxy).
+    trusted_proxies: Annotated[list[str], NoDecode] = []
+
     # Compute status endpoint (US-11.4). Per-target health-probe budget for
     # ``GET /api/v1/compute/status``; the local and remote checks run in parallel,
     # each bounded by this timeout, so the aggregate response stays well under the
@@ -303,6 +312,19 @@ class ApiSettings(BaseSettings):
                 f"mongodb_max_pool_size ({self.mongodb_max_pool_size})"
             )
         return self
+
+    @property
+    def trusted_proxy_set(self) -> frozenset[str]:
+        """Trusted-proxy IPs as a set for O(1) membership in the limiter."""
+        return frozenset(self.trusted_proxies)
+
+    @field_validator("trusted_proxies", mode="before")
+    @classmethod
+    def _split_trusted_proxies(cls, value: object) -> object:
+        """Accept a comma-separated string; blank/unset -> [] (trust nobody)."""
+        if isinstance(value, str):
+            return [ip.strip() for ip in value.split(",") if ip.strip()]
+        return value
 
     @field_validator("cors_allow_origins", mode="before")
     @classmethod

--- a/src/acemusic/api/utils/rate_limit.py
+++ b/src/acemusic/api/utils/rate_limit.py
@@ -6,10 +6,25 @@ curb abuse. Swap for a Redis-backed limiter (e.g. slowapi) if the API ever runs
 multiple workers that must share one limit.
 """
 
+import ipaddress
 import time
+from collections.abc import Collection
 from threading import Lock
 
 from fastapi import HTTPException, Request, status
+
+
+def _normalize_ip(value: str) -> str:
+    """Canonicalize an IP so an IPv4-mapped form (``::ffff:127.0.0.1``) compares
+    equal to its plain IPv4 (``127.0.0.1``); pass non-IP values (``"anonymous"``,
+    a hostname) through raw."""
+    try:
+        ip = ipaddress.ip_address(value)
+    except ValueError:
+        return value
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return str(ip.ipv4_mapped)
+    return str(ip)
 
 
 class FixedWindowRateLimiter:
@@ -46,14 +61,35 @@ class FixedWindowRateLimiter:
                 )
 
 
-def _client_key(request: Request) -> str:
-    # ponytail: keyed by the raw socket peer IP. Behind a trusted reverse proxy,
-    # parse a validated X-Forwarded-For here — spoofable headers are intentionally
-    # not trusted by default.
-    return request.client.host if request.client else "anonymous"
+def _client_key(request: Request, trusted_proxies: Collection[str]) -> str:
+    """Rate-limit key: the real client IP.
+
+    Keyed by the raw socket peer IP, except when that peer is a configured
+    trusted proxy (#283): a same-origin BFF proxies every visitor server-side,
+    so they'd all share the proxy's egress IP. When the peer is trusted, key on
+    the client it forwarded in ``X-Forwarded-For`` (leftmost = original client)
+    instead.
+
+    The header is honored *only* when the immediate peer is trusted, so a
+    directly reachable backend can't be evaded by a spoofed header (AC2/AC3).
+    The forwarded *value* is only as trustworthy as that proxy: the trusted
+    proxy MUST set/replace ``X-Forwarded-For`` with the real client and not pass
+    through a client-supplied one — otherwise a client could still choose its
+    own key. That sanitizing is a property of the deployment's edge, not of this
+    function; see ``ACEMUSIC_API_TRUSTED_PROXIES`` in ``.env.example``.
+    """
+    peer = _normalize_ip(request.client.host) if request.client else "anonymous"
+    trusted = {_normalize_ip(ip) for ip in trusted_proxies}
+    if peer in trusted:
+        forwarded = request.headers.get("x-forwarded-for", "")
+        client = forwarded.split(",")[0].strip()
+        if client:
+            return client
+    return peer
 
 
 def enforce_stream_rate_limit(request: Request) -> None:
     """FastAPI dependency: rate-limit by client IP using the app's limiter."""
     limiter: FixedWindowRateLimiter = request.app.state.stream_limiter
-    limiter.check(_client_key(request))
+    trusted = request.app.state.settings.trusted_proxy_set
+    limiter.check(_client_key(request, trusted))

--- a/src/acemusic/api/utils/rate_limit.py
+++ b/src/acemusic/api/utils/rate_limit.py
@@ -84,7 +84,9 @@ def _client_key(request: Request, trusted_proxies: Collection[str]) -> str:
         forwarded = request.headers.get("x-forwarded-for", "")
         client = forwarded.split(",")[0].strip()
         if client:
-            return client
+            # Normalize like the peer so an edge that emits both ::ffff:1.1.1.1
+            # and 1.1.1.1 for one visitor keys a single bucket, not two.
+            return _normalize_ip(client)
     return peer
 
 

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -49,6 +49,30 @@ class TestApiSettings:
         assert "https://evil.example.com" not in settings.cors_allow_origins
 
 
+class TestTrustedProxies:
+    """issue #283: proxies whose forwarded client-IP header the limiter trusts."""
+
+    def test_default_is_empty(self, monkeypatch):
+        """Unset -> trust nobody, i.e. today's peer-IP-only behavior (AC4)."""
+        monkeypatch.delenv("ACEMUSIC_API_TRUSTED_PROXIES", raising=False)
+        settings = ApiSettings(_env_file=None)
+        assert settings.trusted_proxies == []
+        assert settings.trusted_proxy_set == frozenset()
+
+    def test_parsed_from_comma_separated_env(self, monkeypatch):
+        monkeypatch.setenv("ACEMUSIC_API_TRUSTED_PROXIES", "10.0.0.2, 127.0.0.1")
+        settings = ApiSettings(_env_file=None)
+        assert settings.trusted_proxies == ["10.0.0.2", "127.0.0.1"]
+        assert settings.trusted_proxy_set == frozenset({"10.0.0.2", "127.0.0.1"})
+
+    def test_blank_env_is_empty(self, monkeypatch):
+        """A blank value behaves like unset (trust nobody), unlike CORS which
+        falls back to localhost defaults — an empty trust set is the safe one."""
+        monkeypatch.setenv("ACEMUSIC_API_TRUSTED_PROXIES", "  ")
+        settings = ApiSettings(_env_file=None)
+        assert settings.trusted_proxies == []
+
+
 class TestAuthSettings:
     """OAuth2 / JWT configuration (US-8.3)."""
 

--- a/tests/test_clips_api.py
+++ b/tests/test_clips_api.py
@@ -232,6 +232,13 @@ class TestClientKey:
         req = self._request("::ffff:127.0.0.1", xff="198.51.100.7")
         assert _client_key(req, frozenset({"127.0.0.1"})) == "198.51.100.7"
 
+    def test_forwarded_client_is_normalized_to_one_bucket(self) -> None:
+        # An IPv4-mapped and plain form of the same visitor key one bucket.
+        trusted = frozenset({"10.0.0.2"})
+        mapped = _client_key(self._request("10.0.0.2", xff="::ffff:1.1.1.1"), trusted)
+        plain = _client_key(self._request("10.0.0.2", xff="1.1.1.1"), trusted)
+        assert mapped == plain == "1.1.1.1"
+
 
 class TestEnforceStreamRateLimit:
     """issue #283: the dependency must key per forwarded client behind a trusted

--- a/tests/test_clips_api.py
+++ b/tests/test_clips_api.py
@@ -30,7 +30,7 @@ from acemusic.api.utils.range_requests import (
     parse_range_header,
     parse_range_header_multi,
 )
-from acemusic.api.utils.rate_limit import FixedWindowRateLimiter
+from acemusic.api.utils.rate_limit import FixedWindowRateLimiter, _client_key
 from acemusic.storage import get_storage_backend
 
 requires_ffmpeg = pytest.mark.skipif(
@@ -183,6 +183,91 @@ class TestFixedWindowRateLimiter:
         limiter.check("new-ip")  # triggers a prune sweep
         assert "old-ip" not in limiter._hits
         assert "new-ip" in limiter._hits
+
+
+class TestClientKey:
+    """issue #283: key on the real client behind a trusted BFF proxy, but only
+    when the peer is trusted — otherwise a forwarded header would be spoofable."""
+
+    @staticmethod
+    def _request(peer_ip: str | None, xff: str | None = None):
+        from starlette.requests import Request
+
+        headers = [(b"x-forwarded-for", xff.encode())] if xff is not None else []
+        scope = {
+            "type": "http",
+            "headers": headers,
+            "client": (peer_ip, 12345) if peer_ip else None,
+        }
+        return Request(scope)
+
+    def test_untrusted_peer_ignores_forwarded_header(self) -> None:
+        # AC2/AC3: a direct/untrusted caller's X-Forwarded-For is not trusted;
+        # the limiter keys on the real socket peer.
+        req = self._request("203.0.113.9", xff="1.1.1.1")
+        assert _client_key(req, frozenset()) == "203.0.113.9"
+
+    def test_trusted_proxy_uses_leftmost_forwarded_client(self) -> None:
+        # AC1: behind a trusted BFF, key on the forwarded real client IP so two
+        # visitors don't collapse into the proxy's single egress IP.
+        req = self._request("10.0.0.2", xff="198.51.100.7, 10.0.0.2")
+        assert _client_key(req, frozenset({"10.0.0.2"})) == "198.51.100.7"
+
+    def test_trusted_proxy_without_forwarded_header_falls_back_to_peer(self) -> None:
+        # AC4: nothing forwarded -> behave exactly like today (peer IP).
+        req = self._request("10.0.0.2", xff=None)
+        assert _client_key(req, frozenset({"10.0.0.2"})) == "10.0.0.2"
+
+    def test_trusted_proxy_with_blank_forwarded_header_falls_back_to_peer(self) -> None:
+        req = self._request("10.0.0.2", xff="  ")
+        assert _client_key(req, frozenset({"10.0.0.2"})) == "10.0.0.2"
+
+    def test_missing_client_is_anonymous(self) -> None:
+        req = self._request(None)
+        assert _client_key(req, frozenset()) == "anonymous"
+
+    def test_ipv6_mapped_peer_matches_plain_trusted_ip(self) -> None:
+        # A dual-stack socket may report ::ffff:127.0.0.1 for a proxy an operator
+        # listed as 127.0.0.1; normalization must still recognize it as trusted.
+        req = self._request("::ffff:127.0.0.1", xff="198.51.100.7")
+        assert _client_key(req, frozenset({"127.0.0.1"})) == "198.51.100.7"
+
+
+class TestEnforceStreamRateLimit:
+    """issue #283: the dependency must key per forwarded client behind a trusted
+    proxy — exercises the real settings/limiter wiring, not just _client_key."""
+
+    @staticmethod
+    def _request(app, xff: str):
+        from starlette.requests import Request
+
+        return Request(
+            {
+                "type": "http",
+                "app": app,
+                "headers": [(b"x-forwarded-for", xff.encode())],
+                "client": ("10.0.0.2", 12345),
+            }
+        )
+
+    def test_distinct_forwarded_clients_get_distinct_buckets(self) -> None:
+        from types import SimpleNamespace
+
+        from acemusic.api.utils.rate_limit import enforce_stream_rate_limit
+
+        app = SimpleNamespace(
+            state=SimpleNamespace(
+                settings=SimpleNamespace(trusted_proxy_set=frozenset({"10.0.0.2"})),
+                stream_limiter=FixedWindowRateLimiter(limit=1, window_seconds=60.0),
+            )
+        )
+        # Two visitors, one shared proxy IP: each is allowed its own single hit.
+        enforce_stream_rate_limit(self._request(app, "1.1.1.1"))
+        enforce_stream_rate_limit(self._request(app, "2.2.2.2"))
+        # The first visitor's second hit exceeds their own bucket (not the other's).
+        with pytest.raises(HTTPException) as exc:
+            enforce_stream_rate_limit(self._request(app, "1.1.1.1"))
+        assert exc.value.status_code == 429
 
 
 # ---------------------------------------------------------------------------

--- a/web/app/api/clips/[id]/public/route.test.ts
+++ b/web/app/api/clips/[id]/public/route.test.ts
@@ -62,6 +62,25 @@ describe("GET /api/clips/[id]/public", () => {
     expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
   })
 
+  it("forwards the real client IP so the limiter keys per visitor (#283)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ id: "c1" }), { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await GET(
+      req("http://localhost/api/clips/c1/public", {
+        headers: { "x-forwarded-for": "198.51.100.7, 10.0.0.2" },
+      }),
+      ctx("c1")
+    )
+
+    const [, opts] = fetchMock.mock.calls[0]
+    expect((opts.headers as Record<string, string>)["x-forwarded-for"]).toBe(
+      "198.51.100.7"
+    )
+  })
+
   it("passes backend error status and body through verbatim", async () => {
     const fetchMock = vi
       .fn()

--- a/web/app/api/clips/[id]/public/route.ts
+++ b/web/app/api/clips/[id]/public/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 
 import { BACKEND_URL } from "@/lib/auth-server"
-import { fetchWithTimeout } from "@/lib/proxy-fetch"
+import { clientIpHeaders, fetchWithTimeout } from "@/lib/proxy-fetch"
 
 // Same-origin proxy for GET /api/v1/clips/{clip_id}/public (US-20.0) — the
 // redacted, is_public-scoped metadata read behind a shared /song/{id} link.
@@ -25,6 +25,7 @@ export async function GET(
       {
         headers: {
           accept: "application/json",
+          ...clientIpHeaders(request),
           ...(auth ? { authorization: auth } : {}),
         },
       }

--- a/web/app/api/clips/[id]/stream/route.test.ts
+++ b/web/app/api/clips/[id]/stream/route.test.ts
@@ -32,6 +32,25 @@ describe("GET /api/clips/[id]/stream", () => {
     expect(fetchMock.mock.calls[0][0]).toContain("/api/v1/clips/c1/stream")
   })
 
+  it("forwards the real client IP so the limiter keys per visitor (#283)", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("audio", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await GET(
+      req("http://localhost/api/clips/c1/stream", {
+        headers: { "x-forwarded-for": "198.51.100.7, 10.0.0.2" },
+      }),
+      ctx("c1")
+    )
+
+    const [, opts] = fetchMock.mock.calls[0]
+    expect((opts.headers as Record<string, string>)["x-forwarded-for"]).toBe(
+      "198.51.100.7"
+    )
+  })
+
   it("forwards the Bearer token when present", async () => {
     const fetchMock = vi
       .fn()

--- a/web/app/api/clips/[id]/stream/route.ts
+++ b/web/app/api/clips/[id]/stream/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server"
 
 import { ACCESS_COOKIE } from "@/lib/auth"
 import { BACKEND_URL } from "@/lib/auth-server"
-import { fetchWithTimeout } from "@/lib/proxy-fetch"
+import { clientIpHeaders, fetchWithTimeout } from "@/lib/proxy-fetch"
 
 // Same-origin proxy for GET /api/v1/clips/{clip_id}/stream (US-20.0), the
 // URL an <audio> element points at. Distinct from the sibling /audio route,
@@ -52,6 +52,7 @@ export async function GET(
       `${BACKEND_URL}/api/v1/clips/${encodeURIComponent(id)}/stream${query}`,
       {
         headers: {
+          ...clientIpHeaders(request),
           ...(auth ? { authorization: auth } : {}),
           ...(range ? { range } : {}),
         },

--- a/web/lib/proxy-fetch.test.ts
+++ b/web/lib/proxy-fetch.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { clientIpHeaders } from "@/lib/proxy-fetch"
+
+const withHeaders = (h: Record<string, string>) => ({ headers: new Headers(h) })
+
+describe("clientIpHeaders (#283)", () => {
+  it("uses the leftmost X-Forwarded-For entry (original client)", () => {
+    expect(
+      clientIpHeaders(withHeaders({ "x-forwarded-for": "198.51.100.7, 10.0.0.2" }))
+    ).toEqual({ "x-forwarded-for": "198.51.100.7" })
+  })
+
+  it("falls back to X-Real-IP when no X-Forwarded-For is present", () => {
+    expect(clientIpHeaders(withHeaders({ "x-real-ip": "203.0.113.9" }))).toEqual({
+      "x-forwarded-for": "203.0.113.9",
+    })
+  })
+
+  it("forwards nothing when the client IP is unknown (local dev)", () => {
+    expect(clientIpHeaders(withHeaders({}))).toEqual({})
+  })
+})

--- a/web/lib/proxy-fetch.ts
+++ b/web/lib/proxy-fetch.ts
@@ -15,3 +15,24 @@ export async function fetchWithTimeout(
     clearTimeout(timeout)
   }
 }
+
+// Forward the real client IP so the backend's per-IP rate limiter keys per
+// visitor, not per BFF egress IP (#283). A same-origin proxy calls the backend
+// server-side, so without this every visitor collapses into one shared bucket.
+// Reads the client IP the fronting proxy set (leftmost X-Forwarded-For =
+// original client; X-Real-IP as fallback) and re-forwards a single value.
+//
+// Trust note: this value is only as trustworthy as the header on the inbound
+// request. A production deployment must sit behind an edge proxy that
+// sets/replaces X-Forwarded-For with the true client — a directly-exposed
+// Next server would let a client inject its own value here (inherent to any
+// X-Forwarded-For scheme). Returns {} when no such header is present (local dev
+// with no fronting proxy) so the backend safely falls back to the peer IP.
+export function clientIpHeaders(request: {
+  headers: Headers
+}): Record<string, string> {
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
+    request.headers.get("x-real-ip")?.trim()
+  return ip ? { "x-forwarded-for": ip } : {}
+}


### PR DESCRIPTION
## What

Fixes #283. The public streaming rate limiter keyed on the raw peer IP. Since US-20.0 (#250) put same-origin BFF proxies in front of `GET /clips/{id}/public` and `/stream`, every visitor reached the backend as the Next server's egress IP, so the per-IP limiter collapsed into **one shared bucket for the whole site** — one user seeking a track or a few concurrent viewers could 429 everyone on every `/song/*` page.

## Approach

The approach the issue recommended (trusted-proxy forwarded IP), spanning both tiers:

- **Backend** — new `ACEMUSIC_API_TRUSTED_PROXIES` (comma-separated). `_client_key` trusts the leftmost `X-Forwarded-For` entry **only when the immediate peer is a listed trusted proxy**; otherwise it keeps keying on the peer IP. Empty default = trust nobody, so a directly-reachable backend can't be evaded with a spoofed header and unconfigured deployments behave exactly as today. Peer IPs are normalized so an IPv4-mapped form (`::ffff:127.0.0.1`) matches its plain IPv4.
- **Web BFF** — both proxies forward the real client IP (leftmost `X-Forwarded-For`, `X-Real-IP` fallback) via a shared `clientIpHeaders` helper so the backend can key per visitor.

## Acceptance criteria — demonstrated against the real code

```
AC1 two visitors through the BFF do NOT share a bucket
    visitor A key = '1.1.1.1';  visitor B key = '2.2.2.2'  ->  distinct: True
AC2 a spoofed X-Forwarded-For from an UNTRUSTED peer is ignored
    attacker sends XFF=1.1.1.1 from 203.0.113.9  ->  key = '203.0.113.9' (its real IP)
AC3 direct-to-backend still rate-limits per real IP
    direct client 198.51.100.44  ->  key = '198.51.100.44'
AC4 unconfigured deployment behaves as before (peer IP)
    trusted_proxies default = []; XFF ignored  ->  key = '10.0.0.2' (peer)
End-to-end: A allowed, B allowed, A's 2nd hit -> HTTP 429 (B unaffected)
```

## Tests

- Backend: `TestClientKey` (untrusted-peer, trusted-proxy, no/blank XFF, IPv4-mapped, missing-client), `TestEnforceStreamRateLimit` (dependency wiring 429s the right visitor), `TestTrustedProxies` (CSV/blank/default parsing).
- Web: `clientIpHeaders` unit tests + both route tests assert `x-forwarded-for` is forwarded.
- Backend `pytest` (101 passed, integration deselected), web `vitest` (21 passed), `tsc`/`eslint`/`black`/`ruff` clean.

## Review

Cross-family review by opencode (GLM). It flagged IPv6/loopback normalization (fixed — `_normalize_ip`), a missing end-to-end wiring test (added — `TestEnforceStreamRateLimit`), and that the forwarded value is only as trustworthy as the fronting proxy (addressed via honest comments + the operational note below).

## Known limitations

- The forwarded IP is only as trustworthy as the header on the BFF's inbound request. A production deployment **must** sit behind an edge proxy that sets/replaces `X-Forwarded-For` with the true client; a directly-exposed Next server would let a client inject its own value (inherent to any XFF scheme). Documented in `.env.example` and the code comments.
- Single-process in-memory limiter (unchanged): multi-worker deployments still need a shared store (e.g. Redis) to share one limit — pre-existing, out of scope.
