### PR TITLE
feat(web): US-20.3 Playlists — CRUD, songs, cover, visibility, share, inspiration

### DIFF
--- a/web/app/create/page.tsx
+++ b/web/app/create/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useCallback, useState } from "react"
-import { useRouter } from "next/navigation"
+import { Suspense, useCallback, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useRequireAuth } from "@/hooks/use-require-auth"
@@ -11,10 +11,29 @@ import { SoundsCreationForm } from "@/components/create/SoundsCreationForm"
 import { ModelSelector } from "@/components/create/ModelSelector"
 import { WorkspacePanel } from "@/components/workspace/WorkspacePanel"
 import { ModelSelectionProvider } from "@/contexts/model-selection-context"
+import type { InspirationSelection } from "@/lib/audio-inputs"
 
+// useSearchParams() requires a Suspense boundary in the App Router, so the page
+// body renders inside one (mirrors the Search page).
 export default function CreatePage() {
+  return (
+    <Suspense>
+      <CreatePageBody />
+    </Suspense>
+  )
+}
+
+function CreatePageBody() {
   const { isLoading, isAuthenticated } = useRequireAuth()
   const router = useRouter()
+  const searchParams = useSearchParams()
+
+  // "Use as Inspiration" deep link (US-20.3): /create?inspiration=<id>&inspirationName=<name>
+  // pre-attaches the playlist as an inspiration chip on the Simple form.
+  const inspirationId = searchParams?.get("inspiration")
+  const initialInspiration: InspirationSelection | undefined = inspirationId
+    ? { id: inspirationId, name: searchParams?.get("inspirationName") ?? "Playlist" }
+    : undefined
 
   // Bumped whenever a creation form finishes a generation, so the workspace panel
   // refetches and the new clips appear (US-16.7). Stable callback so it doesn't
@@ -43,7 +62,10 @@ export default function CreatePage() {
               <TabsTrigger value="sounds">Sounds</TabsTrigger>
             </TabsList>
             <TabsContent value="simple">
-              <SimpleCreationForm onGenerated={onGenerated} />
+              <SimpleCreationForm
+                onGenerated={onGenerated}
+                initialInspiration={initialInspiration}
+              />
             </TabsContent>
             <TabsContent value="advanced">
               <AdvancedCreationForm onGenerated={onGenerated} />

--- a/web/app/playlists/[id]/page.tsx
+++ b/web/app/playlists/[id]/page.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { useParams } from "next/navigation"
+
+import { PlaylistDetail } from "@/components/playlists/PlaylistDetail"
+
+// Playlist detail route /playlists/[id] (US-20.3). Thin shim: pull the id from the
+// route and hand off to PlaylistDetail, which reads the shared store and owns the
+// songs, cover, visibility, share, and inspiration UI.
+
+export default function PlaylistDetailPage() {
+  const params = useParams<{ id: string }>()
+  const id = params?.id
+  if (!id) return null
+  return <PlaylistDetail playlistId={id} />
+}

--- a/web/app/playlists/layout.tsx
+++ b/web/app/playlists/layout.tsx
@@ -1,0 +1,13 @@
+import { PlaylistsProvider } from "@/contexts/playlists-context"
+
+// Wraps the /playlists subtree (list + detail) in the shared in-memory store so
+// both routes read and mutate one reactive source (US-20.3). Kept as a layout so
+// navigating between the library and a detail page doesn't reset playlist state.
+
+export default function PlaylistsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <PlaylistsProvider>{children}</PlaylistsProvider>
+}

--- a/web/app/playlists/page.tsx
+++ b/web/app/playlists/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next"
+
+import { PlaylistLibrary } from "@/components/playlists/PlaylistLibrary"
+
+// Playlists library (US-20.3): create, manage, and share playlists. Web-only for
+// now — the data lives in a local mock store (contexts/playlists-context) until a
+// `/playlists` backend lands, mirroring Explore (US-20.1) and Search (US-20.2).
+
+export const metadata: Metadata = {
+  title: "Playlists · Auto Music Studio",
+  description: "Create, manage, and share playlists of songs.",
+}
+
+export default function PlaylistsPage() {
+  return <PlaylistLibrary />
+}

--- a/web/components/create/SimpleCreationForm.tsx
+++ b/web/components/create/SimpleCreationForm.tsx
@@ -21,6 +21,7 @@ import {
   EMPTY_AUDIO_INPUTS,
   type AudioInputsValue,
 } from "@/components/create/AudioInputs"
+import type { InspirationSelection } from "@/lib/audio-inputs"
 
 /**
  * The Simple creation form (US-16.1): describe a song in plain language and go.
@@ -31,7 +32,12 @@ import {
  */
 export function SimpleCreationForm({
   onGenerated,
-}: { onGenerated?: () => void } = {}) {
+  initialInspiration,
+}: {
+  onGenerated?: () => void
+  /** Pre-attached inspiration (US-20.3 "Use as Inspiration" deep link → chip). */
+  initialInspiration?: InspirationSelection
+} = {}) {
   const router = useRouter()
   const { accessToken } = useAuth()
   const { models, selectedModel, isLoading: modelLoading } = useModelSelection()
@@ -44,7 +50,11 @@ export function SimpleCreationForm({
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   // Attached reference audio / voice / inspiration (US-16.8). Tracked here so
   // Clear all resets them and they persist across Simple/Advanced tab switches.
-  const [inputs, setInputs] = useState<AudioInputsValue>(EMPTY_AUDIO_INPUTS)
+  const [inputs, setInputs] = useState<AudioInputsValue>(
+    initialInspiration
+      ? { ...EMPTY_AUDIO_INPUTS, inspiration: initialInspiration }
+      : EMPTY_AUDIO_INPUTS
+  )
   // Neutral notice for non-generation messages, kept separate from the
   // generation state machine.
   const [notice, setNotice] = useState<string | null>(null)

--- a/web/components/playlists/AddSongsDialog.tsx
+++ b/web/components/playlists/AddSongsDialog.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Add01Icon, MusicNote01Icon, Tick02Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { ClipSearchInput } from "@/components/workspace/ClipSearchInput"
+import { getAllClips } from "@/lib/explore"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Add-songs picker (US-20.3). Songs come from the same discovery pool as Explore.
+// Adds are immediate (the parent appends via the store); already-added songs show a
+// check instead of an add button, so the dialog can stay open to add several.
+
+function matches(clip: Clip, needle: string): boolean {
+  if (!needle) return true
+  const hay = `${clip.title ?? ""} ${clip.style_tags.join(" ")}`.toLowerCase()
+  return hay.includes(needle)
+}
+
+export function AddSongsDialog({
+  open,
+  existingIds,
+  onAdd,
+  onOpenChange,
+}: {
+  open: boolean
+  existingIds: string[]
+  onAdd: (clipId: string) => void
+  onOpenChange: (open: boolean) => void
+}) {
+  const [query, setQuery] = useState("")
+  const inPlaylist = new Set(existingIds)
+  const needle = query.trim().toLowerCase()
+  const results = getAllClips().filter((c) => matches(c, needle))
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add songs</DialogTitle>
+          <DialogDescription>
+            Search the catalog and add songs to this playlist.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ClipSearchInput
+          value={query}
+          onChange={setQuery}
+          placeholder="Search songs or styles…"
+          ariaLabel="Search songs to add"
+        />
+
+        <ul className="flex max-h-80 flex-col gap-1 overflow-y-auto">
+          {results.length === 0 ? (
+            <li className="py-6 text-center text-sm text-muted-foreground">
+              No songs match &ldquo;{query}&rdquo;.
+            </li>
+          ) : (
+            results.map((clip) => {
+              const added = inPlaylist.has(clip.id)
+              return (
+                <li
+                  key={clip.id}
+                  className="flex items-center gap-3 rounded-md px-2 py-2 hover:bg-muted"
+                >
+                  <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                    <HugeiconsIcon icon={MusicNote01Icon} size={16} />
+                  </span>
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-sm font-medium">
+                      {clip.title ?? "Untitled clip"}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {clip.style_tags.join(", ")}
+                    </span>
+                  </div>
+                  {added ? (
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <HugeiconsIcon icon={Tick02Icon} size={14} />
+                      Added
+                    </span>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onAdd(clip.id)}
+                      aria-label={`Add ${clip.title ?? "song"}`}
+                    >
+                      <HugeiconsIcon icon={Add01Icon} size={14} />
+                      Add
+                    </Button>
+                  )}
+                </li>
+              )
+            })
+          )}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/playlists/DeletePlaylistDialog.tsx
+++ b/web/components/playlists/DeletePlaylistDialog.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+// Delete confirmation (US-20.3). No alert-dialog primitive in this repo, so it's
+// built on Dialog like DeleteSongDialog. Deleting a playlist doesn't touch the
+// songs themselves — only the collection.
+
+export function DeletePlaylistDialog({
+  open,
+  name,
+  onConfirm,
+  onOpenChange,
+}: {
+  open: boolean
+  name: string | null
+  onConfirm: () => void
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete this playlist?</DialogTitle>
+          <DialogDescription>
+            &ldquo;{name ?? "Untitled playlist"}&rdquo; will be removed. The songs in
+            it are not deleted. This can&apos;t be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              onConfirm()
+              onOpenChange(false)
+            }}
+          >
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/playlists/PlaylistCard.tsx
+++ b/web/components/playlists/PlaylistCard.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import Link from "next/link"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Delete02Icon,
+  Edit02Icon,
+  Globe02Icon,
+  LockIcon,
+  MoreHorizontalIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { PlaylistCover } from "@/components/playlists/PlaylistCover"
+import type { Playlist } from "@/lib/playlists"
+
+// Library grid tile (US-20.3). The whole card links to the detail page; the
+// overflow menu (rename/delete) sits above the link so its clicks don't navigate.
+
+export function PlaylistCard({
+  playlist,
+  onRename,
+  onDelete,
+}: {
+  playlist: Playlist
+  onRename: (playlist: Playlist) => void
+  onDelete: (playlist: Playlist) => void
+}) {
+  const count = playlist.clipIds.length
+  const isPublic = playlist.visibility === "public"
+
+  return (
+    <div className="group/card relative flex flex-col gap-2">
+      <Link
+        href={`/playlists/${playlist.id}`}
+        className="flex flex-col gap-2 rounded-lg outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+        data-testid="playlist-card"
+      >
+        <PlaylistCover playlist={playlist} />
+        <div className="flex flex-col gap-1">
+          <span className="truncate text-sm font-medium" title={playlist.name}>
+            {playlist.name}
+          </span>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>
+              {count} {count === 1 ? "song" : "songs"}
+            </span>
+            <Badge variant="secondary" className="gap-1 text-[10px]">
+              <HugeiconsIcon icon={isPublic ? Globe02Icon : LockIcon} size={11} />
+              {isPublic ? "Public" : "Private"}
+            </Badge>
+          </div>
+        </div>
+      </Link>
+
+      <div className="absolute top-2 right-2 opacity-0 transition-opacity group-hover/card:opacity-100 focus-within:opacity-100">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="secondary"
+              size="icon"
+              className="size-8"
+              aria-label={`Actions for ${playlist.name}`}
+            >
+              <HugeiconsIcon icon={MoreHorizontalIcon} size={16} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => onRename(playlist)}>
+              <HugeiconsIcon icon={Edit02Icon} size={16} />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem variant="destructive" onSelect={() => onDelete(playlist)}>
+              <HugeiconsIcon icon={Delete02Icon} size={16} />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  )
+}

--- a/web/components/playlists/PlaylistCover.test.tsx
+++ b/web/components/playlists/PlaylistCover.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { PlaylistCover } from "@/components/playlists/PlaylistCover"
+import type { Playlist } from "@/lib/playlists"
+
+const pl = (over: Partial<Playlist> = {}): Playlist => ({
+  id: "pl-1",
+  name: "Mix",
+  description: null,
+  visibility: "private",
+  clipIds: [],
+  coverDataUrl: null,
+  createdAt: "2026-07-20T00:00:00Z",
+  ...over,
+})
+
+describe("PlaylistCover", () => {
+  it("renders a glyph mosaic by default (AC4)", () => {
+    render(<PlaylistCover playlist={pl()} clips={[]} />)
+    expect(screen.getByTestId("playlist-mosaic")).toBeInTheDocument()
+    expect(screen.queryByRole("img", { name: "Mix cover" })).toBeInTheDocument()
+  })
+
+  it("renders the custom cover image when uploaded (AC4)", () => {
+    render(<PlaylistCover playlist={pl({ coverDataUrl: "blob:xyz" })} />)
+    const img = screen.getByRole("img", { name: "Mix cover" }) as HTMLImageElement
+    expect(img.src).toContain("blob:xyz")
+    expect(screen.queryByTestId("playlist-mosaic")).not.toBeInTheDocument()
+  })
+})

--- a/web/components/playlists/PlaylistCover.test.tsx
+++ b/web/components/playlists/PlaylistCover.test.tsx
@@ -16,10 +16,16 @@ const pl = (over: Partial<Playlist> = {}): Playlist => ({
 })
 
 describe("PlaylistCover", () => {
-  it("renders a glyph mosaic by default (AC4)", () => {
-    render(<PlaylistCover playlist={pl()} clips={[]} />)
+  it("renders a glyph mosaic when the playlist has songs (AC4)", () => {
+    render(<PlaylistCover playlist={pl({ clipIds: ["a", "b"] })} />)
     expect(screen.getByTestId("playlist-mosaic")).toBeInTheDocument()
-    expect(screen.queryByRole("img", { name: "Mix cover" })).toBeInTheDocument()
+    expect(screen.getByRole("img", { name: "Mix cover" })).toBeInTheDocument()
+  })
+
+  it("renders a single glyph (no mosaic) for an empty playlist", () => {
+    render(<PlaylistCover playlist={pl()} />)
+    expect(screen.queryByTestId("playlist-mosaic")).not.toBeInTheDocument()
+    expect(screen.getByRole("img", { name: "Mix cover" })).toBeInTheDocument()
   })
 
   it("renders the custom cover image when uploaded (AC4)", () => {

--- a/web/components/playlists/PlaylistCover.tsx
+++ b/web/components/playlists/PlaylistCover.tsx
@@ -1,0 +1,73 @@
+import { HugeiconsIcon } from "@hugeicons/react"
+import { MusicNote01Icon } from "@hugeicons/core-free-icons"
+
+import { coverClips, type Playlist } from "@/lib/playlists"
+import { cn } from "@/lib/utils"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Playlist cover (US-20.3). Custom upload wins; otherwise an auto-mosaic of the
+// first up-to-4 songs. There's no authed artwork proxy (real <img src=.../artwork>
+// would 401), so each mosaic tile is a music-note glyph, not a real thumbnail —
+// swap the tile for the clip's artwork when a public artwork endpoint exists.
+
+/** One glyph tile of the mosaic. */
+function Tile({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "flex items-center justify-center bg-muted text-muted-foreground",
+        className
+      )}
+    >
+      <HugeiconsIcon icon={MusicNote01Icon} size={20} aria-hidden />
+    </span>
+  )
+}
+
+export function PlaylistCover({
+  playlist,
+  clips,
+  className,
+}: {
+  playlist: Playlist
+  /** Resolved cover clips; defaults to the playlist's first 4 songs. */
+  clips?: Clip[]
+  className?: string
+}) {
+  const tiles = clips ?? coverClips(playlist)
+
+  const box = cn(
+    "relative aspect-square w-full overflow-hidden rounded-md bg-muted",
+    className
+  )
+
+  if (playlist.coverDataUrl) {
+    return (
+      <div className={box}>
+        {/* eslint-disable-next-line @next/next/no-img-element -- object URL, not an optimizable asset */}
+        <img
+          src={playlist.coverDataUrl}
+          alt={`${playlist.name} cover`}
+          className="size-full object-cover"
+        />
+      </div>
+    )
+  }
+
+  // 2×2 grid; fewer than 4 songs → fill remaining slots with plain glyph tiles so
+  // the cover is always a full square (1 song still reads as a cover, not a crop).
+  const slots = Array.from({ length: 4 }, (_, i) => tiles[i] ?? null)
+
+  return (
+    <div
+      className={cn(box, "grid grid-cols-2 grid-rows-2 gap-px")}
+      data-testid="playlist-mosaic"
+      role="img"
+      aria-label={`${playlist.name} cover`}
+    >
+      {slots.map((clip, i) => (
+        <Tile key={clip?.id ?? `empty-${i}`} />
+      ))}
+    </div>
+  )
+}

--- a/web/components/playlists/PlaylistCover.tsx
+++ b/web/components/playlists/PlaylistCover.tsx
@@ -1,49 +1,37 @@
 import { HugeiconsIcon } from "@hugeicons/react"
 import { MusicNote01Icon } from "@hugeicons/core-free-icons"
 
-import { coverClips, type Playlist } from "@/lib/playlists"
+import type { Playlist } from "@/lib/playlists"
 import { cn } from "@/lib/utils"
-import type { Clip } from "@/lib/workspace-clips"
 
-// Playlist cover (US-20.3). Custom upload wins; otherwise an auto-mosaic of the
-// first up-to-4 songs. There's no authed artwork proxy (real <img src=.../artwork>
-// would 401), so each mosaic tile is a music-note glyph, not a real thumbnail —
-// swap the tile for the clip's artwork when a public artwork endpoint exists.
+// Playlist cover (US-20.3). Custom upload wins; otherwise an auto-mosaic. There's
+// no authed artwork proxy (a real <img src=.../artwork> would 401), so the mosaic
+// is glyph tiles, not real thumbnails — swap a tile for the clip's artwork when a
+// public artwork endpoint exists. An empty playlist shows a single glyph so it
+// reads as "no songs yet" rather than a full cover.
 
-/** One glyph tile of the mosaic. */
-function Tile({ className }: { className?: string }) {
+function box(className?: string) {
+  return cn("relative aspect-square w-full overflow-hidden rounded-md bg-muted", className)
+}
+
+function Glyph({ size }: { size: number }) {
   return (
-    <span
-      className={cn(
-        "flex items-center justify-center bg-muted text-muted-foreground",
-        className
-      )}
-    >
-      <HugeiconsIcon icon={MusicNote01Icon} size={20} aria-hidden />
+    <span className="flex size-full items-center justify-center bg-muted text-muted-foreground">
+      <HugeiconsIcon icon={MusicNote01Icon} size={size} aria-hidden />
     </span>
   )
 }
 
 export function PlaylistCover({
   playlist,
-  clips,
   className,
 }: {
   playlist: Playlist
-  /** Resolved cover clips; defaults to the playlist's first 4 songs. */
-  clips?: Clip[]
   className?: string
 }) {
-  const tiles = clips ?? coverClips(playlist)
-
-  const box = cn(
-    "relative aspect-square w-full overflow-hidden rounded-md bg-muted",
-    className
-  )
-
   if (playlist.coverDataUrl) {
     return (
-      <div className={box}>
+      <div className={box(className)}>
         {/* eslint-disable-next-line @next/next/no-img-element -- object URL, not an optimizable asset */}
         <img
           src={playlist.coverDataUrl}
@@ -54,19 +42,27 @@ export function PlaylistCover({
     )
   }
 
-  // 2×2 grid; fewer than 4 songs → fill remaining slots with plain glyph tiles so
-  // the cover is always a full square (1 song still reads as a cover, not a crop).
-  const slots = Array.from({ length: 4 }, (_, i) => tiles[i] ?? null)
+  const count = playlist.clipIds.length
 
+  if (count === 0) {
+    return (
+      <div className={box(className)} role="img" aria-label={`${playlist.name} cover`}>
+        <Glyph size={28} />
+      </div>
+    )
+  }
+
+  // 2×2 glyph mosaic. Not thumbnails yet (see note above) — the grid is a stand-in
+  // until real artwork lands.
   return (
     <div
-      className={cn(box, "grid grid-cols-2 grid-rows-2 gap-px")}
+      className={cn(box(className), "grid grid-cols-2 grid-rows-2 gap-px")}
       data-testid="playlist-mosaic"
       role="img"
       aria-label={`${playlist.name} cover`}
     >
-      {slots.map((clip, i) => (
-        <Tile key={clip?.id ?? `empty-${i}`} />
+      {Array.from({ length: 4 }, (_, i) => (
+        <Glyph key={i} size={18} />
       ))}
     </div>
   )

--- a/web/components/playlists/PlaylistDetail.test.tsx
+++ b/web/components/playlists/PlaylistDetail.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+
+import { PlaylistDetail } from "@/components/playlists/PlaylistDetail"
+import { PlaylistsProvider } from "@/contexts/playlists-context"
+
+// pl-latenight is seeded public with 5 songs: Neon Skyline, Velvet Static,
+// Pulse Theory, Paper Lanterns, Monochrome Heart (in that order).
+function renderDetail(id = "pl-latenight") {
+  return render(
+    <PlaylistsProvider>
+      <PlaylistDetail playlistId={id} />
+    </PlaylistsProvider>
+  )
+}
+
+const rows = () => screen.getAllByTestId("playlist-song-row")
+// Each row has two links: [0] the play affordance, [1] the title. Use the title.
+const firstRowTitle = () => within(rows()[0]).getAllByRole("link")[1].textContent
+
+describe("PlaylistDetail", () => {
+  it("shows a not-found state for an unknown playlist", () => {
+    renderDetail("nope")
+    expect(screen.getByText("Playlist not found")).toBeInTheDocument()
+  })
+
+  it("lists the playlist songs with playback links", () => {
+    renderDetail()
+    expect(rows()).toHaveLength(5)
+    expect(within(rows()[0]).getAllByRole("link")[0]).toHaveAttribute(
+      "href",
+      "/song/clip-neon"
+    )
+  })
+
+  it("reorders songs down with the move button (AC2)", async () => {
+    const user = userEvent.setup()
+    renderDetail()
+    expect(firstRowTitle()).toBe("Neon Skyline")
+    await user.click(within(rows()[0]).getByRole("button", { name: "Move down" }))
+    expect(firstRowTitle()).toBe("Velvet Static")
+  })
+
+  it("removes a song (AC2)", async () => {
+    const user = userEvent.setup()
+    renderDetail()
+    await user.click(
+      within(rows()[0]).getByRole("button", { name: /Remove .* from playlist/ })
+    )
+    expect(rows()).toHaveLength(4)
+    expect(screen.queryByText("Neon Skyline")).not.toBeInTheDocument()
+  })
+
+  it("opens the add-songs dialog (AC2)", async () => {
+    const user = userEvent.setup()
+    renderDetail()
+    await user.click(screen.getAllByRole("button", { name: "Add songs" })[0])
+    expect(await screen.findByRole("dialog")).toHaveTextContent("Add songs")
+  })
+
+  it("shows a share link for a public playlist and hides it when private (AC3, AC6)", async () => {
+    const user = userEvent.setup()
+    renderDetail()
+    expect(screen.getByText(/\/playlists\/pl-latenight/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("switch", { name: /Public playlist/i }))
+    expect(screen.queryByText(/\/playlists\/pl-latenight/)).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/Make this playlist public to get a shareable link/)
+    ).toBeInTheDocument()
+  })
+
+  it("links Use as Inspiration to the create page with playlist context (AC5)", () => {
+    renderDetail()
+    const link = screen.getByRole("link", { name: /Use as Inspiration/ })
+    expect(link).toHaveAttribute(
+      "href",
+      expect.stringContaining("/create?inspiration=pl-latenight")
+    )
+  })
+})

--- a/web/components/playlists/PlaylistDetail.tsx
+++ b/web/components/playlists/PlaylistDetail.tsx
@@ -59,11 +59,28 @@ export function PlaylistDetail({ playlistId }: { playlistId: string }) {
   const clips = playlistClips(playlist)
   const isPublic = playlist.visibility === "public"
 
+  // Free the previous object URL before replacing/clearing so uploads don't leak
+  // blobs. (Unmount without clearing still leaks the last one — acceptable for a
+  // session-only mock cover; revisit if covers move to real uploads.)
+  const revokePrevCover = () => {
+    if (playlist.coverDataUrl?.startsWith("blob:")) {
+      URL.revokeObjectURL(playlist.coverDataUrl)
+    }
+  }
+
   const onUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
-    if (file) setCover(playlist.id, URL.createObjectURL(file))
+    if (file) {
+      revokePrevCover()
+      setCover(playlist.id, URL.createObjectURL(file))
+    }
     // Reset so re-selecting the same file fires change again.
     e.target.value = ""
+  }
+
+  const clearCover = () => {
+    revokePrevCover()
+    setCover(playlist.id, null)
   }
 
   const copyShare = async () => {
@@ -95,7 +112,7 @@ export function PlaylistDetail({ playlistId }: { playlistId: string }) {
       {/* Header */}
       <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
         <div className="w-40 shrink-0">
-          <PlaylistCover playlist={playlist} clips={clips.slice(0, 4)} />
+          <PlaylistCover playlist={playlist} />
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-3">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -127,7 +144,7 @@ export function PlaylistDetail({ playlistId }: { playlistId: string }) {
               Upload cover
             </Button>
             {playlist.coverDataUrl && (
-              <Button variant="ghost" onClick={() => setCover(playlist.id, null)}>
+              <Button variant="ghost" onClick={clearCover}>
                 <HugeiconsIcon icon={Image01Icon} size={16} />
                 Use mosaic
               </Button>
@@ -156,7 +173,12 @@ export function PlaylistDetail({ playlistId }: { playlistId: string }) {
             </div>
             {isPublic ? (
               <div className="flex items-center gap-2">
-                <code className="max-w-xs truncate rounded bg-muted px-2 py-1 text-xs">
+                {/* Origin is client-only, so the server renders the path and the
+                    client fills in the full URL — suppress the hydration diff. */}
+                <code
+                  suppressHydrationWarning
+                  className="max-w-xs truncate rounded bg-muted px-2 py-1 text-xs"
+                >
                   {buildShareUrl(
                     typeof window !== "undefined" ? window.location.origin : "",
                     playlist.id

--- a/web/components/playlists/PlaylistDetail.tsx
+++ b/web/components/playlists/PlaylistDetail.tsx
@@ -1,0 +1,237 @@
+"use client"
+
+import { useRef, useState } from "react"
+import Link from "next/link"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Add01Icon,
+  ArrowLeft01Icon,
+  Copy01Icon,
+  Globe02Icon,
+  Image01Icon,
+  LockIcon,
+  MusicNote01Icon,
+  SparklesIcon,
+  Tick02Icon,
+  Upload04Icon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { AddSongsDialog } from "@/components/playlists/AddSongsDialog"
+import { PlaylistCover } from "@/components/playlists/PlaylistCover"
+import { PlaylistSongRow } from "@/components/playlists/PlaylistSongRow"
+import { usePlaylists } from "@/contexts/playlists-context"
+import { buildInspirationHref, buildShareUrl, playlistClips } from "@/lib/playlists"
+
+// Playlist detail page (US-20.3): songs with playback links, add/remove/reorder,
+// visibility toggle, cover (auto-mosaic / custom upload), public share link, and
+// "Use as Inspiration". All mutations go through the shared PlaylistsProvider store.
+
+export function PlaylistDetail({ playlistId }: { playlistId: string }) {
+  const {
+    getPlaylist,
+    setVisibility,
+    addClip,
+    removeClip,
+    reorderClips,
+    setCover,
+  } = usePlaylists()
+  const playlist = getPlaylist(playlistId)
+
+  const fileInput = useRef<HTMLInputElement>(null)
+  const [showAdd, setShowAdd] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+
+  if (!playlist) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-20 text-center">
+        <p className="font-medium">Playlist not found</p>
+        <Button asChild variant="outline">
+          <Link href="/playlists">Back to playlists</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  const clips = playlistClips(playlist)
+  const isPublic = playlist.visibility === "public"
+
+  const onUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) setCover(playlist.id, URL.createObjectURL(file))
+    // Reset so re-selecting the same file fires change again.
+    e.target.value = ""
+  }
+
+  const copyShare = async () => {
+    const url = buildShareUrl(window.location.origin, playlist.id)
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — leave the URL visible to copy manually.
+    }
+  }
+
+  const drop = (to: number) => {
+    if (dragIndex != null) reorderClips(playlist.id, dragIndex, to)
+    setDragIndex(null)
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-8">
+      <Link
+        href="/playlists"
+        className="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} size={16} />
+        Playlists
+      </Link>
+
+      {/* Header */}
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
+        <div className="w-40 shrink-0">
+          <PlaylistCover playlist={playlist} clips={clips.slice(0, 4)} />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <HugeiconsIcon icon={isPublic ? Globe02Icon : LockIcon} size={12} />
+            {isPublic ? "Public" : "Private"} · {clips.length}{" "}
+            {clips.length === 1 ? "song" : "songs"}
+          </div>
+          <h1 className="text-2xl font-semibold">{playlist.name}</h1>
+          {playlist.description && (
+            <p className="text-sm text-muted-foreground">{playlist.description}</p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button onClick={() => setShowAdd(true)}>
+              <HugeiconsIcon icon={Add01Icon} size={16} />
+              Add songs
+            </Button>
+            <Button asChild variant="outline">
+              <Link href={buildInspirationHref(playlist)}>
+                <HugeiconsIcon icon={SparklesIcon} size={16} />
+                Use as Inspiration
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => fileInput.current?.click()}
+            >
+              <HugeiconsIcon icon={Upload04Icon} size={16} />
+              Upload cover
+            </Button>
+            {playlist.coverDataUrl && (
+              <Button variant="ghost" onClick={() => setCover(playlist.id, null)}>
+                <HugeiconsIcon icon={Image01Icon} size={16} />
+                Use mosaic
+              </Button>
+            )}
+            <input
+              ref={fileInput}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={onUpload}
+              data-testid="cover-upload-input"
+            />
+          </div>
+
+          {/* Visibility + share */}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <Switch
+                id="playlist-visibility"
+                checked={isPublic}
+                onCheckedChange={(on) =>
+                  setVisibility(playlist.id, on ? "public" : "private")
+                }
+              />
+              <Label htmlFor="playlist-visibility">Public playlist</Label>
+            </div>
+            {isPublic ? (
+              <div className="flex items-center gap-2">
+                <code className="max-w-xs truncate rounded bg-muted px-2 py-1 text-xs">
+                  {buildShareUrl(
+                    typeof window !== "undefined" ? window.location.origin : "",
+                    playlist.id
+                  )}
+                </code>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={copyShare}
+                  aria-label="Copy share link"
+                >
+                  <HugeiconsIcon icon={copied ? Tick02Icon : Copy01Icon} size={14} />
+                  {copied ? "Copied" : "Copy link"}
+                </Button>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Make this playlist public to get a shareable link.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Songs */}
+      {clips.length === 0 ? (
+        <div
+          className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border py-16 text-center"
+          data-testid="playlist-songs-empty"
+        >
+          <HugeiconsIcon
+            icon={MusicNote01Icon}
+            size={28}
+            aria-hidden
+            className="text-muted-foreground"
+          />
+          <p className="font-medium">No songs yet</p>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            Add songs from the catalog to build out this playlist.
+          </p>
+          <Button onClick={() => setShowAdd(true)}>
+            <HugeiconsIcon icon={Add01Icon} size={16} />
+            Add songs
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1" data-testid="playlist-songs">
+          {clips.map((clip, index) => (
+            <PlaylistSongRow
+              key={clip.id}
+              clip={clip}
+              index={index}
+              total={clips.length}
+              onMoveUp={() => reorderClips(playlist.id, index, index - 1)}
+              onMoveDown={() => reorderClips(playlist.id, index, index + 1)}
+              onRemove={() => removeClip(playlist.id, clip.id)}
+              dragging={dragIndex === index}
+              dragProps={{
+                draggable: true,
+                onDragStart: () => setDragIndex(index),
+                onDragOver: (e) => e.preventDefault(),
+                onDrop: () => drop(index),
+                onDragEnd: () => setDragIndex(null),
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      <AddSongsDialog
+        open={showAdd}
+        existingIds={playlist.clipIds}
+        onAdd={(clipId) => addClip(playlist.id, clipId)}
+        onOpenChange={setShowAdd}
+      />
+    </div>
+  )
+}

--- a/web/components/playlists/PlaylistFormDialog.tsx
+++ b/web/components/playlists/PlaylistFormDialog.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+// Create / rename dialog (US-20.3). One dialog serves both: `initial` seeds the
+// fields (rename) or is empty (create). Submit is disabled until the name is
+// non-blank; the parent owns persistence via onSubmit.
+
+export type PlaylistFormDialogProps = {
+  open: boolean
+  mode: "create" | "rename"
+  initial?: { name: string; description: string }
+  onSubmit: (name: string, description: string) => void
+  onOpenChange: (open: boolean) => void
+}
+
+export function PlaylistFormDialog({
+  open,
+  mode,
+  initial,
+  onSubmit,
+  onOpenChange,
+}: PlaylistFormDialogProps) {
+  const [name, setName] = useState(initial?.name ?? "")
+  const [description, setDescription] = useState(initial?.description ?? "")
+
+  // Reset the fields whenever the dialog transitions to open, so a create form
+  // starts blank and a rename form shows the current values. This is the "adjust
+  // state during render on prop change" pattern (React docs) — resetting here
+  // instead of in an effect avoids the set-state-in-effect lint and any flash.
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) {
+      setName(initial?.name ?? "")
+      setDescription(initial?.description ?? "")
+    }
+  }
+
+  const canSubmit = name.trim().length > 0
+  const isCreate = mode === "create"
+
+  const submit = () => {
+    if (!canSubmit) return
+    onSubmit(name, description)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{isCreate ? "New playlist" : "Rename playlist"}</DialogTitle>
+          <DialogDescription>
+            {isCreate
+              ? "Name your playlist. You can add songs and a cover next."
+              : "Update the playlist name or description."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault()
+            submit()
+          }}
+        >
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="playlist-name">Name</Label>
+            <Input
+              id="playlist-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="My playlist"
+              autoFocus
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="playlist-description">Description (optional)</Label>
+            <Textarea
+              id="playlist-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What's this playlist about?"
+              rows={3}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              {isCreate ? "Create" : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/components/playlists/PlaylistLibrary.test.tsx
+++ b/web/components/playlists/PlaylistLibrary.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+
+import { PlaylistLibrary } from "@/components/playlists/PlaylistLibrary"
+import { PlaylistsProvider } from "@/contexts/playlists-context"
+
+function renderLibrary() {
+  return render(
+    <PlaylistsProvider>
+      <PlaylistLibrary />
+    </PlaylistsProvider>
+  )
+}
+
+const cardFor = (name: string) =>
+  screen.getByText(name).closest("[class*='group/card']") as HTMLElement
+
+describe("PlaylistLibrary", () => {
+  it("lists the seeded playlists", () => {
+    renderLibrary()
+    expect(screen.getByText("Late Night Drive")).toBeInTheDocument()
+    expect(screen.getByText("Deep Focus")).toBeInTheDocument()
+    expect(screen.getByText("Summer Anthems")).toBeInTheDocument()
+  })
+
+  it("creates a playlist (AC1)", async () => {
+    const user = userEvent.setup()
+    renderLibrary()
+    await user.click(screen.getByRole("button", { name: "New playlist" }))
+    await user.type(screen.getByLabelText("Name"), "Roadtrip")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+    expect(screen.getByText("Roadtrip")).toBeInTheDocument()
+  })
+
+  it("renames a playlist (AC1)", async () => {
+    const user = userEvent.setup()
+    renderLibrary()
+    const card = cardFor("Deep Focus")
+    await user.click(within(card).getByRole("button", { name: "Actions for Deep Focus" }))
+    await user.click(await screen.findByRole("menuitem", { name: /Rename/ }))
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "Focus Flow")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+    expect(screen.getByText("Focus Flow")).toBeInTheDocument()
+    expect(screen.queryByText("Deep Focus")).not.toBeInTheDocument()
+  })
+
+  it("deletes a playlist with confirmation (AC1)", async () => {
+    const user = userEvent.setup()
+    renderLibrary()
+    const card = cardFor("Summer Anthems")
+    await user.click(within(card).getByRole("button", { name: "Actions for Summer Anthems" }))
+    await user.click(await screen.findByRole("menuitem", { name: /Delete/ }))
+    // Confirmation dialog, then the actual delete.
+    await user.click(screen.getByRole("button", { name: "Delete" }))
+    expect(screen.queryByText("Summer Anthems")).not.toBeInTheDocument()
+  })
+})

--- a/web/components/playlists/PlaylistLibrary.tsx
+++ b/web/components/playlists/PlaylistLibrary.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Add01Icon, Playlist01Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { DeletePlaylistDialog } from "@/components/playlists/DeletePlaylistDialog"
+import { PlaylistCard } from "@/components/playlists/PlaylistCard"
+import { PlaylistFormDialog } from "@/components/playlists/PlaylistFormDialog"
+import { usePlaylists } from "@/contexts/playlists-context"
+import type { Playlist } from "@/lib/playlists"
+
+// Playlists library page (US-20.3). Grid of the user's playlists with create,
+// rename, and delete. State lives in the PlaylistsProvider (shared with the detail
+// route). No auth gate — like Explore/Search, this is a mock-backed Stage-20 page.
+
+type Editing = { mode: "create" | "rename"; playlist?: Playlist }
+
+export function PlaylistLibrary() {
+  const { playlists, create, rename, remove } = usePlaylists()
+  const [editing, setEditing] = useState<Editing | null>(null)
+  const [deleting, setDeleting] = useState<Playlist | null>(null)
+
+  const handleSubmit = (name: string, description: string) => {
+    if (editing?.mode === "rename" && editing.playlist) {
+      rename(editing.playlist.id, name, description)
+    } else {
+      create(name, description)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-8">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-semibold">Playlists</h1>
+        <Button onClick={() => setEditing({ mode: "create" })}>
+          <HugeiconsIcon icon={Add01Icon} size={18} />
+          New playlist
+        </Button>
+      </div>
+
+      {playlists.length === 0 ? (
+        <div
+          className="flex flex-col items-center gap-3 py-20 text-center"
+          data-testid="playlists-empty"
+        >
+          <HugeiconsIcon
+            icon={Playlist01Icon}
+            size={32}
+            aria-hidden
+            className="text-muted-foreground"
+          />
+          <p className="font-medium">No playlists yet</p>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            Create a playlist to curate songs and use them as inspiration for new
+            generations.
+          </p>
+          <Button onClick={() => setEditing({ mode: "create" })}>
+            <HugeiconsIcon icon={Add01Icon} size={18} />
+            New playlist
+          </Button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          {playlists.map((pl) => (
+            <PlaylistCard
+              key={pl.id}
+              playlist={pl}
+              onRename={(p) => setEditing({ mode: "rename", playlist: p })}
+              onDelete={(p) => setDeleting(p)}
+            />
+          ))}
+        </div>
+      )}
+
+      <PlaylistFormDialog
+        open={editing != null}
+        mode={editing?.mode ?? "create"}
+        initial={
+          editing?.playlist
+            ? {
+                name: editing.playlist.name,
+                description: editing.playlist.description ?? "",
+              }
+            : undefined
+        }
+        onSubmit={handleSubmit}
+        onOpenChange={(open) => !open && setEditing(null)}
+      />
+
+      <DeletePlaylistDialog
+        open={deleting != null}
+        name={deleting?.name ?? null}
+        onConfirm={() => deleting && remove(deleting.id)}
+        onOpenChange={(open) => !open && setDeleting(null)}
+      />
+    </div>
+  )
+}

--- a/web/components/playlists/PlaylistSongRow.tsx
+++ b/web/components/playlists/PlaylistSongRow.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import Link from "next/link"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  ArrowDown01Icon,
+  ArrowUp01Icon,
+  Cancel01Icon,
+  DragDropVerticalIcon,
+  MusicNote01Icon,
+  PlayIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { versionLabel } from "@/lib/clip-labels"
+import { formatTime } from "@/lib/clips"
+import type { Clip } from "@/lib/workspace-clips"
+
+// One song in the playlist detail list (US-20.3). Play affordance links to the
+// public song page (playback controls live there — no authed artwork/stream proxy
+// to embed here). Reorder is keyboard-accessible via up/down buttons; native HTML5
+// drag (handled by the parent) is the pointer path for the "drag-to-reorder" AC.
+
+export function PlaylistSongRow({
+  clip,
+  index,
+  total,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+  dragProps,
+  dragging,
+}: {
+  clip: Clip
+  index: number
+  total: number
+  onMoveUp: () => void
+  onMoveDown: () => void
+  onRemove: () => void
+  /** Native drag handlers wired by the parent (PlaylistDetail). */
+  dragProps: React.HTMLAttributes<HTMLDivElement> & { draggable: boolean }
+  dragging: boolean
+}) {
+  const version = versionLabel(clip.model)
+  const styleText = clip.style_tags.join(", ")
+
+  return (
+    <div
+      {...dragProps}
+      data-testid="playlist-song-row"
+      className={`flex items-center gap-3 rounded-md border border-transparent p-2 hover:bg-accent/50 ${
+        dragging ? "opacity-40" : ""
+      }`}
+    >
+      <span
+        aria-hidden
+        className="cursor-grab text-muted-foreground active:cursor-grabbing"
+        title="Drag to reorder"
+      >
+        <HugeiconsIcon icon={DragDropVerticalIcon} size={16} />
+      </span>
+
+      <Link
+        href={`/song/${clip.id}`}
+        aria-label={`Play ${clip.title ?? "Untitled clip"}`}
+        className="group/play relative flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-muted-foreground outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        <HugeiconsIcon
+          icon={MusicNote01Icon}
+          size={18}
+          aria-hidden
+          className="group-hover/play:opacity-0"
+        />
+        <span className="absolute inset-0 flex items-center justify-center bg-background/30 opacity-0 transition-opacity group-hover/play:opacity-100">
+          <HugeiconsIcon icon={PlayIcon} size={18} className="fill-current" />
+        </span>
+      </Link>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Link
+          href={`/song/${clip.id}`}
+          className="truncate text-sm font-medium hover:underline"
+          title={clip.title ?? undefined}
+        >
+          {clip.title ?? "Untitled clip"}
+        </Link>
+        {styleText && (
+          <span className="truncate text-xs text-muted-foreground" title={styleText}>
+            {styleText}
+          </span>
+        )}
+      </div>
+
+      <div className="hidden items-center gap-3 text-xs text-muted-foreground sm:flex">
+        {version && <span>{version}</span>}
+        {clip.duration != null && (
+          <span className="tabular-nums">{formatTime(clip.duration)}</span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-0.5">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          onClick={onMoveUp}
+          disabled={index === 0}
+          aria-label="Move up"
+        >
+          <HugeiconsIcon icon={ArrowUp01Icon} size={16} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          onClick={onMoveDown}
+          disabled={index === total - 1}
+          aria-label="Move down"
+        >
+          <HugeiconsIcon icon={ArrowDown01Icon} size={16} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 text-muted-foreground hover:text-destructive"
+          onClick={onRemove}
+          aria-label={`Remove ${clip.title ?? "song"} from playlist`}
+        >
+          <HugeiconsIcon icon={Cancel01Icon} size={16} />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/config/navigation.ts
+++ b/web/config/navigation.ts
@@ -6,6 +6,7 @@ import {
   MixerIcon,
   MusicNote01Icon,
   Notification01Icon,
+  Playlist01Icon,
   Search01Icon,
   TestTube01Icon,
   TradeUpIcon,
@@ -30,6 +31,7 @@ export const mainNav: NavLinkItem[] = [
   { id: "create", label: "Create", href: "/create", icon: MusicNote01Icon },
   { id: "studio", label: "Studio", href: "/studio", icon: MixerIcon },
   { id: "library", label: "Library", href: "/me", icon: LibraryIcon },
+  { id: "playlists", label: "Playlists", href: "/playlists", icon: Playlist01Icon },
   { id: "search", label: "Search", href: "/search", icon: Search01Icon },
   { id: "feed", label: "Feed", href: "/feed", icon: TradeUpIcon },
   {

--- a/web/contexts/playlists-context.tsx
+++ b/web/contexts/playlists-context.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react"
+
+import {
+  addClip as addClipTo,
+  createPlaylist,
+  initialPlaylists,
+  removeClip as removeClipFrom,
+  renamePlaylist,
+  reorderClips as reorderClipsIn,
+  setCover as setCoverOn,
+  setVisibility as setVisibilityOn,
+  type Playlist,
+  type PlaylistVisibility,
+} from "@/lib/playlists"
+
+// In-memory playlist store (US-20.3). Lives in the /playlists layout so the list
+// page and the detail page share one reactive source — plain component state would
+// reset on navigation between them. Each action applies the matching pure helper
+// from lib/playlists to the one playlist it targets, replacing it immutably so
+// consumers re-render. Swap the initial state + actions for API calls when the
+// /playlists backend exists; the context surface stays the same.
+
+type PlaylistsContextValue = {
+  playlists: Playlist[]
+  getPlaylist: (id: string) => Playlist | undefined
+  create: (name: string, description?: string) => Playlist
+  rename: (id: string, name: string, description?: string) => void
+  remove: (id: string) => void
+  setVisibility: (id: string, visibility: PlaylistVisibility) => void
+  addClip: (id: string, clipId: string) => void
+  removeClip: (id: string, clipId: string) => void
+  reorderClips: (id: string, from: number, to: number) => void
+  setCover: (id: string, coverDataUrl: string | null) => void
+}
+
+const PlaylistsContext = createContext<PlaylistsContextValue | null>(null)
+
+export function PlaylistsProvider({ children }: { children: React.ReactNode }) {
+  const [playlists, setPlaylists] = useState<Playlist[]>(initialPlaylists)
+
+  /** Replace the playlist with matching id by running `fn` over it. */
+  const patch = useCallback(
+    (id: string, fn: (pl: Playlist) => Playlist) =>
+      setPlaylists((list) => list.map((pl) => (pl.id === id ? fn(pl) : pl))),
+    []
+  )
+
+  const create = useCallback((name: string, description = "") => {
+    const pl = createPlaylist(name, description)
+    setPlaylists((list) => [pl, ...list])
+    return pl
+  }, [])
+
+  const value = useMemo<PlaylistsContextValue>(
+    () => ({
+      playlists,
+      getPlaylist: (id) => playlists.find((pl) => pl.id === id),
+      create,
+      rename: (id, name, description) =>
+        patch(id, (pl) => renamePlaylist(pl, name, description)),
+      remove: (id) => setPlaylists((list) => list.filter((pl) => pl.id !== id)),
+      setVisibility: (id, visibility) =>
+        patch(id, (pl) => setVisibilityOn(pl, visibility)),
+      addClip: (id, clipId) => patch(id, (pl) => addClipTo(pl, clipId)),
+      removeClip: (id, clipId) => patch(id, (pl) => removeClipFrom(pl, clipId)),
+      reorderClips: (id, from, to) => patch(id, (pl) => reorderClipsIn(pl, from, to)),
+      setCover: (id, coverDataUrl) => patch(id, (pl) => setCoverOn(pl, coverDataUrl)),
+    }),
+    [playlists, create, patch]
+  )
+
+  return <PlaylistsContext.Provider value={value}>{children}</PlaylistsContext.Provider>
+}
+
+export function usePlaylists(): PlaylistsContextValue {
+  const ctx = useContext(PlaylistsContext)
+  if (!ctx) throw new Error("usePlaylists must be used within a PlaylistsProvider")
+  return ctx
+}

--- a/web/lib/playlists.test.ts
+++ b/web/lib/playlists.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  addClip,
+  buildInspirationHref,
+  buildShareUrl,
+  coverClips,
+  createPlaylist,
+  initialPlaylists,
+  MOSAIC_SLOTS,
+  playlistClips,
+  removeClip,
+  renamePlaylist,
+  reorderClips,
+  setCover,
+  setVisibility,
+  type Playlist,
+} from "@/lib/playlists"
+
+const base = (): Playlist => ({
+  id: "pl-test",
+  name: "Test",
+  description: null,
+  visibility: "private",
+  clipIds: ["a", "b", "c"],
+  coverDataUrl: null,
+  createdAt: "2026-07-20T00:00:00Z",
+})
+
+describe("createPlaylist", () => {
+  it("creates an empty private playlist and trims fields", () => {
+    const pl = createPlaylist("  My Mix  ", "  vibes  ")
+    expect(pl.name).toBe("My Mix")
+    expect(pl.description).toBe("vibes")
+    expect(pl.visibility).toBe("private")
+    expect(pl.clipIds).toEqual([])
+    expect(pl.coverDataUrl).toBeNull()
+    expect(pl.id).toMatch(/^pl-/)
+  })
+
+  it("stores an empty description as null", () => {
+    expect(createPlaylist("Solo").description).toBeNull()
+  })
+})
+
+describe("renamePlaylist", () => {
+  it("updates name and description without mutating the original", () => {
+    const pl = base()
+    const next = renamePlaylist(pl, " Renamed ", "desc")
+    expect(next.name).toBe("Renamed")
+    expect(next.description).toBe("desc")
+    expect(pl.name).toBe("Test") // original untouched
+  })
+})
+
+describe("setVisibility", () => {
+  it("toggles visibility", () => {
+    expect(setVisibility(base(), "public").visibility).toBe("public")
+  })
+})
+
+describe("addClip / removeClip", () => {
+  it("appends a new clip", () => {
+    expect(addClip(base(), "d").clipIds).toEqual(["a", "b", "c", "d"])
+  })
+
+  it("ignores duplicates (each song appears once)", () => {
+    const pl = base()
+    expect(addClip(pl, "b")).toBe(pl) // same reference, no change
+  })
+
+  it("removes a clip", () => {
+    expect(removeClip(base(), "b").clipIds).toEqual(["a", "c"])
+  })
+})
+
+describe("reorderClips", () => {
+  it("moves an item down", () => {
+    expect(reorderClips(base(), 0, 2).clipIds).toEqual(["b", "c", "a"])
+  })
+
+  it("moves an item up", () => {
+    expect(reorderClips(base(), 2, 0).clipIds).toEqual(["c", "a", "b"])
+  })
+
+  it("preserves the set — no additions or removals", () => {
+    const next = reorderClips(base(), 0, 1)
+    expect([...next.clipIds].sort()).toEqual(["a", "b", "c"])
+  })
+
+  it("is a no-op for out-of-range or identical indices", () => {
+    const pl = base()
+    expect(reorderClips(pl, 0, 0)).toBe(pl)
+    expect(reorderClips(pl, -1, 2)).toBe(pl)
+    expect(reorderClips(pl, 0, 9)).toBe(pl)
+  })
+})
+
+describe("setCover", () => {
+  it("sets and clears the custom cover", () => {
+    expect(setCover(base(), "data:x").coverDataUrl).toBe("data:x")
+    expect(setCover(base(), null).coverDataUrl).toBeNull()
+  })
+})
+
+describe("playlistClips / coverClips", () => {
+  const pool = [
+    { id: "x", title: "X" },
+    { id: "y", title: "Y" },
+    { id: "z", title: "Z" },
+  ] as never[]
+  const pl: Playlist = { ...base(), clipIds: ["z", "missing", "x"] }
+
+  it("resolves ids to clips in playlist order, dropping unknown ids", () => {
+    expect(playlistClips(pl, pool).map((c) => c.id)).toEqual(["z", "x"])
+  })
+
+  it("caps cover clips at MOSAIC_SLOTS", () => {
+    const many: Playlist = { ...base(), clipIds: ["x", "y", "z", "x", "y"] }
+    // dedup not enforced here (ids can repeat in the test pool lookup); just assert cap
+    expect(coverClips(many, pool).length).toBeLessThanOrEqual(MOSAIC_SLOTS)
+  })
+})
+
+describe("initialPlaylists", () => {
+  it("seeds playlists that reference real Explore clips", () => {
+    const seeds = initialPlaylists()
+    expect(seeds.length).toBeGreaterThan(0)
+    for (const pl of seeds) {
+      // every seeded id must resolve against the real discovery pool
+      expect(playlistClips(pl).length).toBe(pl.clipIds.length)
+    }
+  })
+})
+
+describe("url builders", () => {
+  it("builds a public share url", () => {
+    expect(buildShareUrl("https://app.test", "pl-1")).toBe(
+      "https://app.test/playlists/pl-1"
+    )
+  })
+
+  it("builds an inspiration href with encoded name", () => {
+    const href = buildInspirationHref({ ...base(), id: "pl-9", name: "Chill & Focus" })
+    expect(href).toContain("/create?")
+    const q = new URLSearchParams(href.split("?")[1])
+    expect(q.get("inspiration")).toBe("pl-9")
+    expect(q.get("inspirationName")).toBe("Chill & Focus")
+  })
+})

--- a/web/lib/playlists.test.ts
+++ b/web/lib/playlists.test.ts
@@ -4,10 +4,8 @@ import {
   addClip,
   buildInspirationHref,
   buildShareUrl,
-  coverClips,
   createPlaylist,
   initialPlaylists,
-  MOSAIC_SLOTS,
   playlistClips,
   removeClip,
   renamePlaylist,
@@ -103,7 +101,7 @@ describe("setCover", () => {
   })
 })
 
-describe("playlistClips / coverClips", () => {
+describe("playlistClips", () => {
   const pool = [
     { id: "x", title: "X" },
     { id: "y", title: "Y" },
@@ -113,12 +111,6 @@ describe("playlistClips / coverClips", () => {
 
   it("resolves ids to clips in playlist order, dropping unknown ids", () => {
     expect(playlistClips(pl, pool).map((c) => c.id)).toEqual(["z", "x"])
-  })
-
-  it("caps cover clips at MOSAIC_SLOTS", () => {
-    const many: Playlist = { ...base(), clipIds: ["x", "y", "z", "x", "y"] }
-    // dedup not enforced here (ids can repeat in the test pool lookup); just assert cap
-    expect(coverClips(many, pool).length).toBeLessThanOrEqual(MOSAIC_SLOTS)
   })
 })
 

--- a/web/lib/playlists.ts
+++ b/web/lib/playlists.ts
@@ -27,9 +27,6 @@ export type Playlist = {
   createdAt: string
 }
 
-/** Max thumbnails composited into an auto-mosaic cover. */
-export const MOSAIC_SLOTS = 4
-
 function newId(): string {
   // crypto.randomUUID exists in browsers and the jsdom/node test env.
   return `pl-${crypto.randomUUID()}`
@@ -129,11 +126,6 @@ export function setCover(pl: Playlist, coverDataUrl: string | null): Playlist {
 export function playlistClips(pl: Playlist, pool: Clip[] = getAllClips()): Clip[] {
   const byId = new Map(pool.map((c) => [c.id, c]))
   return pl.clipIds.map((id) => byId.get(id)).filter((c): c is Clip => c != null)
-}
-
-/** The first up-to-4 resolved clips used to build the auto-mosaic cover. */
-export function coverClips(pl: Playlist, pool: Clip[] = getAllClips()): Clip[] {
-  return playlistClips(pl, pool).slice(0, MOSAIC_SLOTS)
 }
 
 /** Public share URL for a playlist. `origin` comes from the caller (window.location). */

--- a/web/lib/playlists.ts
+++ b/web/lib/playlists.ts
@@ -1,0 +1,152 @@
+// Playlist data seam (US-20.3).
+//
+// Playlists have no backend yet (the coding plan's Beanie API is a later stage):
+// like Explore (US-20.1) and Search (US-20.2), the UI runs on a local, typed mock
+// layer whose shapes mirror the eventual `/playlists` API. Songs are drawn from the
+// same discovery pool as Explore. Mutations here are PURE — each returns a new
+// Playlist — so the client store (contexts/playlists-context) can hold them in React
+// state; swap these bodies for fetch()es when the API lands and callers won't change.
+//
+// ponytail: in-memory only, session-scoped — no localStorage/persistence (YAGNI until
+// there's a real backend to sync with). Custom covers are object URLs, so they also
+// live only for the session.
+
+import { getAllClips } from "@/lib/explore"
+import type { Clip } from "@/lib/workspace-clips"
+
+export type PlaylistVisibility = "private" | "public"
+
+/** A playlist. `clipIds` is the ordered song list; `coverDataUrl` null → auto mosaic. */
+export type Playlist = {
+  id: string
+  name: string
+  description: string | null
+  visibility: PlaylistVisibility
+  clipIds: string[]
+  coverDataUrl: string | null
+  createdAt: string
+}
+
+/** Max thumbnails composited into an auto-mosaic cover. */
+export const MOSAIC_SLOTS = 4
+
+function newId(): string {
+  // crypto.randomUUID exists in browsers and the jsdom/node test env.
+  return `pl-${crypto.randomUUID()}`
+}
+
+function now(): string {
+  return new Date().toISOString()
+}
+
+/**
+ * Seed playlists for the mock store. Reference real Explore clip ids so the detail
+ * page renders actual songs and mosaics. Replace with `GET /playlists` when it lands.
+ */
+export function initialPlaylists(): Playlist[] {
+  return [
+    {
+      id: "pl-latenight",
+      name: "Late Night Drive",
+      description: "Synthwave and lofi for the empty highway.",
+      visibility: "public",
+      clipIds: ["clip-neon", "clip-velvet", "clip-pulse", "clip-paper", "clip-mono"],
+      coverDataUrl: null,
+      createdAt: "2026-07-18T12:00:00Z",
+    },
+    {
+      id: "pl-focus",
+      name: "Deep Focus",
+      description: "Ambient beds to disappear into.",
+      visibility: "private",
+      clipIds: ["clip-glass", "clip-paper", "clip-brass"],
+      coverDataUrl: null,
+      createdAt: "2026-07-16T09:30:00Z",
+    },
+    {
+      id: "pl-anthems",
+      name: "Summer Anthems",
+      description: null,
+      visibility: "public",
+      clipIds: ["clip-tide", "clip-gold"],
+      coverDataUrl: null,
+      createdAt: "2026-07-14T18:45:00Z",
+    },
+  ]
+}
+
+/** A fresh, empty, private playlist. */
+export function createPlaylist(name: string, description = ""): Playlist {
+  return {
+    id: newId(),
+    name: name.trim(),
+    description: description.trim() || null,
+    visibility: "private",
+    clipIds: [],
+    coverDataUrl: null,
+    createdAt: now(),
+  }
+}
+
+/** Rename / re-describe a playlist (empty description → null). */
+export function renamePlaylist(pl: Playlist, name: string, description = ""): Playlist {
+  return { ...pl, name: name.trim(), description: description.trim() || null }
+}
+
+export function setVisibility(pl: Playlist, visibility: PlaylistVisibility): Playlist {
+  return { ...pl, visibility }
+}
+
+/** Append a song, ignoring duplicates (a playlist holds each song once). */
+export function addClip(pl: Playlist, clipId: string): Playlist {
+  if (pl.clipIds.includes(clipId)) return pl
+  return { ...pl, clipIds: [...pl.clipIds, clipId] }
+}
+
+export function removeClip(pl: Playlist, clipId: string): Playlist {
+  return { ...pl, clipIds: pl.clipIds.filter((id) => id !== clipId) }
+}
+
+/**
+ * Move the song at `from` to `to` (drag-to-reorder / up-down buttons). Out-of-range
+ * indices are a no-op, so callers don't have to bounds-check the drag target.
+ */
+export function reorderClips(pl: Playlist, from: number, to: number): Playlist {
+  const n = pl.clipIds.length
+  if (from < 0 || from >= n || to < 0 || to >= n || from === to) return pl
+  const next = [...pl.clipIds]
+  const [moved] = next.splice(from, 1)
+  next.splice(to, 0, moved)
+  return { ...pl, clipIds: next }
+}
+
+/** Set (or clear, with null) a custom cover image. Clearing falls back to the mosaic. */
+export function setCover(pl: Playlist, coverDataUrl: string | null): Playlist {
+  return { ...pl, coverDataUrl }
+}
+
+/** Resolve `clipIds` to Clips in playlist order, dropping ids not in the pool. */
+export function playlistClips(pl: Playlist, pool: Clip[] = getAllClips()): Clip[] {
+  const byId = new Map(pool.map((c) => [c.id, c]))
+  return pl.clipIds.map((id) => byId.get(id)).filter((c): c is Clip => c != null)
+}
+
+/** The first up-to-4 resolved clips used to build the auto-mosaic cover. */
+export function coverClips(pl: Playlist, pool: Clip[] = getAllClips()): Clip[] {
+  return playlistClips(pl, pool).slice(0, MOSAIC_SLOTS)
+}
+
+/** Public share URL for a playlist. `origin` comes from the caller (window.location). */
+export function buildShareUrl(origin: string, id: string): string {
+  return `${origin}/playlists/${id}`
+}
+
+/**
+ * Link that opens the Create page with this playlist as generation context
+ * (AC: "Use as Inspiration"). The create page reads these params and seeds the
+ * inspiration chip.
+ */
+export function buildInspirationHref(pl: Playlist): string {
+  const q = new URLSearchParams({ inspiration: pl.id, inspirationName: pl.name })
+  return `/create?${q.toString()}`
+}


### PR DESCRIPTION
## US-20.3: Playlists

Closes #215

Playlists: create/manage/share collections of songs, with cover art and a
"Use as Inspiration" hand-off into generation. Spec section 30.

### Approach — web-only, mirroring Stage 20
The issue's CodeRabbit plan proposed a full Beanie/FastAPI backend, but Stage 20
(US-20.1 Explore, US-20.2 Search) shipped **web-only** on a typed mock seam that
mirrors the eventual API shape. This PR follows that established pattern rather
than the stale backend plan:

- **`lib/playlists.ts`** — typed seam: `Playlist` type, seed data, and **pure**
  mutation helpers (create/rename/remove/add/remove/reorder/visibility). Songs
  come from the same discovery pool as Explore. Swap helper bodies for `fetch`
  when the `/playlists` API lands; callers won't change.
- **`contexts/playlists-context.tsx`** — a reactive in-memory store, mounted in
  **`app/playlists/layout.tsx`** so the list and detail routes share one source
  (plain component state would reset on navigation between them).

### Acceptance criteria
- [x] Playlists can be created, renamed, and deleted (delete with confirmation)
- [x] Songs can be added, removed, and reordered (up/down buttons **+** native HTML5 drag)
- [x] Public/private toggle changes visibility
- [x] Cover art: auto glyph-mosaic by default, custom upload supported
- [x] "Use as Inspiration" opens `/create` with the playlist pre-attached as an inspiration chip
- [x] Share link works for public playlists (hidden/disabled when private)

### Notable details
- **Cover art** is a glyph mosaic, not real thumbnails — there is no authed
  artwork proxy yet (a real `<img src=.../artwork>` would 401). Custom uploads use
  session-only object URLs (revoked on replace/clear).
- **`PlaylistFormDialog`** resets fields via the render-phase "adjust state on
  prop change" pattern, not an effect (repo bans `set-state-in-effect`).
- **Create page** now reads `?inspiration=&inspirationName=` behind a Suspense
  boundary (mirrors the Search page's `useSearchParams` handling).

### Testing
- `npm run test` — full suite green (1213 tests); 30 new across
  `lib/playlists`, `PlaylistLibrary`, `PlaylistDetail`, `PlaylistCover`
- `npm run typecheck`, `npm run lint`, `npm run build` — all clean
- CI runs Python only; web gates were run locally.

### Review
Cross-family review by **opencode (GLM)** pre-PR. Both findings addressed:
- MAJOR hydration mismatch on the share URL → `suppressHydrationWarning`
- MINOR object-URL leak on cover replace/clear → revoke previous blob

### Known limitations
- Session-only: no persistence/backend (state resets on reload) — intentional for
  this web-only story.
- Not auth-gated, matching Explore/Search (Stage-20 mock pages).
- Reorder drag is pointer-only; keyboard users use the up/down buttons.
- The last uploaded cover's object URL isn't revoked on unmount (only on
  replace/clear) — negligible for a session mock.
