### PR TITLE
feat(web): US-20.6 Notifications page — /notifications (#218)

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import { AppShell, BottomPlaybar } from "@/components/layout"
 import { ThemeProvider } from "@/components/theme-provider"
 import { AuthProvider } from "@/contexts/auth-context"
+import { NotificationsProvider } from "@/contexts/notifications-context"
 import { PlayerProvider } from "@/contexts/player-context"
 import { cn } from "@/lib/utils"
 
@@ -29,11 +30,13 @@ export default function RootLayout({
       <body>
         <ThemeProvider>
           <AuthProvider>
-            <PlayerProvider>
-              <AppShell>{children}</AppShell>
-              {/* Sibling of AppShell so the fixed playbar stays viewport-anchored. */}
-              <BottomPlaybar />
-            </PlayerProvider>
+            <NotificationsProvider>
+              <PlayerProvider>
+                <AppShell>{children}</AppShell>
+                {/* Sibling of AppShell so the fixed playbar stays viewport-anchored. */}
+                <BottomPlaybar />
+              </PlayerProvider>
+            </NotificationsProvider>
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/web/app/notifications/page.tsx
+++ b/web/app/notifications/page.tsx
@@ -1,7 +1,7 @@
+import { NotificationsView } from "@/components/notifications/NotificationsView"
+
+// Notifications route /notifications (US-20.6). State comes from the root
+// NotificationsProvider (app/layout), shared with the sidebar bell badge.
 export default function NotificationsPage() {
-  return (
-    <div className="p-8">
-      <h1 className="text-2xl font-semibold">Notifications</h1>
-    </div>
-  )
+  return <NotificationsView />
 }

--- a/web/components/layout/Sidebar.test.tsx
+++ b/web/components/layout/Sidebar.test.tsx
@@ -4,8 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Sidebar } from "@/components/layout"
 import { AuthProvider } from "@/contexts/auth-context"
+import { NotificationsProvider } from "@/contexts/notifications-context"
 import { mainNav } from "@/config/navigation"
 import { LAYOUT } from "@/lib/constants/layout"
+import { initialNotifications, unreadCount } from "@/lib/notifications"
 import { routerMock } from "@/test/router-mock"
 
 // The Sidebar's account menu now reads auth state, so renders need a provider.
@@ -142,5 +144,24 @@ describe("Sidebar navigation (US-15.3)", () => {
     await user.click(screen.getByRole("button", { name: "Account" }))
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument()
+  })
+})
+
+describe("Sidebar notifications badge (US-20.6, AC5)", () => {
+  it("shows the unread count on the Notifications item when a provider is present", () => {
+    render(
+      <AuthProvider>
+        <NotificationsProvider>
+          <Sidebar />
+        </NotificationsProvider>
+      </AuthProvider>
+    )
+    const badge = screen.getByTestId("nav-unread-badge")
+    expect(badge).toHaveTextContent(String(unreadCount(initialNotifications)))
+  })
+
+  it("renders no badge without a provider (degrades to 0)", () => {
+    renderSidebar()
+    expect(screen.queryByTestId("nav-unread-badge")).not.toBeInTheDocument()
   })
 })

--- a/web/components/layout/Sidebar.tsx
+++ b/web/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   type NavDialogItem,
   type NavLinkItem,
 } from "@/config/navigation"
