### PR TITLE
feat(web): US-20.1 Explore page with five discovery sections (#213)

### DIFF
--- a/web/app/explore/ExplorePage.test.tsx
+++ b/web/app/explore/ExplorePage.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import ExplorePage from "@/app/explore/page"
+
+describe("ExplorePage", () => {
+  it("renders all five discovery sections (AC1)", () => {
+    render(<ExplorePage />)
+    for (const title of [
+      "Trending",
+      "Genre Channels",
+      "Staff Picks",
+      "New Releases",
+      "Charts",
+    ]) {
+      expect(
+        screen.getByRole("heading", { name: title, level: 2 })
+      ).toBeInTheDocument()
+    }
+  })
+
+  it("genre tiles link to genre-filtered search views (AC3)", () => {
+    render(<ExplorePage />)
+    const tiles = screen.getAllByTestId("genre-tile")
+    expect(tiles.length).toBeGreaterThan(0)
+    expect(tiles[0]).toHaveAttribute("href", "/search?style=rock")
+    expect(
+      tiles.every((t) => t.getAttribute("href")?.startsWith("/search?style="))
+    ).toBe(true)
+  })
+
+  it("the Charts section numbers its clips (AC4)", () => {
+    render(<ExplorePage />)
+    const ranks = screen.getAllByTestId("clip-rank")
+    expect(ranks[0]).toHaveTextContent("1")
+    expect(ranks[1]).toHaveTextContent("2")
+  })
+
+  it("every clip card links to a song detail page (AC5)", () => {
+    render(<ExplorePage />)
+    const cards = screen.getAllByTestId("explore-clip-card")
+    expect(cards.length).toBeGreaterThan(0)
+    expect(
+      cards.every((c) => c.getAttribute("href")?.startsWith("/song/"))
+    ).toBe(true)
+  })
+})

--- a/web/app/explore/page.tsx
+++ b/web/app/explore/page.tsx
@@ -1,7 +1,31 @@
+import type { Metadata } from "next"
+
+import { ClipSection } from "@/components/explore/ClipSection"
+import { GenreChannels } from "@/components/explore/GenreChannels"
+import { TrendingSection } from "@/components/explore/TrendingSection"
+import { getCharts, getNewReleases, getStaffPicks } from "@/lib/explore"
+
+// Explore page (US-20.1): five discovery sections — Trending (24h/7d),
+// Genre Channels, Staff Picks, New Releases, and Charts. Data comes from the
+// local mock service (lib/explore) until public discovery endpoints exist; the
+// page stays a server component and only Trending opts into the client for its
+// range toggle.
+
+export const metadata: Metadata = {
+  title: "Explore · Auto Music Studio",
+  description:
+    "Discover trending songs, genre channels, staff picks, new releases, and charts.",
+}
+
 export default function ExplorePage() {
   return (
-    <div className="p-8">
+    <div className="flex flex-col gap-10 p-8">
       <h1 className="text-2xl font-semibold">Explore</h1>
+      <TrendingSection />
+      <GenreChannels />
+      <ClipSection title="Staff Picks" clips={getStaffPicks()} />
+      <ClipSection title="New Releases" clips={getNewReleases()} />
+      <ClipSection title="Charts" clips={getCharts("plays")} ranked />
     </div>
   )
 }

--- a/web/components/explore/ClipSection.tsx
+++ b/web/components/explore/ClipSection.tsx
@@ -1,0 +1,32 @@
+import type { Clip } from "@/lib/workspace-clips"
+import { ExploreClipCard } from "./ExploreClipCard"
+import { SectionRow } from "./SectionRow"
+
+// Generic titled clip row for Explore (US-20.1). Staff Picks, New Releases, and
+// Charts are all "title + a scroll row of clip cards"; the only difference is
+// that Charts shows ranking numbers, so `ranked` adds a 1-based rank overlay.
+// Keeping one component avoids three near-identical copies.
+
+export function ClipSection({
+  title,
+  clips,
+  ranked = false,
+}: {
+  title: string
+  clips: Clip[]
+  /** Charts: show a 1-based ranking number on each card (AC4). */
+  ranked?: boolean
+}) {
+  if (clips.length === 0) return null
+  return (
+    <SectionRow title={title}>
+      {clips.map((clip, i) => (
+        <ExploreClipCard
+          key={clip.id}
+          clip={clip}
+          rank={ranked ? i + 1 : undefined}
+        />
+      ))}
+    </SectionRow>
+  )
+}

--- a/web/components/explore/ExploreClipCard.test.tsx
+++ b/web/components/explore/ExploreClipCard.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ExploreClipCard } from "@/components/explore/ExploreClipCard"
+import { makeClip } from "@/test/clip-factory"
+
+describe("ExploreClipCard", () => {
+  it("links the whole card to the song detail page (AC5)", () => {
+    render(<ExploreClipCard clip={makeClip({ id: "abc", title: "Neon" })} />)
+    const link = screen.getByRole("link", { name: /neon/i })
+    expect(link).toHaveAttribute("href", "/song/abc")
+  })
+
+  it("shows a ranking number only when rank is provided (AC4)", () => {
+    const { rerender } = render(
+      <ExploreClipCard clip={makeClip()} rank={3} />
+    )
+    expect(screen.getByTestId("clip-rank")).toHaveTextContent("3")
+
+    rerender(<ExploreClipCard clip={makeClip()} />)
+    expect(screen.queryByTestId("clip-rank")).not.toBeInTheDocument()
+  })
+
+  it("renders engagement stats when present", () => {
+    render(
+      <ExploreClipCard
+        clip={makeClip({ play_count: 8200, like_count: 640, share_count: 210 })}
+      />
+    )
+    // Intl compact: 8200 → "8.2K".
+    expect(screen.getByText("8.2K")).toBeInTheDocument()
+  })
+})

