### PR TITLE
feat(web): US-21.1 Release Page Layout — song selector + selected-song summary

### DIFF
--- a/web/app/release/page.test.tsx
+++ b/web/app/release/page.test.tsx
@@ -25,6 +25,37 @@ vi.mock("@/hooks/use-clip", () => ({
   useClip: (id: string | undefined) => useClip(id),
 }))
 
+// Stub the release children: SongSelector/SelectedSongSummary have their own
+// tests, so here we only assert the page wires selection/URL correctly.
+vi.mock("@/components/release/SongSelector", () => ({
+  SongSelector: ({
+    onSelect,
+    onCancel,
+  }: {
+    onSelect: (id: string) => void
+    onCancel?: () => void
+  }) => (
+    <div data-testid="song-selector">
+      <button onClick={() => onSelect("c2")}>select-c2</button>
+      {onCancel && <button onClick={onCancel}>cancel-pick</button>}
+    </div>
+  ),
+}))
+vi.mock("@/components/release/SelectedSongSummary", () => ({
+  SelectedSongSummary: ({
+    clip,
+    onChangeSong,
+  }: {
+    clip: { title: string | null }
+    onChangeSong: () => void
+  }) => (
+    <div data-testid="selected-summary">
+      <span>{clip.title}</span>
+      <button onClick={onChangeSong}>change-song</button>
+    </div>
+  ),
+}))
+
 import { ReleasePageContent } from "@/app/release/page"
 
 afterEach(() => {
@@ -37,6 +68,15 @@ function noClip() {
   return { clip: null, loading: false, error: false, notFound: false }
 }
 
+function foundClip(title = "My Mixdown") {
+  return {
+    clip: { id: "c1", title, duration: 65, generation_mode: "studio" },
+    loading: false,
+    error: false,
+    notFound: false,
+  }
+}
+
 describe("ReleasePage", () => {
   it("shows the Mastering and Distribute tabs", () => {
     useClip.mockReturnValue(noClip())
@@ -45,30 +85,60 @@ describe("ReleasePage", () => {
     expect(screen.getByRole("tab", { name: /distribute/i })).toBeInTheDocument()
   })
 
-  it("defaults to the Mastering tab with an empty state when no clip is selected", () => {
+  it("defaults to the Mastering tab and shows the selector when no clip is selected", () => {
     useClip.mockReturnValue(noClip())
     render(<ReleasePageContent />)
     expect(
       screen.getByRole("tab", { name: /mastering/i })
     ).toHaveAttribute("aria-selected", "true")
-    expect(screen.getByText(/no song selected/i)).toBeInTheDocument()
+    expect(screen.getByTestId("song-selector")).toBeInTheDocument()
     // No clip param means we never fetch a clip.
     expect(useClip).toHaveBeenCalledWith(undefined)
   })
 
-  it("preselects the clip from ?clip= and shows its summary", () => {
+  it("preselects the clip from ?clip= and shows its summary (not the selector)", () => {
     searchParamsRef.current = new URLSearchParams("tab=mastering&clip=c1")
-    useClip.mockReturnValue({
-      clip: { id: "c1", title: "My Mixdown", duration: 65, generation_mode: "studio" },
-      loading: false,
-      error: false,
-      notFound: false,
-    })
+    useClip.mockReturnValue(foundClip())
     render(<ReleasePageContent />)
     expect(useClip).toHaveBeenCalledWith("c1")
+    expect(screen.getByTestId("selected-summary")).toBeInTheDocument()
     expect(screen.getByText("My Mixdown")).toBeInTheDocument()
-    expect(screen.getByText(/1:05/)).toBeInTheDocument()
-    expect(screen.getByText(/ready for mastering/i)).toBeInTheDocument()
+    expect(screen.queryByTestId("song-selector")).not.toBeInTheDocument()
+  })
+
+  it("writes ?clip= to the URL when a song is selected", async () => {
+    useClip.mockReturnValue(noClip())
+    const user = userEvent.setup()
+    render(<ReleasePageContent />)
+    await user.click(screen.getByText("select-c2"))
+    expect(replace).toHaveBeenCalledWith("/release?clip=c2")
+  })
+
+  it("reopens the selector when Change Song is clicked, then cancel returns to the summary", async () => {
+    searchParamsRef.current = new URLSearchParams("tab=mastering&clip=c1")
+    useClip.mockReturnValue(foundClip())
+    const user = userEvent.setup()
+    render(<ReleasePageContent />)
+
+    await user.click(screen.getByText("change-song"))
+    expect(screen.getByTestId("song-selector")).toBeInTheDocument()
+    expect(screen.queryByTestId("selected-summary")).not.toBeInTheDocument()
+
+    // With a clip still set, the selector offers a cancel back to the summary.
+    await user.click(screen.getByText("cancel-pick"))
+    expect(screen.getByTestId("selected-summary")).toBeInTheDocument()
+  })
+
+  it("shows a not-found state when the preselected clip is missing", () => {
+    searchParamsRef.current = new URLSearchParams("clip=gone")
+    useClip.mockReturnValue({
+      clip: null,
+      loading: false,
+      error: false,
+      notFound: true,
+    })
+    render(<ReleasePageContent />)
+    expect(screen.getByText(/song not found/i)).toBeInTheDocument()
   })
 
   it("opens the Distribute tab from ?tab=distribute", () => {
@@ -90,12 +160,7 @@ describe("ReleasePage", () => {
 
   it("keeps ?clip= when switching tabs", async () => {
     searchParamsRef.current = new URLSearchParams("tab=mastering&clip=c1")
-    useClip.mockReturnValue({
-      clip: { id: "c1", title: "My Mixdown", duration: 65, generation_mode: "studio" },
-      loading: false,
-      error: false,
-      notFound: false,
-    })
+    useClip.mockReturnValue(foundClip())
     const user = userEvent.setup()
     render(<ReleasePageContent />)
     await user.click(screen.getByRole("tab", { name: /distribute/i }))

--- a/web/app/release/page.tsx
+++ b/web/app/release/page.tsx
@@ -1,92 +1,34 @@
 "use client"
 
-import { Suspense } from "react"
+import { Suspense, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 
-import { Badge } from "@/components/ui/badge"
 import {
   Card,
-  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { SelectedSongSummary } from "@/components/release/SelectedSongSummary"
+import { SongSelector } from "@/components/release/SongSelector"
 import { useClip } from "@/hooks/use-clip"
 import { useRequireAuth } from "@/hooks/use-require-auth"
-import { formatTime } from "@/lib/clips"
-import type { Clip } from "@/lib/workspace-clips"
 
-// Minimal release landing (US-19.6). The studio's "Send to Mastering" bounces a
-// mix and lands here with the new clip pre-selected via ?clip=. This page only
-// confirms the hand-off (selected-song summary) and stubs Distribute — the full
-// mastering workflow is Stage 21 (US-21.1+), which owns this page's real body.
+// Release page (US-21.1). A single destination for preparing and shipping a
+// song: pick a clip (or arrive pre-selected from the Studio's "Send to
+// Mastering", which navigates here with ?clip=), see its summary, then work
+// through the Mastering and Distribute tabs. The tab body placeholders are
+// filled by US-21.2 (mastering) and US-21.4/21.5 (distribution).
+//
+// Selection is URL-driven (?clip=): the selector writes it and pre-selection
+// reads it, so there's one source of truth and it survives a refresh.
 
 type ReleaseTab = "mastering" | "distribute"
 
 /** Coerce the raw ?tab= value to a known tab (defaults to mastering). */
 function parseTab(raw: string | null): ReleaseTab {
   return raw === "distribute" ? "distribute" : "mastering"
-}
-
-/** The pre-selected song's summary, or an empty state prompting a hand-off. */
-function MasteringTab({
-  clipId,
-  clip,
-  loading,
-  notFound,
-}: {
-  clipId: string | undefined
-  clip: Clip | null
-  loading: boolean
-  notFound: boolean
-}) {
-  if (!clipId) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>No song selected</CardTitle>
-          <CardDescription>
-            Send a mix from the Studio&apos;s master bus to master it here.
-          </CardDescription>
-        </CardHeader>
-      </Card>
-    )
-  }
-  if (loading) {
-    return (
-      <p role="status" className="text-sm text-muted-foreground">
-        Loading song…
-      </p>
-    )
-  }
-  if (notFound || !clip) {
-    return <p className="text-sm text-muted-foreground">Song not found.</p>
-  }
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{clip.title ?? "Untitled"}</CardTitle>
-        <CardDescription>{formatTime(clip.duration ?? 0)}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Badge>Ready for mastering</Badge>
-      </CardContent>
-    </Card>
-  )
-}
-
-function DistributeTab() {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Distribution</CardTitle>
-        <CardDescription>
-          Publishing to streaming platforms is coming soon.
-        </CardDescription>
-      </CardHeader>
-    </Card>
-  )
 }
 
 /** Inner page content (testable without the auth gate / Suspense boundary). */
@@ -98,33 +40,85 @@ export function ReleasePageContent() {
   const clipId = searchParams.get("clip") ?? undefined
   const { clip, loading, notFound } = useClip(clipId)
 
+  // "Change Song" reopens the selector while keeping the current ?clip= (so a
+  // cancel returns to the same song). No clip selected ⇒ selector shows anyway.
+  const [picking, setPicking] = useState(false)
+  const showSelector = !clipId || picking
+
+  /** Patch a single query param while preserving the rest of the URL. */
+  function setParam(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set(key, value)
+    router.replace(`/release?${params.toString()}`)
+  }
+
+  function selectClip(id: string) {
+    setParam("clip", id)
+    setPicking(false)
+  }
+
   return (
     <div className="flex flex-col gap-6 p-8">
       <h1 className="text-2xl font-semibold">Mastering &amp; Distribution</h1>
+
+      {/* Header: song selector or selected-song summary. */}
+      {showSelector ? (
+        <SongSelector
+          onSelect={selectClip}
+          onCancel={clipId ? () => setPicking(false) : undefined}
+        />
+      ) : loading ? (
+        <p role="status" className="text-sm text-muted-foreground">
+          Loading song…
+        </p>
+      ) : notFound || !clip ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Song not found</CardTitle>
+            <CardDescription>
+              That song is unavailable.{" "}
+              <button
+                type="button"
+                className="underline underline-offset-2 hover:text-foreground"
+                onClick={() => setPicking(true)}
+              >
+                Choose another
+              </button>
+              .
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <SelectedSongSummary clip={clip} onChangeSong={() => setPicking(true)} />
+      )}
+
       <Tabs
         value={tab}
-        onValueChange={(next) => {
-          // Preserve the rest of the query (notably ?clip= from Send to
-          // Mastering) — replacing with only ?tab= would drop the hand-off.
-          const params = new URLSearchParams(searchParams.toString())
-          params.set("tab", next)
-          router.replace(`/release?${params.toString()}`)
-        }}
+        onValueChange={(next) => setParam("tab", next)}
       >
         <TabsList>
           <TabsTrigger value="mastering">Mastering</TabsTrigger>
           <TabsTrigger value="distribute">Distribute</TabsTrigger>
         </TabsList>
         <TabsContent value="mastering" className="pt-4">
-          <MasteringTab
-            clipId={clipId}
-            clip={clip}
-            loading={loading}
-            notFound={notFound}
-          />
+          <Card>
+            <CardHeader>
+              <CardTitle>Mastering</CardTitle>
+              <CardDescription>
+                Mastering controls will appear here.
+              </CardDescription>
+            </CardHeader>
+          </Card>
         </TabsContent>
         <TabsContent value="distribute" className="pt-4">
-          <DistributeTab />
+          <Card>
+            <CardHeader>
+              <CardTitle>Distribution</CardTitle>
+              <CardDescription>
+                Publishing to streaming platforms is coming soon.
+              </CardDescription>
+            </CardHeader>
+          </Card>
         </TabsContent>
       </Tabs>
     </div>

--- a/web/components/release/SelectedSongSummary.test.tsx
+++ b/web/components/release/SelectedSongSummary.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { SelectedSongSummary } from "@/components/release/SelectedSongSummary"
+import type { Clip } from "@/lib/workspace-clips"
+
+function clip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "c1",
+    workspace_id: "w1",
+    title: "My Mixdown",
+    format: "wav",
+    duration: 65,
+    bpm: null,
+    key: null,
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: "studio",
+    is_public: false,
+    created_at: "2026-01-01",
+    ...overrides,
+  }
+}
+
+describe("SelectedSongSummary", () => {
+  it("shows the title, formatted duration, and status badges", () => {
+    render(<SelectedSongSummary clip={clip()} onChangeSong={vi.fn()} />)
+    expect(screen.getByText("My Mixdown")).toBeInTheDocument()
+    expect(screen.getByText(/1:05/)).toBeInTheDocument()
+    expect(screen.getByText(/not mastered/i)).toBeInTheDocument()
+    expect(screen.getByText(/not distributed/i)).toBeInTheDocument()
+  })
+
+  it("shows a Mastered badge when the clip's generation_mode is mastered", () => {
+    render(
+      <SelectedSongSummary
+        clip={clip({ generation_mode: "mastered" })}
+        onChangeSong={vi.fn()}
+      />
+    )
+    expect(screen.getByText("Mastered")).toBeInTheDocument()
+    expect(screen.queryByText(/not mastered/i)).not.toBeInTheDocument()
+  })
+
+  it("falls back to 'Untitled' when the clip has no title", () => {
+    render(
+      <SelectedSongSummary clip={clip({ title: null })} onChangeSong={vi.fn()} />
+    )
+    expect(screen.getByText("Untitled")).toBeInTheDocument()
+  })
+
+  it("calls onChangeSong when Change Song is clicked", async () => {
+    const onChangeSong = vi.fn()
+    const user = userEvent.setup()
+    render(<SelectedSongSummary clip={clip()} onChangeSong={onChangeSong} />)
+    await user.click(screen.getByRole("button", { name: /change song/i }))
+    expect(onChangeSong).toHaveBeenCalled()
+  })
+})

--- a/web/components/release/SelectedSongSummary.tsx
+++ b/web/components/release/SelectedSongSummary.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { MusicNote01Icon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { formatTime } from "@/lib/clips"
+import type { Clip } from "@/lib/workspace-clips"
+
+/**
+ * Selected-song summary for the release page header (US-21.1). Shows the chosen
+ * clip's thumbnail, title, duration, and its mastering/distribution status, plus
+ * a "Change Song" affordance to reopen the selector.
+ *
+ * ponytail: no artwork proxy exists in web/ (thumbnails are music-glyph
+ * placeholders everywhere), and distribution has no releases API yet — the
+ * Distribute workflow lands in US-21.4/21.5, so distribution status is a static
+ * "Not distributed" until then.
+ */
+export function SelectedSongSummary({
+  clip,
+  onChangeSong,
+}: {
+  clip: Clip
+  onChangeSong: () => void
+}) {
+  // Mastering status is derived from generation_mode per the story plan. No clip
+  // carries "mastered" until the mastering workflow (US-21.2) produces one, so
+  // this reads "Not mastered" for every clip today — correct, not a bug.
+  const mastered = clip.generation_mode === "mastered"
+
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-4 p-4">
+        <span className="flex size-16 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <HugeiconsIcon icon={MusicNote01Icon} size={24} />
+        </span>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <h2 className="truncate text-lg font-semibold">
+            {clip.title ?? "Untitled"}
+          </h2>
+          <p className="text-sm text-muted-foreground tabular-nums">
+            {formatTime(clip.duration ?? 0)}
+          </p>
+          <div className="flex flex-wrap items-center gap-1 pt-1">
+            <Badge variant={mastered ? "default" : "secondary"}>
+              {mastered ? "Mastered" : "Not mastered"}
+            </Badge>
+            <Badge variant="outline">Not distributed</Badge>
+          </div>
+        </div>
+
+        <Button variant="outline" size="sm" onClick={onChangeSong}>
+          Change Song
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/components/release/SongSelector.test.tsx
+++ b/web/components/release/SongSelector.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SongSelector } from "@/components/release/SongSelector"
+import type { Clip, Workspace } from "@/lib/workspace-clips"
+
+let clipsResult: { data: unknown; loading: boolean; error: boolean }
+let wsResult: { defaultWorkspace: Workspace | null; loading: boolean }
+
+vi.mock("@/hooks/use-clips", () => ({ useClips: () => clipsResult }))
+vi.mock("@/hooks/use-workspaces", () => ({ useWorkspaces: () => wsResult }))
+
+const workspace: Workspace = {
+  id: "w1",
+  name: "My Workspace",
+  clip_count: 2,
+  is_default: true,
+  created_at: "2026-01-01",
+  updated_at: null,
+}
+
+function clip(id: string, overrides: Partial<Clip> = {}): Clip {
+  return {
+    id,
+    workspace_id: "w1",
+    title: id,
+    format: "wav",
+    duration: 60,
+    bpm: null,
+    key: null,
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: null,
+    is_public: false,
+    created_at: "2026-01-01",
+    ...overrides,
+  }
+}
+
+function clipsPage(clips: Clip[]) {
+  return { clips, total: clips.length, page: 1, per_page: 20, total_pages: 1 }
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("SongSelector", () => {
+  it("shows a loading state while workspaces/clips load", () => {
+    wsResult = { defaultWorkspace: null, loading: true }
+    clipsResult = { data: null, loading: true, error: false }
+    render(<SongSelector onSelect={vi.fn()} />)
+    expect(screen.getByRole("status")).toHaveTextContent(/loading clips/i)
+  })
+
+  it("renders clips and calls onSelect with the clicked clip's id", async () => {
+    wsResult = { defaultWorkspace: workspace, loading: false }
+    clipsResult = {
+      data: clipsPage([
+        clip("c1", { title: "First Mix", duration: 65, generation_mode: "mastered" }),
+        clip("c2", { title: "Second Mix" }),
+      ]),
+      loading: false,
+      error: false,
+    }
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+    render(<SongSelector onSelect={onSelect} />)
+
+    expect(screen.getByText("First Mix")).toBeInTheDocument()
+    expect(screen.getByText(/1:05/)).toBeInTheDocument()
+    // generation_mode badge is derived from the shared label map.
+    expect(screen.getByText("Mastered")).toBeInTheDocument()
+
+    await user.click(screen.getByText("Second Mix"))
+    expect(onSelect).toHaveBeenCalledWith("c2")
+  })
+
+  it("shows an empty state when the workspace has no clips", () => {
+    wsResult = { defaultWorkspace: workspace, loading: false }
+    clipsResult = { data: clipsPage([]), loading: false, error: false }
+    render(<SongSelector onSelect={vi.fn()} />)
+    expect(screen.getByText(/no clips yet/i)).toBeInTheDocument()
+  })
+
+  it("shows an error state when the clip fetch fails", () => {
+    wsResult = { defaultWorkspace: workspace, loading: false }
+    clipsResult = { data: null, loading: false, error: true }
+    render(<SongSelector onSelect={vi.fn()} />)
+    expect(screen.getByText(/couldn't load clips/i)).toBeInTheDocument()
+  })
+
+  it("renders a Cancel button only when onCancel is provided", async () => {
+    wsResult = { defaultWorkspace: workspace, loading: false }
+    clipsResult = { data: clipsPage([clip("c1")]), loading: false, error: false }
+    const onCancel = vi.fn()
+    const user = userEvent.setup()
+    const { rerender } = render(<SongSelector onSelect={vi.fn()} />)
+    expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument()
+
+    rerender(<SongSelector onSelect={vi.fn()} onCancel={onCancel} />)
+    await user.click(screen.getByRole("button", { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/web/components/release/SongSelector.tsx
+++ b/web/components/release/SongSelector.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { MusicNote01Icon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ClipSearchInput } from "@/components/workspace/ClipSearchInput"
+import { PaginationControls } from "@/components/workspace/PaginationControls"
+import { SortDropdown } from "@/components/workspace/SortDropdown"
+import { useClips } from "@/hooks/use-clips"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
+import { useWorkspaces } from "@/hooks/use-workspaces"
+import { modeLabel } from "@/lib/clip-labels"
+import { formatTime } from "@/lib/clips"
+import type { SortOrder } from "@/lib/workspace-clips"
+
+const PER_PAGE = 20
+
+/**
+ * Release song picker (US-21.1). Browse the workspace's clips and pick one to
+ * master/distribute; the chosen clip id is handed back via `onSelect`. Reuses
+ * the workspace library's data hooks and search/sort/pager controls so the
+ * selection experience matches the Create page's clip library.
+ *
+ * ponytail: scoped to the default workspace (like WorkspacePanel, the app's own
+ * clip library) — no workspace-switcher UI exists yet. Add a workspace dropdown
+ * here if/when multi-workspace switching lands.
+ */
+export function SongSelector({
+  onSelect,
+  onCancel,
+}: {
+  onSelect: (clipId: string) => void
+  /** Shown as a "Cancel" affordance only when a song is already selected. */
+  onCancel?: () => void
+}) {
+  const [search, setSearch] = useState("")
+  const [sort, setSort] = useState<SortOrder>("newest")
+  const [page, setPage] = useState(1)
+  const debouncedSearch = useDebouncedValue(search, 300)
+
+  // New search/sort restarts paging from page 1 (in the handler, not an effect,
+  // to avoid a cascading render — mirrors WorkspacePanel).
+  const onSearchChange = (value: string) => {
+    setSearch(value)
+    setPage(1)
+  }
+  const onSortChange = (value: SortOrder) => {
+    setSort(value)
+    setPage(1)
+  }
+
+  const { defaultWorkspace, loading: workspacesLoading } = useWorkspaces()
+  const {
+    data,
+    loading: clipsLoading,
+    error,
+  } = useClips(
+    {
+      workspace_id: defaultWorkspace?.id,
+      search: debouncedSearch,
+      sort,
+      page,
+      per_page: PER_PAGE,
+    },
+    // Defer until a workspace is resolved so we never fetch unscoped clips.
+    { enabled: defaultWorkspace !== null }
+  )
+
+  const loading = workspacesLoading || clipsLoading
+  const clips = data?.clips ?? []
+  const totalPages = data?.total_pages ?? 1
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ClipSearchInput value={search} onChange={onSearchChange} />
+      <div className="flex items-center justify-between gap-2">
+        <SortDropdown value={sort} onChange={onSortChange} />
+        {onCancel && (
+          <Button variant="ghost" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+      </div>
+
+      {loading ? (
+        <p role="status" className="text-sm text-muted-foreground">
+          Loading clips…
+        </p>
+      ) : error ? (
+        <p className="text-sm text-muted-foreground">
+          Couldn&apos;t load clips. Please try again.
+        </p>
+      ) : clips.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {search ? "No clips match your search." : "No clips yet."}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {clips.map((clip) => {
+            const label = modeLabel(clip.generation_mode)
+            return (
+              <li key={clip.id}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(clip.id)}
+                  className="flex w-full items-center gap-3 rounded-lg border border-border bg-card p-2 text-left transition-colors hover:bg-accent focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+                >
+                  <span className="flex size-12 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                    <HugeiconsIcon icon={MusicNote01Icon} size={18} />
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-sm font-medium">
+                      {clip.title ?? "Untitled clip"}
+                    </span>
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {formatTime(clip.duration ?? 0)}
+                    </span>
+                  </span>
+                  {label && (
+                    <Badge variant="outline" className="text-[10px]">
+                      {label}
+                    </Badge>
+                  )}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {!loading && !error && clips.length > 0 && (
+        <PaginationControls
+          page={page}
+          totalPages={totalPages}
+          onPageChange={setPage}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/components/workspace/WorkspacePanel.tsx
+++ b/web/components/workspace/WorkspacePanel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 
 import { ClipList } from "@/components/workspace/ClipList"
 import { ClipSearchInput } from "@/components/workspace/ClipSearchInput"
@@ -11,6 +11,7 @@ import { SortDropdown } from "@/components/workspace/SortDropdown"
 import { WorkspaceBreadcrumb } from "@/components/workspace/WorkspaceBreadcrumb"
 import { usePlayer } from "@/contexts/player-context"
 import { useClips } from "@/hooks/use-clips"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import { useSubscriptionTier } from "@/hooks/use-subscription-tier"
 import { useWorkspaces } from "@/hooks/use-workspaces"
 import {
@@ -23,16 +24,6 @@ import {
 } from "@/lib/workspace-clips"
 
 const PER_PAGE = 20
-
-/** Debounce a rapidly-changing value (search keystrokes). */
-function useDebouncedValue<T>(value: T, delayMs: number): T {
-  const [debounced, setDebounced] = useState(value)
-  useEffect(() => {
-    const t = setTimeout(() => setDebounced(value), delayMs)
-    return () => clearTimeout(t)
-  }, [value, delayMs])
-  return debounced
-}
 
 /**
  * Right-side clip library for the Create page (US-16.5). Owns search/filter/

--- a/web/hooks/use-debounced-value.ts
+++ b/web/hooks/use-debounced-value.ts
@@ -1,0 +1,18 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+/**
+ * Debounce a rapidly-changing value (e.g. search keystrokes) so downstream
+ * effects — like a server clip query — fire only after the value settles.
+ * Extracted from WorkspacePanel (US-16.5) so the release SongSelector (US-21.1)
+ * can reuse the exact same debounce behaviour.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(t)
+  }, [value, delayMs])
+  return debounced
+}


### PR DESCRIPTION
## US-21.1: Release Page Layout

Closes #220.

Completes the `/release` page for Stage 21. The page **skeleton** (Mastering/Distribute tabs, URL-persisted tab state, and `?clip=` pre-selection from Studio's "Send to Mastering") already shipped in US-19.6; this PR fills the remaining acceptance-criteria gaps.

### What changed
- **Song selector (AC2)** — new `components/release/SongSelector.tsx`: browse the workspace's clips and pick one, reusing `useWorkspaces` / `useClips` and the workspace library's `ClipSearchInput` / `SortDropdown` / `PaginationControls`. Selecting a clip writes `?clip=` to the URL.
- **Selected-song summary (AC4)** — new `components/release/SelectedSongSummary.tsx`, moved to a page **header** (visible on both tabs): music-glyph thumbnail, title, formatted duration, mastering-status badge (derived from `generation_mode`), a distribution-status placeholder, and a **Change Song** button to reopen the selector.
- **Shared debounce** — extracted `useDebouncedValue` from `WorkspacePanel` into `hooks/use-debounced-value.ts` (byte-identical) so the selector reuses it instead of duplicating.

### Acceptance criteria
- [x] AC1 — Release page loads at `/release` with Mastering & Distribute tabs *(US-19.6)*
- [x] AC2 — Song selector allows choosing from workspace clips
- [x] AC3 — Pre-selected song from Studio / clip context menu loads automatically *(US-19.6)*
- [x] AC4 — Selected song summary displays correctly (thumbnail, title, duration, status)
- [x] AC5 — Tab navigation updates the URL and persists on refresh *(US-19.6)*

### Design decisions
- **URL is the single source of truth for selection.** The selector writes `?clip=<id>`; both it and Studio's pre-selection read it. No parallel page-level `useState` — selection survives a refresh for free, and "Change Song" is a small local `picking` boolean.
- **Selector scoped to the default workspace**, matching `WorkspacePanel` (the app's own clip library). No workspace-switcher UI exists anywhere yet, so a dropdown would be net-new scope beyond US-21.1.

### Known limitations (deferred to later Stage-21 stories)
- **Distribution status** renders a static "Not distributed" badge — there's no releases API/lib in `web/` yet; the Distribute workflow is US-21.4/21.5.
- **Tab bodies** are placeholders — mastering controls land in US-21.2; distribution in US-21.4/21.5.
- The mastering badge derives from `generation_mode === "mastered"`; no clip carries that mode until US-21.2 produces one, so it reads "Not mastered" for every clip today (correct, documented in-code).

### Testing
- New: `SongSelector.test.tsx`, `SelectedSongSummary.test.tsx`; updated `app/release/page.test.tsx` (selection wiring, Change Song, not-found, tab/URL persistence).
- Full web suite: **1282 tests pass**. `next build`, `eslint`, and `tsc --noEmit` all clean.
- Cross-family review (opencode / GLM): **no blocking issues**.

> Note: the web frontend isn't in CI (Python-only), so the above were run locally.
