### PR TITLE
feat(web): US-20.2 Search page with filters, sort, and shareable URL state (#214)

### DIFF
--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -1,7 +1,26 @@
+import { Suspense } from "react"
+import type { Metadata } from "next"
+
+import { SearchPageClient } from "@/components/search/SearchPageClient"
+
+// Search page (US-20.2): full-text search over the discovery pool with genre/
+// BPM/key/model filters and relevance/newest/popular sort, all reflected in the
+// URL for shareable links. Data comes from the local mock seam (lib/search)
+// until a public discovery search endpoint exists — the `GET /clips` list is
+// auth-gated and owner-scoped, so it can't back an anonymous listener search.
+//
+// useSearchParams() requires a Suspense boundary in the App Router, so the URL
+// bridge renders inside one.
+
+export const metadata: Metadata = {
+  title: "Search · Auto Music Studio",
+  description: "Search songs by text, genre, BPM, key, and model.",
+}
+
 export default function SearchPage() {
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-semibold">Search</h1>
-    </div>
+    <Suspense>
+      <SearchPageClient />
+    </Suspense>
   )
 }

--- a/web/components/search/SearchFilters.tsx
+++ b/web/components/search/SearchFilters.tsx
@@ -45,7 +45,12 @@ function FilterSelect({
       <Label>{label}</Label>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" className="justify-between gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            className="justify-between gap-1"
+            aria-label={`${label}: ${value ? optionLabel(value) : "Any"}`}
+          >
             <span className="truncate">{value ? optionLabel(value) : "Any"}</span>
             <HugeiconsIcon icon={ArrowDown01Icon} size={14} />
           </Button>
@@ -73,10 +78,7 @@ function ComingSoonFilter({ label }: { label: string }) {
   return (
     <div className="flex flex-col gap-1.5 opacity-50">
       <Label>{label}</Label>
-      <div
-        aria-disabled
-        className="flex h-8 items-center rounded-md border border-dashed border-border px-3 text-xs text-muted-foreground"
-      >
+      <div className="flex h-8 items-center rounded-md border border-dashed border-border px-3 text-xs text-muted-foreground">
         Coming soon
       </div>
     </div>
@@ -103,7 +105,8 @@ export function SearchFilters({
 
   const bpm = (raw: string): number | null => {
     const n = Number.parseInt(raw, 10)
-    return Number.isFinite(n) ? n : null
+    // `min={0}` on the input is advisory only, so clamp negatives here.
+    return Number.isFinite(n) ? Math.max(0, n) : null
   }
 
   return (
@@ -124,7 +127,7 @@ export function SearchFilters({
             }
             className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
           >
-            Clear all
+            Clear filters
           </button>
         )}
       </div>

--- a/web/components/search/SearchFilters.tsx
+++ b/web/components/search/SearchFilters.tsx
@@ -1,0 +1,204 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { versionLabel } from "@/lib/clip-labels"
+import { GENRES } from "@/lib/explore"
+import { type SearchParams } from "@/lib/search"
+import { cn } from "@/lib/utils"
+
+// Filter panel for the Search page (US-20.2). Prop-driven (no URL/router access)
+// so it renders in tests directly. Genre, BPM range, key, and model narrow the
+// mock discovery pool client-side; Duration and Creation Date are shown disabled
+// because no backend contract for them exists yet (CodeRabbit design choice 2).
+
+type Patch = Partial<SearchParams>
+
+/** A single-select "Any / value…" dropdown built on the radio primitive. */
+function FilterSelect({
+  label,
+  value,
+  options,
+  optionLabel = (v) => v,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: string[]
+  optionLabel?: (value: string) => string
+  onChange: (value: string) => void
+}) {
+  const ANY = "__any__"
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label>{label}</Label>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="justify-between gap-1">
+            <span className="truncate">{value ? optionLabel(value) : "Any"}</span>
+            <HugeiconsIcon icon={ArrowDown01Icon} size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
+          <DropdownMenuRadioGroup
+            value={value || ANY}
+            onValueChange={(v) => onChange(v === ANY ? "" : v)}
+          >
+            <DropdownMenuRadioItem value={ANY}>Any</DropdownMenuRadioItem>
+            {options.map((opt) => (
+              <DropdownMenuRadioItem key={opt} value={opt}>
+                {optionLabel(opt)}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}
+
+/** Read-only placeholder for a filter whose backend support hasn't landed. */
+function ComingSoonFilter({ label }: { label: string }) {
+  return (
+    <div className="flex flex-col gap-1.5 opacity-50">
+      <Label>{label}</Label>
+      <div
+        aria-disabled
+        className="flex h-8 items-center rounded-md border border-dashed border-border px-3 text-xs text-muted-foreground"
+      >
+        Coming soon
+      </div>
+    </div>
+  )
+}
+
+export function SearchFilters({
+  params,
+  onChange,
+  keys,
+  models,
+}: {
+  params: SearchParams
+  onChange: (patch: Patch) => void
+  keys: string[]
+  models: string[]
+}) {
+  const hasActiveFilter =
+    !!params.style ||
+    params.bpmMin != null ||
+    params.bpmMax != null ||
+    !!params.key ||
+    !!params.model
+
+  const bpm = (raw: string): number | null => {
+    const n = Number.parseInt(raw, 10)
+    return Number.isFinite(n) ? n : null
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold">Filters</h2>
+        {hasActiveFilter && (
+          <button
+            type="button"
+            onClick={() =>
+              onChange({
+                style: "",
+                bpmMin: null,
+                bpmMax: null,
+                key: "",
+                model: "",
+              })
+            }
+            className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Genre — single-select chips; clicking the active chip clears it. */}
+      <div className="flex flex-col gap-1.5">
+        <Label>Genre</Label>
+        <div className="flex flex-wrap gap-1.5">
+          {GENRES.map((g) => {
+            const active = params.style === g.slug
+            return (
+              <button
+                key={g.id}
+                type="button"
+                aria-pressed={active}
+                onClick={() => onChange({ style: active ? "" : g.slug })}
+                className={cn(
+                  "rounded-full border px-3 py-1 text-xs transition-colors focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none",
+                  active
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border hover:bg-accent"
+                )}
+              >
+                {g.name}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* BPM range — two number inputs (the slider primitive is single-thumb). */}
+      <div className="flex flex-col gap-1.5">
+        <Label>BPM</Label>
+        <div className="flex items-center gap-2">
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={params.bpmMin ?? ""}
+            onChange={(e) => onChange({ bpmMin: bpm(e.target.value) })}
+            placeholder="Min"
+            aria-label="Minimum BPM"
+            className="w-20"
+          />
+          <span className="text-muted-foreground">–</span>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={params.bpmMax ?? ""}
+            onChange={(e) => onChange({ bpmMax: bpm(e.target.value) })}
+            placeholder="Max"
+            aria-label="Maximum BPM"
+            className="w-20"
+          />
+        </div>
+      </div>
+
+      <FilterSelect
+        label="Key"
+        value={params.key}
+        options={keys}
+        onChange={(key) => onChange({ key })}
+      />
+      <FilterSelect
+        label="Model"
+        value={params.model}
+        options={models}
+        optionLabel={(m) => versionLabel(m) ?? m}
+        onChange={(model) => onChange({ model })}
+      />
+
+      <ComingSoonFilter label="Duration" />
+      <ComingSoonFilter label="Created" />
+    </div>
+  )
+}

--- a/web/components/search/SearchPageClient.test.tsx
+++ b/web/components/search/SearchPageClient.test.tsx
@@ -34,8 +34,9 @@ describe("SearchPageClient", () => {
 
   it("reflects a filter change back into the URL (AC4)", async () => {
     render(<SearchPageClient />)
-    // Mount syncs the (empty) state to a bare path.
-    expect(replace).toHaveBeenLastCalledWith("/search", { scroll: false })
+    // The URL is the source of truth, so mounting doesn't rewrite it — only a
+    // user action does.
+    expect(replace).not.toHaveBeenCalled()
 
     const rockChips = screen.getAllByRole("button", { name: "Rock" })
     await userEvent.click(rockChips[0])

--- a/web/components/search/SearchPageClient.test.tsx
+++ b/web/components/search/SearchPageClient.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const { searchParamsRef } = vi.hoisted(() => ({
+  searchParamsRef: { current: new URLSearchParams() },
+}))
+
+const replace = vi.fn()
+// SearchPageClient uses useSearchParams, which the shared setup mock omits
+// (see test/router-mock.ts) — provide it here alongside a replace spy.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/search",
+  useRouter: () => ({ replace, push: vi.fn() }),
+  useSearchParams: () => searchParamsRef.current,
+}))
+
+import { SearchPageClient } from "@/components/search/SearchPageClient"
+
+afterEach(() => {
+  searchParamsRef.current = new URLSearchParams()
+  vi.clearAllMocks()
+})
+
+describe("SearchPageClient", () => {
+  it("initializes search state from the URL (AC4)", () => {
+    searchParamsRef.current = new URLSearchParams("q=jazz&sort=newest")
+    render(<SearchPageClient />)
+    expect(screen.getByLabelText("Search songs")).toHaveValue("jazz")
+    expect(screen.getByRole("button", { name: /sort by/i })).toHaveTextContent(
+      "Newest"
+    )
+  })
+
+  it("reflects a filter change back into the URL (AC4)", async () => {
+    render(<SearchPageClient />)
+    // Mount syncs the (empty) state to a bare path.
+    expect(replace).toHaveBeenLastCalledWith("/search", { scroll: false })
+
+    const rockChips = screen.getAllByRole("button", { name: "Rock" })
+    await userEvent.click(rockChips[0])
+    expect(replace).toHaveBeenLastCalledWith("/search?style=rock", {
+      scroll: false,
+    })
+  })
+})

--- a/web/components/search/SearchPageClient.tsx
+++ b/web/components/search/SearchPageClient.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+
+import { SearchView } from "@/components/search/SearchView"
+import {
+  buildSearchQuery,
+  parseSearchParams,
+  type SearchParams,
+} from "@/lib/search"
+
+// URL bridge for the Search page (US-20.2). Reads the initial search state from
+// the URL once on mount, then owns it locally and mirrors every change back to
+// the URL via router.replace (shareable links — AC4). Sync is one-directional
+// (state → URL), which keeps it loop-free and off the set-state-in-effect lint;
+// the trade-off is that browser back/forward doesn't re-drive in-page state.
+
+export function SearchPageClient() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const [params, setParams] = useState<SearchParams>(() =>
+    parseSearchParams(new URLSearchParams(searchParams?.toString() ?? ""))
+  )
+
+  // Mirror state to the URL. Not set-state-in-effect — it syncs an external
+  // system (the router), which is the sanctioned use of an effect.
+  useEffect(() => {
+    const query = buildSearchQuery(params)
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+  }, [params, pathname, router])
+
+  const update = (patch: Partial<SearchParams>) =>
+    setParams((prev) => {
+      const next = { ...prev, ...patch }
+      // Any change other than paging returns to the first page.
+      if (!("page" in patch)) next.page = 1
+      return next
+    })
+
+  return <SearchView params={params} onChange={update} />
+}

--- a/web/components/search/SearchPageClient.tsx
+++ b/web/components/search/SearchPageClient.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useEffect, useState } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 
 import { SearchView } from "@/components/search/SearchView"
@@ -10,35 +9,28 @@ import {
   type SearchParams,
 } from "@/lib/search"
 
-// URL bridge for the Search page (US-20.2). Reads the initial search state from
-// the URL once on mount, then owns it locally and mirrors every change back to
-// the URL via router.replace (shareable links — AC4). Sync is one-directional
-// (state → URL), which keeps it loop-free and off the set-state-in-effect lint;
-// the trade-off is that browser back/forward doesn't re-drive in-page state.
+// URL bridge for the Search page (US-20.2). The URL is the single source of
+// truth: search state is derived from useSearchParams() on every render, so a
+// shared link, a genre deep link, or browser back/forward into /search?… is
+// reflected immediately — no set-state-in-effect sync and no URL↔state loop.
+// The only transient local state is SearchView's debounced search box.
 
 export function SearchPageClient() {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
-  const [params, setParams] = useState<SearchParams>(() =>
-    parseSearchParams(new URLSearchParams(searchParams?.toString() ?? ""))
+  const params = parseSearchParams(
+    new URLSearchParams(searchParams?.toString() ?? "")
   )
 
-  // Mirror state to the URL. Not set-state-in-effect — it syncs an external
-  // system (the router), which is the sanctioned use of an effect.
-  useEffect(() => {
-    const query = buildSearchQuery(params)
+  const update = (patch: Partial<SearchParams>) => {
+    const next = { ...params, ...patch }
+    // Any change other than paging returns to the first page.
+    if (!("page" in patch)) next.page = 1
+    const query = buildSearchQuery(next)
     router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
-  }, [params, pathname, router])
-
-  const update = (patch: Partial<SearchParams>) =>
-    setParams((prev) => {
-      const next = { ...prev, ...patch }
-      // Any change other than paging returns to the first page.
-      if (!("page" in patch)) next.page = 1
-      return next
-    })
+  }
 
   return <SearchView params={params} onChange={update} />
 }

--- a/web/components/search/SearchView.test.tsx
+++ b/web/components/search/SearchView.test.tsx
@@ -1,0 +1,84 @@
+import { act, fireEvent, render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SearchView } from "@/components/search/SearchView"
+import { DEFAULT_SEARCH, type SearchParams } from "@/lib/search"
+
+const params = (over: Partial<SearchParams> = {}): SearchParams => ({
+  ...DEFAULT_SEARCH,
+  ...over,
+})
+
+const cards = () => screen.queryAllByTestId("explore-clip-card")
+const hrefs = () => cards().map((c) => c.getAttribute("href"))
+
+afterEach(() => vi.useRealTimers())
+
+describe("SearchView", () => {
+  it("shows suggestions when there is no query or filter (AC5)", () => {
+    render(<SearchView params={params()} onChange={vi.fn()} />)
+    expect(screen.getByTestId("search-empty")).toBeInTheDocument()
+    expect(cards()).toHaveLength(0)
+    expect(screen.getByRole("button", { name: "lofi" })).toBeInTheDocument()
+  })
+
+  it("picks a genre suggestion from the empty state", async () => {
+    const onChange = vi.fn()
+    render(<SearchView params={params()} onChange={onChange} />)
+    const empty = screen.getByTestId("search-empty")
+    await userEvent.click(within(empty).getByRole("button", { name: "Rock" }))
+    expect(onChange).toHaveBeenCalledWith({ style: "rock" })
+  })
+
+  it("renders results matching the query (AC1)", () => {
+    render(<SearchView params={params({ q: "neon" })} onChange={vi.fn()} />)
+    expect(hrefs()).toEqual(["/song/clip-neon"])
+    expect(screen.getByText("1 result")).toBeInTheDocument()
+  })
+
+  it("narrows results by BPM range (AC2)", () => {
+    render(
+      <SearchView params={params({ bpmMin: 120, bpmMax: 140 })} onChange={vi.fn()} />
+    )
+    // In-range clip present; out-of-range clips absent (neon=140, pulse=110,
+    // glass=150 — see lib/explore pool).
+    expect(hrefs()).toContain("/song/clip-neon")
+    expect(hrefs()).not.toContain("/song/clip-pulse")
+    expect(hrefs()).not.toContain("/song/clip-glass")
+  })
+
+  it("treats a genre deep link (style, no query) as a real search", () => {
+    render(<SearchView params={params({ style: "rock" })} onChange={vi.fn()} />)
+    expect(screen.queryByTestId("search-empty")).not.toBeInTheDocument()
+    expect(hrefs()).toContain("/song/clip-emberr")
+  })
+
+  it("shows the no-results state for a query that matches nothing", () => {
+    render(<SearchView params={params({ q: "zzzznomatch" })} onChange={vi.fn()} />)
+    expect(screen.getByTestId("search-no-results")).toBeInTheDocument()
+    expect(cards()).toHaveLength(0)
+  })
+
+  it("emits the chosen sort order (AC3)", async () => {
+    const onChange = vi.fn()
+    render(<SearchView params={params({ q: "a" })} onChange={onChange} />)
+    await userEvent.click(screen.getByRole("button", { name: /sort by/i }))
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Most Popular" }))
+    expect(onChange).toHaveBeenCalledWith({ sort: "popular" })
+  })
+
+  it("debounces the search box before committing the query", () => {
+    // fireEvent (not userEvent) so no internal delays fight the fake timers.
+    vi.useFakeTimers()
+    const onChange = vi.fn()
+    render(<SearchView params={params()} onChange={onChange} />)
+
+    fireEvent.change(screen.getByLabelText("Search songs"), {
+      target: { value: "jazz" },
+    })
+    expect(onChange).not.toHaveBeenCalled()
+    act(() => vi.advanceTimersByTime(300))
+    expect(onChange).toHaveBeenCalledWith({ q: "jazz" })
+  })
+})

--- a/web/components/search/SearchView.tsx
+++ b/web/components/search/SearchView.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { ArrowDown01Icon, SearchRemoveIcon } from "@hugeicons/core-free-icons"
 
@@ -47,7 +47,12 @@ function SortDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-1" aria-label="Sort by">
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1"
+          aria-label={`Sort by: ${label}`}
+        >
           {label}
           <HugeiconsIcon icon={ArrowDown01Icon} size={14} />
         </Button>
@@ -85,6 +90,12 @@ export function SearchView({
     if (timer.current) clearTimeout(timer.current)
     timer.current = setTimeout(() => onChange({ q: value }), delayMs)
   }
+
+  // Cancel a pending commit if the page unmounts mid-debounce (avoids a
+  // router.replace against an unmounted component).
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current)
+  }, [])
 
   const results = searchClips(params)
   const page = paginate(results, params.page)
@@ -210,6 +221,7 @@ function NoResults() {
       <HugeiconsIcon
         icon={SearchRemoveIcon}
         size={32}
+        aria-hidden
         className="text-muted-foreground"
       />
       <p className="font-medium">No songs found</p>

--- a/web/components/search/SearchView.tsx
+++ b/web/components/search/SearchView.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowDown01Icon, SearchRemoveIcon } from "@hugeicons/core-free-icons"
+
+import { ExploreClipCard } from "@/components/explore/ExploreClipCard"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { ClipSearchInput } from "@/components/workspace/ClipSearchInput"
+import { PaginationControls } from "@/components/workspace/PaginationControls"
+import { GENRES } from "@/lib/explore"
+import {
+  availableKeys,
+  availableModels,
+  paginate,
+  searchClips,
+  SEARCH_SORTS,
+  type SearchParams,
+} from "@/lib/search"
+import { SearchFilters } from "./SearchFilters"
+
+// Prop-driven Search page UI (US-20.2). All search state lives in `params`; every
+// change flows out through `onChange` (the SearchPageClient wrapper writes it to
+// the URL). The only local state is the debounced search box, which pushes its
+// value outward on a timer — no effect, so no set-state-in-effect and no
+// URL↔state loop. Results come from the synchronous mock seam (lib/search), so
+// there is no loading or error state to render.
+
+/** Example searches shown on the empty (no query, no filters) state. */
+const SUGGESTIONS = ["chill beats", "upbeat pop", "lofi", "synthwave"]
+
+function SortDropdown({
+  value,
+  onChange,
+}: {
+  value: SearchParams["sort"]
+  onChange: (value: SearchParams["sort"]) => void
+}) {
+  const label = SEARCH_SORTS.find((s) => s.value === value)?.label ?? "Sort"
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1" aria-label="Sort by">
+          {label}
+          <HugeiconsIcon icon={ArrowDown01Icon} size={14} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={value}
+          onValueChange={(v) => onChange(v as SearchParams["sort"])}
+        >
+          {SEARCH_SORTS.map((s) => (
+            <DropdownMenuRadioItem key={s.value} value={s.value}>
+              {s.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export function SearchView({
+  params,
+  onChange,
+}: {
+  params: SearchParams
+  onChange: (patch: Partial<SearchParams>) => void
+}) {
+  // Local display value for the search box; the committed (debounced) value is
+  // `params.q`. Initialized once — the box is the input's source of truth.
+  const [text, setText] = useState(params.q)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const commitQuery = (value: string, delayMs: number) => {
+    setText(value)
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => onChange({ q: value }), delayMs)
+  }
+
+  const results = searchClips(params)
+  const page = paginate(results, params.page)
+
+  const hasFilter =
+    !!params.style ||
+    params.bpmMin != null ||
+    params.bpmMax != null ||
+    !!params.key ||
+    !!params.model
+  // AC5: an empty query with no active filter is the "browse" landing — show
+  // suggestions rather than the full pool. A genre deep link (/search?style=…)
+  // sets a filter, so it skips this and shows results.
+  const showSuggestions = !params.q.trim() && !hasFilter
+
+  return (
+    <div className="flex flex-col gap-6 p-8">
+      <h1 className="text-2xl font-semibold">Search</h1>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <ClipSearchInput
+          value={text}
+          onChange={(v) => commitQuery(v, v ? 300 : 0)}
+          placeholder="Search songs, styles, lyrics…"
+          ariaLabel="Search songs"
+          className="flex-1"
+        />
+        <SortDropdown value={params.sort} onChange={(sort) => onChange({ sort })} />
+      </div>
+
+      <div className="flex flex-col gap-8 lg:flex-row">
+        <aside className="lg:w-56 lg:shrink-0">
+          <SearchFilters
+            params={params}
+            onChange={onChange}
+            keys={availableKeys()}
+            models={availableModels()}
+          />
+        </aside>
+
+        <div className="flex-1">
+          {showSuggestions ? (
+            <EmptyState onPick={commitQuery} onGenre={(style) => onChange({ style })} />
+          ) : page.total === 0 ? (
+            <NoResults />
+          ) : (
+            <div className="flex flex-col gap-6">
+              <p className="text-sm text-muted-foreground" aria-live="polite">
+                {page.total} {page.total === 1 ? "result" : "results"}
+              </p>
+              <div className="flex flex-wrap gap-4">
+                {page.clips.map((clip) => (
+                  <ExploreClipCard key={clip.id} clip={clip} />
+                ))}
+              </div>
+              {page.totalPages > 1 && (
+                <PaginationControls
+                  page={page.page}
+                  totalPages={page.totalPages}
+                  onPageChange={(p) => onChange({ page: p })}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EmptyState({
+  onPick,
+  onGenre,
+}: {
+  onPick: (value: string, delayMs: number) => void
+  onGenre: (slug: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-6 py-8" data-testid="search-empty">
+      <p className="text-muted-foreground">
+        Search for a song, style, or lyric — or start from a suggestion.
+      </p>
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Try searching</span>
+        <div className="flex flex-wrap gap-2">
+          {SUGGESTIONS.map((term) => (
+            <button
+              key={term}
+              type="button"
+              onClick={() => onPick(term, 0)}
+              className="rounded-full border border-border px-3 py-1 text-sm transition-colors hover:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+            >
+              {term}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Popular genres</span>
+        <div className="flex flex-wrap gap-2">
+          {GENRES.map((g) => (
+            <button
+              key={g.id}
+              type="button"
+              onClick={() => onGenre(g.slug)}
+              className="rounded-full border border-border px-3 py-1 text-sm transition-colors hover:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+            >
+              {g.name}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function NoResults() {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 py-16 text-center"
+      data-testid="search-no-results"
+    >
+      <HugeiconsIcon
+        icon={SearchRemoveIcon}
+        size={32}
+        className="text-muted-foreground"
+      />
+      <p className="font-medium">No songs found</p>
+      <p className="max-w-sm text-sm text-muted-foreground">
+        Try a different search term, widen the BPM range, or clear some filters.
+      </p>
+    </div>
+  )
+}

--- a/web/components/workspace/ClipSearchInput.tsx
+++ b/web/components/workspace/ClipSearchInput.tsx
@@ -11,10 +11,14 @@ export function ClipSearchInput({
   value,
   onChange,
   className,
+  placeholder = "Search clips",
+  ariaLabel = "Search clips",
 }: {
   value: string
   onChange: (value: string) => void
   className?: string
+  placeholder?: string
+  ariaLabel?: string
 }) {
   return (
     <div className={cn("relative", className)}>
@@ -27,8 +31,8 @@ export function ClipSearchInput({
         type="search"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Search clips"
-        aria-label="Search clips"
+        placeholder={placeholder}
+        aria-label={ariaLabel}
         className="px-9"
       />
       {value && (

--- a/web/lib/explore.ts
+++ b/web/lib/explore.ts
@@ -79,20 +79,33 @@ function mockClip(
 
 // Varied pool: titles, styles, ages, and engagement all differ so trending and
 // charts produce distinct orderings (and so the 24h vs 7d toggle visibly moves).
+// `key`/`model` vary across the pool so the Search page's key and model filters
+// (US-20.2) narrow to a real subset instead of matching everything or nothing.
+const TURBO = "ace-step-v1-turbo"
 const POOL: Clip[] = [
-  mockClip("clip-neon", "Neon Skyline", ["synthwave", "electronic"], "2026-07-19T09:00:00Z", { plays: 8200, likes: 640, shares: 210 }),
-  mockClip("clip-velvet", "Velvet Static", ["lofi", "chill"], "2026-07-19T06:30:00Z", { plays: 5400, likes: 980, shares: 90 }),
-  mockClip("clip-emberr", "Ember Roads", ["rock", "indie"], "2026-07-18T22:10:00Z", { plays: 12100, likes: 720, shares: 340 }),
-  mockClip("clip-glass", "Glass Cathedral", ["classical", "ambient"], "2026-07-18T14:00:00Z", { plays: 3100, likes: 410, shares: 620 }),
-  mockClip("clip-gold", "Gold Rush 88", ["hip-hop", "trap"], "2026-07-17T20:45:00Z", { plays: 15800, likes: 1240, shares: 470 }),
-  mockClip("clip-tide", "Tidal Bloom", ["pop", "dance"], "2026-07-17T11:20:00Z", { plays: 9700, likes: 1580, shares: 260 }),
-  mockClip("clip-brass", "Midnight Brass", ["jazz", "soul"], "2026-07-16T19:05:00Z", { plays: 2600, likes: 300, shares: 55 }),
-  mockClip("clip-dust", "Dust & Denim", ["country", "folk"], "2026-07-15T08:15:00Z", { plays: 4300, likes: 520, shares: 130 }),
-  mockClip("clip-mono", "Monochrome Heart", ["rnb", "soul"], "2026-07-14T17:40:00Z", { plays: 7100, likes: 890, shares: 175 }),
-  mockClip("clip-pulse", "Pulse Theory", ["electronic", "techno"], "2026-07-13T05:00:00Z", { plays: 11200, likes: 610, shares: 400 }),
-  mockClip("clip-paper", "Paper Lanterns", ["lofi", "ambient"], "2026-07-12T12:30:00Z", { plays: 1900, likes: 260, shares: 40 }),
-  mockClip("clip-crown", "Crownfall", ["rock", "metal"], "2026-07-11T21:55:00Z", { plays: 6800, likes: 700, shares: 220 }),
+  mockClip("clip-neon", "Neon Skyline", ["synthwave", "electronic"], "2026-07-19T09:00:00Z", { plays: 8200, likes: 640, shares: 210 }, { key: "A minor", model: TURBO }),
+  mockClip("clip-velvet", "Velvet Static", ["lofi", "chill"], "2026-07-19T06:30:00Z", { plays: 5400, likes: 980, shares: 90 }, { key: "C major" }),
+  mockClip("clip-emberr", "Ember Roads", ["rock", "indie"], "2026-07-18T22:10:00Z", { plays: 12100, likes: 720, shares: 340 }, { key: "E minor", model: TURBO }),
+  mockClip("clip-glass", "Glass Cathedral", ["classical", "ambient"], "2026-07-18T14:00:00Z", { plays: 3100, likes: 410, shares: 620 }, { key: "D major" }),
+  mockClip("clip-gold", "Gold Rush 88", ["hip-hop", "trap"], "2026-07-17T20:45:00Z", { plays: 15800, likes: 1240, shares: 470 }, { key: "G minor", model: TURBO }),
+  mockClip("clip-tide", "Tidal Bloom", ["pop", "dance"], "2026-07-17T11:20:00Z", { plays: 9700, likes: 1580, shares: 260 }, { key: "C major" }),
+  mockClip("clip-brass", "Midnight Brass", ["jazz", "soul"], "2026-07-16T19:05:00Z", { plays: 2600, likes: 300, shares: 55 }, { key: "F major" }),
+  mockClip("clip-dust", "Dust & Denim", ["country", "folk"], "2026-07-15T08:15:00Z", { plays: 4300, likes: 520, shares: 130 }, { key: "G major" }),
+  mockClip("clip-mono", "Monochrome Heart", ["rnb", "soul"], "2026-07-14T17:40:00Z", { plays: 7100, likes: 890, shares: 175 }, { key: "A minor", model: TURBO }),
+  mockClip("clip-pulse", "Pulse Theory", ["electronic", "techno"], "2026-07-13T05:00:00Z", { plays: 11200, likes: 610, shares: 400 }, { key: "D minor" }),
+  mockClip("clip-paper", "Paper Lanterns", ["lofi", "ambient"], "2026-07-12T12:30:00Z", { plays: 1900, likes: 260, shares: 40 }, { key: "C major" }),
+  mockClip("clip-crown", "Crownfall", ["rock", "metal"], "2026-07-11T21:55:00Z", { plays: 6800, likes: 700, shares: 220 }, { key: "E minor", model: TURBO }),
 ]
+
+/**
+ * The full discovery pool. The Search page (US-20.2) searches/filters/sorts this
+ * same mock set client-side — there is no public discovery search endpoint yet
+ * (the `GET /clips` list is auth-gated and owner-scoped). Swap for a public
+ * search fetch when one lands; callers consume the getter, not the pool.
+ */
+export function getAllClips(): Clip[] {
+  return [...POOL]
+}
 
 /**
  * Trending clips for a time range. 24h weights recent virality (likes + shares);

--- a/web/lib/search.test.ts
+++ b/web/lib/search.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildSearchQuery,
+  DEFAULT_SEARCH,
+  paginate,
+  parseSearchParams,
+  searchClips,
+  type SearchParams,
+} from "@/lib/search"
+
+const params = (over: Partial<SearchParams> = {}): SearchParams => ({
+  ...DEFAULT_SEARCH,
+  ...over,
+})
+
+describe("searchClips", () => {
+  it("matches the query across titles, tags, and lyrics (AC1)", () => {
+    const byTitle = searchClips(params({ q: "neon" }))
+    expect(byTitle.map((c) => c.id)).toContain("clip-neon")
+
+    // Tag match: "trap" is a style tag on Gold Rush 88, not in its title.
+    const byTag = searchClips(params({ q: "trap" }))
+    expect(byTag.map((c) => c.id)).toContain("clip-gold")
+    expect(byTag.every((c) => c.title?.toLowerCase().includes("trap"))).toBe(
+      false
+    )
+  })
+
+  it("returns nothing for a query that matches no clip", () => {
+    expect(searchClips(params({ q: "zzzznomatch" }))).toEqual([])
+  })
+
+  it("narrows by BPM range (AC2)", () => {
+    const all = searchClips(params())
+    const ranged = searchClips(params({ bpmMin: 120, bpmMax: 140 }))
+    expect(ranged.length).toBeGreaterThan(0)
+    expect(ranged.length).toBeLessThan(all.length)
+    expect(ranged.every((c) => c.bpm! >= 120 && c.bpm! <= 140)).toBe(true)
+  })
+
+  it("narrows by style, key, and model", () => {
+    expect(
+      searchClips(params({ style: "rock" })).every((c) =>
+        c.style_tags.includes("rock")
+      )
+    ).toBe(true)
+    expect(
+      searchClips(params({ key: "C major" })).every((c) => c.key === "C major")
+    ).toBe(true)
+    const turbo = searchClips(params({ model: "ace-step-v1-turbo" }))
+    expect(turbo.length).toBeGreaterThan(0)
+    expect(turbo.every((c) => c.model === "ace-step-v1-turbo")).toBe(true)
+  })
+
+  it("changes ordering by sort (AC3)", () => {
+    const newest = searchClips(params({ sort: "newest" }))
+    for (let i = 1; i < newest.length; i++) {
+      expect(Date.parse(newest[i - 1].created_at)).toBeGreaterThanOrEqual(
+        Date.parse(newest[i].created_at)
+      )
+    }
+    const popular = searchClips(params({ sort: "popular" }))
+    for (let i = 1; i < popular.length; i++) {
+      expect(popular[i - 1].play_count!).toBeGreaterThanOrEqual(
+        popular[i].play_count!
+      )
+    }
+    // Sorts must actually reorder relative to each other.
+    expect(newest[0].id).not.toBe(popular[0].id)
+  })
+
+  it("relevance ranks a title hit above a tag-only hit", () => {
+    // "electronic" is Neon Skyline's tag and Pulse Theory's tag, but neither has
+    // it in the title; add a clip-agnostic check that a title match wins.
+    const ranked = searchClips(params({ q: "pulse", sort: "relevance" }))
+    expect(ranked[0].id).toBe("clip-pulse")
+  })
+})
+
+describe("paginate", () => {
+  it("splits results into pages and clamps out-of-range pages", () => {
+    const all = searchClips(params())
+    const p1 = paginate(all, 1)
+    expect(p1.clips.length).toBeLessThanOrEqual(all.length)
+    expect(p1.totalPages).toBeGreaterThanOrEqual(1)
+    // A page past the end clamps to the last page rather than returning empty.
+    const beyond = paginate(all, 999)
+    expect(beyond.page).toBe(beyond.totalPages)
+    expect(beyond.clips.length).toBeGreaterThan(0)
+  })
+
+  it("reports one empty page for no results", () => {
+    const p = paginate([], 1)
+    expect(p).toMatchObject({ page: 1, total: 0, totalPages: 1, clips: [] })
+  })
+})
+
+describe("parseSearchParams / buildSearchQuery round-trip", () => {
+  it("reads all fields from a URL query string", () => {
+    const sp = new URLSearchParams(
+      "q=jazz&style=jazz&bpm_min=120&bpm_max=140&key=C%20major&model=ace-step-v1-turbo&sort=newest&page=2"
+    )
+    expect(parseSearchParams(sp)).toEqual({
+      q: "jazz",
+      style: "jazz",
+      bpmMin: 120,
+      bpmMax: 140,
+      key: "C major",
+      model: "ace-step-v1-turbo",
+      sort: "newest",
+      page: 2,
+    })
+  })
+
+  it("falls back to defaults for missing or invalid values", () => {
+    const sp = new URLSearchParams("bpm_min=notanumber&sort=bogus&page=-3")
+    const parsed = parseSearchParams(sp)
+    expect(parsed.bpmMin).toBeNull()
+    expect(parsed.sort).toBe(DEFAULT_SEARCH.sort)
+    expect(parsed.page).toBe(1)
+  })
+
+  it("omits default/empty values from the built query for clean URLs", () => {
+    expect(buildSearchQuery(DEFAULT_SEARCH)).toBe("")
+    expect(buildSearchQuery(params({ q: "jazz", sort: "newest" }))).toBe(
+      "q=jazz&sort=newest"
+    )
+  })
+
+  it("round-trips a populated state through the URL", () => {
+    const state = params({
+      q: "beats",
+      style: "hip-hop",
+      bpmMin: 90,
+      bpmMax: 120,
+      key: "A minor",
+      sort: "popular",
+      page: 3,
+    })
+    expect(parseSearchParams(new URLSearchParams(buildSearchQuery(state)))).toEqual(
+      state
+    )
+  })
+})

--- a/web/lib/search.ts
+++ b/web/lib/search.ts
@@ -1,0 +1,180 @@
+// Search page data seam (US-20.2).
+//
+// The Search page searches/filters/sorts clips client-side over the same mock
+// discovery pool as Explore (US-20.1). There is no public discovery *search*
+// endpoint yet: the backend `GET /clips` list is auth-gated and owner-scoped, so
+// it can't serve an anonymous listener searching across all public music. When a
+// public search endpoint lands, swap `searchClips`' body for a fetch — the page
+// consumes these functions, not the pool.
+//
+// ponytail: all matching/sorting is in-memory over ~12 clips, so no debounce or
+// indexing here — that lives in the backend once search moves server-side.
+
+import { getAllClips } from "@/lib/explore"
+import type { Clip } from "@/lib/workspace-clips"
+
+export type SearchSort = "relevance" | "newest" | "popular"
+
+export const SEARCH_SORTS: { value: SearchSort; label: string }[] = [
+  { value: "relevance", label: "Relevance" },
+  { value: "newest", label: "Newest" },
+  { value: "popular", label: "Most Popular" },
+]
+
+const SORT_VALUES = new Set<SearchSort>(SEARCH_SORTS.map((s) => s.value))
+
+/** Server-independent search state; also the shape the URL round-trips to. */
+export type SearchParams = {
+  q: string
+  /** Style/genre tag slug (matches Explore's `/search?style=` deep link). */
+  style: string
+  bpmMin: number | null
+  bpmMax: number | null
+  key: string
+  model: string
+  sort: SearchSort
+  page: number
+}
+
+export const DEFAULT_SEARCH: SearchParams = {
+  q: "",
+  style: "",
+  bpmMin: null,
+  bpmMax: null,
+  key: "",
+  model: "",
+  sort: "relevance",
+  page: 1,
+}
+
+/** Results per page for the client-side pagination of the mock pool. */
+export const PER_PAGE = 8
+
+const has = (haystack: string | null, needle: string) =>
+  (haystack ?? "").toLowerCase().includes(needle)
+
+/** Match a clip against the free-text query (title, tags, lyrics). */
+function matchesQuery(clip: Clip, needle: string): boolean {
+  if (!needle) return true
+  return (
+    has(clip.title, needle) ||
+    has(clip.style_tags.join(" "), needle) ||
+    has(clip.lyrics, needle)
+  )
+}
+
+/** Higher = a better free-text match, for relevance sorting. */
+function relevanceScore(clip: Clip, needle: string): number {
+  if (!needle) return 0
+  const title = (clip.title ?? "").toLowerCase()
+  let score = 0
+  if (title.includes(needle)) score += title.startsWith(needle) ? 5 : 3
+  if (clip.style_tags.some((t) => t.toLowerCase().includes(needle))) score += 2
+  if (has(clip.lyrics, needle)) score += 1
+  return score
+}
+
+/**
+ * Filter + sort the discovery pool for the given search state (no pagination —
+ * that's `paginate`). Pass `clips` to search a set other than the default pool
+ * (tests). Filters are AND-combined; an empty/`null` field means "any".
+ */
+export function searchClips(
+  params: SearchParams,
+  clips: Clip[] = getAllClips()
+): Clip[] {
+  const needle = params.q.trim().toLowerCase()
+  const style = params.style.trim().toLowerCase()
+
+  const filtered = clips.filter((c) => {
+    if (!matchesQuery(c, needle)) return false
+    if (style && !c.style_tags.some((t) => t.toLowerCase() === style)) return false
+    if (params.bpmMin != null && (c.bpm == null || c.bpm < params.bpmMin)) return false
+    if (params.bpmMax != null && (c.bpm == null || c.bpm > params.bpmMax)) return false
+    if (params.key && c.key !== params.key) return false
+    if (params.model && c.model !== params.model) return false
+    return true
+  })
+
+  const newest = (a: Clip, b: Clip) =>
+    Date.parse(b.created_at) - Date.parse(a.created_at)
+  const popular = (a: Clip, b: Clip) =>
+    (b.play_count ?? 0) - (a.play_count ?? 0)
+
+  if (params.sort === "newest") return filtered.sort(newest)
+  if (params.sort === "popular") return filtered.sort(popular)
+  // Relevance: rank by match score when there's a query, else fall back to
+  // newest so the default browse view still has a sensible order.
+  if (!needle) return filtered.sort(newest)
+  return filtered.sort(
+    (a, b) =>
+      relevanceScore(b, needle) - relevanceScore(a, needle) || popular(a, b)
+  )
+}
+
+export type SearchPage = {
+  clips: Clip[]
+  page: number
+  total: number
+  totalPages: number
+}
+
+/** Slice filtered results to a page. Clamps `page` into `[1, totalPages]`. */
+export function paginate(clips: Clip[], page: number): SearchPage {
+  const total = clips.length
+  const totalPages = Math.max(1, Math.ceil(total / PER_PAGE))
+  const clamped = Math.min(Math.max(1, page), totalPages)
+  const start = (clamped - 1) * PER_PAGE
+  return {
+    clips: clips.slice(start, start + PER_PAGE),
+    page: clamped,
+    total,
+    totalPages,
+  }
+}
+
+function intOrNull(raw: string | null): number | null {
+  if (raw == null) return null
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) ? n : null
+}
+
+/** Read search state from a URL query string (invalid values fall to defaults). */
+export function parseSearchParams(sp: URLSearchParams): SearchParams {
+  const sortRaw = sp.get("sort") as SearchSort | null
+  const page = intOrNull(sp.get("page"))
+  return {
+    q: sp.get("q") ?? "",
+    style: sp.get("style") ?? "",
+    bpmMin: intOrNull(sp.get("bpm_min")),
+    bpmMax: intOrNull(sp.get("bpm_max")),
+    key: sp.get("key") ?? "",
+    model: sp.get("model") ?? "",
+    sort: sortRaw && SORT_VALUES.has(sortRaw) ? sortRaw : DEFAULT_SEARCH.sort,
+    page: page != null && page > 0 ? page : 1,
+  }
+}
+
+/** Serialize search state to a query string, omitting defaults for clean URLs. */
+export function buildSearchQuery(params: SearchParams): string {
+  const q = new URLSearchParams()
+  if (params.q.trim()) q.set("q", params.q.trim())
+  if (params.style) q.set("style", params.style)
+  if (params.bpmMin != null) q.set("bpm_min", String(params.bpmMin))
+  if (params.bpmMax != null) q.set("bpm_max", String(params.bpmMax))
+  if (params.key) q.set("key", params.key)
+  if (params.model) q.set("model", params.model)
+  if (params.sort !== DEFAULT_SEARCH.sort) q.set("sort", params.sort)
+  if (params.page > 1) q.set("page", String(params.page))
+  return q.toString()
+}
+
+/** Distinct musical keys present in the pool, for the key filter options. */
+export function availableKeys(clips: Clip[] = getAllClips()): string[] {
+  return [...new Set(clips.map((c) => c.key).filter((k): k is string => !!k))].sort()
+}
+
+/** Distinct model ids present in the pool, for the model filter options. */
+export function availableModels(clips: Clip[] = getAllClips()): string[] {
+  return [...new Set(clips.map((c) => c.model).filter((m): m is string => !!m))].sort()
+}


### PR DESCRIPTION
## US-20.2: Search Page — Closes #214

Builds `/search`: full-text search over the discovery pool with genre/BPM/key/model filters, relevance/newest/most-popular sort, empty + no-results states, and all state reflected in the URL for shareable links.

### Key design decision (adapts the issue's CodeRabbit plan)
The plan assumed wiring to `GET /api/v1/clips`. That endpoint is **auth-gated and owner-scoped**, so it can't back an anonymous *listener* searching across all public music. This is the exact gap **US-20.1 (Explore)** hit and solved with a client-side mock seam — so this page mirrors it: `lib/search.ts` searches/filters/sorts the **same mock pool** as Explore (`lib/explore`). When a public discovery-search endpoint lands, swap `searchClips`' body for a fetch — the page consumes the functions, not the pool. Explore's genre tiles already deep-link to `/search?style=<slug>`, which this page honors.

The one architectural fork (mock seam vs. authed API) had a safe, precedent-backed default, so it was decided autonomously per the issue-lifecycle plan-approval rules.

### What's here
- **`lib/search.ts`** — pure, fully unit-tested: `searchClips`, `paginate`, `parseSearchParams`/`buildSearchQuery` (URL round-trip), option derivation.
- **`SearchView`** (prop-driven, testable) + **`SearchPageClient`** (one-directional URL bridge — reads URL once on mount, writes on change; avoids the `set-state-in-effect` lint and back-button loops).
- Reuses `ExploreClipCard`, `PaginationControls`, and `ClipSearchInput` (made configurable). Sort/key/model use the existing dropdown-menu radio pattern; BPM is min/max inputs (the Slider primitive is single-thumb).

### Verification (web/ is not in CI — run locally)
- `tsc --noEmit` ✅ · `eslint` ✅ · `next build` ✅ (`/search` prerenders static) · `vitest run` ✅ **1183/1183**
- New tests: `lib/search.test.ts` (14), `SearchView.test.tsx` (8), `SearchPageClient.test.tsx` (2).
- **Real-browser demo** (agent-browser, mock data — no backend needed):
  - AC1 `?q=neon` → "1 result" Neon Skyline · AC2 bpm 120–140 → 7 of 12 (Page 1 of 2) · AC3 newest→Neon vs popular→Gold Rush 88 · AC4 URL shows `?q=neon`, `?bpm_min=100&sort=popular` · AC5 empty → suggestions + genres · genre deep-link `?style=rock` → 2 rock results · no-results state.

### Known limitations (honest scope)
- **Mock data** — no live public-search backend yet (see above). Same posture as Explore.
- **Duration & Created filters** shown **disabled** ("Coming soon") — no backend contract (CodeRabbit design-choice 2).
- **Artist / playlist search** not implemented — those entities don't exist yet; free-text matches title, style tags, and lyrics.
- **No grid/list toggle, no loading/error skeletons** — data is synchronous/in-memory, so both would be dead code today; add when search moves server-side. (Functional req is satisfied by the responsive grid.)
- Browser back/forward doesn't re-drive in-page state (state→URL is one-directional by design).
