### PR TITLE
feat(web): US-20.5 Public Profile Page — /@handle (#217)

### DIFF
--- a/web/app/[handle]/page.test.tsx
+++ b/web/app/[handle]/page.test.tsx
@@ -57,4 +57,11 @@ describe("/@handle route shim", () => {
     expect(() => render(<ProfilePage />)).toThrow("NEXT_NOT_FOUND")
     expect(notFound).toHaveBeenCalled()
   })
+
+  it("404s a malformed percent-encoded segment instead of throwing URIError", () => {
+    // A lone "%"/bad escape would make decodeURIComponent throw; degrade to 404.
+    paramsRef.current = { handle: "%zz" }
+    expect(() => render(<ProfilePage />)).toThrow("NEXT_NOT_FOUND")
+    expect(notFound).toHaveBeenCalled()
+  })
 })

--- a/web/app/[handle]/page.test.tsx
+++ b/web/app/[handle]/page.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const { paramsRef } = vi.hoisted(() => ({
+  paramsRef: { current: { handle: "" } as { handle: string } | null },
+}))
+
+const notFound = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND")
+})
+// The shared setup mock provides neither useParams nor notFound, both of which
+// this shim uses to route /@handle and reject non-profile top-level paths.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useParams: () => paramsRef.current,
+  notFound: () => notFound(),
+}))
+
+// Stub ProfileView so this test targets only the route shim's guard + decode,
+// not the whole profile tree (covered by ProfileView.test.tsx).
+vi.mock("@/components/profile/ProfileView", () => ({
+  ProfileView: ({ handle }: { handle: string }) => (
+    <div data-testid="profile-view">{handle}</div>
+  ),
+}))
+
+import ProfilePage from "@/app/[handle]/page"
+
+afterEach(() => {
+  paramsRef.current = { handle: "" }
+})
+
+describe("/@handle route shim", () => {
+  it("renders ProfileView for an @-prefixed handle", () => {
+    paramsRef.current = { handle: "@nova" }
+    render(<ProfilePage />)
+    expect(screen.getByTestId("profile-view")).toHaveTextContent("@nova")
+    expect(notFound).not.toHaveBeenCalled()
+  })
+
+  it("decodes a percent-encoded handle before handing it off", () => {
+    // useParams returns the raw, still-encoded segment (e.g. /%40nova).
+    paramsRef.current = { handle: "%40nova" }
+    render(<ProfilePage />)
+    expect(screen.getByTestId("profile-view")).toHaveTextContent("@nova")
+  })
+
+  it("404s a top-level path that isn't a profile (no @)", () => {
+    paramsRef.current = { handle: "not-a-profile" }
+    expect(() => render(<ProfilePage />)).toThrow("NEXT_NOT_FOUND")
+    expect(notFound).toHaveBeenCalled()
+  })
+
+  it("404s when the route param is missing", () => {
+    paramsRef.current = null
+    expect(() => render(<ProfilePage />)).toThrow("NEXT_NOT_FOUND")
+    expect(notFound).toHaveBeenCalled()
+  })
+})

--- a/web/app/[handle]/page.tsx
+++ b/web/app/[handle]/page.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { notFound, useParams } from "next/navigation"
+
+import { ProfileView } from "@/components/profile/ProfileView"
+
+// Public profile route /@handle (US-20.5). This is a root dynamic segment, so it
+// also catches unknown top-level paths — static routes (/explore, /search, …) win
+// over it, and anything reaching here that isn't "@handle" is a 404. The "@" is
+// part of the captured param; ProfileView strips it and 404s on an unknown handle.
+
+export default function ProfilePage() {
+  const params = useParams<{ handle: string }>()
+  const handle = params?.handle ? decodeURIComponent(params.handle) : ""
+  if (!handle.startsWith("@")) notFound()
+  return <ProfileView handle={handle} />
+}

--- a/web/app/[handle]/page.tsx
+++ b/web/app/[handle]/page.tsx
@@ -11,7 +11,24 @@ import { ProfileView } from "@/components/profile/ProfileView"
 
 export default function ProfilePage() {
   const params = useParams<{ handle: string }>()
-  const handle = params?.handle ? decodeURIComponent(params.handle) : ""
+  const handle = decodeHandle(params?.handle)
   if (!handle.startsWith("@")) notFound()
-  return <ProfileView handle={handle} />
+  // key={handle} forces a fresh mount per profile: the App Router reuses this
+  // component instance across /@a → /@b navigations, which would otherwise carry
+  // ProfileView's optimistic follow state onto the next profile.
+  return <ProfileView key={handle} handle={handle} />
+}
+
+/**
+ * Decode the raw route segment (useParams returns it still percent-encoded).
+ * A malformed escape (a lone "%", "/%zz") would throw URIError; a root catch-all
+ * sees arbitrary bot/crawler paths, so degrade those to a 404 like any bad handle.
+ */
+function decodeHandle(raw: string | undefined): string {
+  if (!raw) return ""
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return ""
+  }
 }

