### PR TITLE
fix(web): refresh access token ahead of expiry so owner pages survive it (#285)

### DIFF
--- a/web/contexts/auth-context.test.tsx
+++ b/web/contexts/auth-context.test.tsx
@@ -220,13 +220,15 @@ describe("AuthProvider", () => {
       releaseRefresh = resolve
     })
     let call = 0
-    const fetchMock = vi.fn(async (url: string) => {
+    let refreshSignal: AbortSignal | undefined
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       if (url === "/api/auth/logout") return ok({})
       if (url !== "/api/auth/refresh") return unauthorized
       call += 1
       // Mount restores an (already-expired) token so the visibility listener
       // will start a background refresh; that second refresh hangs on the gate.
       if (call === 1) return ok({ access_token: tokenExpiring(-10) })
+      refreshSignal = init?.signal ?? undefined
       await gate
       return ok({ access_token: tokenExpiring(15 * 60) })
     })
@@ -250,9 +252,12 @@ describe("AuthProvider", () => {
     await waitFor(() =>
       expect(screen.getByTestId("state")).toHaveTextContent("out")
     )
+    // logout aborts the in-flight refresh so the browser never applies its
+    // rotated Set-Cookie (the HTTP/2-reorder cookie-resurrection vector).
+    expect(refreshSignal?.aborted).toBe(true)
 
-    // The in-flight refresh now resolves 2xx — it must NOT flip the session
-    // back to authenticated.
+    // Even if the (aborted) refresh still resolves 2xx, it must NOT flip the
+    // in-memory session back to authenticated.
     await act(async () => {
       releaseRefresh()
       await gate

--- a/web/contexts/auth-context.test.tsx
+++ b/web/contexts/auth-context.test.tsx
@@ -193,8 +193,11 @@ describe("AuthProvider", () => {
           <Probe />
         </AuthProvider>
       )
+      // Advance 0ms: flush the mount refresh without firing the expired token's
+      // scheduled retry (armed at REFRESH_RETRY_MS), so `call` reflects only the
+      // mount request here.
       await act(async () => {
-        await vi.runOnlyPendingTimersAsync()
+        await vi.advanceTimersByTimeAsync(0)
       })
       expect(call).toBe(1)
       expect(screen.getByTestId("state")).toHaveTextContent("in:")

--- a/web/contexts/auth-context.test.tsx
+++ b/web/contexts/auth-context.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -8,6 +8,16 @@ import { useAuth } from "@/hooks/use-auth"
 const accessToken = `h.${Buffer.from(
   JSON.stringify({ sub: "u1", email: "musician@example.com" })
 ).toString("base64url")}.s`
+
+/** A token that carries an `exp` claim `secondsFromNow` in the future. */
+const tokenExpiring = (secondsFromNow: number) =>
+  `h.${Buffer.from(
+    JSON.stringify({
+      sub: "u1",
+      email: "musician@example.com",
+      exp: Math.floor(Date.now() / 1000) + secondsFromNow,
+    })
+  ).toString("base64url")}.s`
 
 function Probe() {
   const { isLoading, isAuthenticated, user, logout } = useAuth()
@@ -57,6 +67,148 @@ describe("AuthProvider", () => {
     await waitFor(() =>
       expect(screen.getByTestId("state")).toHaveTextContent("out")
     )
+  })
+
+  // NB: waitFor() deadlocks under fake timers (it polls on the frozen clock),
+  // so these tests flush the mount refresh with act()+runOnlyPendingTimersAsync
+  // and assert synchronously instead.
+  it("refreshes ahead of expiry and applies the rotated token", async () => {
+    vi.useFakeTimers()
+    try {
+      let call = 0
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url !== "/api/auth/refresh") return unauthorized
+        call += 1
+        // First mount restores a token expiring in 15 min; the scheduled
+        // refresh yields a fresh 15-min token before the first one dies.
+        return ok({ access_token: tokenExpiring(15 * 60) })
+      })
+      vi.stubGlobal("fetch", fetchMock)
+      render(
+        <AuthProvider>
+          <Probe />
+        </AuthProvider>
+      )
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync()
+      })
+      expect(call).toBe(1)
+      expect(screen.getByTestId("state")).toHaveTextContent("in:")
+
+      // Advance past the refresh-ahead point (~1 min before expiry).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+      })
+      expect(call).toBeGreaterThanOrEqual(2)
+      // Still signed in on the rotated token — no manual reload needed.
+      expect(screen.getByTestId("state")).toHaveTextContent("in:")
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("signs out when a scheduled refresh finds the session revoked", async () => {
+    vi.useFakeTimers()
+    try {
+      let call = 0
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url !== "/api/auth/refresh") return unauthorized
+        call += 1
+        // Mount succeeds; the next (scheduled) refresh is rejected — the
+        // refresh token was revoked, so the session is unrecoverable.
+        return call === 1 ? ok({ access_token: tokenExpiring(15 * 60) }) : unauthorized
+      })
+      vi.stubGlobal("fetch", fetchMock)
+      render(
+        <AuthProvider>
+          <Probe />
+        </AuthProvider>
+      )
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync()
+      })
+      expect(screen.getByTestId("state")).toHaveTextContent("in:")
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+      })
+      // isAuthenticated flips false → useRequireAuth redirects to /login.
+      expect(screen.getByTestId("state")).toHaveTextContent("out")
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("keeps the session signed in when a refresh hits a transient 5xx", async () => {
+    vi.useFakeTimers()
+    try {
+      let call = 0
+      const serverError = { ok: false, status: 503, json: async () => ({}) }
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url !== "/api/auth/refresh") return unauthorized
+        call += 1
+        // Mount restores a token; the scheduled refresh then hits a 503. A
+        // transient backend error must NOT sign the user out.
+        return call === 1 ? ok({ access_token: tokenExpiring(15 * 60) }) : serverError
+      })
+      vi.stubGlobal("fetch", fetchMock)
+      render(
+        <AuthProvider>
+          <Probe />
+        </AuthProvider>
+      )
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync()
+      })
+      expect(screen.getByTestId("state")).toHaveTextContent("in:")
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+      })
+      // The refresh was attempted (and retried) but the still-decodable token
+      // keeps the user authenticated — no bounce to /login on a blip.
+      expect(call).toBeGreaterThanOrEqual(2)
+      expect(screen.getByTestId("state")).toHaveTextContent("in:")
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("coalesces concurrent refreshes into a single in-flight request", async () => {
+    vi.useFakeTimers()
+    try {
+      let call = 0
+      // Mount restores an already-expired token (decodes to a user, so the tab
+      // stays "in", but the visibility listener treats it as needing a refresh).
+      // Refreshes after mount hang, so two triggers overlap in flight.
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url !== "/api/auth/refresh") return unauthorized
+        call += 1
+        if (call === 1) return ok({ access_token: tokenExpiring(-10) })
+        return new Promise(() => {}) // never settles — stays in flight
+      })
+      vi.stubGlobal("fetch", fetchMock)
+      render(
+        <AuthProvider>
+          <Probe />
+        </AuthProvider>
+      )
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync()
+      })
+      expect(call).toBe(1)
+      expect(screen.getByTestId("state")).toHaveTextContent("in:")
+
+      // Two visibility events fire their handlers synchronously; the
+      // single-flight guard must let only ONE new refresh reach the network.
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"))
+        document.dispatchEvent(new Event("visibilitychange"))
+      })
+      expect(call).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("clears the session on logout", async () => {

--- a/web/contexts/auth-context.test.tsx
+++ b/web/contexts/auth-context.test.tsx
@@ -214,6 +214,52 @@ describe("AuthProvider", () => {
     }
   })
 
+  it("does not let an in-flight refresh resurrect the session after logout", async () => {
+    let releaseRefresh: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve
+    })
+    let call = 0
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/auth/logout") return ok({})
+      if (url !== "/api/auth/refresh") return unauthorized
+      call += 1
+      // Mount restores an (already-expired) token so the visibility listener
+      // will start a background refresh; that second refresh hangs on the gate.
+      if (call === 1) return ok({ access_token: tokenExpiring(-10) })
+      await gate
+      return ok({ access_token: tokenExpiring(15 * 60) })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("state")).toHaveTextContent("in:")
+    )
+
+    // Kick off a background refresh, then log out while it is still in flight.
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+    await waitFor(() => expect(call).toBe(2))
+    await user.click(screen.getByRole("button", { name: "logout" }))
+    await waitFor(() =>
+      expect(screen.getByTestId("state")).toHaveTextContent("out")
+    )
+
+    // The in-flight refresh now resolves 2xx — it must NOT flip the session
+    // back to authenticated.
+    await act(async () => {
+      releaseRefresh()
+      await gate
+    })
+    expect(screen.getByTestId("state")).toHaveTextContent("out")
+  })
+
   it("clears the session on logout", async () => {
     const fetchMock = vi.fn(async (url: string) =>
       url === "/api/auth/refresh" ? ok({ access_token: accessToken }) : ok({})

--- a/web/contexts/auth-context.tsx
+++ b/web/contexts/auth-context.tsx
@@ -5,12 +5,24 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react"
 import { useRouter } from "next/navigation"
 
-import { decodeAccessToken, type AuthUser } from "@/lib/auth"
+import { decodeAccessToken, decodeTokenExp, type AuthUser } from "@/lib/auth"
+
+// Refresh this long before the access token's `exp` so a renewed token is in
+// hand before the old one dies. Also the "near expiry" window the visibility
+// listener uses to decide a returning tab needs a fresh token.
+// ponytail: 60s comfortably clears background-tab timer throttling (~1/min);
+// widen if a shorter access-token lifetime makes it cut too close.
+const REFRESH_SKEW_MS = 60_000
+
+// After a *transient* refresh failure (5xx/429/network) the token is still
+// valid for up to REFRESH_SKEW_MS, so retry soon rather than let it expire.
+const REFRESH_RETRY_MS = 15_000
 
 type AuthContextValue = {
   user: AuthUser | null
@@ -34,24 +46,82 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [accessToken, setAccessToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
-  // On mount, try to restore a session via the refresh cookie.
+  // Rotate the access token via the refresh cookie. Single-flight: concurrent
+  // callers (the scheduled refresh-ahead and the visibility listener) share one
+  // request so they can't race the backend's single-use refresh token into
+  // revocation (#285). Returns the new token, or null if none was obtained.
+  //
+  // 401/403 means the refresh token is gone/revoked → the session is
+  // unrecoverable, so clear the access token: `isAuthenticated` flips false and
+  // useRequireAuth redirects to /login. Any other failure (5xx, 429, network)
+  // is transient — keep the current token and let the caller retry; signing out
+  // a valid user on a backend blip would be worse than the blip.
+  const refreshing = useRef<Promise<string | null> | null>(null)
+  const refresh = useCallback((): Promise<string | null> => {
+    if (refreshing.current) return refreshing.current
+    const inflight = fetch("/api/auth/refresh", { method: "POST" })
+      .then(async (res) => {
+        if (res.status === 401 || res.status === 403) {
+          setAccessToken(null)
+          return null
+        }
+        if (!res.ok) return null
+        const { access_token } = (await res.json()) as { access_token?: string }
+        setAccessToken(access_token ?? null)
+        return access_token ?? null
+      })
+      .catch(() => null)
+      .finally(() => {
+        refreshing.current = null
+      })
+    refreshing.current = inflight
+    return inflight
+  }, [])
+
+  // On mount, restore a session via the refresh cookie.
   useEffect(() => {
     let active = true
-    fetch("/api/auth/refresh", { method: "POST" })
-      .then(async (res) => {
-        if (active && res.ok) {
-          const { access_token } = await res.json()
-          setAccessToken(access_token)
-        }
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (active) setIsLoading(false)
-      })
+    refresh().finally(() => {
+      if (active) setIsLoading(false)
+    })
     return () => {
       active = false
     }
-  }, [])
+  }, [refresh])
+
+  // Refresh-ahead: schedule a renewal ~REFRESH_SKEW_MS before the current
+  // token's `exp`. A token already past expiry isn't scheduled here (a returning
+  // tab or the retry chain below recovers it) — this avoids a busy-loop if the
+  // backend ever hands back a stale token.
+  useEffect(() => {
+    if (!accessToken) return
+    const exp = decodeTokenExp(accessToken)
+    if (exp === null || exp <= Date.now()) return
+    let timer: ReturnType<typeof setTimeout>
+    const run = async () => {
+      // A successful refresh rotates the token, re-running this effect to
+      // schedule the next renewal. A transient failure leaves the token
+      // unchanged (no re-run), so re-arm a short retry rather than let it die.
+      const rotated = await refresh()
+      if (!rotated) timer = setTimeout(run, REFRESH_RETRY_MS)
+    }
+    timer = setTimeout(run, Math.max(0, exp - REFRESH_SKEW_MS - Date.now()))
+    return () => clearTimeout(timer)
+  }, [accessToken, refresh])
+
+  // A backgrounded tab throttles timers, so the scheduled refresh can fire late.
+  // When such a tab comes back, renew immediately if the token is missing its
+  // safety window — covers "tab left open past the token lifetime" (#285).
+  useEffect(() => {
+    function onVisible() {
+      if (document.visibilityState !== "visible" || !accessToken) return
+      const exp = decodeTokenExp(accessToken)
+      if (exp !== null && exp - REFRESH_SKEW_MS > Date.now()) return
+      refresh()
+    }
+    document.addEventListener("visibilitychange", onVisible)
+    return () => document.removeEventListener("visibilitychange", onVisible)
+  }, [accessToken, refresh])
 
   const login = useCallback(async (provider: string) => {
     const res = await fetch(`/api/auth/login/${provider}`, { method: "POST" })

--- a/web/contexts/auth-context.tsx
+++ b/web/contexts/auth-context.tsx
@@ -57,6 +57,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // is transient — keep the current token and let the caller retry; signing out
   // a valid user on a backend blip would be worse than the blip.
   const refreshing = useRef<Promise<string | null> | null>(null)
+  const refreshAbort = useRef<AbortController | null>(null)
   // Bumped by logout to invalidate any refresh issued before it: since
   // AuthProvider is root-mounted (never unmounts on the client-side nav to
   // /login), a refresh in flight when the user signs out would otherwise resolve
@@ -65,7 +66,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const refresh = useCallback((): Promise<string | null> => {
     if (refreshing.current) return refreshing.current
     const epoch = sessionEpoch.current
-    const inflight = fetch("/api/auth/refresh", { method: "POST" })
+    // The controller lets logout abort an in-flight refresh: aborting discards
+    // the response before the browser applies its rotated Set-Cookie, so an
+    // HTTP/2-reordered refresh can't reinstate the session cookies after logout.
+    const controller = new AbortController()
+    refreshAbort.current = controller
+    const inflight = fetch("/api/auth/refresh", {
+      method: "POST",
+      signal: controller.signal,
+    })
       .then(async (res) => {
         // A logout while this request was in flight invalidates its result.
         if (sessionEpoch.current !== epoch) return null
@@ -81,6 +90,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .catch(() => null)
       .finally(() => {
         refreshing.current = null
+        if (refreshAbort.current === controller) refreshAbort.current = null
       })
     refreshing.current = inflight
     return inflight
@@ -162,8 +172,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   )
 
   const logout = useCallback(async () => {
-    // Invalidate any in-flight refresh and clear the token up front, so a
-    // background refresh resolving mid-logout can't resurrect the session.
+    // Cancel any in-flight refresh before anything else so its rotated
+    // Set-Cookie is never applied; the epoch bump additionally drops a refresh
+    // whose response already arrived but whose handler hasn't run. Only then
+    // clear the token and hit /logout, whose cookie-clear is now the last write.
+    refreshAbort.current?.abort()
     sessionEpoch.current += 1
     setAccessToken(null)
     await fetch("/api/auth/logout", { method: "POST" }).catch(() => {})

--- a/web/contexts/auth-context.tsx
+++ b/web/contexts/auth-context.tsx
@@ -57,10 +57,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // is transient — keep the current token and let the caller retry; signing out
   // a valid user on a backend blip would be worse than the blip.
   const refreshing = useRef<Promise<string | null> | null>(null)
+  // Bumped by logout to invalidate any refresh issued before it: since
+  // AuthProvider is root-mounted (never unmounts on the client-side nav to
+  // /login), a refresh in flight when the user signs out would otherwise resolve
+  // afterwards and resurrect the token — re-authing a session they just ended.
+  const sessionEpoch = useRef(0)
   const refresh = useCallback((): Promise<string | null> => {
     if (refreshing.current) return refreshing.current
+    const epoch = sessionEpoch.current
     const inflight = fetch("/api/auth/refresh", { method: "POST" })
       .then(async (res) => {
+        // A logout while this request was in flight invalidates its result.
+        if (sessionEpoch.current !== epoch) return null
         if (res.status === 401 || res.status === 403) {
           setAccessToken(null)
           return null
@@ -154,8 +162,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   )
 
   const logout = useCallback(async () => {
-    await fetch("/api/auth/logout", { method: "POST" }).catch(() => {})
+    // Invalidate any in-flight refresh and clear the token up front, so a
+    // background refresh resolving mid-logout can't resurrect the session.
+    sessionEpoch.current += 1
     setAccessToken(null)
+    await fetch("/api/auth/logout", { method: "POST" }).catch(() => {})
     router.push("/login")
   }, [router])
 

--- a/web/contexts/auth-context.tsx
+++ b/web/contexts/auth-context.tsx
@@ -90,23 +90,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [refresh])
 
   // Refresh-ahead: schedule a renewal ~REFRESH_SKEW_MS before the current
-  // token's `exp`. A token already past expiry isn't scheduled here (a returning
-  // tab or the retry chain below recovers it) — this avoids a busy-loop if the
-  // backend ever hands back a stale token.
+  // token's `exp`. A token that arrives already past its safety window (clock
+  // skew, a very short lifetime) schedules at the retry cadence rather than
+  // being skipped — otherwise a foreground tab that never fires visibilitychange
+  // could sit on a dead token (the very bug #285 is about). The retry cadence
+  // also caps any busy-loop if the backend ever hands back a stale token.
   useEffect(() => {
     if (!accessToken) return
     const exp = decodeTokenExp(accessToken)
-    if (exp === null || exp <= Date.now()) return
+    if (exp === null) return // no exp claim → nothing to schedule against
+    let active = true
     let timer: ReturnType<typeof setTimeout>
     const run = async () => {
       // A successful refresh rotates the token, re-running this effect to
       // schedule the next renewal. A transient failure leaves the token
       // unchanged (no re-run), so re-arm a short retry rather than let it die.
+      // `active` stops a retry from orphaning if the effect tore down mid-flight
+      // (e.g. logout during the in-flight refresh) and looping forever.
       const rotated = await refresh()
-      if (!rotated) timer = setTimeout(run, REFRESH_RETRY_MS)
+      if (active && !rotated) timer = setTimeout(run, REFRESH_RETRY_MS)
     }
-    timer = setTimeout(run, Math.max(0, exp - REFRESH_SKEW_MS - Date.now()))
-    return () => clearTimeout(timer)
+    const untilRefresh = exp - REFRESH_SKEW_MS - Date.now()
+    timer = setTimeout(run, untilRefresh > 0 ? untilRefresh : REFRESH_RETRY_MS)
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
   }, [accessToken, refresh])
 
   // A backgrounded tab throttles timers, so the scheduled refresh can fire late.

--- a/web/contexts/model-selection-context.tsx
+++ b/web/contexts/model-selection-context.tsx
@@ -72,20 +72,29 @@ export function ModelSelectionProvider({ children }: { children: ReactNode }) {
   // The no-token case is handled in the isLoading derivation below (no seeding
   // to wait for), so this effect only runs the authenticated fetch.
   //
-  // ponytail: deliberately does NOT reset seedResolved/userTouched when
-  // accessToken changes. In this app accessToken flips null→token once on mount
-  // (auth-context restores it once; logout navigates away and unmounts this
-  // provider), so the re-fetch window never occurs in practice — and resetting
-  // userTouched would risk clobbering a model the user explicitly picked.
+  // Keyed on token *presence*, not identity: the access token now rotates
+  // mid-session (auth refresh-ahead, #285), and this seed only needs to run once
+  // per session — re-fetching /me on every rotation is wasted work. The current
+  // token is read from a ref so a rotation doesn't retrigger, while the initial
+  // null→token transition still seeds. seedResolved/userTouched are deliberately
+  // never reset, so a rotation can't reopen the window that clobbers a user pick.
+  const hasToken = accessToken !== null
+  // Latest token in a ref (updated in an effect, not during render) so the seed
+  // effect reads it without a `accessToken` dep — a rotation updates the ref but
+  // doesn't retrigger the /me fetch.
+  const tokenRef = useRef(accessToken)
   useEffect(() => {
-    if (authLoading || !accessToken) return
+    tokenRef.current = accessToken
+  }, [accessToken])
+  useEffect(() => {
+    if (authLoading || !tokenRef.current) return
     let active = true
     // Bound the fetch: isLoading is gated on seedResolved (set in .finally), so a
     // hung profile request would otherwise leave the Create buttons permanently
     // disabled. On abort, .catch keeps the default model/free tier and .finally
     // still resolves the seed.
     fetch("/api/users/me", {
-      headers: { authorization: `Bearer ${accessToken}` },
+      headers: { authorization: `Bearer ${tokenRef.current}` },
       signal: AbortSignal.timeout(5000),
     })
       .then(async (res) => (res.ok ? ((await res.json()) as UserProfile) : null))
@@ -105,7 +114,7 @@ export function ModelSelectionProvider({ children }: { children: ReactNode }) {
     return () => {
       active = false
     }
-  }, [accessToken, authLoading])
+  }, [hasToken, authLoading])
 
   // Loading until the models list settles and — when there's a user whose saved
   // default could still arrive — the profile seed resolves. With no token (auth

--- a/web/hooks/use-clip-audio.test.tsx
+++ b/web/hooks/use-clip-audio.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useClipAudio } from "@/hooks/use-clip-audio"
+
+// The decode is the expensive part (fetch + Web Audio decode) — mock it so we
+// can count how often it runs across token rotations.
+vi.mock("@/lib/audio-peaks", () => ({
+  decodeClipAudio: vi.fn(async () => ({ sampleRate: 48000, peaks: new Float32Array(0) })),
+}))
+
+import { decodeClipAudio } from "@/lib/audio-peaks"
+
+const mockDecode = vi.mocked(decodeClipAudio)
+
+afterEach(() => {
+  mockDecode.mockClear()
+})
+
+describe("useClipAudio", () => {
+  it("decodes once and does not re-decode when the token rotates", async () => {
+    const { result, rerender } = renderHook(
+      ({ token }) => useClipAudio("clip-1", token),
+      { initialProps: { token: "tok-1" } }
+    )
+    await waitFor(() => expect(result.current.status).toBe("ready"))
+    expect(mockDecode).toHaveBeenCalledTimes(1)
+
+    // A background auth refresh hands the editor a new token — the already
+    // decoded buffer must not be re-fetched/re-decoded (#285 ripple).
+    rerender({ token: "tok-2" })
+    rerender({ token: "tok-3" })
+    expect(mockDecode).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-decodes when the clip id changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ id }) => useClipAudio(id, "tok-1"),
+      { initialProps: { id: "clip-1" } }
+    )
+    await waitFor(() => expect(result.current.status).toBe("ready"))
+    rerender({ id: "clip-2" })
+    await waitFor(() => expect(mockDecode).toHaveBeenCalledTimes(2))
+    expect(mockDecode).toHaveBeenLastCalledWith(
+      "clip-2",
+      "tok-1",
+      expect.any(AbortSignal)
+    )
+  })
+
+  it("kicks off the decode once the token arrives (null → present)", async () => {
+    const { result, rerender } = renderHook(
+      ({ token }: { token: string | null }) => useClipAudio("clip-1", token),
+      { initialProps: { token: null as string | null } }
+    )
+    expect(mockDecode).not.toHaveBeenCalled()
+    expect(result.current.status).toBe("loading")
+
+    rerender({ token: "tok-1" })
+    await waitFor(() => expect(result.current.status).toBe("ready"))
+    expect(mockDecode).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/hooks/use-clip-audio.ts
+++ b/web/hooks/use-clip-audio.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { decodeClipAudio, type ClipAudio } from "@/lib/audio-peaks"
 
@@ -16,22 +16,36 @@ type Outcome =
 
 /**
  * Decode a clip's audio into peak data for the waveform editor (US-18.1).
- * Fetches through the authed same-origin proxy and re-decodes when the id or
- * token changes; the in-flight decode is aborted on change/unmount. The outcome
- * is tagged with its clip id, so a result whose id no longer matches the
- * requested one reads as "loading" — no stale audio flashes under a new id, and
- * no synchronous setState is needed to reset between clips.
+ * Fetches through the authed same-origin proxy and re-decodes when the id
+ * changes; the in-flight decode is aborted on change/unmount. The outcome is
+ * tagged with its clip id, so a result whose id no longer matches the requested
+ * one reads as "loading" — no stale audio flashes under a new id, and no
+ * synchronous setState is needed to reset between clips.
+ *
+ * Keyed on token *presence*, not identity: the access token now rotates
+ * mid-session (auth refresh-ahead, #285), and re-decoding the whole clip on
+ * every rotation would be pure wasted network+CPU (the buffer is read once).
+ * The latest token is read from a ref so a rotation doesn't retrigger the
+ * decode, while a null→token transition still kicks off the initial load.
  */
 export function useClipAudio(
   clipId: string | undefined,
   token: string | null
 ): ClipAudioState {
   const [outcome, setOutcome] = useState<Outcome | null>(null)
+  // Latest token kept in a ref (updated in an effect, not during render) so the
+  // decode effect can read it without listing `token` as a dep — a rotation
+  // updates the ref but doesn't retrigger the decode.
+  const tokenRef = useRef(token)
+  useEffect(() => {
+    tokenRef.current = token
+  }, [token])
+  const hasToken = token !== null
 
   useEffect(() => {
-    if (!clipId || !token) return
+    if (!clipId || !tokenRef.current) return
     const ctl = new AbortController()
-    decodeClipAudio(clipId, token, ctl.signal)
+    decodeClipAudio(clipId, tokenRef.current, ctl.signal)
       .then((audio) => {
         if (!ctl.signal.aborted) setOutcome({ id: clipId, kind: "ready", audio })
       })
@@ -39,7 +53,7 @@ export function useClipAudio(
         if (!ctl.signal.aborted) setOutcome({ id: clipId, kind: "error" })
       })
     return () => ctl.abort()
-  }, [clipId, token])
+  }, [clipId, hasToken])
 
   const current = outcome?.id === clipId ? outcome : null
   if (!current) return { status: "loading" }

--- a/web/lib/auth.test.ts
+++ b/web/lib/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   decodeAccessToken,
+  decodeTokenExp,
   isSupportedProvider,
   parseStateSetCookies,
   safeInternalPath,
@@ -26,6 +27,23 @@ describe("decodeAccessToken", () => {
   it("returns null for a malformed token", () => {
     expect(decodeAccessToken("not-a-jwt")).toBeNull()
     expect(decodeAccessToken("")).toBeNull()
+  })
+})
+
+describe("decodeTokenExp", () => {
+  it("returns the exp claim in milliseconds", () => {
+    // exp is seconds-since-epoch in a JWT; the helper returns ms.
+    expect(decodeTokenExp(jwt({ exp: 1_700_000_000 }))).toBe(1_700_000_000_000)
+  })
+
+  it("returns null when exp is missing or not a number", () => {
+    expect(decodeTokenExp(jwt({ sub: "u1" }))).toBeNull()
+    expect(decodeTokenExp(jwt({ exp: "soon" }))).toBeNull()
+  })
+
+  it("returns null for a malformed token", () => {
+    expect(decodeTokenExp("not-a-jwt")).toBeNull()
+    expect(decodeTokenExp("")).toBeNull()
   })
 })
 

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -39,41 +39,44 @@ export function safeInternalPath(raw: string | null, fallback = "/create"): stri
 }
 
 /**
- * Decode the (unverified) JWT payload purely to show identity in the UI. The
- * token's trust is established server-side; this is display-only. Returns null
- * if the token is missing the expected claims or is malformed.
+ * Base64url-decode a JWT's payload segment into its claims, or null if the
+ * token is malformed. Unverified — trust is established server-side; callers use
+ * this only to read display identity and timing hints.
  */
-export function decodeAccessToken(token: string): AuthUser | null {
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
   try {
     const payload = token.split(".")[1]
     if (!payload) return null
     let b64 = payload.replace(/-/g, "+").replace(/_/g, "/")
     b64 += "=".repeat((4 - (b64.length % 4)) % 4)
-    const claims = JSON.parse(atob(b64)) as { sub?: string; email?: string }
-    if (!claims.sub || !claims.email) return null
-    return { id: claims.sub, email: claims.email }
+    return JSON.parse(atob(b64)) as Record<string, unknown>
   } catch {
     return null
   }
 }
 
 /**
- * Read the (unverified) `exp` claim from a JWT and return it in milliseconds,
- * or null if the token is malformed or carries no numeric `exp`. Used to
- * schedule a refresh-ahead before the access token dies. Trust is established
- * server-side; this is only a timing hint for the client.
+ * Decode the (unverified) JWT payload purely to show identity in the UI.
+ * Returns null if the token is missing the expected claims or is malformed.
  */
-export function decodeTokenExp(token: string): number | null {
-  try {
-    const payload = token.split(".")[1]
-    if (!payload) return null
-    let b64 = payload.replace(/-/g, "+").replace(/_/g, "/")
-    b64 += "=".repeat((4 - (b64.length % 4)) % 4)
-    const claims = JSON.parse(atob(b64)) as { exp?: unknown }
-    return typeof claims.exp === "number" ? claims.exp * 1000 : null
-  } catch {
+export function decodeAccessToken(token: string): AuthUser | null {
+  const claims = decodeJwtPayload(token)
+  const sub = claims?.sub
+  const email = claims?.email
+  if (typeof sub !== "string" || !sub || typeof email !== "string" || !email) {
     return null
   }
+  return { id: sub, email }
+}
+
+/**
+ * Read the (unverified) `exp` claim from a JWT and return it in milliseconds,
+ * or null if the token is malformed or carries no numeric `exp`. Used to
+ * schedule a refresh-ahead before the access token dies.
+ */
+export function decodeTokenExp(token: string): number | null {
+  const exp = decodeJwtPayload(token)?.exp
+  return typeof exp === "number" ? exp * 1000 : null
 }
 
 /**

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -58,6 +58,25 @@ export function decodeAccessToken(token: string): AuthUser | null {
 }
 
 /**
+ * Read the (unverified) `exp` claim from a JWT and return it in milliseconds,
+ * or null if the token is malformed or carries no numeric `exp`. Used to
+ * schedule a refresh-ahead before the access token dies. Trust is established
+ * server-side; this is only a timing hint for the client.
+ */
+export function decodeTokenExp(token: string): number | null {
+  try {
+    const payload = token.split(".")[1]
+    if (!payload) return null
+    let b64 = payload.replace(/-/g, "+").replace(/_/g, "/")
+    b64 += "=".repeat((4 - (b64.length % 4)) % 4)
+    const claims = JSON.parse(atob(b64)) as { exp?: unknown }
+    return typeof claims.exp === "number" ? claims.exp * 1000 : null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Pull `oauth_state_*` cookies out of a backend `Set-Cookie` header list,
  * returning just the `name`/`value` so the BFF can re-emit them under its own
  * path. Cookie attributes (path/secure/etc.) are intentionally dropped.


### PR DESCRIPTION
Fixes #285.

## Problem
The access token was minted once on `AuthProvider` mount and **never refreshed**, and the client never inspected `exp`. A tab left open past `access_token_expire_minutes` kept a dead token for the rest of the session — App Router doesn't remount the provider on client-side nav. Owner-only pages (`/studio`, `/release` via `useClip`) then rendered **"Couldn't load this song"** on the 401, with no redirect to re-auth.

## Fix (at the source, in `AuthProvider`)
- **Single-flight `refresh()`** shared by mount, the scheduler, and the visibility listener — concurrent triggers share one request, so they can't race the backend's **single-use** refresh token into revocation.
- **Refresh-ahead**: schedules a renewal ~60s before the JWT `exp`; each success chains the next.
- **Refresh-on-visibility**: a backgrounded tab throttles timers, so when it returns and its token is near/past expiry it renews immediately.
- **Unrecoverable vs transient**: a `401/403` clears the token → `isAuthenticated` flips false → `useRequireAuth` redirects to `/login`. A transient `5xx/429/network` error keeps the current token and re-arms a short retry (signing a valid user out on a backend blip would be worse than the blip).
- `decodeTokenExp()` helper added to `lib/auth.ts`.

**Why no per-hook changes:** every authed hook already lists `accessToken` in its effect deps, so a rotated token automatically re-fires their fetches and recovers the page. The fix collapses to one provider instead of ~10 hooks. `usePublicClip` is untouched.

## Acceptance criteria
- [x] A tab left open past the access-token lifetime can still load `/studio` and `/release` without a manual reload — refresh-ahead + visibility keep the token live; a rotated token re-fires `useClip`.
- [x] An unrecoverable session (refresh revoked → 401) redirects to `/login` rather than rendering "Couldn't load this song".
- [x] Concurrent authenticated requests around an expiry boundary don't race the rotating refresh token — single-flight `refresh()`.
- [x] The public song page still renders for a signed-out visitor — `usePublicClip` path unchanged.

## Tests
- `lib/auth.test.ts`: `decodeTokenExp` (exp→ms, missing/malformed → null).
- `contexts/auth-context.test.tsx`: refresh-ahead applies the rotated token; a scheduled refresh finding the session revoked signs out; a transient 5xx keeps the session; concurrent triggers coalesce to one request.
- Full web suite: **1144 passing**; `tsc` + `eslint` clean; production `build` green.

## Review
Cross-family review via `codex` (GLM/opencode timed out). It flagged the transient-5xx-signs-out case (a MAJOR) — **fixed** in this branch (only 401/403 clears the token; transient errors retry). Its MINOR (setState-after-unmount) is not applicable: React 19 no longer warns and `AuthProvider` is the app-root provider.

## Known limitations
- **Cross-tab single-use race** (pre-existing, noted in `api/auth/refresh/route.ts`): two tabs refreshing the *same* pre-rotation cookie in the same instant — the second 401s. In practice the shared httpOnly cookie is already rotated by the time the second tab reads it. Per-tab single-flight fully covers the within-tab case.
- **No per-hook 401 replay**: recovery relies on the provider keeping the token fresh (it re-fires consumers via their `accessToken` dep). A refresh is not triggered by arbitrary user interaction — only by the scheduler, the retry chain, or `visibilitychange`.
- CI is Python-only; the web gates above were run locally.
