### PR TITLE
feat(web): US-20.4 Short-Form Feed — vertical auto-play discovery feed

### DIFF
--- a/web/app/feed/page.tsx
+++ b/web/app/feed/page.tsx
@@ -1,7 +1,16 @@
+import type { Metadata } from "next"
+
+import { FeedView } from "@/components/feed/FeedView"
+
+// Short-form feed (US-20.4): a vertical snap-scroll of auto-playing short clips.
+// Web-only for now — items come from the local mock seam (lib/feed) over the same
+// discovery pool as Explore, until a `GET /feed` endpoint exists.
+
+export const metadata: Metadata = {
+  title: "Feed · Auto Music Studio",
+  description: "A vertical feed of short clips that auto-play as you scroll.",
+}
+
 export default function FeedPage() {
-  return (
-    <div className="p-8">
-      <h1 className="text-2xl font-semibold">Feed</h1>
-    </div>
-  )
+  return <FeedView />
 }

--- a/web/components/feed/FeedItemCard.test.tsx
+++ b/web/components/feed/FeedItemCard.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { FeedItemCard } from "@/components/feed/FeedItemCard"
+import { PlayerProvider } from "@/contexts/player-context"
+import { getFeedPage, type FeedItem } from "@/lib/feed"
+
+// jsdom doesn't implement media playback; stub it so the auto-play effect runs.
+let play: ReturnType<typeof vi.fn>
+let pause: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  play = vi.fn().mockResolvedValue(undefined)
+  pause = vi.fn()
+  HTMLMediaElement.prototype.play = play as unknown as HTMLMediaElement["play"]
+  HTMLMediaElement.prototype.pause = pause as unknown as HTMLMediaElement["pause"]
+})
+afterEach(() => vi.restoreAllMocks())
+
+const item: FeedItem = getFeedPage(1).items[0]
+
+function renderCard(active: boolean) {
+  return render(
+    <PlayerProvider>
+      <FeedItemCard item={item} active={active} />
+    </PlayerProvider>
+  )
+}
+
+describe("FeedItemCard", () => {
+  it("shows title, artist, and style tags as overlays (AC3)", () => {
+    renderCard(false)
+    expect(screen.getByRole("heading", { name: item.title! })).toBeInTheDocument()
+    expect(screen.getByText(item.artist)).toBeInTheDocument()
+    for (const tag of item.style_tags) {
+      expect(screen.getByText(tag)).toBeInTheDocument()
+    }
+  })
+
+  it("auto-plays when active and pauses when not (AC2)", () => {
+    const { rerender } = renderCard(true)
+    expect(play).toHaveBeenCalled()
+
+    rerender(
+      <PlayerProvider>
+        <FeedItemCard item={item} active={false} />
+      </PlayerProvider>
+    )
+    expect(pause).toHaveBeenCalled()
+  })
+
+  it("toggles like state (AC4)", async () => {
+    const user = userEvent.setup()
+    renderCard(false)
+    const like = screen.getByRole("button", { name: "Like" })
+    expect(like).toHaveAttribute("aria-pressed", "false")
+    await user.click(like)
+    expect(
+      screen.getByRole("button", { name: "Liked" })
+    ).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("links remix to the song page and inspire to Create (AC4)", () => {
+    renderCard(false)
+    expect(screen.getByRole("link", { name: "Remix" })).toHaveAttribute(
+      "href",
+      `/song/${item.id}`
+    )
+    expect(screen.getByRole("link", { name: "Inspire" })).toHaveAttribute(
+      "href",
+      expect.stringContaining(`/create?inspiration=${item.id}`)
+    )
+  })
+
+  it("opens the share dialog (AC4)", async () => {
+    const user = userEvent.setup()
+    renderCard(false)
+    await user.click(screen.getByRole("button", { name: "Share" }))
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+  })
+})

--- a/web/components/feed/FeedItemCard.tsx
+++ b/web/components/feed/FeedItemCard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import Link from "next/link"
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
@@ -86,24 +86,35 @@ export function FeedItemCard({
   const liked = state.likedIds.includes(item.id)
   const styleText = item.style_tags.join(", ")
 
-  // Sync the audio element to `active`: play when scrolled into view, pause when
-  // out. play() may reject under the browser autoplay policy (no gesture yet); we
-  // swallow it and the play button stays available. No setState here.
+  // Start this item's audio, first pausing the global bottom playbar so the two
+  // never overlap (entering the feed mid-playback would otherwise double up).
+  // play() may reject under the autoplay policy (no gesture yet) — swallowed; the
+  // play button stays available.
+  const startAudio = useCallback(
+    (audio: HTMLAudioElement) => {
+      dispatch({ type: "pause" })
+      void audio.play().catch(() => {})
+    },
+    [dispatch]
+  )
+
+  // Sync the audio element to `active`: play when scrolled into view, pause (and
+  // rewind) when out. No setState here — the element's own events drive isPlaying.
   useEffect(() => {
     const audio = audioRef.current
     if (!audio) return
     if (active) {
-      void audio.play().catch(() => {})
+      startAudio(audio)
     } else {
       audio.pause()
       audio.currentTime = 0
     }
-  }, [active])
+  }, [active, startAudio])
 
   const togglePlay = () => {
     const audio = audioRef.current
     if (!audio) return
-    if (audio.paused) void audio.play().catch(() => {})
+    if (audio.paused) startAudio(audio)
     else audio.pause()
   }
 

--- a/web/components/feed/FeedItemCard.tsx
+++ b/web/components/feed/FeedItemCard.tsx
@@ -1,0 +1,198 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  FavouriteIcon,
+  MusicNote01Icon,
+  PauseIcon,
+  PlayIcon,
+  RepeatIcon,
+  Share01Icon,
+  SparklesIcon,
+} from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { ShareModal } from "@/components/song/ShareModal"
+import { usePlayer } from "@/contexts/player-context"
+import { clipInspirationHref, type FeedItem } from "@/lib/feed"
+import { cn } from "@/lib/utils"
+
+// One short-form feed item (US-20.4). Full-height card with a glyph artwork
+// backdrop (no authed artwork proxy), title/artist/tag overlays, and an action
+// rail. Owns its own <audio>: an effect drives play/pause off the `active` prop
+// (the in-view item), which is a side-effect syncing to an external element — not
+// set-state-in-effect. The play/pause icon tracks the element's own events.
+
+/** Vertical action-rail button. */
+function RailButton({
+  icon,
+  label,
+  active,
+  onClick,
+  href,
+}: {
+  icon: typeof PlayIcon
+  label: string
+  active?: boolean
+  onClick?: () => void
+  href?: string
+}) {
+  const className = cn(
+    "flex flex-col items-center gap-1 rounded-lg p-2 text-white/90 outline-none transition-colors hover:bg-white/10 focus-visible:ring-3 focus-visible:ring-white/40",
+    active && "text-primary"
+  )
+  const inner = (
+    <>
+      <HugeiconsIcon
+        icon={icon}
+        size={26}
+        className={cn(active && "fill-current")}
+      />
+      <span className="text-[11px] font-medium">{label}</span>
+    </>
+  )
+  return href ? (
+    <Link href={href} aria-label={label} className={className}>
+      {inner}
+    </Link>
+  ) : (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      onClick={onClick}
+      className={className}
+    >
+      {inner}
+    </button>
+  )
+}
+
+export function FeedItemCard({
+  item,
+  active,
+}: {
+  item: FeedItem
+  /** True when this is the in-view item — drives auto-play. */
+  active: boolean
+}) {
+  const { state, dispatch } = usePlayer()
+  const audioRef = useRef<HTMLAudioElement>(null)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
+
+  const liked = state.likedIds.includes(item.id)
+  const styleText = item.style_tags.join(", ")
+
+  // Sync the audio element to `active`: play when scrolled into view, pause when
+  // out. play() may reject under the browser autoplay policy (no gesture yet); we
+  // swallow it and the play button stays available. No setState here.
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+    if (active) {
+      void audio.play().catch(() => {})
+    } else {
+      audio.pause()
+      audio.currentTime = 0
+    }
+  }, [active])
+
+  const togglePlay = () => {
+    const audio = audioRef.current
+    if (!audio) return
+    if (audio.paused) void audio.play().catch(() => {})
+    else audio.pause()
+  }
+
+  return (
+    <section
+      data-testid="feed-item"
+      data-active={active}
+      aria-label={`${item.title ?? "Untitled clip"} by ${item.artist}`}
+      className="relative flex h-full w-full items-stretch justify-center p-3"
+    >
+      {/* Artwork backdrop: glyph + gradient for text legibility. */}
+      <button
+        type="button"
+        onClick={togglePlay}
+        aria-label={isPlaying ? "Pause" : "Play"}
+        className="group relative w-full max-w-md overflow-hidden rounded-2xl bg-gradient-to-b from-muted to-muted-foreground/20 outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        <span className="absolute inset-0 flex items-center justify-center text-muted-foreground/40">
+          <HugeiconsIcon icon={MusicNote01Icon} size={96} aria-hidden />
+        </span>
+        {/* Center play/pause affordance; visible when paused or on hover. */}
+        <span
+          className={cn(
+            "absolute inset-0 flex items-center justify-center bg-black/10 transition-opacity",
+            isPlaying ? "opacity-0 group-hover:opacity-100" : "opacity-100"
+          )}
+        >
+          <span className="flex size-16 items-center justify-center rounded-full bg-black/45 text-white">
+            <HugeiconsIcon icon={isPlaying ? PauseIcon : PlayIcon} size={32} />
+          </span>
+        </span>
+        {/* Bottom gradient scrim behind the text overlays. */}
+        <span className="absolute inset-x-0 bottom-0 h-2/5 bg-gradient-to-t from-black/70 to-transparent" />
+      </button>
+
+      {/* Text overlays (title / artist / tags). */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 mx-auto flex max-w-md flex-col gap-2 p-5 pr-16 text-white">
+        <h2 className="text-lg font-semibold drop-shadow">
+          {item.title ?? "Untitled clip"}
+        </h2>
+        <p className="text-sm text-white/80 drop-shadow">{item.artist}</p>
+        {styleText && (
+          <div className="flex flex-wrap gap-1">
+            {item.style_tags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="bg-white/15 text-white">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Action rail. */}
+      <div className="absolute right-2 bottom-6 flex flex-col items-center gap-3">
+        <RailButton
+          icon={FavouriteIcon}
+          label={liked ? "Liked" : "Like"}
+          active={liked}
+          onClick={() => dispatch({ type: "like/toggle", id: item.id })}
+        />
+        <RailButton
+          icon={Share01Icon}
+          label="Share"
+          onClick={() => setShareOpen(true)}
+        />
+        <RailButton icon={RepeatIcon} label="Remix" href={`/song/${item.id}`} />
+        <RailButton
+          icon={SparklesIcon}
+          label="Inspire"
+          href={clipInspirationHref(item)}
+        />
+      </div>
+
+      <audio
+        ref={audioRef}
+        src={item.audioUrl}
+        loop
+        preload="none"
+        onPlay={() => setIsPlaying(true)}
+        onPause={() => setIsPlaying(false)}
+        data-testid="feed-audio"
+      />
+
+      <ShareModal
+        open={shareOpen}
+        clipId={item.id}
+        clipTitle={item.title}
+        onClose={() => setShareOpen(false)}
+      />
+    </section>
+  )
+}

--- a/web/components/feed/FeedView.test.tsx
+++ b/web/components/feed/FeedView.test.tsx
@@ -1,0 +1,103 @@
+import { act, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { FeedView } from "@/components/feed/FeedView"
+import { PlayerProvider } from "@/contexts/player-context"
+import { FEED_PAGE_SIZE } from "@/lib/feed"
+
+// --- IntersectionObserver mock ---------------------------------------------
+// Records every observer instance so tests can fire callbacks for a given target.
+type MockInstance = {
+  cb: IntersectionObserverCallback
+  els: Set<Element>
+}
+let instances: MockInstance[] = []
+
+class MockIO {
+  cb: IntersectionObserverCallback
+  els = new Set<Element>()
+  constructor(cb: IntersectionObserverCallback) {
+    this.cb = cb
+    instances.push({ cb, els: this.els })
+  }
+  observe(el: Element) {
+    this.els.add(el)
+  }
+  unobserve(el: Element) {
+    this.els.delete(el)
+  }
+  disconnect() {
+    this.els.clear()
+  }
+  takeRecords() {
+    return []
+  }
+}
+
+/** Fire an intersection for `el` at `ratio` on whichever observer watches it. */
+function fireIntersect(el: Element, ratio: number) {
+  const inst = instances.find((i) => i.els.has(el))
+  if (!inst) throw new Error("no observer for element")
+  act(() => {
+    inst.cb(
+      [
+        {
+          target: el,
+          isIntersecting: ratio > 0,
+          intersectionRatio: ratio,
+        } as unknown as IntersectionObserverEntry,
+      ],
+      inst as unknown as IntersectionObserver
+    )
+  })
+}
+
+beforeEach(() => {
+  instances = []
+  vi.stubGlobal("IntersectionObserver", MockIO)
+  HTMLMediaElement.prototype.play = vi
+    .fn()
+    .mockResolvedValue(undefined) as unknown as HTMLMediaElement["play"]
+  HTMLMediaElement.prototype.pause = vi.fn() as unknown as HTMLMediaElement["pause"]
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+const renderFeed = () =>
+  render(
+    <PlayerProvider>
+      <FeedView />
+    </PlayerProvider>
+  )
+
+const wrappers = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll<HTMLElement>("[data-key]"))
+const items = () => screen.getAllByTestId("feed-item")
+
+describe("FeedView", () => {
+  it("renders a first page of items in a scroll layout (AC1)", () => {
+    renderFeed()
+    expect(screen.getByTestId("feed-scroll")).toBeInTheDocument()
+    expect(items()).toHaveLength(FEED_PAGE_SIZE)
+  })
+
+  it("marks the first item active by default, then follows the most-visible one (AC2)", () => {
+    const { container } = renderFeed()
+    expect(items()[0]).toHaveAttribute("data-active", "true")
+
+    // Second item scrolls into view.
+    fireIntersect(wrappers(container)[1], 0.9)
+    expect(items()[1]).toHaveAttribute("data-active", "true")
+    expect(items()[0]).toHaveAttribute("data-active", "false")
+  })
+
+  it("loads more items when the sentinel is reached (AC5)", () => {
+    const { container } = renderFeed()
+    expect(items()).toHaveLength(FEED_PAGE_SIZE)
+    const sentinel = container.querySelector('[data-testid="feed-sentinel"]')!
+    fireIntersect(sentinel, 1)
+    expect(items()).toHaveLength(FEED_PAGE_SIZE * 2)
+  })
+})

--- a/web/components/feed/FeedView.tsx
+++ b/web/components/feed/FeedView.tsx
@@ -80,18 +80,17 @@ export function FeedView() {
     return () => obs.disconnect()
   }, [loadMore, feed.hasMore])
 
-  const registerItem = (key: string) => (el: HTMLElement | null) => {
-    const map = itemEls.current
-    const prev = map.get(key)
-    if (prev) activeObserver.current?.unobserve(prev)
-    if (el) {
-      map.set(key, el)
-      activeObserver.current?.observe(el)
-    } else {
-      map.delete(key)
-      ratios.current.delete(key)
-    }
-  }
+  // Stable ref callback (reads the key from data-key). Kept identity-stable so a
+  // re-render — e.g. when the active item changes — doesn't detach/reattach every
+  // item and churn the ratio map. Items are append-only, so there's no per-item
+  // unobserve; the observer's disconnect() on unmount is the only cleanup needed.
+  const registerItem = useCallback((el: HTMLElement | null) => {
+    if (!el) return
+    const key = el.dataset.key
+    if (!key) return
+    itemEls.current.set(key, el)
+    activeObserver.current?.observe(el)
+  }, [])
 
   return (
     <div
@@ -103,7 +102,7 @@ export function FeedView() {
         <div
           key={item.key}
           data-key={item.key}
-          ref={registerItem(item.key)}
+          ref={registerItem}
           className="h-full w-full snap-start snap-always"
         >
           <FeedItemCard item={item} active={item.key === activeKey} />

--- a/web/components/feed/FeedView.tsx
+++ b/web/components/feed/FeedView.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+import { FeedItemCard } from "@/components/feed/FeedItemCard"
+import { getFeedPage } from "@/lib/feed"
+
+// Short-form feed (US-20.4). A snap-scroll column of full-height items. Two
+// IntersectionObservers: one marks the most-visible item active (auto-play/pause),
+// the other watches a bottom sentinel to append the next page (infinite scroll).
+// State comes from the mock seam (lib/feed); no loading/error state to render since
+// getFeedPage is synchronous.
+
+export function FeedView() {
+  const firstPage = useMemo(() => getFeedPage(1), [])
+  const [feed, setFeed] = useState(firstPage)
+  const [activeKey, setActiveKey] = useState(firstPage.items[0]?.key ?? "")
+
+  // Element + visibility bookkeeping for the active-item observer.
+  const itemEls = useRef(new Map<string, HTMLElement>())
+  const ratios = useRef(new Map<string, number>())
+  const activeObserver = useRef<IntersectionObserver | null>(null)
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  const loadMore = useCallback(() => {
+    setFeed((cur) => {
+      if (!cur.hasMore) return cur
+      const next = getFeedPage(cur.page + 1)
+      return {
+        page: next.page,
+        hasMore: next.hasMore,
+        items: [...cur.items, ...next.items],
+      }
+    })
+  }, [])
+
+  // Active-item observer: track each item's visible ratio and make the most-
+  // visible one active. Created once; items register via their ref callback.
+  useEffect(() => {
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          const key = (e.target as HTMLElement).dataset.key
+          if (key) ratios.current.set(key, e.isIntersecting ? e.intersectionRatio : 0)
+        }
+        let bestKey = ""
+        let bestRatio = 0
+        for (const [key, ratio] of ratios.current) {
+          if (ratio > bestRatio) {
+            bestRatio = ratio
+            bestKey = key
+          }
+        }
+        if (bestKey) setActiveKey(bestKey)
+      },
+      { threshold: [0.25, 0.5, 0.75] }
+    )
+    activeObserver.current = obs
+    itemEls.current.forEach((el) => obs.observe(el))
+    return () => {
+      obs.disconnect()
+      activeObserver.current = null
+    }
+  }, [])
+
+  // Sentinel observer: append the next page when the loader scrolls into view.
+  // Re-bound when hasMore flips so it stops observing once the feed is exhausted.
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el || !feed.hasMore) return
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) loadMore()
+      },
+      { rootMargin: "300px" }
+    )
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [loadMore, feed.hasMore])
+
+  const registerItem = (key: string) => (el: HTMLElement | null) => {
+    const map = itemEls.current
+    const prev = map.get(key)
+    if (prev) activeObserver.current?.unobserve(prev)
+    if (el) {
+      map.set(key, el)
+      activeObserver.current?.observe(el)
+    } else {
+      map.delete(key)
+      ratios.current.delete(key)
+    }
+  }
+
+  return (
+    <div
+      data-testid="feed-scroll"
+      aria-label="Short-form feed"
+      className="h-full snap-y snap-mandatory overflow-y-scroll bg-black"
+    >
+      {feed.items.map((item) => (
+        <div
+          key={item.key}
+          data-key={item.key}
+          ref={registerItem(item.key)}
+          className="h-full w-full snap-start snap-always"
+        >
+          <FeedItemCard item={item} active={item.key === activeKey} />
+        </div>
+      ))}
+
+      {feed.hasMore && (
+        <div
+          ref={sentinelRef}
+          data-testid="feed-sentinel"
+          className="flex h-16 items-center justify-center text-white/60"
+        >
+          <HugeiconsIcon icon={Loading03Icon} size={24} className="animate-spin" />
+          <span className="sr-only">Loading more</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/lib/feed.test.ts
+++ b/web/lib/feed.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  artistForClip,
+  clipInspirationHref,
+  FEED_AUDIO_URL,
+  FEED_MAX_PAGES,
+  FEED_PAGE_SIZE,
+  getFeedPage,
+} from "@/lib/feed"
+
+describe("artistForClip", () => {
+  it("is deterministic for a given id", () => {
+    expect(artistForClip("clip-neon")).toBe(artistForClip("clip-neon"))
+  })
+
+  it("always returns a non-empty name", () => {
+    for (const id of ["clip-neon", "clip-gold", "x", ""]) {
+      expect(artistForClip(id).length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("getFeedPage", () => {
+  it("returns a full page of items with real clip ids and shared audio", () => {
+    const { items } = getFeedPage(1)
+    expect(items).toHaveLength(FEED_PAGE_SIZE)
+    for (const item of items) {
+      expect(item.id).toMatch(/^clip-/) // real clip id preserved for actions
+      expect(item.audioUrl).toBe(FEED_AUDIO_URL)
+      expect(item.artist).toBeTruthy()
+    }
+  })
+
+  it("gives every item a unique render key across pages", () => {
+    const keys = new Set<string>()
+    for (let p = 1; p <= FEED_MAX_PAGES; p++) {
+      for (const item of getFeedPage(p).items) keys.add(item.key)
+    }
+    expect(keys.size).toBe(FEED_PAGE_SIZE * FEED_MAX_PAGES)
+  })
+
+  it("reports hasMore until the last page (infinite scroll terminates)", () => {
+    expect(getFeedPage(1).hasMore).toBe(true)
+    expect(getFeedPage(FEED_MAX_PAGES).hasMore).toBe(false)
+  })
+
+  it("clamps out-of-range pages", () => {
+    expect(getFeedPage(0).page).toBe(1)
+    expect(getFeedPage(999).page).toBe(FEED_MAX_PAGES)
+  })
+
+  it("cycles the pool so later pages still have items", () => {
+    expect(getFeedPage(FEED_MAX_PAGES).items).toHaveLength(FEED_PAGE_SIZE)
+  })
+})
+
+describe("clipInspirationHref", () => {
+  it("links to Create with the clip as inspiration", () => {
+    const item = getFeedPage(1).items[0]
+    const href = clipInspirationHref(item)
+    const q = new URLSearchParams(href.split("?")[1])
+    expect(href.startsWith("/create?")).toBe(true)
+    expect(q.get("inspiration")).toBe(item.id)
+    expect(q.get("inspirationName")).toBe(item.title ?? "Untitled clip")
+  })
+})

--- a/web/lib/feed.ts
+++ b/web/lib/feed.ts
@@ -1,0 +1,124 @@
+// Short-form feed data seam (US-20.4).
+//
+// Like Explore (US-20.1) and Search (US-20.2), the feed has no backend: it runs on
+// the same local mock pool. This module composes a discovery "mix" and paginates it
+// for infinite scroll. Swap `getFeedPage`'s body for a cursor fetch when a
+// `GET /feed` endpoint exists; the FeedView consumes the getter, not the pool.
+//
+// ponytail: the pool is ~12 clips, so infinite scroll cycles it with a per-page
+// render key rather than fetching more — real audio + a real feed replace both the
+// shared sample URL and the cycling. Nothing here is load-bearing beyond the demo.
+
+import { getNewReleases, getStaffPicks, getTrendingClips } from "@/lib/explore"
+import type { Clip } from "@/lib/workspace-clips"
+
+/** Every feed item plays this shared sample — the mock pool has no per-clip audio.
+ *  Swap for `streamUrl(clip.id)` once discovery serves real streams. */
+export const FEED_AUDIO_URL = "/demo/sample.wav"
+
+export const FEED_PAGE_SIZE = 5
+
+/** Cap so infinite scroll terminates (the pool is finite); real feeds page forever. */
+export const FEED_MAX_PAGES = 5
+
+/** Mock artist names — clips carry no artist field, so one is assigned per clip. */
+const ARTISTS = [
+  "Nova Reverie",
+  "The Glass Hours",
+  "Kairo",
+  "Velvet Circuit",
+  "Lucid Ffield",
+  "Mono Mirage",
+  "Saffron Kites",
+  "Echo & Ember",
+]
+
+/** Stable string hash → index; keeps artist assignment deterministic per clip id. */
+function hashIndex(id: string, mod: number): number {
+  let h = 0
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0
+  return h % mod
+}
+
+/** Deterministic mock artist for a clip. */
+export function artistForClip(id: string): string {
+  return ARTISTS[hashIndex(id, ARTISTS.length)]
+}
+
+/**
+ * A feed item: a Clip plus display extras. `id` stays the real clip id (likes,
+ * share, remix, and links all key on it); `key` is a per-page-unique render key so
+ * a cycled pool doesn't produce duplicate React keys.
+ */
+export type FeedItem = Clip & {
+  artist: string
+  audioUrl: string
+  key: string
+}
+
+/**
+ * The feed "algorithm": interleave trending, new releases, and staff picks, then
+ * dedupe by id (first occurrence wins). Followed-artist content isn't modeled yet
+ * (no follow graph), so staff picks stand in for personalized recommendations.
+ */
+function baseFeed(): Clip[] {
+  const trending = getTrendingClips("7d")
+  const fresh = getNewReleases()
+  const picks = getStaffPicks()
+
+  const ordered: Clip[] = []
+  const seen = new Set<string>()
+  // Round-robin the three sources so the feed doesn't front-load one bucket.
+  const sources = [trending, fresh, picks]
+  const maxLen = Math.max(...sources.map((s) => s.length))
+  for (let i = 0; i < maxLen; i++) {
+    for (const source of sources) {
+      const clip = source[i]
+      if (clip && !seen.has(clip.id)) {
+        seen.add(clip.id)
+        ordered.push(clip)
+      }
+    }
+  }
+  return ordered
+}
+
+function toFeedItem(clip: Clip, page: number, index: number): FeedItem {
+  return {
+    ...clip,
+    artist: artistForClip(clip.id),
+    audioUrl: FEED_AUDIO_URL,
+    key: `${clip.id}--p${page}#${index}`,
+  }
+}
+
+export type FeedPage = {
+  items: FeedItem[]
+  page: number
+  hasMore: boolean
+}
+
+/**
+ * One page of the feed (1-based). The base mix is cycled so pages past the pool's
+ * length keep returning items (infinite scroll) with unique render keys, up to
+ * `FEED_MAX_PAGES`.
+ */
+export function getFeedPage(page: number): FeedPage {
+  const base = baseFeed()
+  const clamped = Math.min(Math.max(1, Math.trunc(page)), FEED_MAX_PAGES)
+  const start = (clamped - 1) * FEED_PAGE_SIZE
+  const items = Array.from({ length: FEED_PAGE_SIZE }, (_, i) => {
+    const clip = base[(start + i) % base.length]
+    return toFeedItem(clip, clamped, i)
+  })
+  return { items, page: clamped, hasMore: clamped < FEED_MAX_PAGES }
+}
+
+/** Link that opens Create with this clip pre-attached as inspiration (US-20.3 seam). */
+export function clipInspirationHref(item: FeedItem): string {
+  const q = new URLSearchParams({
+    inspiration: item.id,
+    inspirationName: item.title ?? "Untitled clip",
+  })
+  return `/create?${q.toString()}`
+}


### PR DESCRIPTION
## US-20.4: Short-Form Feed

Closes #216

A TikTok-style vertical feed at `/feed`: full-height cards that auto-play as they
scroll into view, with title/artist/tag overlays and a like/share/remix/inspire
action rail. Spec section 26.

### Approach — web-only, mirroring Stage 20
The issue's CodeRabbit plan proposed a full backend (`/api/v1/feed`, a Like Beanie
model) and even assumed the Next.js app didn't exist yet (its Design Choice 3
predates Stage 15). It's stale. This PR follows the established Stage-20 pattern
(US-20.1/.2/.3): a self-contained page on a typed mock seam.

- **`lib/feed.ts`** — composes a discovery "mix" (trending + new + staff picks,
  round-robined and deduped) over the Explore pool and paginates it for infinite
  scroll. Swap `getFeedPage` for a cursor fetch when `GET /feed` lands.
- **`components/feed/FeedView.tsx`** — snap-scroll column; **two IntersectionObservers**
  (one marks the most-visible item active for auto-play, one watches a bottom
  sentinel for infinite scroll).
- **`components/feed/FeedItemCard.tsx`** — self-contained `<audio>` driven by the
  `active` prop; overlays + action rail.

### Acceptance criteria
- [x] Feed renders items in a vertical scroll layout
- [x] Audio auto-plays when an item enters the viewport and pauses when it leaves
- [x] Overlays display song title, artist, and style tags
- [x] Like, share, remix, and use-as-inspiration buttons are functional
- [x] Infinite scroll loads more items as the user reaches the bottom

### Action-button seams (no backend)
- **Like** → player context `like/toggle` + `likedIds` (persisted to localStorage)
- **Share** → reuses `ShareModal`
- **Remix** → links to `/song/[id]` (where the remix flow lives)
- **Inspire** → `/create?inspiration=<id>&inspirationName=<title>` (the US-20.3 deep link)

### Auto-play reality
Discovery clips have no per-clip audio, so every item plays the shared
`public/demo/sample.wav` — auto-play/pause is genuinely demonstrable with real
sound. A one-line swap to `streamUrl(clip.id)` lands it on real streams later.
`play()` is attempted on becoming active and its rejection swallowed (browser
autoplay policy may require a gesture first); the play button stays available.

### Testing
- `npm run test` — full suite green (**1229 tests**, +16 new across `lib/feed`,
  `FeedView`, `FeedItemCard`; IntersectionObserver + media playback are mocked)
- `npm run typecheck`, `npm run lint`, `npm run build` — all clean
- CI runs Python only; web gates were run locally.

### Review
Cross-family review: opencode (GLM) timed out on this diff, so **`codex` (fallback)**
was used; findings are posted as a PR comment and addressed. A proactive self-review
already fixed an IntersectionObserver ref-callback churn issue before review.

### Known limitations
- Session-only, no backend/persistence (feed cycles a ~12-clip pool up to 5 pages).
- Artist names are mock (clips carry no artist field yet).
- All items share the demo sample audio (see above).
- If the global bottom playbar were already playing, the feed's own audio could
  double up — negligible today since mock clips can't stream through the playbar.
- Auto-play with sound may need a first user gesture (browser policy).