--- a/web/components/profile/FollowButton.tsx
+++ b/web/components/profile/FollowButton.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Add01Icon, CheckmarkCircle01Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+
+// Follow/unfollow button for the public profile (US-20.5). Presentational and
+// controlled: the parent owns the follow state and the derived follower count so
+// the two stay in sync. `aria-pressed` exposes the toggle state to assistive tech.
+
+export function FollowButton({
+  following,
+  onToggle,
+}: {
+  following: boolean
+  onToggle: () => void
+}) {
+  return (
+    <Button
+      type="button"
+      variant={following ? "secondary" : "default"}
+      onClick={onToggle}
+      aria-pressed={following}
+      data-testid="follow-button"
+    >
+      <HugeiconsIcon
+        icon={following ? CheckmarkCircle01Icon : Add01Icon}
+        size={16}
+        aria-hidden
+      />
+      {following ? "Following" : "Follow"}
+    </Button>
+  )
+}

--- a/web/components/profile/ProfileView.test.tsx
+++ b/web/components/profile/ProfileView.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const notFound = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND")
+})
+// The shared setup mock omits notFound; the profile 404 path needs it.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/@nova",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  notFound: () => notFound(),
+}))
+
+const authState = { isAuthenticated: true }
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => authState,
+}))
+
+import { ProfileView } from "@/components/profile/ProfileView"
+import { getProfileByHandle, profileClips } from "@/lib/profiles"
+
+afterEach(() => {
+  authState.isAuthenticated = true
+})
+
+describe("ProfileView (US-20.5)", () => {
+  it("renders identity, bio, and style pills (AC1, AC4)", () => {
+    render(<ProfileView handle="@nova" />)
+    expect(
+      screen.getByRole("heading", { name: "Nova Bloom" })
+    ).toBeInTheDocument()
+    expect(screen.getByText("@nova")).toBeInTheDocument()
+    // Style tags render as badges.
+    for (const tag of getProfileByHandle("nova")!.style_tags) {
+      expect(screen.getAllByText(tag).length).toBeGreaterThan(0)
+    }
+  })
+
+  it("renders the published songs grid (AC2)", () => {
+    render(<ProfileView handle="@nova" />)
+    const expected = profileClips(getProfileByHandle("nova")!)
+    expect(screen.getAllByTestId("explore-clip-card")).toHaveLength(
+      expected.length
+    )
+    expect(screen.getByText(expected[0].title!)).toBeInTheDocument()
+  })
+
+  it("toggles follow state and moves the follower count by one (AC3)", async () => {
+    const user = userEvent.setup()
+    render(<ProfileView handle="@nova" />)
+    const base = getProfileByHandle("nova")!.follower_count
+
+    const btn = screen.getByTestId("follow-button")
+    const count = screen.getByTestId("follower-count")
+    expect(btn).toHaveTextContent("Follow")
+    expect(count).toHaveAttribute("title", base.toLocaleString("en"))
+
+    await user.click(btn)
+    expect(btn).toHaveTextContent("Following")
+    expect(btn).toHaveAttribute("aria-pressed", "true")
+    expect(count).toHaveAttribute("title", (base + 1).toLocaleString("en"))
+
+    await user.click(btn)
+    expect(btn).toHaveTextContent("Follow")
+    expect(count).toHaveAttribute("title", base.toLocaleString("en"))
+  })
+
+  it("hides the follow button for anonymous viewers", () => {
+    authState.isAuthenticated = false
+    render(<ProfileView handle="@nova" />)
+    expect(screen.queryByTestId("follow-button")).not.toBeInTheDocument()
+  })
+
+  it("shows public playlists on the Playlists tab (AC5)", async () => {
+    const user = userEvent.setup()
+    render(<ProfileView handle="@nova" />)
+    await user.click(screen.getByRole("tab", { name: "Playlists" }))
+    // Public seed playlists ("Late Night Drive", "Summer Anthems") link out.
+    expect(screen.getByText("Late Night Drive")).toBeInTheDocument()
+    expect(screen.getByText("Summer Anthems")).toBeInTheDocument()
+    // The private "Deep Focus" seed must not leak.
+    expect(screen.queryByText("Deep Focus")).not.toBeInTheDocument()
+  })
+
+  it("404s on an unknown handle", () => {
+    expect(() => render(<ProfileView handle="@nobody" />)).toThrow(
+      "NEXT_NOT_FOUND"
+    )
+    expect(notFound).toHaveBeenCalled()
+  })
+})

