### PR TITLE
feat: US-20.7 Publish and Visibility Controls (three-state private/unlisted/public) (#219)

### DIFF
--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -5,12 +5,14 @@ consistent clip shape as the platform migrates from SQLite to MongoDB.
 """
 
 from datetime import datetime
+from typing import Any
 
 from beanie import Document, PydanticObjectId
-from pydantic import Field
+from pydantic import Field, model_validator
 from pymongo import ASCENDING, DESCENDING, IndexModel
 
 from .common import utcnow
+from .distribution import VisibilityState
 
 
 class Clip(Document):
@@ -50,8 +52,30 @@ class Clip(Document):
     # with that release. Globally unique via the partial index below — a recording
     # gets exactly one ISRC, never reused — while clips without one stay None.
     isrc: str | None = None
+    # US-20.7: visibility is the source of truth (private/unlisted/public).
+    visibility: VisibilityState = VisibilityState.PRIVATE
+    # ponytail: is_public is a stored denormalization synced from `visibility`
+    # (see the validators below) purely so existing Mongo queries filtering on
+    # {"is_public": True} keep matching without a data migration. Never set it
+    # directly — set `visibility` instead.
     is_public: bool = False  # documents predating US-9.3 load as private
     created_at: datetime = Field(default_factory=utcnow)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _backfill_visibility_from_legacy_is_public(cls, data: Any) -> Any:
+        # Documents written before US-20.7 have is_public but no visibility key
+        # at all; without this they'd silently load as PRIVATE (the field
+        # default) and a legacy public clip would regress to private.
+        if isinstance(data, dict) and "visibility" not in data and "is_public" in data:
+            data = dict(data)
+            data["visibility"] = VisibilityState.PUBLIC if data["is_public"] else VisibilityState.PRIVATE
+        return data
+
+    @model_validator(mode="after")
+    def _sync_is_public(self) -> "Clip":
+        self.is_public = self.visibility == VisibilityState.PUBLIC
+        return self
 
     class Settings:
         name = "clips"

--- a/src/acemusic/api/models/clip.py
+++ b/src/acemusic/api/models/clip.py
@@ -74,8 +74,21 @@ class Clip(Document):
 
     @model_validator(mode="after")
     def _sync_is_public(self) -> "Clip":
+        # Keeps the invariant on construction and on load (Beanie re-validates
+        # query results). It does NOT fire on plain attribute assignment
+        # (validate_assignment is False on beanie.Document), so writers must not
+        # assign `visibility` directly — use `set_visibility` below.
         self.is_public = self.visibility == VisibilityState.PUBLIC
         return self
+
+    def set_visibility(self, visibility: VisibilityState) -> None:
+        # The only correct way to change visibility on an existing document.
+        # Setting the field alone would leave the `is_public` denormalization
+        # stale in stored BSON (the after-validator doesn't run on assignment),
+        # which would leak unlisted/private clips into `{"is_public": True}`
+        # server-side queries (search/explore/similar). Set both together.
+        self.visibility = visibility
+        self.is_public = visibility == VisibilityState.PUBLIC
 
     class Settings:
         name = "clips"

--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -2,13 +2,17 @@
 
 * ``GET    /clips``           → paginated list with search/filter/sort (US-9.4)
 * ``GET    /clips/{id}``      → clip metadata (404 if missing/not owned)
-* ``PATCH  /clips/{id}``      → rename and/or publish (title, is_public; US-17.6)
+* ``PATCH  /clips/{id}``      → rename and/or change visibility (title, visibility; US-17.6, US-20.7)
 * ``DELETE /clips/{id}``      → remove the record and its stored audio
 * ``GET    /clips/{id}/audio``→ stream audio, byte ranges + ``?format=`` (US-9.3)
 * ``GET    /clips/{id}/public``→ metadata for anonymous/non-owner callers (US-20.0)
 
-CRUD is owner-scoped; the audio/stream/public endpoints honor ``is_public``, which
-the PATCH publish toggle sets (guarded — see :func:`acemusic.api.services.clips.update_clip_fields`).
+CRUD is owner-scoped; the audio endpoint honors the three-state ``visibility``
+(private/unlisted/public — US-20.7): owner always, non-owner for unlisted/public.
+The ``is_public`` field stays a synced denormalization (``visibility == public``)
+so ``{"is_public": True}`` queries (public listings) keep excluding unlisted
+clips unchanged. The PATCH visibility change is guarded going public — see
+:func:`acemusic.api.services.clips.update_clip_fields`.
 Note ``GET /clips/{id}`` and ``GET /clips/{id}/public`` are deliberately distinct:
 the former 404s on another user's clip even when public, the latter is the
 narrower, redacted read that makes link sharing work.
@@ -28,7 +32,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from acemusic.storage import get_storage_backend
 
 from ..auth.dependencies import CurrentUser, get_current_user, get_current_user_optional, require_existing_user
-from ..models import Clip
+from ..models import Clip, VisibilityState
 from ..services import clips as clip_service
 from ..services.audio_conversion import convert_audio_format
 from ..services.clips import get_clip_for_audio_access, get_clip_for_streaming
@@ -94,16 +98,20 @@ class ClipSearchParams(BaseModel):
 
 
 class ClipUpdate(BaseModel):
-    """Clip edit payload. ``extra="forbid"`` rejects any field other than the two
-    client-writable ones (title, is_public) with 422. Both are optional; an
-    omitted field is left unchanged."""
+    """Clip edit payload. ``extra="forbid"`` rejects any field other than the
+    client-writable ones (title, is_public, visibility) with 422. All are
+    optional; an omitted field is left unchanged."""
 
     model_config = ConfigDict(extra="forbid")
 
     title: Annotated[str, Field(min_length=1, max_length=CLIP_TITLE_MAX_LENGTH)] | None = None
-    # US-17.6 publish toggle. Going public is guarded (title + style tags) in the
-    # service; unpublishing is always allowed.
+    # US-17.6 publish toggle, kept for back-compat. Superseded by `visibility`
+    # (US-20.7); going public via either field is guarded (title + style tags)
+    # in the service, unpublishing is always allowed.
     is_public: bool | None = None
+    # US-20.7 three-state visibility. Takes precedence over is_public when both
+    # are supplied in the same request (see update_clip_fields).
+    visibility: VisibilityState | None = None
 
     @field_validator("title")
     @classmethod
@@ -117,10 +125,12 @@ class ClipUpdate(BaseModel):
 
     @model_validator(mode="after")
     def _reject_explicit_null(self) -> "ClipUpdate":
-        # An omitted title is a no-op; an explicit null is a malformed request
-        # (title has no "cleared" state) and must not masquerade as success.
+        # An omitted field is a no-op; an explicit null is a malformed request
+        # (neither field has a "cleared" state) and must not masquerade as success.
         if "title" in self.model_fields_set and self.title is None:
             raise ValueError("title must be a non-empty string; omit the field to leave it unchanged.")
+        if "visibility" in self.model_fields_set and self.visibility is None:
+            raise ValueError("visibility must be one of private/unlisted/public; omit the field to leave it unchanged.")
         return self
 
 
@@ -143,6 +153,7 @@ class ClipResponse(BaseModel):
     parent_clip_ids: list[str]
     generation_mode: str | None
     is_public: bool
+    visibility: VisibilityState
     created_at: datetime
 
     @classmethod
@@ -164,6 +175,7 @@ class ClipResponse(BaseModel):
             parent_clip_ids=[str(pid) for pid in clip.parent_clip_ids],
             generation_mode=clip.generation_mode,
             is_public=clip.is_public,
+            visibility=clip.visibility,
             created_at=clip.created_at,
         )
 
@@ -367,9 +379,11 @@ async def update_clip(
     body: ClipUpdate,
     current: CurrentUser = Depends(require_existing_user),
 ) -> ClipResponse:
-    """Rename and/or publish the clip; an empty body is a no-op returning the
+    """Rename and/or change visibility; an empty body is a no-op returning the
     current state. Going public without a title or style tags is rejected 422."""
-    clip = await clip_service.update_clip_fields(clip_id, current.user_id, title=body.title, is_public=body.is_public)
+    clip = await clip_service.update_clip_fields(
+        clip_id, current.user_id, title=body.title, is_public=body.is_public, visibility=body.visibility
+    )
     return ClipResponse.from_clip(clip)
 
 

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -176,16 +176,17 @@ async def get_clip_for_streaming(clip_id: str, current_user_id: str | None) -> C
 
     Authenticated requests follow :func:`get_clip_for_audio_access` (404 for
     unknown, 403 for another user's private clip). Anonymous requests
-    (``current_user_id is None``) may only reach public clips; a private or
-    unknown clip is an indistinguishable 404 so the endpoint never reveals a
-    private clip's existence to a stranger.
+    (``current_user_id is None``) may reach public *and* unlisted clips — an
+    unlisted clip is link-shared, so its direct link must open for a signed-out
+    recipient (US-20.7, AC5). A private or unknown clip is an indistinguishable
+    404 so the endpoint never reveals a private clip's existence to a stranger.
     """
     if current_user_id is not None:
         return await get_clip_for_audio_access(clip_id, current_user_id)
 
     oid = coerce_object_id(clip_id)
     clip = await Clip.get(oid) if oid is not None else None
-    if clip is None or not clip.is_public:
+    if clip is None or clip.visibility == VisibilityState.PRIVATE:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found.")
     return clip
 

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -22,7 +22,7 @@ from fastapi import HTTPException, status
 
 from acemusic.storage import get_storage_backend
 
-from ..models import ArtworkOption, Clip
+from ..models import ArtworkOption, Clip, VisibilityState
 from . import daw_export as daw_export_service, workspaces as workspace_service
 from .common import coerce_object_id
 
@@ -156,15 +156,17 @@ async def find_similar_clips(
 async def get_clip_for_audio_access(clip_id: str, current_user_id: str) -> Clip:
     """Return ``clip_id``'s clip if ``current_user_id`` may retrieve its audio.
 
-    Raises 404 for malformed/unknown ids and 403 for another user's private
-    clip. Unlike jobs (which 404 to hide existence), clips deliberately
-    distinguish 403 so sharing flows can tell "ask the owner" from "gone".
+    Raises 404 for malformed/unknown ids and 403 for another user's *private*
+    clip (US-20.7: unlisted and public both allow non-owner access — unlisted
+    is "link sharing", not "hidden"). Unlike jobs (which 404 to hide existence),
+    clips deliberately distinguish 403 so sharing flows can tell "ask the owner"
+    from "gone".
     """
     oid = coerce_object_id(clip_id)
     clip = await Clip.get(oid) if oid is not None else None
     if clip is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found.")
-    if str(clip.user_id) != current_user_id and not clip.is_public:
+    if str(clip.user_id) != current_user_id and clip.visibility == VisibilityState.PRIVATE:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="This clip is private.")
     return clip
 
@@ -309,19 +311,28 @@ async def update_clip_fields(
     *,
     title: str | None = None,
     is_public: bool | None = None,
+    visibility: VisibilityState | None = None,
 ) -> Clip:
-    """Apply the client-writable clip fields — title (rename) and/or is_public
-    (the US-17.6 publish toggle). ``None`` leaves a field unchanged. A title
-    supplied in the same call is applied before the publish guard runs, so a
-    rename-and-publish request is validated against the new title."""
+    """Apply the client-writable clip fields — title (rename) and/or visibility
+    (US-20.7's three-state control, superseding US-17.6's ``is_public`` toggle).
+    ``None`` leaves a field unchanged. A title supplied in the same call is
+    applied before the publish guard runs, so a rename-and-publish request is
+    validated against the new title.
+
+    ``visibility`` is the source of truth; a legacy ``is_public`` bool is mapped
+    onto it (True -> public, False -> private) when ``visibility`` itself is not
+    given, so old callers/tests keep working unchanged.
+    """
     clip = await get_owned_clip(clip_id, user_id)
     if title is not None:
         clip.title = title
-    if is_public:
+    if visibility is None and is_public is not None:
+        visibility = VisibilityState.PUBLIC if is_public else VisibilityState.PRIVATE
+    if visibility == VisibilityState.PUBLIC:
         _enforce_publish_guard(clip)
-    if is_public is not None:
-        clip.is_public = is_public
-    if title is not None or is_public is not None:
+    if visibility is not None:
+        clip.visibility = visibility
+    if title is not None or visibility is not None:
         await clip.save()
     return clip
 

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -328,6 +328,10 @@ async def update_clip_fields(
     if title is not None:
         clip.title = title
     if visibility is None and is_public is not None:
+        # A legacy is_public=False can't express UNLISTED, so it collapses an
+        # unlisted clip to PRIVATE. That's intended: a caller old enough to send
+        # the boolean has no unlisted concept, and PRIVATE is the safe (more
+        # restrictive) resolution. Modern clients send `visibility` and skip this.
         visibility = VisibilityState.PUBLIC if is_public else VisibilityState.PRIVATE
     if visibility == VisibilityState.PUBLIC:
         _enforce_publish_guard(clip)

--- a/src/acemusic/api/services/clips.py
+++ b/src/acemusic/api/services/clips.py
@@ -332,7 +332,7 @@ async def update_clip_fields(
     if visibility == VisibilityState.PUBLIC:
         _enforce_publish_guard(clip)
     if visibility is not None:
-        clip.visibility = visibility
+        clip.set_visibility(visibility)
     if title is not None or visibility is not None:
         await clip.save()
     return clip

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -225,7 +225,7 @@ async def update_visibility(release: Release, visibility: VisibilityState) -> Re
 
     clip = await clip_service.find_owned_clip(str(release.clip_id), str(release.user_id))
     if clip is not None and clip.visibility != visibility:
-        clip.visibility = visibility
+        clip.set_visibility(visibility)
         await clip.save()
     return release
 

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -215,9 +215,11 @@ async def update_visibility(release: Release, visibility: VisibilityState) -> Re
     does not re-fetch. Visibility is a sharing preference, not part of the
     submission lifecycle, so it is editable in any state (unlike metadata, which
     locks after submission). The source clip's own ``visibility`` (US-20.7,
-    which gates non-owner audio access) is mirrored to match — ``is_public``
-    then auto-syncs on the clip's save. A deleted source clip is tolerated (the
-    release keeps its visibility).
+    which gates non-owner audio access) is mirrored to match via
+    ``Clip.set_visibility``, which syncs the ``is_public`` denormalization
+    in-memory before the save (the after-validator does NOT run on a plain
+    assignment). A deleted source clip is tolerated (the release keeps its
+    visibility).
     """
     release.visibility = visibility
     release.updated_at = utcnow()

--- a/src/acemusic/api/services/releases.py
+++ b/src/acemusic/api/services/releases.py
@@ -214,19 +214,18 @@ async def update_visibility(release: Release, visibility: VisibilityState) -> Re
     Takes an already-owned ``release`` (the router has validated ownership), so it
     does not re-fetch. Visibility is a sharing preference, not part of the
     submission lifecycle, so it is editable in any state (unlike metadata, which
-    locks after submission). The source clip's ``is_public`` flag — what actually
-    gates non-owner audio access — is synced too: only ``public`` exposes the clip;
-    ``unlisted``/``private`` keep it owner-only (there is no link-token sharing
-    concept). A deleted source clip is tolerated (the release keeps its visibility).
+    locks after submission). The source clip's own ``visibility`` (US-20.7,
+    which gates non-owner audio access) is mirrored to match — ``is_public``
+    then auto-syncs on the clip's save. A deleted source clip is tolerated (the
+    release keeps its visibility).
     """
     release.visibility = visibility
     release.updated_at = utcnow()
     await release.save()
 
-    is_public = visibility == VisibilityState.PUBLIC
     clip = await clip_service.find_owned_clip(str(release.clip_id), str(release.user_id))
-    if clip is not None and clip.is_public != is_public:
-        clip.is_public = is_public
+    if clip is not None and clip.visibility != visibility:
+        clip.visibility = visibility
         await clip.save()
     return release
 

--- a/tests/test_clips_visibility_api.py
+++ b/tests/test_clips_visibility_api.py
@@ -1,0 +1,253 @@
+"""Tests for the three-state clip visibility model (US-20.7, issue #219).
+
+Extends the existing two-state ``is_public`` publish toggle (US-17.6) to a
+three-state ``visibility`` enum (private/unlisted/public) on the *existing*
+``PATCH /clips/{id}`` endpoint — no new endpoint. ``is_public`` stays a stored,
+auto-synced denormalization of ``visibility == PUBLIC`` so
+``{"is_public": True}`` Mongo queries (public listings, similarity scope) keep
+matching unchanged and legacy public clips never regress to private.
+"""
+
+import itertools
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, VisibilityState, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+CLIPS_URL = f"{API_V1_PREFIX}/clips"
+
+_SEQ = itertools.count(1)
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_missing_auth_header_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.patch(f"{CLIPS_URL}/{PydanticObjectId()}", json={"visibility": "public"})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Model unit test — no DB needed, pure Pydantic validator behavior
+# ---------------------------------------------------------------------------
+
+
+class TestVisibilityModelSync:
+    def _base_kwargs(self) -> dict:
+        return dict(
+            id=PydanticObjectId(),
+            workspace_id=PydanticObjectId(),
+            user_id=PydanticObjectId(),
+            file_path="u/w/clips/c.wav",
+        )
+
+    def test_legacy_doc_with_only_is_public_backfills_visibility(self) -> None:
+        # Simulates a pre-US-20.7 Mongo document: no "visibility" key at all.
+        clip = Clip(**self._base_kwargs(), is_public=True)
+        assert clip.visibility == VisibilityState.PUBLIC
+
+        clip = Clip(**self._base_kwargs(), is_public=False)
+        assert clip.visibility == VisibilityState.PRIVATE
+
+    def test_visibility_unlisted_forces_is_public_false(self) -> None:
+        clip = Clip(**self._base_kwargs(), visibility=VisibilityState.UNLISTED)
+        assert clip.is_public is False
+
+    def test_visibility_public_forces_is_public_true(self) -> None:
+        clip = Clip(**self._base_kwargs(), visibility=VisibilityState.PUBLIC)
+        assert clip.is_public is True
+
+    def test_visibility_wins_over_conflicting_is_public(self) -> None:
+        # visibility is the source of truth even if a caller passes a
+        # contradictory is_public alongside it.
+        clip = Clip(**self._base_kwargs(), visibility=VisibilityState.PUBLIC, is_public=False)
+        assert clip.is_public is True
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str):
+    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+
+
+async def _make_workspace(user, name: str = "WS") -> Workspace:
+    workspace = Workspace(name=name, user_id=user.id)
+    await workspace.insert()
+    return workspace
+
+
+async def _insert_clip(
+    user,
+    workspace: Workspace,
+    *,
+    title: str | None = "Ready",
+    style_tags: list[str] | None = None,
+    visibility: VisibilityState = VisibilityState.PRIVATE,
+    store_bytes: bytes | None = None,
+) -> Clip:
+    clip_id = PydanticObjectId()
+    file_path = f"{user.id}/{workspace.id}/clips/{clip_id}.wav"
+    if store_bytes is not None:
+        get_storage_backend().upload(file_path, store_bytes)
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=file_path,
+        format="wav",
+        title=title,
+        style_tags=style_tags if style_tags is not None else ["lofi"],
+        visibility=visibility,
+    )
+    await clip.insert()
+    return clip
+
+
+@pytest.mark.integration
+class TestVisibilityTransitions:
+    async def test_private_to_unlisted_to_public_to_private(self, client, settings) -> None:
+        user = await _make_user(f"vis-transitions-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace)
+        headers = _auth_headers(user, settings)
+
+        resp = await client.patch(f"{CLIPS_URL}/{clip.id}", json={"visibility": "unlisted"}, headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["visibility"] == "unlisted"
+        assert resp.json()["is_public"] is False
+        fetched = await client.get(f"{CLIPS_URL}/{clip.id}", headers=headers)
+        assert fetched.json()["visibility"] == "unlisted"
+
+        resp = await client.patch(f"{CLIPS_URL}/{clip.id}", json={"visibility": "public"}, headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["visibility"] == "public"
+        assert resp.json()["is_public"] is True
+        fetched = await client.get(f"{CLIPS_URL}/{clip.id}", headers=headers)
+        assert fetched.json()["visibility"] == "public"
+        assert fetched.json()["is_public"] is True
+
+        resp = await client.patch(f"{CLIPS_URL}/{clip.id}", json={"visibility": "private"}, headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["visibility"] == "private"
+        assert resp.json()["is_public"] is False
+        stored = await Clip.get(clip.id)
+        assert stored.visibility == VisibilityState.PRIVATE
+        assert stored.is_public is False
+
+    async def test_public_without_title_returns_422(self, client, settings) -> None:
+        user = await _make_user(f"vis-no-title-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title=None, style_tags=["lofi"])
+        headers = _auth_headers(user, settings)
+
+        resp = await client.patch(f"{CLIPS_URL}/{clip.id}", json={"visibility": "public"}, headers=headers)
+        assert resp.status_code == 422
+        assert (await Clip.get(clip.id)).visibility == VisibilityState.PRIVATE
+
+    async def test_public_without_style_tags_returns_422(self, client, settings) -> None:
+        user = await _make_user(f"vis-no-tags-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace, title="Ready", style_tags=[])
+        headers = _auth_headers(user, settings)
+
+        resp = await client.patch(f"{CLIPS_URL}/{clip.id}", json={"visibility": "public"}, headers=headers)
+        assert resp.status_code == 422
+        assert (await Clip.get(clip.id)).visibility == VisibilityState.PRIVATE
+
+    async def test_explicit_null_visibility_returns_422(self, client, settings) -> None:
+        user = await _make_user(f"vis-null-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace)
+        headers = _auth_headers(user, settings)
+
+        resp = await client.patch(f"{CLIPS_URL}/{clip.id}", json={"visibility": None}, headers=headers)
+        assert resp.status_code == 422
+
+    async def test_cross_user_patch_returns_404(self, client, settings) -> None:
+        owner = await _make_user(f"vis-owner-{next(_SEQ)}@example.com")
+        other = await _make_user(f"vis-other-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(owner)
+        clip = await _insert_clip(owner, workspace)
+
+        resp = await client.patch(
+            f"{CLIPS_URL}/{clip.id}",
+            json={"visibility": "public"},
+            headers=_auth_headers(other, settings),
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestVisibilityAudioAccess:
+    async def test_non_owner_can_get_audio_for_unlisted_clip(self, client, settings, local_storage) -> None:
+        owner = await _make_user(f"vis-audio-owner-{next(_SEQ)}@example.com")
+        stranger = await _make_user(f"vis-audio-stranger-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(owner)
+        clip = await _insert_clip(
+            owner, workspace, visibility=VisibilityState.UNLISTED, store_bytes=b"RIFF....WAVEfake"
+        )
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/audio", headers=_auth_headers(stranger, settings))
+        assert resp.status_code == 200
+
+    async def test_non_owner_gets_403_for_private_clip_audio(self, client, settings, local_storage) -> None:
+        owner = await _make_user(f"vis-audio-private-owner-{next(_SEQ)}@example.com")
+        stranger = await _make_user(f"vis-audio-private-stranger-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(owner)
+        clip = await _insert_clip(owner, workspace, visibility=VisibilityState.PRIVATE, store_bytes=b"RIFF....WAVEfake")
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/audio", headers=_auth_headers(stranger, settings))
+        assert resp.status_code == 403

--- a/tests/test_clips_visibility_api.py
+++ b/tests/test_clips_visibility_api.py
@@ -39,46 +39,72 @@ class TestAuthGate:
         assert resp.status_code == 401
 
 
+def _model_base_kwargs() -> dict:
+    return dict(
+        id=PydanticObjectId(),
+        workspace_id=PydanticObjectId(),
+        user_id=PydanticObjectId(),
+        file_path="u/w/clips/c.wav",
+    )
+
+
 # ---------------------------------------------------------------------------
-# Model unit test — no DB needed, pure Pydantic validator behavior
+# Model unit test — no DB, no Beanie init. `set_visibility` is a plain method,
+# so `model_construct` (which bypasses Beanie's collection-bound __init__) lets
+# this guard the assignment invariant even when MongoDB is unavailable.
 # ---------------------------------------------------------------------------
 
 
 class TestVisibilityModelSync:
-    def _base_kwargs(self) -> dict:
-        return dict(
-            id=PydanticObjectId(),
-            workspace_id=PydanticObjectId(),
-            user_id=PydanticObjectId(),
-            file_path="u/w/clips/c.wav",
-        )
+    def test_set_visibility_keeps_is_public_synced_on_assignment(self) -> None:
+        # The after-validator that syncs is_public does NOT fire on attribute
+        # assignment (validate_assignment is off), so writers must go through
+        # set_visibility. If they don't, the stale is_public denormalization
+        # leaks unlisted/private clips into {"is_public": True} queries.
+        clip = Clip.model_construct(visibility=VisibilityState.PUBLIC, is_public=True)
 
-    def test_legacy_doc_with_only_is_public_backfills_visibility(self) -> None:
-        # Simulates a pre-US-20.7 Mongo document: no "visibility" key at all.
-        clip = Clip(**self._base_kwargs(), is_public=True)
-        assert clip.visibility == VisibilityState.PUBLIC
-
-        clip = Clip(**self._base_kwargs(), is_public=False)
-        assert clip.visibility == VisibilityState.PRIVATE
-
-    def test_visibility_unlisted_forces_is_public_false(self) -> None:
-        clip = Clip(**self._base_kwargs(), visibility=VisibilityState.UNLISTED)
+        clip.set_visibility(VisibilityState.UNLISTED)
+        assert clip.visibility == VisibilityState.UNLISTED
         assert clip.is_public is False
 
-    def test_visibility_public_forces_is_public_true(self) -> None:
-        clip = Clip(**self._base_kwargs(), visibility=VisibilityState.PUBLIC)
+        clip.set_visibility(VisibilityState.PUBLIC)
         assert clip.is_public is True
 
-    def test_visibility_wins_over_conflicting_is_public(self) -> None:
-        # visibility is the source of truth even if a caller passes a
-        # contradictory is_public alongside it.
-        clip = Clip(**self._base_kwargs(), visibility=VisibilityState.PUBLIC, is_public=False)
-        assert clip.is_public is True
+        clip.set_visibility(VisibilityState.PRIVATE)
+        assert clip.is_public is False
 
 
 # ---------------------------------------------------------------------------
 # Integration — real MongoDB
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestVisibilityValidators:
+    """The before/after validators only run on real Pydantic construction, which
+    for a Beanie Document requires init_beanie — hence the ``mongo_db`` fixture."""
+
+    def test_legacy_doc_with_only_is_public_backfills_visibility(self, mongo_db) -> None:
+        # Simulates a pre-US-20.7 Mongo document: no "visibility" key at all.
+        clip = Clip(**_model_base_kwargs(), is_public=True)
+        assert clip.visibility == VisibilityState.PUBLIC
+
+        clip = Clip(**_model_base_kwargs(), is_public=False)
+        assert clip.visibility == VisibilityState.PRIVATE
+
+    def test_visibility_unlisted_forces_is_public_false(self, mongo_db) -> None:
+        clip = Clip(**_model_base_kwargs(), visibility=VisibilityState.UNLISTED)
+        assert clip.is_public is False
+
+    def test_visibility_public_forces_is_public_true(self, mongo_db) -> None:
+        clip = Clip(**_model_base_kwargs(), visibility=VisibilityState.PUBLIC)
+        assert clip.is_public is True
+
+    def test_visibility_wins_over_conflicting_is_public(self, mongo_db) -> None:
+        # visibility is the source of truth even if a caller passes a
+        # contradictory is_public alongside it.
+        clip = Clip(**_model_base_kwargs(), visibility=VisibilityState.PUBLIC, is_public=False)
+        assert clip.is_public is True
 
 
 def _async_client(app) -> httpx.AsyncClient:

--- a/tests/test_clips_visibility_api.py
+++ b/tests/test_clips_visibility_api.py
@@ -187,6 +187,27 @@ class TestVisibilityTransitions:
         assert stored.visibility == VisibilityState.PRIVATE
         assert stored.is_public is False
 
+    async def test_is_public_denormalization_synced_in_raw_bson(self, client, settings) -> None:
+        # Reading a clip back through Clip.get()/ClipResponse re-runs the sync
+        # validator and self-heals is_public, so it masks a stale stored value.
+        # Server-side queries (search/explore/similar) filter the raw BSON on
+        # {"is_public": True}, so the DENORMALIZATION IN STORAGE must be correct.
+        # Assert on the raw pymongo document — this is what caught set-on-assign
+        # not re-running the after-validator.
+        user = await _make_user(f"vis-raw-bson-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(user)
+        clip = await _insert_clip(user, workspace)
+        headers = _auth_headers(user, settings)
+        raw = Clip.get_pymongo_collection()
+
+        await client.patch(f"{CLIPS_URL}/{clip.id}", json={"visibility": "public"}, headers=headers)
+        doc = await raw.find_one({"_id": clip.id})
+        assert doc["visibility"] == "public" and doc["is_public"] is True
+
+        await client.patch(f"{CLIPS_URL}/{clip.id}", json={"visibility": "unlisted"}, headers=headers)
+        doc = await raw.find_one({"_id": clip.id})
+        assert doc["visibility"] == "unlisted" and doc["is_public"] is False  # not stale True
+
     async def test_public_without_title_returns_422(self, client, settings) -> None:
         user = await _make_user(f"vis-no-title-{next(_SEQ)}@example.com")
         workspace = await _make_workspace(user)

--- a/tests/test_clips_visibility_api.py
+++ b/tests/test_clips_visibility_api.py
@@ -251,3 +251,28 @@ class TestVisibilityAudioAccess:
 
         resp = await client.get(f"{CLIPS_URL}/{clip.id}/audio", headers=_auth_headers(stranger, settings))
         assert resp.status_code == 403
+
+
+@pytest.mark.integration
+class TestUnlistedAnonymousLinkAccess:
+    """AC5: an unlisted clip's direct link must open for a signed-out recipient
+    (link sharing = "not hidden"), while a private clip stays an indistinguishable
+    404. Both the anonymous metadata read and stream route through
+    ``get_clip_for_streaming``, so this exercises that shared resolver."""
+
+    async def test_anonymous_can_read_unlisted_clip_metadata(self, client) -> None:
+        owner = await _make_user(f"vis-anon-unlisted-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(owner)
+        clip = await _insert_clip(owner, workspace, visibility=VisibilityState.UNLISTED)
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/public")  # no auth header
+        assert resp.status_code == 200
+        assert resp.json()["visibility"] == "unlisted"
+
+    async def test_anonymous_gets_404_for_private_clip_metadata(self, client) -> None:
+        owner = await _make_user(f"vis-anon-private-{next(_SEQ)}@example.com")
+        workspace = await _make_workspace(owner)
+        clip = await _insert_clip(owner, workspace, visibility=VisibilityState.PRIVATE)
+
+        resp = await client.get(f"{CLIPS_URL}/{clip.id}/public")  # no auth header
+        assert resp.status_code == 404

--- a/web/components/song/SongDetail.test.tsx
+++ b/web/components/song/SongDetail.test.tsx
@@ -122,7 +122,12 @@ describe("SongDetail", () => {
     expect(screen.getByText("C minor")).toBeInTheDocument()
     // "1:35" (95s) shows in both the player time readout and the metadata.
     expect(screen.getAllByText("1:35").length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText("Private")).toBeInTheDocument()
+    // Scoped: the header's visibility badge also renders "Private" for the owner.
+    expect(
+      within(screen.getByRole("region", { name: "Details" })).getByText(
+        "Private"
+      )
+    ).toBeInTheDocument()
   })
 
   it("renders the waveform player with click-to-seek support", async () => {
@@ -142,7 +147,7 @@ describe("SongDetail", () => {
     expect(screen.getByText("Driving through the night")).toBeInTheDocument()
   })
 
-  it("exposes inline like/dislike/share/publish actions", async () => {
+  it("exposes inline like/dislike/share/visibility actions", async () => {
     stubFetch({ clip: clip() })
     renderDetail()
     await screen.findByText("Midnight Drive")
@@ -150,7 +155,7 @@ describe("SongDetail", () => {
     expect(screen.getByRole("button", { name: "Dislike" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: "Publish (make public)" })
+      screen.getByRole("button", { name: "Visibility: Private" })
     ).toBeInTheDocument()
   })
 
@@ -268,20 +273,21 @@ describe("SongDetail full action menu (US-17.2)", () => {
     ).toHaveAttribute("aria-disabled", "true")
   })
 
-  it("shares publish state between the menu and the header button", async () => {
+  it("shares publish state between the menu and the header visibility toggle", async () => {
     stubFetch({ clip: clip() })
     renderDetail()
     await openActions()
     await userEvent.click(screen.getByRole("menuitem", { name: /publish/i }))
 
     expect(
-      screen.getByRole("button", { name: "Unpublish (make private)" })
+      screen.getByRole("button", { name: "Visibility: Public" })
     ).toBeInTheDocument()
 
-    // And the other direction: the header button updates the menu label.
+    // And the other direction: the header toggle updates the menu label.
     await userEvent.click(
-      screen.getByRole("button", { name: "Unpublish (make private)" })
+      screen.getByRole("button", { name: "Visibility: Public" })
     )
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Private" }))
     await openActions()
     expect(screen.getByRole("menuitem", { name: /^publish$/i })).toBeInTheDocument()
   })
@@ -406,10 +412,7 @@ describe("SongDetail (public link)", () => {
     await screen.findByText("Midnight Drive")
 
     expect(
-      screen.queryByRole("button", { name: /publish \(make public\)/i })
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: /unpublish/i })
+      screen.queryByRole("button", { name: /visibility/i })
     ).not.toBeInTheDocument()
     expect(
       screen.queryByRole("button", { name: /song actions menu/i })
@@ -427,7 +430,7 @@ describe("SongDetail (public link)", () => {
     await screen.findByText("Midnight Drive")
 
     expect(
-      screen.getByRole("button", { name: /unpublish/i })
+      screen.getByRole("button", { name: "Visibility: Public" })
     ).toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: /song actions menu/i })

--- a/web/components/song/SongDetail.tsx
+++ b/web/components/song/SongDetail.tsx
@@ -81,9 +81,9 @@ function SongDetailContent({ clip }: { clip: Clip }) {
       <main className="flex min-w-0 flex-1 flex-col gap-6">
         <SongHeader
           clip={clip}
-          isPublic={actions.isPublic}
+          visibility={actions.visibility}
           isOwner={isOwner}
-          onPublishToggle={actions.togglePublish}
+          onVisibilityChange={(_id, next) => actions.setVisibility(next)}
           // Every item in the menu acts on the clip (edit, remix, publish,
           // delete), so a visitor gets no menu at all rather than a shell of
           // disabled rows. Like/Dislike/Share stay — anyone can re-share a link.

--- a/web/components/song/SongHeader.test.tsx
+++ b/web/components/song/SongHeader.test.tsx
@@ -58,49 +58,48 @@ describe("SongHeader", () => {
     ).toHaveAttribute("aria-pressed", "true")
   })
 
-  it("optimistically toggles publish and emits the callback", async () => {
+  it("optimistically changes visibility and emits the callback", async () => {
     const user = userEvent.setup()
-    const onPublishToggle = vi.fn()
-    renderHeader({ isOwner: true, onPublishToggle })
+    const onVisibilityChange = vi.fn()
+    renderHeader({ isOwner: true, onVisibilityChange })
     await user.click(
-      screen.getByRole("button", { name: "Publish (make public)" })
+      screen.getByRole("button", { name: "Visibility: Private" })
     )
-    expect(onPublishToggle).toHaveBeenCalledWith("c1", true)
+    await user.click(screen.getByRole("menuitemradio", { name: "Public" }))
+    expect(onVisibilityChange).toHaveBeenCalledWith("c1", "public")
     expect(
-      screen.getByRole("button", { name: "Unpublish (make private)" })
+      screen.getByRole("button", { name: "Visibility: Public" })
     ).toBeInTheDocument()
   })
 
-  it("toggles publish inline even without a callback (no persisting parent)", async () => {
+  it("changes visibility inline even without a callback (no persisting parent)", async () => {
     const user = userEvent.setup()
     renderHeader({ isOwner: true })
     await user.click(
-      screen.getByRole("button", { name: "Publish (make public)" })
+      screen.getByRole("button", { name: "Visibility: Private" })
     )
+    await user.click(screen.getByRole("menuitemradio", { name: "Unlisted" }))
     expect(
-      screen.getByRole("button", { name: "Unpublish (make private)" })
-    ).toHaveAttribute("aria-pressed", "true")
+      screen.getByRole("button", { name: "Visibility: Unlisted" })
+    ).toBeInTheDocument()
   })
 
-  it("hides the publish toggle from a non-owner, keeping like/dislike/share", () => {
+  it("hides the visibility toggle from a non-owner, keeping like/dislike/share", () => {
     renderHeader({ isOwner: false })
     expect(
-      screen.queryByRole("button", { name: /publish \(make public\)/i })
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: /unpublish/i })
+      screen.queryByRole("button", { name: /visibility/i })
     ).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Like" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Dislike" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
   })
 
-  it("fails closed: an omitted isOwner hides the publish toggle", () => {
+  it("fails closed: an omitted isOwner hides the visibility toggle", () => {
     // The header renders on a public page (US-20.0), so a caller that forgets
     // the prop must not hand a stranger a control over someone else's clip.
     renderHeader()
     expect(
-      screen.queryByRole("button", { name: /publish \(make public\)/i })
+      screen.queryByRole("button", { name: /visibility/i })
     ).not.toBeInTheDocument()
   })
 

--- a/web/components/song/SongHeader.tsx
+++ b/web/components/song/SongHeader.tsx
@@ -2,39 +2,37 @@
 
 import { useMemo, useState, type ReactNode } from "react"
 import { HugeiconsIcon } from "@hugeicons/react"
-import {
-  FavouriteIcon,
-  GlobeIcon,
-  Share01Icon,
-  ThumbsDownIcon,
-} from "@hugeicons/core-free-icons"
+import { FavouriteIcon, Share01Icon, ThumbsDownIcon } from "@hugeicons/core-free-icons"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { ShareModal } from "@/components/song/ShareModal"
+import { VisibilityBadge } from "@/components/song/VisibilityBadge"
+import { VisibilityToggle } from "@/components/song/VisibilityToggle"
 import { usePlayer } from "@/contexts/player-context"
 import { modeLabel, versionLabel } from "@/lib/clip-labels"
 import { cn } from "@/lib/utils"
-import type { Clip } from "@/lib/workspace-clips"
+import { visibilityOf, type Clip, type Visibility } from "@/lib/workspace-clips"
 
-// Song-detail header (US-17.1 / US-17.6): title, artist, style/version/mode
-// badges, and the inline Like / Dislike / Share / Publish controls. Like and
-// Dislike are wired to the global player store (persisted in localStorage, so
-// they survive a reload — as in ClipCard). Share opens the ShareModal. Publish
-// is prop-driven: SongDetail passes the persisted `isPublic` + a `onPublishToggle`
-// that hits the API with a guard; standalone it falls back to a local optimistic
-// toggle. `onDislike`/`onShare` remain optional observers.
+// Song-detail header (US-17.1 / US-17.6, tri-state in US-20.7): title, artist,
+// style/version/mode/visibility badges, and the inline Like / Dislike / Share /
+// Visibility controls. Like and Dislike are wired to the global player store
+// (persisted in localStorage, so they survive a reload — as in ClipCard). Share
+// opens the ShareModal. The visibility picker is prop-driven: SongDetail passes
+// the persisted `visibility` + an `onVisibilityChange` that hits the API with a
+// guard (only reachable going "public"); standalone it falls back to a local
+// optimistic toggle. `onDislike`/`onShare` remain optional observers.
 
 export type SongHeaderProps = {
   clip: Clip
   onDislike?: (id: string) => void
   onShare?: (id: string) => void
-  onPublishToggle?: (id: string, next: boolean) => void
+  onVisibilityChange?: (id: string, next: Visibility) => void
   /**
-   * Controlled visibility. When the parent owns publish state (US-17.2's
+   * Controlled visibility. When the parent owns visibility state (US-17.2's
    * action menu shares it), this wins over the local optimistic toggle.
    */
-  isPublic?: boolean
+  visibility?: Visibility
   /**
    * Whether the viewer owns this clip (US-20.0). Only the owner may change
    * visibility, so the Publish toggle is hidden otherwise. Defaults to **false**:
@@ -51,8 +49,8 @@ export function SongHeader({
   clip,
   onDislike,
   onShare,
-  onPublishToggle,
-  isPublic: isPublicProp,
+  onVisibilityChange,
+  visibility: visibilityProp,
   isOwner = false,
   actions,
 }: SongHeaderProps) {
@@ -61,9 +59,11 @@ export function SongHeader({
   const dislikedSet = useMemo(() => new Set(state.dislikedIds), [state.dislikedIds])
   const liked = likedSet.has(clip.id)
   const disliked = dislikedSet.has(clip.id)
-  const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
+  const [optimisticVisibility, setOptimisticVisibility] = useState<Visibility | null>(
+    null
+  )
   const [shareOpen, setShareOpen] = useState(false)
-  const isPublic = isPublicProp ?? optimisticPublic ?? clip.is_public
+  const visibility = visibilityProp ?? optimisticVisibility ?? visibilityOf(clip)
 
   const version = versionLabel(clip.model)
   const mode = modeLabel(clip.generation_mode)
@@ -78,14 +78,13 @@ export function SongHeader({
     onShare?.(clip.id)
   }
 
-  function togglePublish() {
-    const next = !isPublic
-    onPublishToggle?.(clip.id, next)
-    // When wired via SongDetail, `isPublic` is controlled by useSongActions
+  function changeVisibility(next: Visibility) {
+    onVisibilityChange?.(clip.id, next)
+    // When wired via SongDetail, `visibility` is controlled by useSongActions
     // (which persists + guards + rolls back), so this local flip is shadowed and
     // the hook owns the visible state. It only takes effect for a standalone,
-    // uncontrolled SongHeader (no isPublic prop) as immediate local feedback.
-    setOptimisticPublic(next)
+    // uncontrolled SongHeader (no visibility prop) as immediate local feedback.
+    setOptimisticVisibility(next)
   }
 
   return (
@@ -98,17 +97,16 @@ export function SongHeader({
         <p className="text-sm text-muted-foreground">Unknown artist</p>
       </div>
 
-      {(version || mode || clip.style_tags.length > 0) && (
-        <div className="flex flex-wrap items-center gap-1">
-          {version && <Badge variant="secondary">{version}</Badge>}
-          {mode && <Badge variant="outline">{mode}</Badge>}
-          {clip.style_tags.map((tag) => (
-            <Badge key={tag} variant="outline">
-              {tag}
-            </Badge>
-          ))}
-        </div>
-      )}
+      <div className="flex flex-wrap items-center gap-1">
+        {version && <Badge variant="secondary">{version}</Badge>}
+        {mode && <Badge variant="outline">{mode}</Badge>}
+        {clip.style_tags.map((tag) => (
+          <Badge key={tag} variant="outline">
+            {tag}
+          </Badge>
+        ))}
+        {isOwner && <VisibilityBadge visibility={visibility} />}
+      </div>
 
       <div className="flex flex-wrap items-center gap-1">
         <Button
@@ -144,16 +142,7 @@ export function SongHeader({
           <HugeiconsIcon icon={Share01Icon} size={18} />
         </Button>
         {isOwner && (
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            aria-label={isPublic ? "Unpublish (make private)" : "Publish (make public)"}
-            aria-pressed={isPublic}
-            onClick={togglePublish}
-            className={cn(isPublic && "text-primary")}
-          >
-            <HugeiconsIcon icon={GlobeIcon} size={18} />
-          </Button>
+          <VisibilityToggle value={visibility} onChange={changeVisibility} />
         )}
         {actions && <div className="ml-auto">{actions}</div>}
       </div>

--- a/web/components/song/SongMetadata.test.tsx
+++ b/web/components/song/SongMetadata.test.tsx
@@ -46,6 +46,11 @@ describe("SongMetadata", () => {
     expect(screen.getByText("Public")).toBeInTheDocument()
   })
 
+  it("shows the three-state visibility label, including Unlisted", () => {
+    render(<SongMetadata clip={clip({ visibility: "unlisted", is_public: false })} />)
+    expect(screen.getByText("Unlisted")).toBeInTheDocument()
+  })
+
   it("omits null fields instead of rendering blanks", () => {
     render(<SongMetadata clip={clip({ bpm: null, key: null, model: null })} />)
     expect(screen.queryByText("BPM")).not.toBeInTheDocument()

--- a/web/components/song/SongMetadata.tsx
+++ b/web/components/song/SongMetadata.tsx
@@ -2,7 +2,7 @@
 
 import { versionLabel } from "@/lib/clip-labels"
 import { formatTime } from "@/lib/clips"
-import type { Clip } from "@/lib/workspace-clips"
+import { type Clip, visibilityOf } from "@/lib/workspace-clips"
 
 // Song-detail metadata panel (US-17.1): the clip's display fields. Only fields
 // the backend ClipResponse actually carries are shown; null values are skipped
@@ -31,7 +31,8 @@ export function SongMetadata({ clip }: { clip: Clip }) {
   if (clip.duration != null)
     rows.push({ label: "Duration", value: formatTime(clip.duration) })
   rows.push({ label: "Created", value: formatDate(clip.created_at) })
-  rows.push({ label: "Visibility", value: clip.is_public ? "Public" : "Private" })
+  const vis = visibilityOf(clip)
+  rows.push({ label: "Visibility", value: vis[0].toUpperCase() + vis.slice(1) })
 
   return (
     <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-3">

--- a/web/components/song/VisibilityBadge.test.tsx
+++ b/web/components/song/VisibilityBadge.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { VisibilityBadge } from "@/components/song/VisibilityBadge"
+
+describe("VisibilityBadge", () => {
+  it("labels each visibility state", () => {
+    const { rerender } = render(<VisibilityBadge visibility="private" />)
+    expect(screen.getByText("Private")).toBeInTheDocument()
+
+    rerender(<VisibilityBadge visibility="unlisted" />)
+    expect(screen.getByText("Unlisted")).toBeInTheDocument()
+
+    rerender(<VisibilityBadge visibility="public" />)
+    expect(screen.getByText("Public")).toBeInTheDocument()
+  })
+})

--- a/web/components/song/VisibilityBadge.tsx
+++ b/web/components/song/VisibilityBadge.tsx
@@ -1,0 +1,28 @@
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react"
+import { GlobeIcon, LinkIcon, LockIcon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import type { Visibility } from "@/lib/workspace-clips"
+
+// US-20.7: read-only visibility indicator shown alongside a clip's other
+// metadata badges (version, mode, style tags).
+
+const CONFIG: Record<Visibility, { label: string; icon: IconSvgElement }> = {
+  private: { label: "Private", icon: LockIcon },
+  unlisted: { label: "Unlisted", icon: LinkIcon },
+  public: { label: "Public", icon: GlobeIcon },
+}
+
+export type VisibilityBadgeProps = {
+  visibility: Visibility
+}
+
+export function VisibilityBadge({ visibility }: VisibilityBadgeProps) {
+  const { label, icon } = CONFIG[visibility]
+  return (
+    <Badge variant="outline" className="text-[10px]">
+      <HugeiconsIcon icon={icon} size={12} />
+      {label}
+    </Badge>
+  )
+}

--- a/web/components/song/VisibilityToggle.test.tsx
+++ b/web/components/song/VisibilityToggle.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { VisibilityToggle } from "@/components/song/VisibilityToggle"
+
+describe("VisibilityToggle", () => {
+  it("shows the current state's icon and label on the trigger", () => {
+    render(<VisibilityToggle value="unlisted" onChange={vi.fn()} />)
+    expect(
+      screen.getByRole("button", { name: "Visibility: Unlisted" })
+    ).toBeInTheDocument()
+  })
+
+  it("lists all three options and marks the current one selected", async () => {
+    render(<VisibilityToggle value="private" onChange={vi.fn()} />)
+    await userEvent.click(
+      screen.getByRole("button", { name: /visibility: private/i })
+    )
+    const privateItem = screen.getByRole("menuitemradio", { name: "Private" })
+    expect(privateItem).toHaveAttribute("aria-checked", "true")
+    expect(
+      screen.getByRole("menuitemradio", { name: "Unlisted" })
+    ).toHaveAttribute("aria-checked", "false")
+    expect(
+      screen.getByRole("menuitemradio", { name: "Public" })
+    ).toHaveAttribute("aria-checked", "false")
+  })
+
+  it("calls onChange with the selected option", async () => {
+    const onChange = vi.fn()
+    render(<VisibilityToggle value="private" onChange={onChange} />)
+    await userEvent.click(
+      screen.getByRole("button", { name: /visibility: private/i })
+    )
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Public" }))
+    expect(onChange).toHaveBeenCalledWith("public")
+  })
+
+  it("disables the trigger when disabled", () => {
+    render(<VisibilityToggle value="private" onChange={vi.fn()} disabled />)
+    expect(screen.getByRole("button", { name: /visibility/i })).toBeDisabled()
+  })
+})

--- a/web/components/song/VisibilityToggle.tsx
+++ b/web/components/song/VisibilityToggle.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react"
+import { GlobeIcon, LinkIcon, LockIcon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import type { Visibility } from "@/lib/workspace-clips"
+
+// US-20.7: Private/Unlisted/Public picker, replacing the two-state publish
+// toggle (US-17.6). Built on the same dropdown-menu radio primitive as
+// SortDropdown — the auto check indicator marks the current selection.
+
+const ORDER: Visibility[] = ["private", "unlisted", "public"]
+
+const CONFIG: Record<Visibility, { label: string; icon: IconSvgElement }> = {
+  private: { label: "Private", icon: LockIcon },
+  unlisted: { label: "Unlisted", icon: LinkIcon },
+  public: { label: "Public", icon: GlobeIcon },
+}
+
+export type VisibilityToggleProps = {
+  value: Visibility
+  onChange: (next: Visibility) => void
+  disabled?: boolean
+}
+
+export function VisibilityToggle({
+  value,
+  onChange,
+  disabled = false,
+}: VisibilityToggleProps) {
+  const current = CONFIG[value]
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label={`Visibility: ${current.label}`}
+          disabled={disabled}
+          className={cn(value === "public" && "text-primary")}
+        >
+          <HugeiconsIcon icon={current.icon} size={16} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={value}
+          onValueChange={(v) => onChange(v as Visibility)}
+        >
+          {ORDER.map((v) => (
+            <DropdownMenuRadioItem key={v} value={v}>
+              <HugeiconsIcon icon={CONFIG[v].icon} size={14} />
+              {CONFIG[v].label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/components/workspace/ClipCard.test.tsx
+++ b/web/components/workspace/ClipCard.test.tsx
@@ -175,36 +175,72 @@ describe("ClipCard", () => {
     expect(onShare).toHaveBeenCalledWith("c1")
   })
 
-  it("publishes a ready clip, persisting via the PATCH proxy", async () => {
+  it("shows the current visibility as a badge", () => {
+    renderCard()
+    expect(screen.getByText("Private")).toBeInTheDocument()
+  })
+
+  it("changes visibility to public for a ready clip, persisting via the PATCH proxy", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "c1", visibility: "public" }), {
+          status: 200,
+        })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+    const onVisibilityChange = vi.fn()
+    renderCard({ onVisibilityChange })
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Visibility: Private" })
+    )
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Public" }))
+
+    expect(onVisibilityChange).toHaveBeenCalledWith("c1", "public")
+    await waitFor(() =>
+      expect(screen.getByText("Public")).toBeInTheDocument()
+    )
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/clips/c1")
+    expect(opts.method).toBe("PATCH")
+    expect(JSON.parse(opts.body as string)).toEqual({
+      visibility: "public",
+    })
+    vi.unstubAllGlobals()
+  })
+
+  it("changes visibility to unlisted without a guard, even on an incomplete clip", async () => {
     const fetchMock = vi.fn(() =>
       Promise.resolve(
-        new Response(JSON.stringify({ id: "c1", is_public: true }), {
+        new Response(JSON.stringify({ id: "c1", visibility: "unlisted" }), {
           status: 200,
         })
       )
     )
     vi.stubGlobal("fetch", fetchMock)
-    const onPublishToggle = vi.fn()
-    renderCard({ onPublishToggle })
+    render(
+      <AllProviders>
+        <ClipCard clip={clip({ title: null, style_tags: [] })} />
+      </AllProviders>
+    )
 
-    const publish = screen.getByRole("button", { name: /publish|make public/i })
-    expect(publish).toHaveAttribute("aria-pressed", "false")
-    await userEvent.click(publish)
+    await userEvent.click(
+      screen.getByRole("button", { name: "Visibility: Private" })
+    )
+    await userEvent.click(
+      screen.getByRole("menuitemradio", { name: "Unlisted" })
+    )
 
-    expect(onPublishToggle).toHaveBeenCalledWith("c1", true)
     await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: /unpublish|make private/i })
-      ).toHaveAttribute("aria-pressed", "true")
+      expect(screen.getByText("Unlisted")).toBeInTheDocument()
     )
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/clips/c1",
-      expect.objectContaining({ method: "PATCH" })
-    )
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalled()
     vi.unstubAllGlobals()
   })
 
-  it("prompts instead of publishing an incomplete clip", async () => {
+  it("prompts instead of publishing an incomplete clip, without a PATCH", async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal("fetch", fetchMock)
     render(
@@ -213,8 +249,10 @@ describe("ClipCard", () => {
       </AllProviders>
     )
     await userEvent.click(
-      screen.getByRole("button", { name: /publish|make public/i })
+      screen.getByRole("button", { name: "Visibility: Private" })
     )
+    await userEvent.click(screen.getByRole("menuitemradio", { name: "Public" }))
+
     expect(await screen.findByRole("dialog")).toHaveTextContent(
       /before publishing/i
     )

--- a/web/components/workspace/ClipCard.tsx
+++ b/web/components/workspace/ClipCard.tsx
@@ -7,7 +7,6 @@ import {
   Delete02Icon,
   Edit02Icon,
   FavouriteIcon,
-  GlobeIcon,
   LockIcon,
   MoreHorizontalIcon,
   MusicNote01Icon,
@@ -33,6 +32,8 @@ import { DeleteSongDialog } from "@/components/song/DeleteSongDialog"
 import { PublishGuardPrompt } from "@/components/song/PublishGuardPrompt"
 import { ShareModal } from "@/components/song/ShareModal"
 import { SongActionModal } from "@/components/song/SongActionModal"
+import { VisibilityBadge } from "@/components/song/VisibilityBadge"
+import { VisibilityToggle } from "@/components/song/VisibilityToggle"
 import { usePlayer } from "@/contexts/player-context"
 import { useSongActions } from "@/hooks/use-song-actions"
 import { setClipDragData, setDragTrackType } from "@/lib/clip-drag"
@@ -41,16 +42,18 @@ import { modeLabel, versionLabel } from "@/lib/clip-labels"
 import { formatTime, trackFromClip } from "@/lib/clips"
 import { isFullSongEligible } from "@/lib/song-structure"
 import { cn } from "@/lib/utils"
-import type { Clip } from "@/lib/workspace-clips"
+import type { Clip, Visibility } from "@/lib/workspace-clips"
 
 // US-16.6 / US-17.5 / US-17.6: the reusable clip card. Play, Like and Dislike are
 // wired to the global player store (Like/Dislike persist in localStorage). Share
-// opens the ShareModal; Publish persists through useSongActions (guarded — needs a
-// title + a style tag to go public). The ⋯ menu and Remix CTA also dispatch
-// through useSongActions (US-17.5) — the same registry-driven seam the song-detail
-// menu uses — so any action opens its modal, navigates, downloads, publishes, or
-// confirms a delete wherever a card is rendered. `onDislike`/`onShare`/
-// `onPublishToggle` remain optional observers for parent analytics/refetch.
+// opens the ShareModal; the visibility picker (US-20.7, née the two-state Publish
+// toggle) persists through useSongActions (guarded — needs a title + a style tag
+// to go public; private/unlisted are ungated). The ⋯ menu and Remix CTA also
+// dispatch through useSongActions (US-17.5) — the same registry-driven seam the
+// song-detail menu uses — so any action opens its modal, navigates, downloads,
+// changes visibility, or confirms a delete wherever a card is rendered.
+// `onDislike`/`onShare`/`onVisibilityChange` remain optional observers for
+// parent analytics/refetch.
 // The action vocabulary lives in lib/song-actions (US-17.2) and is re-exported
 // here so existing imports keep working. The card is also a native HTML5 drag
 // source (US-19.1): dragging it onto a Studio track lane carries an "add"
@@ -72,8 +75,8 @@ export type ClipCardProps = {
   onGetFullSong?: (id: string) => void
   onDislike?: (id: string) => void
   onShare?: (id: string) => void
-  /** Publish toggle; `next` is the requested visibility. */
-  onPublishToggle?: (id: string, next: boolean) => void
+  /** Visibility picker (US-20.7); `next` is the requested tri-state value. */
+  onVisibilityChange?: (id: string, next: Visibility) => void
   /** Free-tier users see Pro-only menu items locked (badge + lock, disabled). */
   isFreeTier?: boolean
   /** Called after this clip is deleted so the list can drop the card. */
@@ -120,7 +123,7 @@ export function ClipCard({
   onGetFullSong,
   onDislike,
   onShare,
-  onPublishToggle,
+  onVisibilityChange,
   isFreeTier = false,
   onDeleted,
 }: ClipCardProps) {
@@ -146,8 +149,8 @@ export function ClipCard({
   // sync with parent/refetch updates while still reflecting the user's own edit.
   const [optimisticTitle, setOptimisticTitle] = useState<string | null>(null)
   const title = optimisticTitle ?? clip.title
-  // Publish visibility is owned by useSongActions (optimistic + persisted + rollback).
-  const isPublic = actions.isPublic
+  // Visibility is owned by useSongActions (optimistic + persisted + rollback).
+  const visibility = actions.visibility
 
   const version = versionLabel(clip.model)
   const metadataLabel = modeLabel(clip.generation_mode)
@@ -193,12 +196,11 @@ export function ClipCard({
     onShare?.(clip.id)
   }
 
-  function togglePublish() {
-    const next = !isPublic
-    onPublishToggle?.(clip.id, next) // optional observer
+  function changeVisibility(next: Visibility) {
+    onVisibilityChange?.(clip.id, next) // optional observer
     // Persist + guard (needs a title + style tag to go public); optimistic with
     // rollback lives in useSongActions.
-    actions.togglePublish(clip.id, next)
+    actions.setVisibility(next)
   }
 
   return (
@@ -287,20 +289,19 @@ export function ClipCard({
         )}
 
         {/* Badges. */}
-        {(version || metadataLabel) && (
-          <div className="flex flex-wrap items-center gap-1">
-            {version && (
-              <Badge variant="secondary" className="text-[10px]">
-                {version}
-              </Badge>
-            )}
-            {metadataLabel && (
-              <Badge variant="outline" className="text-[10px]">
-                {metadataLabel}
-              </Badge>
-            )}
-          </div>
-        )}
+        <div className="flex flex-wrap items-center gap-1">
+          {version && (
+            <Badge variant="secondary" className="text-[10px]">
+              {version}
+            </Badge>
+          )}
+          {metadataLabel && (
+            <Badge variant="outline" className="text-[10px]">
+              {metadataLabel}
+            </Badge>
+          )}
+          <VisibilityBadge visibility={visibility} />
+        </div>
 
         {/* Style description (full text on hover via title attr). */}
         {styleText && (
@@ -346,18 +347,7 @@ export function ClipCard({
           >
             <HugeiconsIcon icon={Share01Icon} size={16} />
           </Button>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            aria-label={
-              isPublic ? "Unpublish (make private)" : "Publish (make public)"
-            }
-            aria-pressed={isPublic}
-            onClick={togglePublish}
-            className={cn(isPublic && "text-primary")}
-          >
-            <HugeiconsIcon icon={GlobeIcon} size={16} />
-          </Button>
+          <VisibilityToggle value={visibility} onChange={changeVisibility} />
 
           {showFullSong && (
             <Button

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -153,7 +153,7 @@ describe("useSongActions", () => {
       const [url, opts] = fetchMock.mock.calls[0]
       expect(url).toBe("/api/clips/c1")
       expect(opts.method).toBe("PATCH")
-      expect(JSON.parse(opts.body as string)).toEqual({ is_public: true })
+      expect(JSON.parse(opts.body as string)).toEqual({ visibility: "public" })
       expect(result.current.publishGuard).toBeNull()
     })
 
@@ -242,8 +242,44 @@ describe("useSongActions", () => {
       await waitFor(() => expect(result.current.isPublic).toBe(false))
       expect(result.current.publishGuard).toBeNull()
       expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
-        is_public: false,
+        visibility: "private",
       })
+    })
+  })
+
+  describe("visibility picker (US-20.7)", () => {
+    it("sets unlisted without guarding, even on an incomplete clip", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: "c1", visibility: "unlisted" }), {
+          status: 200,
+        })
+      )
+      vi.stubGlobal("fetch", fetchMock)
+      const { result } = setup(clip({ title: null, style_tags: [] }))
+      expect(result.current.visibility).toBe("private")
+
+      await act(async () => {
+        result.current.setVisibility("unlisted")
+      })
+      await waitFor(() => expect(result.current.visibility).toBe("unlisted"))
+      expect(result.current.publishGuard).toBeNull()
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({
+        visibility: "unlisted",
+      })
+    })
+
+    it("guards going public but not going unlisted, for the same incomplete clip", async () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal("fetch", fetchMock)
+      const { result } = setup(clip({ title: null, style_tags: [] }))
+
+      act(() => void result.current.setVisibility("public"))
+      expect(result.current.publishGuard).toEqual({
+        missingTitle: true,
+        missingStyleTags: true,
+      })
+      expect(result.current.visibility).toBe("private")
+      expect(fetchMock).not.toHaveBeenCalled()
     })
   })
 

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -12,12 +12,13 @@ import {
 } from "@/lib/clips"
 import { submitRemaster } from "@/lib/editing"
 import { findSongAction, type SongActionId } from "@/lib/song-actions"
-import type { Clip } from "@/lib/workspace-clips"
+import { visibilityOf, type Clip, type Visibility } from "@/lib/workspace-clips"
 
 // US-17.2: dispatch for the full action menu. Routes a selected action to its
 // workflow: navigation (editor/studio), a workflow modal (content lands in
 // US-17.3+), a file download, or an inline operation (the US-17.6 publish
-// toggle — optimistic with real persistence + rollback — and delete).
+// toggle, extended to the tri-state Private/Unlisted/Public picker in
+// US-20.7 — optimistic with real persistence + rollback — and delete).
 
 /** Which publish requirements a clip is missing, for the guard prompt (US-17.6). */
 export type PublishGuard = {
@@ -57,12 +58,16 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
-  const [optimisticPublic, setOptimisticPublic] = useState<boolean | null>(null)
-  // Set when a publish is blocked (client guard) or rejected (server 422); drives
-  // the PublishGuardPrompt. Null means no prompt.
+  const [optimisticVisibility, setOptimisticVisibility] = useState<Visibility | null>(
+    null
+  )
+  // Set when going public is blocked (client guard) or rejected (server 422);
+  // drives the PublishGuardPrompt. Null means no prompt. Unlisted has no
+  // requirements, so it never sets this.
   const [publishGuard, setPublishGuard] = useState<PublishGuard | null>(null)
 
-  const isPublic = optimisticPublic ?? clip.is_public
+  const visibility = optimisticVisibility ?? visibilityOf(clip)
+  const isPublic = visibility === "public"
 
   function handleAction(action: SongActionId) {
     const workflow = findSongAction(action)?.workflow
@@ -104,7 +109,7 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
         accessToken
       )
     } else if (action === "publish-toggle") {
-      void doPublish(!isPublic)
+      void setVisibility(isPublic ? "private" : "public")
     } else if (action === "delete") {
       // Start the confirmation clean — actionError is shared with the download
       // flow, so a prior download failure must not show up in this dialog.
@@ -114,26 +119,28 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
   }
 
   /**
-   * Publish/unpublish the clip with optimistic UI and rollback (US-17.6).
-   * Going public is guarded client-side (needs a title + a style tag) so the
-   * prompt shows before any request; a server 422 (fields changed since load)
-   * rolls back and prompts too. Other failures roll back and surface an error.
+   * Change the clip's visibility with optimistic UI and rollback (US-17.6,
+   * tri-state in US-20.7). Only going "public" is guarded client-side (needs
+   * a title + a style tag), so the prompt shows before any request; a server
+   * 422 (fields changed since load) rolls back and prompts too. Private and
+   * unlisted have no requirements. Other failures roll back and surface an
+   * error.
    */
-  async function doPublish(next: boolean) {
+  async function setVisibility(next: Visibility) {
     if (!accessToken) return
-    if (next) {
+    if (next === "public") {
       const guard = publishGuardFor(clip)
       if (guard) {
         setPublishGuard(guard)
         return
       }
     }
-    const prev = isPublic
-    setOptimisticPublic(next)
+    const prev = visibility
+    setOptimisticVisibility(next)
     setActionError(null)
     const result = await updateClipVisibility(clip.id, next, accessToken)
     if (!result.ok) {
-      setOptimisticPublic(prev) // rollback
+      setOptimisticVisibility(prev) // rollback
       // Prefer the client-side guard prompt, which names the missing fields.
       // But a server 422 can win a race where local `clip` still looks ready
       // (fields changed since load); recomputing the guard would then be
@@ -177,6 +184,9 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
   }
 
   return {
+    /** Tri-state visibility (US-20.7): "private" | "unlisted" | "public". */
+    visibility,
+    /** Back-compat derived flag: `visibility === "public"`. */
     isPublic,
     /** One-click remaster lifecycle (US-17.3); drives the inline progress line. */
     remasterState: remaster.state,
@@ -195,8 +205,14 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
     actionError,
     clearActionError: () => setActionError(null),
     handleAction,
-    /** SongHeader/ClipCard-compatible publish callback (id, next). Persists. */
-    togglePublish: (_id: string, next: boolean) => void doPublish(next),
+    /** Set the clip's visibility directly (US-20.7 picker). Persists + guards. */
+    setVisibility,
+    /**
+     * Back-compat two-state callback (SongHeader/ClipCard's old boolean
+     * shape). Maps `next` onto "public"/"private" via `setVisibility`.
+     */
+    togglePublish: (_id: string, next: boolean) =>
+      void setVisibility(next ? "public" : "private"),
     /** Non-null while the publish guard prompt should show; names what's missing. */
     publishGuard,
     dismissPublishGuard: () => setPublishGuard(null),

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -207,12 +207,6 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
     handleAction,
     /** Set the clip's visibility directly (US-20.7 picker). Persists + guards. */
     setVisibility,
-    /**
-     * Back-compat two-state callback (SongHeader/ClipCard's old boolean
-     * shape). Maps `next` onto "public"/"private" via `setVisibility`.
-     */
-    togglePublish: (_id: string, next: boolean) =>
-      void setVisibility(next ? "public" : "private"),
     /** Non-null while the publish guard prompt should show; names what's missing. */
     publishGuard,
     dismissPublishGuard: () => setPublishGuard(null),

--- a/web/lib/clips.test.ts
+++ b/web/lib/clips.test.ts
@@ -45,24 +45,41 @@ describe("updateClipVisibility", () => {
     vi.unstubAllGlobals()
   })
 
-  it("PATCHes the BFF route with the token and is_public body", async () => {
+  it("PATCHes the BFF route with the token and a visibility body", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(
-        new Response(JSON.stringify({ id: "c1", is_public: true }), {
+        new Response(JSON.stringify({ id: "c1", visibility: "public" }), {
           status: 200,
         })
       )
     vi.stubGlobal("fetch", fetchMock)
 
-    const result = await updateClipVisibility("c1", true, "tok")
-    expect(result).toEqual({ ok: true, isPublic: true })
+    const result = await updateClipVisibility("c1", "public", "tok")
+    expect(result).toEqual({ ok: true, visibility: "public" })
 
     const [url, opts] = fetchMock.mock.calls[0]
     expect(url).toBe("/api/clips/c1")
     expect(opts.method).toBe("PATCH")
     expect(opts.headers.authorization).toBe("Bearer tok")
-    expect(JSON.parse(opts.body)).toEqual({ is_public: true })
+    expect(JSON.parse(opts.body)).toEqual({ visibility: "public" })
+  })
+
+  it("PATCHes with the unlisted visibility", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ id: "c1", visibility: "unlisted" }), {
+          status: 200,
+        })
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await updateClipVisibility("c1", "unlisted", "tok")
+    expect(result).toEqual({ ok: true, visibility: "unlisted" })
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      visibility: "unlisted",
+    })
   })
 
   it("flags a 422 as a guard failure and carries the detail message", async () => {
@@ -75,7 +92,7 @@ describe("updateClipVisibility", () => {
         )
       )
     )
-    const result = await updateClipVisibility("c1", true, "tok")
+    const result = await updateClipVisibility("c1", "public", "tok")
     expect(result).toEqual({
       ok: false,
       guardFailed: true,
@@ -88,13 +105,13 @@ describe("updateClipVisibility", () => {
       "fetch",
       vi.fn().mockResolvedValue(new Response("{}", { status: 500 }))
     )
-    const result = await updateClipVisibility("c1", true, "tok")
+    const result = await updateClipVisibility("c1", "public", "tok")
     expect(result).toMatchObject({ ok: false, guardFailed: false })
   })
 
   it("returns a non-guard error when the request throws", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("net down")))
-    const result = await updateClipVisibility("c1", false, "tok")
+    const result = await updateClipVisibility("c1", "private", "tok")
     expect(result).toMatchObject({ ok: false, guardFailed: false })
   })
 })

--- a/web/lib/clips.ts
+++ b/web/lib/clips.ts
@@ -9,6 +9,8 @@
 // proxy route behind it, so cover art does not load. Left as-is — US-20.0 needs
 // audio, and artwork wants its own proxy + placeholder story.
 
+import type { Visibility } from "@/lib/workspace-clips"
+
 /** A single playable item in the player queue. */
 export type Track = {
   id: string
@@ -97,20 +99,22 @@ export async function downloadClipAudio(
   return true
 }
 
-/** Outcome of a publish-toggle attempt (US-17.6). */
+/** Outcome of a visibility-change attempt (US-17.6 / tri-state in US-20.7). */
 export type VisibilityResult =
-  | { ok: true; isPublic: boolean }
+  | { ok: true; visibility: Visibility }
   | { ok: false; guardFailed: boolean; message: string }
 
 /**
- * Persist a clip's public/private state via `PATCH /api/clips/{id}` (US-17.6).
- * A 422 is the backend publish guard (missing title/style tags) — surfaced as
- * `guardFailed` so the caller can prompt for the missing fields instead of
- * showing a generic error. All other failures return `guardFailed: false`.
+ * Persist a clip's visibility via `PATCH /api/clips/{id}` (US-17.6, extended
+ * to the tri-state Private/Unlisted/Public in US-20.7). A 422 is the backend
+ * publish guard (missing title/style tags, only reachable going "public") —
+ * surfaced as `guardFailed` so the caller can prompt for the missing fields
+ * instead of showing a generic error. All other failures return
+ * `guardFailed: false`.
  */
 export async function updateClipVisibility(
   id: string,
-  isPublic: boolean,
+  visibility: Visibility,
   accessToken: string
 ): Promise<VisibilityResult> {
   let res: Response
@@ -121,7 +125,7 @@ export async function updateClipVisibility(
         authorization: `Bearer ${accessToken}`,
         "content-type": "application/json",
       },
-      body: JSON.stringify({ is_public: isPublic }),
+      body: JSON.stringify({ visibility }),
     })
   } catch {
     return {
@@ -130,7 +134,7 @@ export async function updateClipVisibility(
       message: "Couldn't reach the server. Please try again.",
     }
   }
-  if (res.ok) return { ok: true, isPublic }
+  if (res.ok) return { ok: true, visibility }
   const detail = (await res.json().catch(() => ({}))) as { detail?: unknown }
   const message =
     typeof detail.detail === "string"

--- a/web/lib/workspace-clips.ts
+++ b/web/lib/workspace-clips.ts
@@ -8,6 +8,9 @@
 
 export type SortOrder = "newest" | "oldest"
 
+/** Tri-state clip visibility (US-20.7). Mirrors the backend enum. */
+export type Visibility = "private" | "unlisted" | "public"
+
 /** A clip as returned by GET /api/v1/clips (ClipResponse). No `updated_at`. */
 export type Clip = {
   id: string
@@ -31,6 +34,12 @@ export type Clip = {
   parent_clip_ids: string[]
   generation_mode: string | null
   is_public: boolean
+  /**
+   * Tri-state visibility (US-20.7). Optional: older reads/mocks may omit it,
+   * so derive with `visibilityOf` rather than reading this directly — it
+   * falls back to `is_public` and keeps the two fields in sync.
+   */
+  visibility?: Visibility
   created_at: string
   /**
    * Server-computed viewer ownership, present only on the public read (US-20.0);
@@ -47,6 +56,14 @@ export type Clip = {
   play_count?: number
   like_count?: number
   share_count?: number
+}
+
+/**
+ * Single source of truth for a clip's visibility (US-20.7). Prefers the
+ * `visibility` field; falls back to `is_public` for reads that predate it.
+ */
+export function visibilityOf(clip: Pick<Clip, "visibility" | "is_public">): Visibility {
+  return clip.visibility ?? (clip.is_public ? "public" : "private")
 }
 
 /** A workspace as returned by GET /api/v1/workspaces (WorkspaceResponse). */


### PR DESCRIPTION
## Summary
Implements #219 (US-20.7): three-state clip visibility — **Private / Unlisted / Public** — extending the existing two-state `is_public` publish toggle (US-17.6) rather than building a parallel system.

**Backend (FastAPI/Beanie, covered by CI):**
- `Clip` gains a `visibility: VisibilityState` enum as the source of truth; `is_public` becomes a stored denormalization kept in sync (`is_public == visibility==PUBLIC`) so existing `{is_public: True}` Mongo queries (public listings/search/similar) keep excluding unlisted clips with no data migration. A before-validator back-fills legacy docs; `Clip.set_visibility()` maintains the invariant on writes.
- Reuses the existing `PATCH /clips/{id}` endpoint (accepts `visibility`); the publish guard (title + ≥1 style tag) fires when going PUBLIC.
- Access control: authenticated non-owners and **anonymous link recipients** can reach PUBLIC and UNLISTED clips; only PRIVATE is owner-only (404/403).

**Web (Next.js, run locally — not in CI):**
- New `VisibilityToggle` (Private/Unlisted/Public dropdown) and `VisibilityBadge` (Lock/Link/Globe), integrated into `ClipCard` (workspace) and `SongHeader` (song detail).
- `useSongActions` extended to tri-state with optimistic update + rollback; reuses `PublishGuardPrompt` for the missing-title/tag prompt.
- Song metadata row shows the tri-state label (including Unlisted).

## Acceptance Criteria
- [x] AC1 — Visibility toggle switches between private, unlisted, and public
- [x] AC2 — Publishing (→ public) without a title or style tag shows a prompt (client + server 422)
- [x] AC3 — Visibility change persists after reload (`visibility` field; `is_public` stays synced in stored BSON)
- [x] AC4 — Clip cards show a badge indicating current visibility state
- [x] AC5 — Unlisted clips are accessible via direct link (incl. signed-out) but excluded from search/explore/similar

## Test Plan
- [x] TDD: backend pytest (unit + `@integration`), web Vitest
- [x] Backend: default suite + `-m integration` green (visibility, crud, similar, releases, audio-access, anonymous link access)
- [x] Web: typecheck, lint, full Vitest (1270 tests), `next build` all green locally
- [x] Linting clean (black/ruff via pre-commit; eslint/tsc)
- [x] Internal code review (advisory) completed
- [x] Cross-family review: **opencode (GLM)** — found the `is_public`-desync-on-save Critical (independently matched by internal review); fixed via `Clip.set_visibility()` + raw-BSON regression test + no-DB unit guard; re-reviewed
- [x] Test mutation sanity check (the raw-BSON test fails when the sync is dropped)

## Known Limitations / Intentionally Deferred
- **`SongActionsMenu` "Publish/Unpublish" item stays two-state** — the legacy inline menu item toggles public↔private only; the new tri-state picker sits alongside it and is the way to reach Unlisted. Full menu migration is out of scope.
- **Legacy `is_public: false` on an unlisted clip collapses to PRIVATE** — a caller old enough to send the boolean has no unlisted concept; PRIVATE is the safe resolution. Modern clients send `visibility`. Documented in `update_clip_fields`.
- **No live end-to-end demo in this environment** — the web app has no GPU/backend stack wired here and `/create` is auth-gated, so verification is via component/API tests (Vitest + pytest), not a running full stack. See the demo evidence section on the PR.

## Implementation Notes
- **Deviated from the CodeRabbit issue plan**, whose research ("no frontend exists") predated the US-20.1–20.6 web app: reused the existing `PATCH /clips/{id}` endpoint instead of adding a new `PATCH /clips/{id}/visibility`, and kept `is_public` as a synced denormalization (not a pure computed property) to avoid rewriting every `{is_public: True}` query and to avoid the legacy-public-clip regression that plan would have caused.
- Scope (full-stack minimal vs web-only-deferral) was confirmed with the repo owner before implementation.

Closes #219