+import { useUnreadCount } from "@/contexts/notifications-context"
 import { useAuth } from "@/hooks/use-auth"
 import { cn } from "@/lib/utils"
 import {
@@ -49,10 +50,13 @@ function NavLink({
   item,
   expanded,
   active,
+  badge,
 }: {
   item: NavLinkItem
   expanded: boolean
   active: boolean
+  /** Unread count overlaid on the icon (0/undefined hides it). Used by the bell. */
+  badge?: number
 }) {
   return (
     <Link
@@ -67,7 +71,18 @@ function NavLink({
         !expanded && "justify-center px-0"
       )}
     >
-      <HugeiconsIcon icon={item.icon} size={22} className="shrink-0" />
+      <span className="relative shrink-0">
+        <HugeiconsIcon icon={item.icon} size={22} />
+        {badge ? (
+          <span
+            data-testid="nav-unread-badge"
+            aria-label={`${badge} unread`}
+            className="absolute -top-1.5 -right-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground"
+          >
+            {badge > 99 ? "99+" : badge}
+          </span>
+        ) : null}
+      </span>
       {expanded && <span className="truncate text-sm">{item.label}</span>}
     </Link>
   )
@@ -158,6 +173,7 @@ function NavDialog({
 export function Sidebar() {
   const pathname = usePathname()
   const [expanded, setExpanded] = useState(false)
+  const unreadCount = useUnreadCount()
 
   return (
     <aside
@@ -192,6 +208,7 @@ export function Sidebar() {
             item={item}
             expanded={expanded}
             active={isActive(pathname, item.href)}
+            badge={item.id === "notifications" ? unreadCount : undefined}
           />
         ))}
       </nav>

--- a/web/components/notifications/NotificationItem.tsx
+++ b/web/components/notifications/NotificationItem.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import Link from "next/link"
+import { HugeiconsIcon } from "@hugeicons/react"
+
+import { useNotifications } from "@/contexts/notifications-context"
+import {
+  NOTIFICATION_META,
+  relativeTime,
+  type AppNotification,
+} from "@/lib/notifications"
+import { cn } from "@/lib/utils"
+
+/**
+ * One notification row (US-20.6). A link to the relevant content (AC2); clicking
+ * also marks it read (AC3 indicator clears). Distinct icon per type (AC1); an
+ * unread dot on the right is the unread indicator.
+ */
+export function NotificationItem({ notification }: { notification: AppNotification }) {
+  const { markRead } = useNotifications()
+  const meta = NOTIFICATION_META[notification.type]
+
+  return (
+    <Link
+      href={notification.href}
+      onClick={() => markRead(notification.id)}
+      data-testid="notification-item"
+      className={cn(
+        "flex items-start gap-3 rounded-lg px-3 py-3 outline-none transition-colors hover:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50",
+        !notification.read && "bg-accent/40"
+      )}
+    >
+      <span
+        className={cn(
+          "mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full bg-muted",
+          meta.tone
+        )}
+      >
+        <HugeiconsIcon icon={meta.icon} size={18} aria-hidden />
+      </span>
+
+      <span className="min-w-0 flex-1">
+        <span
+          className={cn(
+            "block text-sm",
+            notification.read ? "text-muted-foreground" : "font-medium text-foreground"
+          )}
+        >
+          {notification.message}
+        </span>
+        <span className="mt-0.5 block text-xs text-muted-foreground">
+          {relativeTime(notification.createdAt)}
+        </span>
+      </span>
+
+      {!notification.read && (
+        <span
+          data-testid="unread-dot"
+          aria-label="Unread"
+          className="mt-2 size-2 shrink-0 rounded-full bg-primary"
+        />
+      )}
+    </Link>
+  )
+}

--- a/web/components/notifications/NotificationItem.tsx
+++ b/web/components/notifications/NotificationItem.tsx
@@ -48,7 +48,13 @@ export function NotificationItem({ notification }: { notification: AppNotificati
         >
           {notification.message}
         </span>
-        <span className="mt-0.5 block text-xs text-muted-foreground">
+        {/* Relative time uses Date.now(), which differs between the static
+            prerender and client hydration — suppress the expected text mismatch
+            (React's documented escape hatch for timestamps). */}
+        <span
+          suppressHydrationWarning
+          className="mt-0.5 block text-xs text-muted-foreground"
+        >
           {relativeTime(notification.createdAt)}
         </span>
       </span>
@@ -56,6 +62,7 @@ export function NotificationItem({ notification }: { notification: AppNotificati
       {!notification.read && (
         <span
           data-testid="unread-dot"
+          role="img"
           aria-label="Unread"
           className="mt-2 size-2 shrink-0 rounded-full bg-primary"
         />

--- a/web/components/notifications/NotificationsView.test.tsx
+++ b/web/components/notifications/NotificationsView.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+
+import { NotificationsView } from "@/components/notifications/NotificationsView"
+import { NotificationsProvider } from "@/contexts/notifications-context"
+import { initialNotifications, unreadCount } from "@/lib/notifications"
+
+function renderView() {
+  return render(
+    <NotificationsProvider>
+      <NotificationsView />
+    </NotificationsProvider>
+  )
+}
+
+describe("NotificationsView (US-20.6)", () => {
+  it("lists notifications with a distinct icon and message per type (AC1)", () => {
+    renderView()
+    // First page (PAGE_SIZE=5) rendered; each row carries its message + an icon.
+    for (const n of initialNotifications.slice(0, 5)) {
+      expect(screen.getByText(n.message)).toBeInTheDocument()
+    }
+    expect(screen.getAllByTestId("notification-item").length).toBe(5)
+  })
+
+  it("each row links to the relevant content (AC2)", () => {
+    renderView()
+    const rows = screen.getAllByTestId("notification-item")
+    initialNotifications.slice(0, 5).forEach((n, i) => {
+      expect(rows[i]).toHaveAttribute("href", n.href)
+    })
+  })
+
+  it("shows an unread indicator on unread notifications only (AC3)", () => {
+    renderView()
+    const shown = initialNotifications.slice(0, 5)
+    const unreadInPage = shown.filter((n) => !n.read).length
+    expect(screen.getAllByTestId("unread-dot").length).toBe(unreadInPage)
+  })
+
+  it("marks a single notification read on click, clearing its dot (AC3)", async () => {
+    const user = userEvent.setup()
+    renderView()
+    const firstUnread = initialNotifications.find((n) => !n.read)!
+    const before = screen.getAllByTestId("unread-dot").length
+    await user.click(screen.getByText(firstUnread.message))
+    expect(screen.getAllByTestId("unread-dot").length).toBe(before - 1)
+  })
+
+  it('"Mark all as read" clears every unread indicator and disables itself (AC4)', async () => {
+    const user = userEvent.setup()
+    renderView()
+    expect(unreadCount(initialNotifications)).toBeGreaterThan(0)
+    const button = screen.getByRole("button", { name: "Mark all as read" })
+    expect(button).toBeEnabled()
+    await user.click(button)
+    expect(screen.queryAllByTestId("unread-dot")).toHaveLength(0)
+    expect(button).toBeDisabled()
+    expect(screen.getByText("You're all caught up")).toBeInTheDocument()
+  })
+
+  it("reveals older notifications in pages (infinite-scroll substitute)", async () => {
+    const user = userEvent.setup()
+    renderView()
+    expect(screen.getAllByTestId("notification-item").length).toBe(5)
+    await user.click(screen.getByRole("button", { name: "Show older notifications" }))
+    expect(screen.getAllByTestId("notification-item").length).toBe(
+      initialNotifications.length
+    )
+    // All revealed → the reveal button is gone.
+    expect(
+      screen.queryByRole("button", { name: "Show older notifications" })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web/components/notifications/NotificationsView.test.tsx
+++ b/web/components/notifications/NotificationsView.test.tsx
@@ -2,9 +2,11 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it } from "vitest"
 
-import { NotificationsView } from "@/components/notifications/NotificationsView"
+import { NotificationsView, PAGE_SIZE } from "@/components/notifications/NotificationsView"
 import { NotificationsProvider } from "@/contexts/notifications-context"
 import { initialNotifications, unreadCount } from "@/lib/notifications"
+
+const firstPage = initialNotifications.slice(0, PAGE_SIZE)
 
 function renderView() {
   return render(
@@ -15,27 +17,27 @@ function renderView() {
 }
 
 describe("NotificationsView (US-20.6)", () => {
-  it("lists notifications with a distinct icon and message per type (AC1)", () => {
+  it("lists the first page of notifications with a message per row, all types on page 1 (AC1)", () => {
     renderView()
-    // First page (PAGE_SIZE=5) rendered; each row carries its message + an icon.
-    for (const n of initialNotifications.slice(0, 5)) {
+    for (const n of firstPage) {
       expect(screen.getByText(n.message)).toBeInTheDocument()
     }
-    expect(screen.getAllByTestId("notification-item").length).toBe(5)
+    expect(screen.getAllByTestId("notification-item").length).toBe(firstPage.length)
+    // AC1: every notification type is represented on the first page.
+    expect(new Set(firstPage.map((n) => n.type)).size).toBe(7)
   })
 
   it("each row links to the relevant content (AC2)", () => {
     renderView()
     const rows = screen.getAllByTestId("notification-item")
-    initialNotifications.slice(0, 5).forEach((n, i) => {
+    firstPage.forEach((n, i) => {
       expect(rows[i]).toHaveAttribute("href", n.href)
     })
   })
 
   it("shows an unread indicator on unread notifications only (AC3)", () => {
     renderView()
-    const shown = initialNotifications.slice(0, 5)
-    const unreadInPage = shown.filter((n) => !n.read).length
+    const unreadInPage = firstPage.filter((n) => !n.read).length
     expect(screen.getAllByTestId("unread-dot").length).toBe(unreadInPage)
   })
 
@@ -63,7 +65,8 @@ describe("NotificationsView (US-20.6)", () => {
   it("reveals older notifications in pages (infinite-scroll substitute)", async () => {
     const user = userEvent.setup()
     renderView()
-    expect(screen.getAllByTestId("notification-item").length).toBe(5)
+    expect(screen.getAllByTestId("notification-item").length).toBe(PAGE_SIZE)
+    expect(initialNotifications.length).toBeGreaterThan(PAGE_SIZE) // reveal is real
     await user.click(screen.getByRole("button", { name: "Show older notifications" }))
     expect(screen.getAllByTestId("notification-item").length).toBe(
       initialNotifications.length

--- a/web/components/notifications/NotificationsView.tsx
+++ b/web/components/notifications/NotificationsView.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState } from "react"
+
+import { NotificationItem } from "@/components/notifications/NotificationItem"
+import { Button } from "@/components/ui/button"
+import { useNotifications } from "@/contexts/notifications-context"
+
+// Notifications page body (US-20.6). Lists activity (likes, remixes, followers,
+// generation/mastering/distribution updates, system) with per-type icons, unread
+// indicators, and "Mark all as read". Data + mutations come from the root
+// NotificationsProvider, shared with the sidebar bell badge.
+
+// ponytail: the seed is 7 items, so "infinite scroll" is a Show-older reveal in
+// PAGE_SIZE chunks rather than an IntersectionObserver — the real feed (US-20.4)
+// already has the observer; swap this for a cursor fetch when the API lands.
+const PAGE_SIZE = 5
+
+export function NotificationsView() {
+  const { notifications, unreadCount, markAllRead } = useNotifications()
+  const [visible, setVisible] = useState(PAGE_SIZE)
+  const shown = notifications.slice(0, visible)
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <header className="mb-6 flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Notifications</h1>
+          <p className="text-sm text-muted-foreground">
+            {unreadCount > 0 ? `${unreadCount} unread` : "You're all caught up"}
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={markAllRead}
+          disabled={unreadCount === 0}
+        >
+          Mark all as read
+        </Button>
+      </header>
+
+      {notifications.length === 0 ? (
+        <p className="py-16 text-center text-sm text-muted-foreground">
+          No notifications yet.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {shown.map((notification) => (
+            <li key={notification.id}>
+              <NotificationItem notification={notification} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {visible < notifications.length && (
+        <div className="mt-4 flex justify-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setVisible((v) => v + PAGE_SIZE)}
+          >
+            Show older notifications
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/components/notifications/NotificationsView.tsx
+++ b/web/components/notifications/NotificationsView.tsx
@@ -11,9 +11,9 @@ import { useNotifications } from "@/contexts/notifications-context"
 // indicators, and "Mark all as read". Data + mutations come from the root
 // NotificationsProvider, shared with the sidebar bell badge.
 
-// ponytail: the seed is 7 items, so "infinite scroll" is a Show-older reveal in
-// PAGE_SIZE chunks rather than an IntersectionObserver — the real feed (US-20.4)
-// already has the observer; swap this for a cursor fetch when the API lands.
+// The seed is 7 items, so "infinite scroll" is a Show-older reveal in PAGE_SIZE
+// chunks rather than an IntersectionObserver — the real feed (US-20.4) already has
+// the observer; swap this for a cursor fetch when the API lands.
 const PAGE_SIZE = 5
 
 export function NotificationsView() {

--- a/web/components/notifications/NotificationsView.tsx
+++ b/web/components/notifications/NotificationsView.tsx
@@ -11,10 +11,11 @@ import { useNotifications } from "@/contexts/notifications-context"
 // indicators, and "Mark all as read". Data + mutations come from the root
 // NotificationsProvider, shared with the sidebar bell badge.
 
-// The seed is 7 items, so "infinite scroll" is a Show-older reveal in PAGE_SIZE
-// chunks rather than an IntersectionObserver — the real feed (US-20.4) already has
-// the observer; swap this for a cursor fetch when the API lands.
-const PAGE_SIZE = 5
+// "Infinite scroll" is a Show-older reveal in PAGE_SIZE chunks rather than an
+// IntersectionObserver — the real feed (US-20.4) already has the observer; swap
+// this for a cursor fetch when the API lands. PAGE_SIZE covers all seven types on
+// the first page; older history reveals on demand.
+export const PAGE_SIZE = 7
 
 export function NotificationsView() {
   const { notifications, unreadCount, markAllRead } = useNotifications()

--- a/web/contexts/notifications-context.tsx
+++ b/web/contexts/notifications-context.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react"
+
+import {
+  initialNotifications,
+  markAllRead as markAllReadIn,
+  markRead as markReadIn,
+  unreadCount as countUnread,
+  type AppNotification,
+} from "@/lib/notifications"
+
+// In-memory notifications store (US-20.6). Lives in the ROOT layout — unlike the
+// route-scoped Playlists store — because the unread-count badge renders in the
+// Sidebar (root layout) while the list + mutations live on /notifications, and
+// both must read one reactive source so "mark all as read" clears the badge.
+// Each action runs the matching pure helper from lib/notifications. Swap the seed
+// for a fetch and the actions for PATCH calls when the API exists; surface stays.
+
+type NotificationsContextValue = {
+  notifications: AppNotification[]
+  unreadCount: number
+  markRead: (id: string) => void
+  markAllRead: () => void
+}
+
+const NotificationsContext = createContext<NotificationsContextValue | null>(null)
+
+export function NotificationsProvider({ children }: { children: React.ReactNode }) {
+  const [notifications, setNotifications] = useState<AppNotification[]>(initialNotifications)
+
+  const markRead = useCallback((id: string) => {
+    setNotifications((list) => markReadIn(list, id))
+  }, [])
+
+  const markAllRead = useCallback(() => {
+    setNotifications((list) => markAllReadIn(list))
+  }, [])
+
+  const value = useMemo<NotificationsContextValue>(
+    () => ({
+      notifications,
+      unreadCount: countUnread(notifications),
+      markRead,
+      markAllRead,
+    }),
+    [notifications, markRead, markAllRead]
+  )
+
+  return (
+    <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>
+  )
+}
+
+export function useNotifications(): NotificationsContextValue {
+  const ctx = useContext(NotificationsContext)
+  if (!ctx) throw new Error("useNotifications must be used within a NotificationsProvider")
+  return ctx
+}
+
+/** Unread count for cross-cutting chrome (the sidebar bell) that can render
+ *  outside the provider — e.g. Sidebar/AppShell unit tests. Degrades to 0 (badge
+ *  hidden) rather than throwing, so those suites need no provider wrapper. */
+export function useUnreadCount(): number {
+  return useContext(NotificationsContext)?.unreadCount ?? 0
+}

--- a/web/lib/notifications.test.ts
+++ b/web/lib/notifications.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  initialNotifications,
+  markAllRead,
+  markRead,
+  NOTIFICATION_META,
+  relativeTime,
+  unreadCount,
+  type NotificationType,
+} from "@/lib/notifications"
+
+const ALL_TYPES: NotificationType[] = [
+  "like",
+  "remix",
+  "follow",
+  "generation_complete",
+  "mastering_complete",
+  "distribution_update",
+  "system",
+]
+
+describe("notifications seam", () => {
+  it("seeds one of every notification type, each with an href and message (AC1, AC2)", () => {
+    const types = new Set(initialNotifications.map((n) => n.type))
+    for (const t of ALL_TYPES) expect(types.has(t)).toBe(true)
+    expect(initialNotifications.every((n) => n.message && n.href)).toBe(true)
+  })
+
+  it("maps every type to a distinct icon + label (AC1)", () => {
+    const icons = ALL_TYPES.map((t) => NOTIFICATION_META[t].icon)
+    expect(new Set(icons).size).toBe(ALL_TYPES.length)
+    expect(ALL_TYPES.every((t) => NOTIFICATION_META[t].label.length > 0)).toBe(true)
+  })
+
+  it("counts only unread (AC5)", () => {
+    const list = [
+      { ...initialNotifications[0], read: false },
+      { ...initialNotifications[1], read: true },
+      { ...initialNotifications[2], read: false },
+    ]
+    expect(unreadCount(list)).toBe(2)
+  })
+
+  it("markRead flips one item immutably, leaving the rest untouched", () => {
+    const list = initialNotifications.map((n) => ({ ...n, read: false }))
+    const next = markRead(list, list[1].id)
+    expect(next[1].read).toBe(true)
+    expect(next[0].read).toBe(false)
+    expect(next).not.toBe(list)
+    expect(list[1].read).toBe(false) // original unchanged
+    // Unrelated items keep identity (no needless re-render churn).
+    expect(next[0]).toBe(list[0])
+  })
+
+  it("markAllRead clears every unread indicator (AC4)", () => {
+    const list = initialNotifications.map((n) => ({ ...n, read: false }))
+    expect(unreadCount(markAllRead(list))).toBe(0)
+  })
+
+  it("relativeTime buckets ages deterministically", () => {
+    const now = new Date("2026-07-22T12:00:00Z").getTime()
+    const at = (ms: number) => new Date(now - ms).toISOString()
+    expect(relativeTime(at(5_000), now)).toBe("just now")
+    expect(relativeTime(at(5 * 60_000), now)).toBe("5m ago")
+    expect(relativeTime(at(3 * 3_600_000), now)).toBe("3h ago")
+    expect(relativeTime(at(2 * 86_400_000), now)).toBe("2d ago")
+    expect(relativeTime(at(9 * 86_400_000), now)).toBe("1w ago")
+  })
+})

--- a/web/lib/notifications.test.ts
+++ b/web/lib/notifications.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { getAllClips } from "@/lib/explore"
 import {
   initialNotifications,
   markAllRead,
@@ -9,6 +10,7 @@ import {
   unreadCount,
   type NotificationType,
 } from "@/lib/notifications"
+import { getProfileByHandle } from "@/lib/profiles"
 
 const ALL_TYPES: NotificationType[] = [
   "like",
@@ -25,6 +27,23 @@ describe("notifications seam", () => {
     const types = new Set(initialNotifications.map((n) => n.type))
     for (const t of ALL_TYPES) expect(types.has(t)).toBe(true)
     expect(initialNotifications.every((n) => n.message && n.href)).toBe(true)
+  })
+
+  it("every notification links to real, resolvable content — no dead ends (AC2)", () => {
+    // Guards against linking a Genre.id (g-*) or unknown handle as a /song or
+    // /@profile target, which would dead-end on "not found".
+    const clipIds = new Set(getAllClips().map((c) => c.id))
+    const staticRoutes = new Set(["/release", "/explore"])
+    for (const n of initialNotifications) {
+      const where = `${n.id} → ${n.href}`
+      if (n.href.startsWith("/song/")) {
+        expect(clipIds.has(n.href.slice("/song/".length)), where).toBe(true)
+      } else if (n.href.startsWith("/@")) {
+        expect(getProfileByHandle(n.href.slice(1)), where).not.toBeNull()
+      } else {
+        expect(staticRoutes.has(n.href), where).toBe(true)
+      }
+    }
   })
 
   it("maps every type to a distinct icon + label (AC1)", () => {

--- a/web/lib/notifications.ts
+++ b/web/lib/notifications.ts
@@ -8,8 +8,8 @@
 // sidebar bell badge off this seed + these pure helpers. When the API lands, swap
 // the seed for a fetch and the helpers for PATCH calls — callers won't change.
 //
-// ponytail: session-scoped, synchronous, no persistence and no polling — there is
-// nothing to poll against yet. Real-time updates arrive with the real endpoint.
+// Session-scoped, synchronous, no persistence and no polling — there is nothing
+// to poll against yet. Real-time updates arrive with the real endpoint.
 
 import type { IconSvgElement } from "@hugeicons/react"
 import {

--- a/web/lib/notifications.ts
+++ b/web/lib/notifications.ts
@@ -62,23 +62,25 @@ export const NOTIFICATION_META: Record<NotificationType, TypeMeta> = {
 
 const MINUTE = 60_000
 
-/** Seed notifications — one of every type, mixing read + unread, linking to real
- *  content (song ids from the Explore pool, @handles from Profiles). Timestamps
- *  are relative to load so the demo always shows fresh "Xm/Xh ago" values. */
+/** Seed notifications — one of every type, mixing read + unread. Song links use
+ *  real clip ids from the Explore pool (clip-*) — the same `/song/{clip.id}` target
+ *  ExploreClipCard uses — and @handles from Profiles; titles match those clips so
+ *  the link lands on the named song. Timestamps are relative to load so the demo
+ *  always shows fresh "Xm/Xh ago" values. */
 export const initialNotifications: AppNotification[] = [
   {
     id: "n-like-1",
     type: "like",
-    message: 'Ember liked your song "Neon Overdrive"',
-    href: "/song/g-electronic",
+    message: 'Ember liked your song "Neon Skyline"',
+    href: "/song/clip-neon",
     createdAt: minutesAgo(4),
     read: false,
   },
   {
     id: "n-remix-1",
     type: "remix",
-    message: 'Sol remixed your song "Midnight Circuit"',
-    href: "/song/g-rock",
+    message: 'Sol remixed your song "Crownfall"',
+    href: "/song/clip-crown",
     createdAt: minutesAgo(38),
     read: false,
   },
@@ -93,15 +95,15 @@ export const initialNotifications: AppNotification[] = [
   {
     id: "n-gen-1",
     type: "generation_complete",
-    message: 'Your song "Golden Hour" finished generating',
-    href: "/song/g-pop",
+    message: 'Your song "Gold Rush 88" finished generating',
+    href: "/song/clip-gold",
     createdAt: minutesAgo(5 * 60),
     read: true,
   },
   {
     id: "n-master-1",
     type: "mastering_complete",
-    message: 'Mastering complete for "Velvet Skyline"',
+    message: 'Mastering complete for "Velvet Static"',
     href: "/release",
     createdAt: minutesAgo(26 * 60),
     read: true,
@@ -109,7 +111,7 @@ export const initialNotifications: AppNotification[] = [
   {
     id: "n-dist-1",
     type: "distribution_update",
-    message: '"Neon Overdrive" is now live on Spotify',
+    message: '"Neon Skyline" is now live on Spotify',
     href: "/release",
     createdAt: minutesAgo(2 * 24 * 60),
     read: true,
@@ -128,8 +130,8 @@ export const initialNotifications: AppNotification[] = [
   {
     id: "n-like-2",
     type: "like",
-    message: 'Aria liked your song "Paper Moon"',
-    href: "/song/g-jazz",
+    message: 'Aria liked your song "Paper Lanterns"',
+    href: "/song/clip-paper",
     createdAt: minutesAgo(11 * 24 * 60),
     read: true,
   },
@@ -144,7 +146,7 @@ export const initialNotifications: AppNotification[] = [
   {
     id: "n-dist-2",
     type: "distribution_update",
-    message: '"Golden Hour" was submitted to Apple Music',
+    message: '"Gold Rush 88" was submitted to Apple Music',
     href: "/release",
     createdAt: minutesAgo(20 * 24 * 60),
     read: true,

--- a/web/lib/notifications.ts
+++ b/web/lib/notifications.ts
@@ -1,0 +1,158 @@
+// Notifications data seam (US-20.6).
+//
+// Like Explore (US-20.1), Search (US-20.2), Playlists (US-20.3), the Feed
+// (US-20.4), and Profiles (US-20.5), the notifications page has no backend: there
+// is no GET /notifications endpoint and no per-type event stream. This module is
+// the local, typed mock layer whose shapes mirror the eventual notifications API.
+// The reactive store (contexts/notifications-context) drives both the page and the
+// sidebar bell badge off this seed + these pure helpers. When the API lands, swap
+// the seed for a fetch and the helpers for PATCH calls — callers won't change.
+//
+// ponytail: session-scoped, synchronous, no persistence and no polling — there is
+// nothing to poll against yet. Real-time updates arrive with the real endpoint.
+
+import type { IconSvgElement } from "@hugeicons/react"
+import {
+  FavouriteIcon,
+  GitBranchIcon,
+  Megaphone01Icon,
+  MixerIcon,
+  MusicNote01Icon,
+  Upload01Icon,
+  UserAdd01Icon,
+} from "@hugeicons/core-free-icons"
+
+/** The seven notification kinds from spec section 31. */
+export type NotificationType =
+  | "like"
+  | "remix"
+  | "follow"
+  | "generation_complete"
+  | "mastering_complete"
+  | "distribution_update"
+  | "system"
+
+/** One notification. `href` is where clicking it navigates (AC2). */
+export type AppNotification = {
+  id: string
+  type: NotificationType
+  message: string
+  href: string
+  /** ISO timestamp; rendered via relativeTime(). */
+  createdAt: string
+  read: boolean
+}
+
+type TypeMeta = { icon: IconSvgElement; tone: string; label: string }
+
+/** Per-type icon + accent tone + short label. Distinct icon per type (AC1). */
+export const NOTIFICATION_META: Record<NotificationType, TypeMeta> = {
+  like: { icon: FavouriteIcon, tone: "text-rose-500", label: "Like" },
+  remix: { icon: GitBranchIcon, tone: "text-violet-500", label: "Remix" },
+  follow: { icon: UserAdd01Icon, tone: "text-blue-500", label: "Follower" },
+  generation_complete: {
+    icon: MusicNote01Icon,
+    tone: "text-emerald-500",
+    label: "Generation",
+  },
+  mastering_complete: { icon: MixerIcon, tone: "text-amber-500", label: "Mastering" },
+  distribution_update: { icon: Upload01Icon, tone: "text-sky-500", label: "Distribution" },
+  system: { icon: Megaphone01Icon, tone: "text-muted-foreground", label: "System" },
+}
+
+const MINUTE = 60_000
+
+/** Seed notifications — one of every type, mixing read + unread, linking to real
+ *  content (song ids from the Explore pool, @handles from Profiles). Timestamps
+ *  are relative to load so the demo always shows fresh "Xm/Xh ago" values. */
+export const initialNotifications: AppNotification[] = [
+  {
+    id: "n-like-1",
+    type: "like",
+    message: 'Ember liked your song "Neon Overdrive"',
+    href: "/song/g-electronic",
+    createdAt: minutesAgo(4),
+    read: false,
+  },
+  {
+    id: "n-remix-1",
+    type: "remix",
+    message: 'Sol remixed your song "Midnight Circuit"',
+    href: "/song/g-rock",
+    createdAt: minutesAgo(38),
+    read: false,
+  },
+  {
+    id: "n-follow-1",
+    type: "follow",
+    message: "Nova started following you",
+    href: "/@nova",
+    createdAt: minutesAgo(3 * 60),
+    read: false,
+  },
+  {
+    id: "n-gen-1",
+    type: "generation_complete",
+    message: 'Your song "Golden Hour" finished generating',
+    href: "/song/g-pop",
+    createdAt: minutesAgo(5 * 60),
+    read: true,
+  },
+  {
+    id: "n-master-1",
+    type: "mastering_complete",
+    message: 'Mastering complete for "Velvet Skyline"',
+    href: "/release",
+    createdAt: minutesAgo(26 * 60),
+    read: true,
+  },
+  {
+    id: "n-dist-1",
+    type: "distribution_update",
+    message: '"Neon Overdrive" is now live on Spotify',
+    href: "/release",
+    createdAt: minutesAgo(2 * 24 * 60),
+    read: true,
+  },
+  {
+    id: "n-sys-1",
+    type: "system",
+    message: "New: collaborative playlists are here — give them a try.",
+    href: "/explore",
+    createdAt: minutesAgo(9 * 24 * 60),
+    read: false,
+  },
+]
+
+function minutesAgo(min: number): string {
+  return new Date(Date.now() - min * MINUTE).toISOString()
+}
+
+/** Count of unread notifications — drives the sidebar bell badge (AC5). */
+export function unreadCount(list: AppNotification[]): number {
+  return list.reduce((n, item) => n + (item.read ? 0 : 1), 0)
+}
+
+/** Return a new list with the one notification marked read (immutable). */
+export function markRead(list: AppNotification[], id: string): AppNotification[] {
+  return list.map((item) => (item.id === id && !item.read ? { ...item, read: true } : item))
+}
+
+/** Return a new list with every notification marked read (AC4). */
+export function markAllRead(list: AppNotification[]): AppNotification[] {
+  return list.map((item) => (item.read ? item : { ...item, read: true }))
+}
+
+/** Compact relative age, e.g. "just now", "5m ago", "3h ago", "2d ago", "1w ago".
+ *  `now` is injectable so callers/tests are deterministic. */
+export function relativeTime(iso: string, now: number = Date.now()): string {
+  const s = Math.max(0, Math.round((now - new Date(iso).getTime()) / 1000))
+  if (s < 60) return "just now"
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  if (d < 7) return `${d}d ago`
+  return `${Math.floor(d / 7)}w ago`
+}

--- a/web/lib/notifications.ts
+++ b/web/lib/notifications.ts
@@ -122,6 +122,33 @@ export const initialNotifications: AppNotification[] = [
     createdAt: minutesAgo(9 * 24 * 60),
     read: false,
   },
+  // Older, already-read history — makes the paged reveal ("Show older") genuine
+  // without changing the unread count. The first page (PAGE_SIZE) still covers all
+  // seven types above; these repeat types further down the timeline.
+  {
+    id: "n-like-2",
+    type: "like",
+    message: 'Aria liked your song "Paper Moon"',
+    href: "/song/g-jazz",
+    createdAt: minutesAgo(11 * 24 * 60),
+    read: true,
+  },
+  {
+    id: "n-follow-2",
+    type: "follow",
+    message: "Kite started following you",
+    href: "/@ember",
+    createdAt: minutesAgo(14 * 24 * 60),
+    read: true,
+  },
+  {
+    id: "n-dist-2",
+    type: "distribution_update",
+    message: '"Golden Hour" was submitted to Apple Music',
+    href: "/release",
+    createdAt: minutesAgo(20 * 24 * 60),
+    read: true,
+  },
 ]
 
 function minutesAgo(min: number): string {


### PR DESCRIPTION
## US-20.6 Notifications Page — `/notifications`

Closes #218. Part of **Stage 20: Discovery & Social UI**.

A notifications page showing likes, remixes, followers, generation/mastering/
distribution updates, and system announcements, plus an unread-count badge on the
sidebar bell.

### Scope: web-only (deviation from the CodeRabbit plan)

The CodeRabbit plan proposed a full backend (Beanie model + service + REST router +
integration tests). That contradicts the **established Stage-20 pattern** — US-20.1…
20.5 all shipped web-only on a `lib/*` mock data seam + presentational components +
(when stateful) a React context store. This PR follows that precedent. Notification
*creation* from other services (likes, follows, job completion) is separate work per
the plan's own Design Choice 3.

### What's here

- **`lib/notifications.ts`** — `AppNotification` type, the 7 notification types with a
  distinct icon + accent per type, a seed feed linking to real content (song ids from
  the Explore pool, `@handles` from Profiles), and pure helpers `markRead` /
  `markAllRead` / `unreadCount` + a small `relativeTime()` formatter.
- **`contexts/notifications-context.tsx`** — `NotificationsProvider` mounted at the
  **root** layout (not route-scoped like Playlists) so the sidebar badge and the page
  share one reactive store; `useUnreadCount()` degrades to 0 outside a provider so
  cross-cutting chrome (Sidebar) needs no wrapper in unit tests.
- **`components/notifications/`** — `NotificationsView` (list, "Mark all as read",
  paged reveal) + `NotificationItem` (per-type icon, unread dot, click → navigate +
  mark read).
- **Sidebar** — unread-count badge on the Notifications nav item.
- **`app/notifications/page.tsx`** — renders `NotificationsView` (replaces the stub).

### Acceptance criteria

- [x] Notifications page lists all types with correct icons and messages
- [x] Clicking a notification navigates to the relevant content (song / profile / release)
- [x] Unread notifications show a visual indicator
- [x] "Mark all as read" clears unread indicators
- [x] Bell icon in sidebar shows unread count

### Test evidence

- New: `lib/notifications.test.ts` (seam/helpers), `NotificationsView.test.tsx`
  (list, links, unread dot, mark-one, mark-all, paged reveal), 2 Sidebar badge tests.
- Full local gate (web is not in CI): **`tsc --noEmit` clean · `eslint` clean ·
  `vitest run` 1258/1258 passing · `next build` OK** (`/notifications` prerenders static).
- Cross-family review (opencode/GLM) run pre-PR; fixes applied in the 2nd commit:
  timestamp hydration guard, unread-dot a11y `role="img"`, comment hygiene.

### Known limitations

- **No backend / no real-time.** The seam is synchronous local state; there is no
  `GET /notifications` endpoint to poll yet. Real-time updates arrive when the API lands
  (the getter/store surfaces are the swap seam).
- **Seed timestamps are baked** at build time for the static page (mock data), so the
  relative age drifts; `suppressHydrationWarning` covers the expected server/client delta.
- The empty-state branch is unreachable with the current seed (no delete path) — kept as
  the correct rendering for a future empty fetch.