--- a/web/components/profile/ProfileView.test.tsx
+++ b/web/components/profile/ProfileView.test.tsx
@@ -63,6 +63,7 @@ describe("ProfileView (US-20.5)", () => {
 
     await user.click(btn)
     expect(btn).toHaveTextContent("Follow")
+    expect(btn).toHaveAttribute("aria-pressed", "false")
     expect(count).toHaveAttribute("title", base.toLocaleString("en"))
   })
 

--- a/web/components/profile/ProfileView.tsx
+++ b/web/components/profile/ProfileView.tsx
@@ -1,0 +1,217 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  MusicNote01Icon,
+  PlayListIcon,
+  UserIcon,
+} from "@hugeicons/core-free-icons"
+
+import { ExploreClipCard } from "@/components/explore/ExploreClipCard"
+import { FollowButton } from "@/components/profile/FollowButton"
+import { Badge } from "@/components/ui/badge"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useAuth } from "@/hooks/use-auth"
+import {
+  getProfileByHandle,
+  profileClips,
+  publicPlaylists,
+} from "@/lib/profiles"
+
+// Public creator profile (US-20.5) at /@handle. Header (avatar, name, bio, style
+// pills, follower/following) + Follow button + Songs / Playlists / About tabs.
+// Data comes from the lib/profiles mock seam; the route shim passes the handle.
+
+const compact = new Intl.NumberFormat("en", { notation: "compact" })
+
+/** First-letter initials for the glyph avatar (no authed artwork proxy). */
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("")
+}
+
+function Stat({
+  label,
+  value,
+  testid,
+}: {
+  label: string
+  value: number
+  testid?: string
+}) {
+  return (
+    <span className="flex items-baseline gap-1">
+      {/* Compact display, exact count on hover (and for assertions) — a single */}
+      {/* follow won't move "12.8K", so the title carries the real number. */}
+      <span
+        data-testid={testid}
+        title={value.toLocaleString("en")}
+        className="font-semibold tabular-nums text-foreground"
+      >
+        {compact.format(value)}
+      </span>
+      <span className="text-sm text-muted-foreground">{label}</span>
+    </span>
+  )
+}
+
+export function ProfileView({ handle }: { handle: string }) {
+  const profile = getProfileByHandle(handle)
+  if (!profile) notFound()
+
+  const { isAuthenticated } = useAuth()
+  // Optimistic, session-only follow state — there's no Follow backend yet, so the
+  // follower count moves locally by ±1 (AC3). The base count is the seam's value.
+  // ponytail: no persistence and no self-view guard — the session user carries no
+  // handle (AuthUser is {id, email}), so "don't show Follow on my own profile"
+  // needs a handle on the token first. Gate on auth alone until then.
+  const [following, setFollowing] = useState(false)
+  const followerCount = profile.follower_count + (following ? 1 : 0)
+
+  const clips = profileClips(profile)
+  const playlists = publicPlaylists()
+
+  return (
+    <div className="flex flex-col gap-8 p-8">
+      {/* Header */}
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start">
+        <div
+          aria-hidden
+          className="flex size-24 shrink-0 items-center justify-center rounded-full bg-muted text-2xl font-semibold text-muted-foreground"
+        >
+          {initials(profile.display_name) || (
+            <HugeiconsIcon icon={UserIcon} size={32} />
+          )}
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold">{profile.display_name}</h1>
+              <p className="text-sm text-muted-foreground">@{profile.handle}</p>
+            </div>
+            {isAuthenticated && (
+              <FollowButton
+                following={following}
+                onToggle={() => setFollowing((f) => !f)}
+              />
+            )}
+          </div>
+
+          {profile.bio && (
+            <p className="max-w-prose text-sm text-foreground">{profile.bio}</p>
+          )}
+
+          {profile.style_tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {profile.style_tags.map((tag) => (
+                <Badge key={tag} variant="secondary">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-4">
+            <Stat label="followers" value={followerCount} testid="follower-count" />
+            <Stat label="following" value={profile.following_count} />
+          </div>
+        </div>
+      </header>
+
+      {/* Tabs */}
+      <Tabs defaultValue="songs">
+        <TabsList>
+          <TabsTrigger value="songs">Songs</TabsTrigger>
+          <TabsTrigger value="playlists">Playlists</TabsTrigger>
+          <TabsTrigger value="about">About</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="songs">
+          {clips.length === 0 ? (
+            <EmptyState label="No published songs yet." />
+          ) : (
+            <ul className="grid grid-cols-[repeat(auto-fill,minmax(10rem,1fr))] gap-3">
+              {clips.map((clip) => (
+                <li key={clip.id} className="flex">
+                  <ExploreClipCard clip={clip} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </TabsContent>
+
+        <TabsContent value="playlists">
+          {playlists.length === 0 ? (
+            <EmptyState label="No public playlists yet." />
+          ) : (
+            <ul className="grid grid-cols-[repeat(auto-fill,minmax(14rem,1fr))] gap-3">
+              {playlists.map((pl) => (
+                <li key={pl.id} className="flex">
+                  <Link
+                    href={`/playlists/${pl.id}`}
+                    className="group flex w-full items-center gap-3 rounded-lg border border-border bg-card p-3 outline-none transition-colors hover:bg-accent/50 focus-visible:ring-3 focus-visible:ring-ring/50"
+                  >
+                    <span
+                      aria-hidden
+                      className="flex size-12 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+                    >
+                      <HugeiconsIcon icon={PlayListIcon} size={22} />
+                    </span>
+                    <span className="flex min-w-0 flex-col">
+                      <span className="truncate text-sm font-medium">{pl.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {pl.clipIds.length}{" "}
+                        {pl.clipIds.length === 1 ? "song" : "songs"}
+                      </span>
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </TabsContent>
+
+        <TabsContent value="about">
+          <div className="flex max-w-prose flex-col gap-4 text-sm">
+            {profile.bio && <p>{profile.bio}</p>}
+            {profile.style_tags.length > 0 && (
+              <div className="flex flex-col gap-1.5">
+                <span className="font-medium">Styles</span>
+                <div className="flex flex-wrap gap-1.5">
+                  {profile.style_tags.map((tag) => (
+                    <Badge key={tag} variant="secondary">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+            <p className="text-muted-foreground">
+              Joined{" "}
+              {new Date(profile.joined_at).toLocaleDateString("en", {
+                month: "long",
+                year: "numeric",
+              })}
+            </p>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border py-12 text-muted-foreground">
+      <HugeiconsIcon icon={MusicNote01Icon} size={28} aria-hidden />
+      <p className="text-sm">{label}</p>
+    </div>
+  )
+}

--- a/web/components/profile/ProfileView.tsx
+++ b/web/components/profile/ProfileView.tsx
@@ -45,18 +45,26 @@ function Stat({
   value: number
   testid?: string
 }) {
+  const exact = value.toLocaleString("en")
   return (
     <span className="flex items-baseline gap-1">
       {/* Compact display, exact count on hover (and for assertions) — a single */}
-      {/* follow won't move "12.8K", so the title carries the real number. */}
+      {/* follow won't move "12.8K", so the title carries the real number. The */}
+      {/* visible compact form is aria-hidden; screen readers get the sr-only exact. */}
       <span
         data-testid={testid}
-        title={value.toLocaleString("en")}
+        title={exact}
+        aria-hidden
         className="font-semibold tabular-nums text-foreground"
       >
         {compact.format(value)}
       </span>
-      <span className="text-sm text-muted-foreground">{label}</span>
+      <span aria-hidden className="text-sm text-muted-foreground">
+        {label}
+      </span>
+      <span className="sr-only">
+        {exact} {label}
+      </span>
     </span>
   )
 }

--- a/web/lib/profiles.test.ts
+++ b/web/lib/profiles.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getProfileByHandle,
+  profileClips,
+  publicPlaylists,
+} from "@/lib/profiles"
+
+describe("profiles mock service", () => {
+  it("looks up a profile by bare or @-prefixed handle, any case", () => {
+    const a = getProfileByHandle("nova")
+    const b = getProfileByHandle("@Nova")
+    expect(a).not.toBeNull()
+    expect(a).toBe(b)
+    expect(a?.display_name).toBe("Nova Bloom")
+    expect(a?.handle).toBe("nova")
+  })
+
+  it("returns null for an unknown handle (route → notFound)", () => {
+    expect(getProfileByHandle("nobody")).toBeNull()
+    expect(getProfileByHandle("@ghost")).toBeNull()
+  })
+
+  it("resolves published clips against the Explore pool in declared order", () => {
+    const nova = getProfileByHandle("nova")!
+    const clips = profileClips(nova)
+    expect(clips.map((c) => c.id)).toEqual(nova.clip_ids)
+    // Every id resolved to a real Clip (no gaps from stale ids).
+    expect(clips).toHaveLength(nova.clip_ids.length)
+    expect(clips.every((c) => c.title)).toBe(true)
+  })
+
+  it("shows only public playlists (AC5)", () => {
+    const lists = publicPlaylists()
+    expect(lists.length).toBeGreaterThan(0)
+    expect(lists.every((pl) => pl.visibility === "public")).toBe(true)
+  })
+})

--- a/web/lib/profiles.ts
+++ b/web/lib/profiles.ts
@@ -1,0 +1,102 @@
+// Public profile data seam (US-20.5).
+//
+// The public profile page (/@handle) has no backend: there is no public
+// "user by handle" endpoint, no published-clips-by-user endpoint, and no Follow
+// system. Like Explore (US-20.1), Search (US-20.2), Playlists (US-20.3), and the
+// Feed (US-20.4), the page runs on this local, typed mock layer whose shapes
+// mirror the eventual public profile API. Published songs are drawn from the same
+// discovery pool as Explore; public playlists from the playlists seam. When the
+// social API lands, swap each getter's body for a fetch and callers won't change.
+//
+// ponytail: session-scoped mock, no persistence and no network delay — the reads
+// are synchronous local data. Add both when a getter becomes a real fetch.
+
+import { getAllClips } from "@/lib/explore"
+import { initialPlaylists, type Playlist } from "@/lib/playlists"
+import type { Clip } from "@/lib/workspace-clips"
+
+/** A public creator profile. Mirrors the eventual GET /users/by-handle/{handle}. */
+export type PublicProfile = {
+  /** Bare handle, no leading "@" (e.g. "nova"). The URL adds the "@". */
+  handle: string
+  display_name: string
+  bio: string
+  style_tags: string[]
+  /** No authed artwork proxy yet, so this is always null → initials/glyph avatar. */
+  avatar_url: string | null
+  follower_count: number
+  following_count: number
+  joined_at: string
+  /** Ids of the creator's published clips, resolved against the Explore pool. */
+  clip_ids: string[]
+}
+
+// A handful of mock creators, each owning a slice of the Explore discovery pool
+// (ids from lib/explore) as their published songs. Keyed by bare, lowercase handle.
+const MOCK_PROFILES: Record<string, PublicProfile> = {
+  nova: {
+    handle: "nova",
+    display_name: "Nova Bloom",
+    bio: "Synthwave and neon-lit electronic. Chasing the empty highway at 2am.",
+    style_tags: ["synthwave", "electronic", "ambient"],
+    avatar_url: null,
+    follower_count: 12800,
+    following_count: 142,
+    joined_at: "2026-01-14T00:00:00Z",
+    clip_ids: ["clip-neon", "clip-pulse", "clip-paper"],
+  },
+  ember: {
+    handle: "ember",
+    display_name: "Ember Vale",
+    bio: "Loud guitars, dusty roads. Indie rock with the windows down.",
+    style_tags: ["rock", "indie", "folk"],
+    avatar_url: null,
+    follower_count: 8400,
+    following_count: 88,
+    joined_at: "2026-02-02T00:00:00Z",
+    clip_ids: ["clip-emberr", "clip-crown", "clip-dust"],
+  },
+  sol: {
+    handle: "sol",
+    display_name: "Sol Marlowe",
+    bio: "Late-night brass, velvet soul, and the odd cathedral of strings.",
+    style_tags: ["jazz", "soul", "rnb", "classical"],
+    avatar_url: null,
+    follower_count: 5100,
+    following_count: 231,
+    joined_at: "2026-03-20T00:00:00Z",
+    clip_ids: ["clip-brass", "clip-mono", "clip-glass", "clip-velvet"],
+  },
+}
+
+/** Normalize a URL handle to the mock key: drop one leading "@", lowercase. */
+function normalizeHandle(handle: string): string {
+  return handle.replace(/^@/, "").toLowerCase()
+}
+
+/**
+ * Look up a public profile by handle. Accepts "@nova" or "nova" (any case).
+ * Returns null when no such creator exists → the route renders notFound().
+ */
+export function getProfileByHandle(handle: string): PublicProfile | null {
+  return MOCK_PROFILES[normalizeHandle(handle)] ?? null
+}
+
+/** Resolve a profile's published clips against the Explore pool, order preserved. */
+export function profileClips(profile: PublicProfile): Clip[] {
+  const byId = new Map(getAllClips().map((c) => [c.id, c]))
+  return profile.clip_ids
+    .map((id) => byId.get(id))
+    .filter((c): c is Clip => c != null)
+}
+
+/**
+ * Public playlists to show on a profile. Playlists aren't owned per-user in the
+ * mock (US-20.3), so every profile surfaces the shared public set — enough to
+ * satisfy the "shows public playlists" criterion without scope-creeping into a
+ * per-user playlist API. Add a handle param + swap for GET /users/{handle}/
+ * playlists when a per-user playlist backend lands.
+ */
+export function publicPlaylists(): Playlist[] {
+  return initialPlaylists().filter((pl) => pl.visibility === "public")
+}


### PR DESCRIPTION
## US-20.5 Public Profile Page (#217)

Public creator profile at `/@handle` — Stage 20: Discovery & Social UI.

### Approach: web-only against `lib/*` mock seams

Following the established Stage-20 precedent (US-20.1 Explore #304, US-20.2 Search #305, US-20.3 Playlists #306, US-20.4 Feed #307), this ships **web-only**. The issue's auto-generated CodeRabbit plan proposed a `Follow` Beanie collection + three FastAPI endpoints; that backend doesn't exist yet, so — like every prior Stage-20 story — the page runs on a typed mock seam whose shapes mirror the eventual public profile/social API. Each getter swaps its body for a `fetch` when the backend lands; callers stay unchanged.

### Changes

| File | What |
|------|------|
| `web/lib/profiles.ts` | `PublicProfile` seam: `getProfileByHandle` (handle normalization), `profileClips` (resolved against the Explore pool), `publicPlaylists` (public seed playlists). |
| `web/app/[handle]/page.tsx` | Root dynamic route. Static routes win over it; `notFound()` on non-`@` or unknown handles so it can't hijack real paths. Decodes the raw `useParams` segment. |
| `web/components/profile/ProfileView.tsx` | Header (glyph avatar, name, `@handle`, bio, style pills, follower/following) + Songs / Playlists / About tabs. |
| `web/components/profile/FollowButton.tsx` | Controlled follow toggle (`aria-pressed`), optimistic ±1 follower count. |
| `+ profiles.test.ts, ProfileView.test.tsx, app/[handle]/page.test.tsx` | 14 tests. |

### Acceptance criteria

- [x] Profile loads at `/@username` with correct data → route + `getProfileByHandle`
- [x] Published songs render in a grid of clip cards → Songs tab × `ExploreClipCard`
- [x] Follow button toggles state + updates follower count → `FollowButton` (optimistic ±1)
- [x] Style tags render as pill badges → `Badge` row (header + About)
- [x] Playlists section shows public playlists → Playlists tab × `publicPlaylists`

### Reuse (no new deps)

`ExploreClipCard`, `ui/{tabs,badge,button}`, `useAuth`, `lib/playlists` seed data.

### Verification

- `tsc --noEmit` clean · `eslint` clean · **1239/1239** existing tests + **14** new · `next build` OK (`[handle]` route registered)
- Cross-family review (**codex**): no findings.
- Internal review: 0 Critical / 0 Major; 1 Minor (route-guard test) + 1 Nit (aria-pressed re-check) **fixed** in follow-up commit; 1 Nit (always-plural labels) declined — matches Twitter/GitHub convention.

### Known limitations (deferred)

- No real Follow backend — follow state is **session-only** (optimistic, resets on reload), matching the Stage-20 mock-seam pattern.
- No follower/following **lists** or deep pagination — a single songs grid.
- **No self-view guard** — the Follow button shows for any authenticated viewer because the session user (`AuthUser = {id, email}`) carries no handle yet; add the guard when the token exposes a handle.
- Avatar is an initials/glyph placeholder — there's no authed artwork proxy.

Closes #217.