--- a/web/components/explore/ExploreClipCard.tsx
+++ b/web/components/explore/ExploreClipCard.tsx
@@ -57,9 +57,13 @@ export function ExploreClipCard({
         <HugeiconsIcon
           icon={MusicNote01Icon}
           size={28}
+          aria-hidden
           className="group-hover/card:opacity-0"
         />
-        <span className="absolute inset-0 flex items-center justify-center bg-background/30 opacity-0 transition-opacity group-hover/card:opacity-100">
+        <span
+          aria-hidden
+          className="absolute inset-0 flex items-center justify-center bg-background/30 opacity-0 transition-opacity group-hover/card:opacity-100"
+        >
           <HugeiconsIcon icon={PlayIcon} size={28} className="fill-current" />
         </span>
         {rank != null && (

--- a/web/components/explore/ExploreClipCard.tsx
+++ b/web/components/explore/ExploreClipCard.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  FavouriteIcon,
+  MusicNote01Icon,
+  PlayIcon,
+  Share01Icon,
+} from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { versionLabel } from "@/lib/clip-labels"
+import { formatTime } from "@/lib/clips"
+import { cn } from "@/lib/utils"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Presentational discovery card for the Explore page (US-20.1). Deliberately NOT
+// the workspace ClipCard: this one is for anonymous browsing, so it has no owner
+// actions (rename/publish/remix/drag/player dispatch) — the whole card is one
+// link to the public song detail page. Artwork shows a music-note glyph: there
+// is no authed artwork proxy, so a real <img src=.../artwork> would 401.
+
+/** Compact engagement number: 8200 → "8.2K". */
+const compact = new Intl.NumberFormat("en", { notation: "compact" })
+
+function Stat({ icon, value }: { icon: typeof PlayIcon; value: number }) {
+  return (
+    <span className="flex items-center gap-0.5 tabular-nums">
+      <HugeiconsIcon icon={icon} size={12} />
+      {compact.format(value)}
+    </span>
+  )
+}
+
+export function ExploreClipCard({
+  clip,
+  rank,
+}: {
+  clip: Clip
+  /** Chart position (1-based); when set, shows a ranking-number overlay (AC4). */
+  rank?: number
+}) {
+  const version = versionLabel(clip.model)
+  const styleText = clip.style_tags.join(", ")
+  const hasStats =
+    clip.play_count != null ||
+    clip.like_count != null ||
+    clip.share_count != null
+
+  return (
+    <Link
+      href={`/song/${clip.id}`}
+      data-testid="explore-clip-card"
+      className="group/card flex w-40 shrink-0 flex-col gap-2 rounded-lg border border-border bg-card p-2 outline-none transition-colors hover:bg-accent/50 focus-visible:ring-3 focus-visible:ring-ring/50"
+    >
+      {/* Square artwork placeholder with duration + optional rank overlays. */}
+      <div className="relative flex aspect-square items-center justify-center overflow-hidden rounded-md bg-muted text-muted-foreground">
+        <HugeiconsIcon
+          icon={MusicNote01Icon}
+          size={28}
+          className="group-hover/card:opacity-0"
+        />
+        <span className="absolute inset-0 flex items-center justify-center bg-background/30 opacity-0 transition-opacity group-hover/card:opacity-100">
+          <HugeiconsIcon icon={PlayIcon} size={28} className="fill-current" />
+        </span>
+        {rank != null && (
+          <span
+            data-testid="clip-rank"
+            className="absolute top-1 left-1 flex size-6 items-center justify-center rounded-md bg-background/85 text-sm font-bold tabular-nums"
+          >
+            {rank}
+          </span>
+        )}
+        {clip.duration != null && (
+          <span className="absolute right-1 bottom-1 rounded bg-background/80 px-1 text-[10px] tabular-nums">
+            {formatTime(clip.duration)}
+          </span>
+        )}
+      </div>
+
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="truncate text-sm font-medium" title={clip.title ?? undefined}>
+          {clip.title ?? "Untitled clip"}
+        </span>
+        {styleText && (
+          <p title={styleText} className="truncate text-xs text-muted-foreground">
+            {styleText}
+          </p>
+        )}
+        <div className="flex flex-wrap items-center gap-1">
+          {version && (
+            <Badge variant="secondary" className="text-[10px]">
+              {version}
+            </Badge>
+          )}
+          {hasStats && (
+            <div
+              className={cn(
+                "flex items-center gap-2 text-[10px] text-muted-foreground",
+                version && "ml-auto"
+              )}
+            >
+              {clip.play_count != null && (
+                <Stat icon={PlayIcon} value={clip.play_count} />
+              )}
+              {clip.like_count != null && (
+                <Stat icon={FavouriteIcon} value={clip.like_count} />
+              )}
+              {clip.share_count != null && (
+                <Stat icon={Share01Icon} value={clip.share_count} />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/web/components/explore/GenreChannels.tsx
+++ b/web/components/explore/GenreChannels.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link"
+
+import { getGenreChannels } from "@/lib/explore"
+import { SectionRow } from "./SectionRow"
+
+// Genre channel tiles (US-20.1, AC3). Each tile links to the genre-filtered
+// search view. Styled distinctly from clip cards — larger, bold label on a
+// per-genre gradient — so channels read as navigation, not individual songs.
+
+// Deterministic gradient per genre so tiles look varied but stable across
+// renders (no artwork to key off of yet).
+const GRADIENTS = [
+  "from-rose-500/70 to-orange-400/70",
+  "from-sky-500/70 to-indigo-500/70",
+  "from-amber-500/70 to-yellow-400/70",
+  "from-violet-500/70 to-fuchsia-500/70",
+  "from-emerald-500/70 to-teal-400/70",
+  "from-pink-500/70 to-purple-500/70",
+  "from-cyan-500/70 to-blue-500/70",
+  "from-lime-500/70 to-green-500/70",
+]
+
+export function GenreChannels() {
+  const genres = getGenreChannels()
+  return (
+    <SectionRow title="Genre Channels">
+      {genres.map((genre, i) => (
+        <Link
+          key={genre.id}
+          href={`/search?style=${genre.slug}`}
+          data-testid="genre-tile"
+          className={`flex aspect-video w-48 shrink-0 items-end rounded-lg bg-gradient-to-br p-3 text-lg font-bold text-white shadow-sm outline-none transition-transform hover:scale-[1.02] focus-visible:ring-3 focus-visible:ring-ring/50 ${GRADIENTS[i % GRADIENTS.length]}`}
+        >
+          {genre.name}
+        </Link>
+      ))}
+    </SectionRow>
+  )
+}

--- a/web/components/explore/SectionRow.tsx
+++ b/web/components/explore/SectionRow.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react"
+
+// Titled horizontal scroll row for an Explore section (US-20.1). A header slot
+// carries the title plus optional controls (e.g. the trending range toggle),
+// then children scroll horizontally with scroll-snap.
+//
+// ponytail: relies on native touch/trackpad horizontal scroll — no hover arrow
+// buttons. Add them if pointer-only desktop users can't reach the overflow.
+
+export function SectionRow({
+  title,
+  action,
+  children,
+}: {
+  title: string
+  /** Optional controls rendered at the end of the header row. */
+  action?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <section aria-label={title} className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        {action}
+      </div>
+      <div className="flex gap-3 overflow-x-auto scroll-smooth pb-2 [scroll-snap-type:x_mandatory] [&>*]:scroll-snap-align-start">
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/web/components/explore/SectionRow.tsx
+++ b/web/components/explore/SectionRow.tsx
@@ -23,7 +23,7 @@ export function SectionRow({
         <h2 className="text-lg font-semibold">{title}</h2>
         {action}
       </div>
-      <div className="flex gap-3 overflow-x-auto scroll-smooth pb-2 [scroll-snap-type:x_mandatory] [&>*]:scroll-snap-align-start">
+      <div className="flex snap-x snap-mandatory scroll-smooth gap-3 overflow-x-auto pb-2 [&>*]:snap-start">
         {children}
       </div>
     </section>

--- a/web/components/explore/TrendingSection.test.tsx
+++ b/web/components/explore/TrendingSection.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { TrendingSection } from "@/components/explore/TrendingSection"
+
+// First clip's link target, used to detect that the 24h/7d toggle reorders.
+function firstCardHref(): string | null {
+  return screen.getAllByTestId("explore-clip-card")[0].getAttribute("href")
+}
+
+describe("TrendingSection", () => {
+  it("re-ranks the row when switching 24h ↔ 7d (AC2)", () => {
+    render(<TrendingSection />)
+
+    // Defaults to 24h (weights likes+shares).
+    const toggle24h = screen.getByRole("button", { name: "24h" })
+    expect(toggle24h).toHaveAttribute("aria-pressed", "true")
+    const href24h = firstCardHref()
+
+    fireEvent.click(screen.getByRole("button", { name: "7d" }))
+    expect(screen.getByRole("button", { name: "7d" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    )
+    // 7d weights plays — a different clip leads the row.
+    expect(firstCardHref()).not.toBe(href24h)
+  })
+})

--- a/web/components/explore/TrendingSection.tsx
+++ b/web/components/explore/TrendingSection.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { getTrendingClips, type TrendingRange } from "@/lib/explore"
+import { ExploreClipCard } from "./ExploreClipCard"
+import { SectionRow } from "./SectionRow"
+
+// Trending section (US-20.1, AC2). A 24h/7d segmented toggle re-reads the mock
+// service; the two ranges rank by different signals, so the row reorders. Uses a
+// plain two-Button group (no ToggleGroup primitive in the kit, and Tabs would
+// unmount the row on switch).
+
+const RANGES: { value: TrendingRange; label: string }[] = [
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7d" },
+]
+
+export function TrendingSection() {
+  const [range, setRange] = useState<TrendingRange>("24h")
+  const clips = useMemo(() => getTrendingClips(range), [range])
+
+  const toggle = (
+    <div
+      role="group"
+      aria-label="Trending time range"
+      data-slot="button-group"
+      className="flex gap-1"
+    >
+      {RANGES.map((r) => (
+        <Button
+          key={r.value}
+          size="sm"
+          variant={range === r.value ? "default" : "outline"}
+          aria-pressed={range === r.value}
+          onClick={() => setRange(r.value)}
+        >
+          {r.label}
+        </Button>
+      ))}
+    </div>
+  )
+
+  return (
+    <SectionRow title="Trending" action={toggle}>
+      {clips.map((clip) => (
+        <ExploreClipCard key={clip.id} clip={clip} />
+      ))}
+    </SectionRow>
+  )
+}

--- a/web/lib/explore.test.ts
+++ b/web/lib/explore.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  GENRES,
+  getCharts,
+  getGenreChannels,
+  getNewReleases,
+  getStaffPicks,
+  getTrendingClips,
+} from "@/lib/explore"
+
+describe("explore mock service", () => {
+  it("returns all eight genre channels", () => {
+    expect(getGenreChannels()).toBe(GENRES)
+    expect(GENRES).toHaveLength(8)
+    expect(GENRES.map((g) => g.slug)).toContain("hip-hop")
+  })
+
+  it("trends differently for 24h vs 7d (AC2)", () => {
+    const day = getTrendingClips("24h")
+    const week = getTrendingClips("7d")
+    expect(day.length).toBeGreaterThan(0)
+    // 24h weights likes+shares, 7d weights plays — leaders must differ.
+    expect(day[0].id).not.toBe(week[0].id)
+    // 24h ordered by likes+shares desc.
+    const dayScore = (i: number) =>
+      (day[i].like_count ?? 0) + (day[i].share_count ?? 0)
+    expect(dayScore(0)).toBeGreaterThanOrEqual(dayScore(1))
+    // 7d ordered by plays desc.
+    expect(week[0].play_count).toBeGreaterThanOrEqual(week[1].play_count ?? 0)
+  })
+
+  it("charts are ranked highest-first by the chosen metric (AC4)", () => {
+    const byPlays = getCharts("plays")
+    for (let i = 1; i < byPlays.length; i++) {
+      expect(byPlays[i - 1].play_count!).toBeGreaterThanOrEqual(
+        byPlays[i].play_count!
+      )
+    }
+    // A different metric can reorder the top clip.
+    expect(getCharts("likes")[0].like_count).toBeGreaterThanOrEqual(
+      getCharts("likes")[1].like_count ?? 0
+    )
+  })
+
+  it("new releases are newest-first", () => {
+    const items = getNewReleases()
+    for (let i = 1; i < items.length; i++) {
+      expect(Date.parse(items[i - 1].created_at)).toBeGreaterThanOrEqual(
+        Date.parse(items[i].created_at)
+      )
+    }
+  })
+
+  it("staff picks are a non-empty curated subset of public clips", () => {
+    const picks = getStaffPicks()
+    expect(picks.length).toBeGreaterThan(0)
+    expect(picks.every((c) => c.is_public)).toBe(true)
+  })
+})

--- a/web/lib/explore.ts
+++ b/web/lib/explore.ts
@@ -1,0 +1,133 @@
+// Explore page mock data service (US-20.1).
+//
+// The Explore page (trending, genre channels, staff picks, new releases, charts)
+// has no backend: only a single-clip public read exists (/api/clips/{id}/public),
+// and the list endpoint is owner-scoped. So the five sections read from this
+// local, typed mock layer whose shapes mirror the eventual public discovery API
+// (Clip + engagement counters). When those endpoints land, swap each getter's
+// body for a fetch and delete the pool — the components consume these functions,
+// not the data.
+//
+// ponytail: no artificial network delay / IntersectionObserver lazy-load here —
+// the reads are synchronous local data, so there is nothing to defer. Add both
+// when a getter becomes a real network fetch.
+
+import type { Clip } from "@/lib/workspace-clips"
+
+/** A genre channel tile. Mirrors the eventual GET /genres shape. */
+export type Genre = {
+  id: string
+  name: string
+  slug: string
+}
+
+export type TrendingRange = "24h" | "7d"
+export type ChartMetric = "plays" | "likes" | "shares"
+
+/** Chart metric → the Clip engagement field it ranks by. */
+const METRIC_FIELD: Record<ChartMetric, "play_count" | "like_count" | "share_count"> = {
+  plays: "play_count",
+  likes: "like_count",
+  shares: "share_count",
+}
+
+export const GENRES: Genre[] = [
+  { id: "g-rock", name: "Rock", slug: "rock" },
+  { id: "g-electronic", name: "Electronic", slug: "electronic" },
+  { id: "g-hip-hop", name: "Hip Hop", slug: "hip-hop" },
+  { id: "g-classical", name: "Classical", slug: "classical" },
+  { id: "g-jazz", name: "Jazz", slug: "jazz" },
+  { id: "g-pop", name: "Pop", slug: "pop" },
+  { id: "g-rnb", name: "R&B", slug: "rnb" },
+  { id: "g-country", name: "Country", slug: "country" },
+]
+
+/** Build a mock discovery clip; only discovery-relevant fields are meaningful. */
+function mockClip(
+  id: string,
+  title: string,
+  style_tags: string[],
+  created_at: string,
+  engagement: { plays: number; likes: number; shares: number },
+  extra: Partial<Clip> = {}
+): Clip {
+  return {
+    id,
+    workspace_id: null,
+    title,
+    format: "wav",
+    duration: 90 + (engagement.plays % 120),
+    bpm: 100 + (engagement.likes % 60),
+    key: null,
+    style_tags,
+    lyrics: null,
+    vocal_language: null,
+    model: "ace-step-v1",
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: "generate",
+    is_public: true,
+    created_at,
+    is_owner: false,
+    play_count: engagement.plays,
+    like_count: engagement.likes,
+    share_count: engagement.shares,
+    ...extra,
+  }
+}
+
+// Varied pool: titles, styles, ages, and engagement all differ so trending and
+// charts produce distinct orderings (and so the 24h vs 7d toggle visibly moves).
+const POOL: Clip[] = [
+  mockClip("clip-neon", "Neon Skyline", ["synthwave", "electronic"], "2026-07-19T09:00:00Z", { plays: 8200, likes: 640, shares: 210 }),
+  mockClip("clip-velvet", "Velvet Static", ["lofi", "chill"], "2026-07-19T06:30:00Z", { plays: 5400, likes: 980, shares: 90 }),
+  mockClip("clip-emberr", "Ember Roads", ["rock", "indie"], "2026-07-18T22:10:00Z", { plays: 12100, likes: 720, shares: 340 }),
+  mockClip("clip-glass", "Glass Cathedral", ["classical", "ambient"], "2026-07-18T14:00:00Z", { plays: 3100, likes: 410, shares: 620 }),
+  mockClip("clip-gold", "Gold Rush 88", ["hip-hop", "trap"], "2026-07-17T20:45:00Z", { plays: 15800, likes: 1240, shares: 470 }),
+  mockClip("clip-tide", "Tidal Bloom", ["pop", "dance"], "2026-07-17T11:20:00Z", { plays: 9700, likes: 1580, shares: 260 }),
+  mockClip("clip-brass", "Midnight Brass", ["jazz", "soul"], "2026-07-16T19:05:00Z", { plays: 2600, likes: 300, shares: 55 }),
+  mockClip("clip-dust", "Dust & Denim", ["country", "folk"], "2026-07-15T08:15:00Z", { plays: 4300, likes: 520, shares: 130 }),
+  mockClip("clip-mono", "Monochrome Heart", ["rnb", "soul"], "2026-07-14T17:40:00Z", { plays: 7100, likes: 890, shares: 175 }),
+  mockClip("clip-pulse", "Pulse Theory", ["electronic", "techno"], "2026-07-13T05:00:00Z", { plays: 11200, likes: 610, shares: 400 }),
+  mockClip("clip-paper", "Paper Lanterns", ["lofi", "ambient"], "2026-07-12T12:30:00Z", { plays: 1900, likes: 260, shares: 40 }),
+  mockClip("clip-crown", "Crownfall", ["rock", "metal"], "2026-07-11T21:55:00Z", { plays: 6800, likes: 700, shares: 220 }),
+]
+
+/**
+ * Trending clips for a time range. 24h weights recent virality (likes + shares);
+ * 7d weights sustained plays — so the two ranges surface a different lead clip.
+ */
+export function getTrendingClips(range: TrendingRange): Clip[] {
+  const score =
+    range === "24h"
+      ? (c: Clip) => (c.like_count ?? 0) + (c.share_count ?? 0)
+      : (c: Clip) => c.play_count ?? 0
+  return [...POOL].sort((a, b) => score(b) - score(a)).slice(0, 8)
+}
+
+/** Genre channel tiles. */
+export function getGenreChannels(): Genre[] {
+  return GENRES
+}
+
+/** Editorially curated highlights (a fixed hand-picked subset). */
+export function getStaffPicks(): Clip[] {
+  const picks = ["clip-glass", "clip-velvet", "clip-brass", "clip-mono", "clip-paper"]
+  return picks.map((id) => POOL.find((c) => c.id === id)!).filter(Boolean)
+}
+
+/** Recently published clips, newest first. */
+export function getNewReleases(): Clip[] {
+  return [...POOL].sort(
+    (a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)
+  )
+}
+
+/** Top clips ranked by the chosen engagement metric, highest first. */
+export function getCharts(metric: ChartMetric = "plays"): Clip[] {
+  const field = METRIC_FIELD[metric]
+  return [...POOL]
+    .sort((a, b) => (b[field] ?? 0) - (a[field] ?? 0))
+    .slice(0, 10)
+}

--- a/web/lib/workspace-clips.ts
+++ b/web/lib/workspace-clips.ts
@@ -39,6 +39,14 @@ export type Clip = {
    * `=== true` rather than treating absence as ownership.
    */
   is_owner?: boolean
+  /**
+   * Engagement counters for discovery ranking (trending/charts, US-20.1).
+   * Optional: the backend has no counters yet, so authed/owner reads omit them
+   * and only the Explore mock service populates them. Gate on presence.
+   */
+  play_count?: number
+  like_count?: number
+  share_count?: number
 }
 
 /** A workspace as returned by GET /api/v1/workspaces (WorkspaceResponse). */


### PR DESCRIPTION
## US-20.1: Explore Page

Closes #213. First story of Stage 20 (Discovery & Social UI). Web-only.

Builds the `/explore` page with five discovery sections: **Trending** (24h/7d
toggle), **Genre Channels**, **Staff Picks**, **New Releases**, and **Charts**
(ranked). Every clip is a card linking to `/song/[id]`.

### Adapted from the stale plan
The CodeRabbit plan was written when `web/` was an empty `.gitkeep`. The app has
since been fully built, so this PR **skips** all of "Phase 1: bootstrap Next.js /
Nova / Tailwind" and the `/song/[id]` + sidebar-link tasks — those already exist.

- New presentational `ExploreClipCard` (not the owner-oriented workspace
  `ClipCard`, which carries rename/publish/remix/drag/player semantics wrong for
  anonymous browsing).
- One generic `ClipSection` powers Staff Picks / New Releases / Charts instead of
  three near-identical components.
- Data comes from a typed local mock service (`lib/explore.ts`), since no public
  discovery backend exists yet (only single-clip public read). Swapping to real
  endpoints later touches only that file.

### Acceptance criteria — all verified (SSR HTML + tests)
- [x] Renders all five content sections
- [x] Trending filters by 24h and 7d (ranks by likes+shares vs plays)
- [x] Genre tiles navigate to `/search?style=<slug>`
- [x] Charts display ranking numbers (1–10)
- [x] Clicking a clip navigates to `/song/[id]`

### Testing
- `web/lib/explore.test.ts`, `ExploreClipCard.test.tsx`, `TrendingSection.test.tsx`,
  `ExplorePage.test.tsx` — 13 new tests.
- Full local gate: **typecheck ✓ · lint ✓ · 1161/1161 vitest ✓ · `next build` ✓**.
- Cross-family review via `codex` (opencode timed out): "No blocking issues";
  two Minor findings fixed (scroll-snap utility class + `aria-hidden` on
  decorative icons).

### Known limitations (deferred, with clear upgrade paths)
- **Mock data.** All engagement/trending/charts numbers are local mock. Genre
  tiles link to `/search?style=…` but the Search page (US-20.2) is still a
  placeholder, so the filtered view isn't populated yet.
- **No lazy loading.** `ponytail:` sections read synchronous local data, so there
  is nothing to defer — the Intersection Observer / Suspense lazy-load lands when
  a getter becomes a real network fetch.
- **No scroll-arrow buttons.** Rows use native horizontal scroll + scroll-snap.
- **Artwork placeholders.** Cards show a music-note glyph (no authed artwork proxy
  exists).

> Note: the `web/` frontend is not covered by CI (Python-only). Gates above were
> run locally on this branch.
