### PR TITLE
feat(web): US-21.2 Mastering Workflow — mastering tab on /release (#221)

### DIFF
--- a/web/app/api/mastering/jobs/[jobId]/approve/route.ts
+++ b/web/app/api/mastering/jobs/[jobId]/approve/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for POST /api/v1/mastering/jobs/{job_id}/approve (US-21.2).
+// Promotes a chosen preview to the final master. Status/body pass through
+// verbatim (200 with {clip_id, audio_url}, 401, 404, 422).
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ jobId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { jobId } = await ctx.params
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/mastering/jobs/${encodeURIComponent(jobId)}/approve`,
+      {
+        method: "POST",
+        headers: {
+          authorization: auth,
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: await request.text(),
+      }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Mastering service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/mastering/jobs/[jobId]/previews/route.ts
+++ b/web/app/api/mastering/jobs/[jobId]/previews/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/mastering/jobs/{job_id}/previews (US-21.2).
+// Returns the A/B comparison set (original audio/metrics + every mastered
+// candidate). Status/body pass through verbatim (200, 401, 404).
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ jobId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { jobId } = await ctx.params
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/mastering/jobs/${encodeURIComponent(jobId)}/previews`,
+      { headers: { authorization: auth, accept: "application/json" } }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Mastering service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/mastering/jobs/[jobId]/route.ts
+++ b/web/app/api/mastering/jobs/[jobId]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/mastering/jobs/{job_id} (US-21.2). The
+// mastering tab polls this after a 202 to drive queued → processing →
+// completed/failed. Status/body pass through verbatim (200 with the job detail,
+// 401, 404 when the job is unknown or not owned).
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ jobId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { jobId } = await ctx.params
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/mastering/jobs/${encodeURIComponent(jobId)}`,
+      { headers: { authorization: auth, accept: "application/json" } }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Mastering service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/mastering/jobs/route.ts
+++ b/web/app/api/mastering/jobs/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for POST /api/v1/mastering/jobs (US-21.2). The client holds
+// the access token in memory and sends it as a Bearer header; this route
+// forwards it so the backend URL stays server-side. Status/body pass through
+// verbatim: 202 (queued), 401, 402 (insufficient credits), 404, 422.
+
+const TARGET = `${BACKEND_URL}/api/v1/mastering/jobs`
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  let res: Response
+  try {
+    res = await fetch(TARGET, {
+      method: "POST",
+      headers: {
+        authorization: auth,
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: await request.text(),
+    })
+  } catch {
+    return NextResponse.json(
+      { detail: "Mastering service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/release/page.test.tsx
+++ b/web/app/release/page.test.tsx
@@ -41,6 +41,13 @@ vi.mock("@/components/release/SongSelector", () => ({
     </div>
   ),
 }))
+// The mastering tab has its own tests and pulls in auth/job hooks; stub it so
+// the page test stays focused on selection/URL wiring.
+vi.mock("@/components/mastering/mastering-tab", () => ({
+  MasteringTab: ({ selectedClip }: { selectedClip: { id: string } | null }) => (
+    <div data-testid="mastering-tab">{selectedClip?.id ?? "no-clip"}</div>
+  ),
+}))
 vi.mock("@/components/release/SelectedSongSummary", () => ({
   SelectedSongSummary: ({
     clip,

--- a/web/app/release/page.tsx
+++ b/web/app/release/page.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { MasteringTab } from "@/components/mastering/mastering-tab"
 import { SelectedSongSummary } from "@/components/release/SelectedSongSummary"
 import { SongSelector } from "@/components/release/SongSelector"
 import { useClip } from "@/hooks/use-clip"
@@ -101,14 +102,7 @@ export function ReleasePageContent() {
           <TabsTrigger value="distribute">Distribute</TabsTrigger>
         </TabsList>
         <TabsContent value="mastering" className="pt-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Mastering</CardTitle>
-              <CardDescription>
-                Mastering controls will appear here.
-              </CardDescription>
-            </CardHeader>
-          </Card>
+          <MasteringTab selectedClip={clip ?? null} />
         </TabsContent>
         <TabsContent value="distribute" className="pt-4">
           <Card>

--- a/web/components/mastering/mastering-config.test.tsx
+++ b/web/components/mastering/mastering-config.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { MasteringConfig } from "@/components/mastering/mastering-config"
+
+afterEach(() => vi.clearAllMocks())
+
+describe("MasteringConfig", () => {
+  it("offers all five profiles and all three services", () => {
+    render(<MasteringConfig onStart={vi.fn()} />)
+    for (const label of ["Streaming", "SoundCloud", "Club / DJ", "Vinyl", "Custom"]) {
+      expect(screen.getByRole("radio", { name: new RegExp(label) })).toBeInTheDocument()
+    }
+    for (const label of ["Dolby.io", "LANDR", "Bakuage"]) {
+      expect(screen.getByRole("radio", { name: new RegExp(label) })).toBeInTheDocument()
+    }
+  })
+
+  it("starts with a valid default config (streaming + dolby, wav)", async () => {
+    const onStart = vi.fn()
+    const user = userEvent.setup()
+    render(<MasteringConfig onStart={onStart} />)
+
+    await user.click(screen.getByRole("button", { name: /start mastering/i }))
+    expect(onStart).toHaveBeenCalledWith({ profile: "streaming", service: "dolby", format: "wav" })
+  })
+
+  it("reveals a LUFS input for the custom profile and submits it as target_lufs", async () => {
+    const onStart = vi.fn()
+    const user = userEvent.setup()
+    render(<MasteringConfig onStart={onStart} />)
+
+    await user.click(screen.getByRole("radio", { name: /custom/i }))
+    const input = screen.getByLabelText(/target loudness/i)
+    await user.clear(input)
+    await user.type(input, "-9")
+
+    await user.click(screen.getByRole("button", { name: /start mastering/i }))
+    expect(onStart).toHaveBeenCalledWith({
+      profile: "custom",
+      service: "dolby",
+      format: "wav",
+      target_lufs: -9,
+    })
+  })
+
+  it("disables Start when the custom LUFS is out of range", async () => {
+    const user = userEvent.setup()
+    render(<MasteringConfig onStart={vi.fn()} />)
+
+    await user.click(screen.getByRole("radio", { name: /custom/i }))
+    const input = screen.getByLabelText(/target loudness/i)
+    await user.clear(input)
+    await user.type(input, "-3") // above the -5 ceiling
+
+    expect(screen.getByRole("button", { name: /start mastering/i })).toBeDisabled()
+    expect(screen.getByText(/between -70 and -5/i)).toBeInTheDocument()
+  })
+
+  it("honors the disabled prop", () => {
+    render(<MasteringConfig onStart={vi.fn()} disabled />)
+    expect(screen.getByRole("button", { name: /start mastering/i })).toBeDisabled()
+  })
+})

--- a/web/components/mastering/mastering-config.tsx
+++ b/web/components/mastering/mastering-config.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import {
+  CUSTOM_LUFS_MAX,
+  CUSTOM_LUFS_MIN,
+  MASTERING_PROFILES,
+  MASTERING_SERVICES,
+  type MasteringConfig,
+  type MasteringProfile,
+  type MasteringService,
+} from "@/lib/mastering"
+
+/**
+ * Mastering configuration panel (US-21.2): pick a profile (loudness target), a
+ * service, and — for the Custom profile — a LUFS target, then start the job.
+ *
+ * The two selectors are inlined RadioGroups (the codebase has no Select/
+ * ToggleGroup primitive, and neither selector has an independent consumer). The
+ * Custom profile reveals a LUFS input constrained to the backend's remaster
+ * bounds; an out-of-range value keeps Start disabled so a bad value never 422s.
+ */
+export function MasteringConfig({
+  onStart,
+  disabled = false,
+}: {
+  onStart: (config: MasteringConfig) => void
+  /** Disable the whole form (e.g. while a job is submitting). */
+  disabled?: boolean
+}) {
+  const [profile, setProfile] = useState<MasteringProfile>("streaming")
+  const [service, setService] = useState<MasteringService>("dolby")
+  // Raw input string; parsed + range-checked only for the custom profile.
+  const [customLufs, setCustomLufs] = useState("-14")
+
+  const customValue = Number(customLufs)
+  const customValid =
+    customLufs.trim() !== "" &&
+    Number.isFinite(customValue) &&
+    customValue >= CUSTOM_LUFS_MIN &&
+    customValue <= CUSTOM_LUFS_MAX
+  const canStart = !disabled && (profile !== "custom" || customValid)
+
+  function handleStart() {
+    const config: MasteringConfig = { profile, service, format: "wav" }
+    if (profile === "custom") config.target_lufs = customValue
+    onStart(config)
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Profile selector */}
+      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+        <legend className="text-sm font-medium">Mastering profile</legend>
+        <RadioGroup
+          value={profile}
+          onValueChange={(v) => setProfile(v as MasteringProfile)}
+          aria-label="Mastering profile"
+        >
+          {MASTERING_PROFILES.map((p) => (
+            <div key={p.value} className="flex items-center gap-2">
+              <RadioGroupItem value={p.value} id={`profile-${p.value}`} />
+              <Label htmlFor={`profile-${p.value}`} className="font-normal">
+                {p.label}
+                {p.lufs !== null && (
+                  <span className="ml-1 text-muted-foreground tabular-nums">
+                    ({p.lufs} LUFS)
+                  </span>
+                )}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+
+        {profile === "custom" && (
+          <div className="flex flex-col gap-1 pl-6">
+            <Label htmlFor="custom-lufs" className="text-xs text-muted-foreground">
+              Target loudness (LUFS)
+            </Label>
+            <Input
+              id="custom-lufs"
+              type="number"
+              inputMode="numeric"
+              min={CUSTOM_LUFS_MIN}
+              max={CUSTOM_LUFS_MAX}
+              value={customLufs}
+              onChange={(e) => setCustomLufs(e.target.value)}
+              className="w-32"
+              aria-invalid={!customValid}
+            />
+            {!customValid && (
+              <p className="text-xs text-destructive">
+                Enter a value between {CUSTOM_LUFS_MIN} and {CUSTOM_LUFS_MAX}.
+              </p>
+            )}
+          </div>
+        )}
+      </fieldset>
+
+      {/* Service selector */}
+      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+        <legend className="text-sm font-medium">Mastering service</legend>
+        <RadioGroup
+          value={service}
+          onValueChange={(v) => setService(v as MasteringService)}
+          aria-label="Mastering service"
+        >
+          {MASTERING_SERVICES.map((s) => (
+            <div key={s.value} className="flex items-center gap-2">
+              <RadioGroupItem value={s.value} id={`service-${s.value}`} />
+              <Label htmlFor={`service-${s.value}`} className="font-normal">
+                {s.label}
+                <span className="ml-1 text-muted-foreground tabular-nums">
+                  ({s.cost} credits)
+                </span>
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </fieldset>
+
+      <div>
+        <Button onClick={handleStart} disabled={!canStart}>
+          Start Mastering
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/components/mastering/mastering-metrics.test.tsx
+++ b/web/components/mastering/mastering-metrics.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { MasteringMetrics } from "@/components/mastering/mastering-metrics"
+
+afterEach(() => vi.clearAllMocks())
+
+describe("MasteringMetrics", () => {
+  it("shows a fallback when no metrics are present", () => {
+    render(<MasteringMetrics metrics={undefined} />)
+    expect(screen.getByText(/metrics not available/i)).toBeInTheDocument()
+  })
+
+  it("shows loudness with a signed delta vs. original", () => {
+    render(<MasteringMetrics metrics={{ loudness: -14 }} loudnessDelta={6} />)
+    expect(screen.getByText(/-14\.0 LUFS/)).toBeInTheDocument()
+    expect(screen.getByText(/\+6\.0 dB vs\. original/)).toBeInTheDocument()
+  })
+
+  it("renders an EQ visualization when bands are present", () => {
+    const bands = Array.from({ length: 16 }, (_, i) => i - 8)
+    render(<MasteringMetrics metrics={{ loudness: -14, eq_bands: bands }} />)
+    expect(screen.getByRole("img", { name: /equalizer, 16 bands/i })).toBeInTheDocument()
+  })
+
+  it("degrades gracefully for a loudness-only service (no EQ, no stereo)", () => {
+    render(<MasteringMetrics metrics={{ loudness: -12 }} />)
+    expect(screen.getByText(/-12\.0 LUFS/)).toBeInTheDocument()
+    expect(screen.queryByRole("img")).not.toBeInTheDocument()
+    expect(screen.queryByText(/stereo image/i)).not.toBeInTheDocument()
+  })
+
+  it("shows stereo image when provided", () => {
+    render(<MasteringMetrics metrics={{ loudness: -14, stereo_width: 0.8, stereo_balance: 0.1 }} />)
+    expect(screen.getByText(/stereo image/i)).toBeInTheDocument()
+    expect(screen.getByText(/width 0\.80/)).toBeInTheDocument()
+  })
+})

--- a/web/components/mastering/mastering-metrics.tsx
+++ b/web/components/mastering/mastering-metrics.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import type { MasteringMetrics } from "@/lib/mastering"
+
+/** Signed dB string, e.g. "+6.0 dB" / "-2.3 dB". */
+function signed(value: number, unit = " dB") {
+  const sign = value > 0 ? "+" : ""
+  return `${sign}${value.toFixed(1)}${unit}`
+}
+
+/**
+ * A centered EQ bar chart (US-21.2). Each band's gain is drawn as a bar above or
+ * below a zero line, normalized to the largest magnitude present. Dolby returns
+ * 16 bands; other services may return none (then this isn't rendered).
+ */
+function EqBands({ bands }: { bands: number[] }) {
+  const peak = Math.max(1e-6, ...bands.map((b) => Math.abs(b)))
+  const width = 200
+  const height = 60
+  const mid = height / 2
+  const barW = width / bands.length
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="h-16 w-full max-w-xs"
+      role="img"
+      aria-label={`Equalizer, ${bands.length} bands`}
+    >
+      <line x1={0} y1={mid} x2={width} y2={mid} className="stroke-border" strokeWidth={1} />
+      {bands.map((gain, i) => {
+        const h = (Math.abs(gain) / peak) * (mid - 2)
+        const x = i * barW + barW * 0.15
+        const y = gain >= 0 ? mid - h : mid
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={y}
+            width={barW * 0.7}
+            height={h}
+            className="fill-primary"
+          />
+        )
+      })}
+    </svg>
+  )
+}
+
+/**
+ * Mastering analysis metrics for the selected preview (US-21.2): integrated
+ * loudness (with delta vs. original), a 16-band EQ visualization, and stereo
+ * image — each shown only when the backend provides it, so a loudness-only
+ * service (Bakuage) degrades gracefully to just the loudness row.
+ */
+export function MasteringMetrics({
+  metrics,
+  loudnessDelta,
+}: {
+  metrics?: MasteringMetrics
+  loudnessDelta?: number | null
+}) {
+  const hasLoudness = metrics?.loudness !== undefined
+  const hasEq = !!metrics?.eq_bands && metrics.eq_bands.length > 0
+  const hasStereo =
+    metrics?.stereo_width !== undefined || metrics?.stereo_balance !== undefined
+
+  if (!metrics || (!hasLoudness && !hasEq && !hasStereo)) {
+    return <p className="text-sm text-muted-foreground">Metrics not available.</p>
+  }
+
+  return (
+    <dl className="flex flex-col gap-3 text-sm">
+      {hasLoudness && (
+        <div className="flex items-baseline justify-between gap-4">
+          <dt className="text-muted-foreground">Loudness</dt>
+          <dd className="tabular-nums">
+            {metrics.loudness!.toFixed(1)} LUFS
+            {loudnessDelta !== null && loudnessDelta !== undefined && (
+              <span className="ml-1 text-muted-foreground">
+                ({signed(loudnessDelta)} vs. original)
+              </span>
+            )}
+          </dd>
+        </div>
+      )}
+
+      {hasEq && (
+        <div className="flex flex-col gap-1">
+          <dt className="text-muted-foreground">EQ</dt>
+          <dd>
+            <EqBands bands={metrics.eq_bands!} />
+          </dd>
+        </div>
+      )}
+
+      {hasStereo && (
+        <div className="flex items-baseline justify-between gap-4">
+          <dt className="text-muted-foreground">Stereo image</dt>
+          <dd className="tabular-nums">
+            {metrics.stereo_width !== undefined && (
+              <span>width {metrics.stereo_width.toFixed(2)}</span>
+            )}
+            {metrics.stereo_balance !== undefined && (
+              <span className="ml-2">balance {signed(metrics.stereo_balance, "")}</span>
+            )}
+          </dd>
+        </div>
+      )}
+    </dl>
+  )
+}

--- a/web/components/mastering/mastering-status.test.tsx
+++ b/web/components/mastering/mastering-status.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { MasteringStatus } from "@/components/mastering/mastering-status"
+
+afterEach(() => vi.clearAllMocks())
+
+describe("MasteringStatus", () => {
+  it.each([
+    ["submitting", /submitting/i],
+    ["queued", /queued/i],
+    ["processing", /in progress/i],
+  ] as const)("shows a progress status for %s", (status, re) => {
+    render(<MasteringStatus status={status} />)
+    expect(screen.getByRole("status")).toHaveTextContent(re)
+  })
+
+  it("shows the error and a Retry button when failed", async () => {
+    const onRetry = vi.fn()
+    const user = userEvent.setup()
+    render(<MasteringStatus status="failed" error="boom" onRetry={onRetry} />)
+
+    expect(screen.getByRole("alert")).toHaveTextContent("boom")
+    await user.click(screen.getByRole("button", { name: /retry/i }))
+    expect(onRetry).toHaveBeenCalled()
+  })
+
+  it("omits Retry when no handler is given", () => {
+    render(<MasteringStatus status="failed" error="boom" />)
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument()
+  })
+})

--- a/web/components/mastering/mastering-status.tsx
+++ b/web/components/mastering/mastering-status.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Alert01Icon,
+  ArrowTurnBackwardIcon,
+  Loading03Icon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+
+/** The in-progress/terminal-failure phases the status panel renders. */
+export type MasteringStatusPhase =
+  | "submitting"
+  | "queued"
+  | "processing"
+  | "failed"
+
+const LABELS: Record<Exclude<MasteringStatusPhase, "failed">, string> = {
+  submitting: "Submitting mastering job…",
+  queued: "Queued — waiting for a mastering slot…",
+  processing: "Mastering in progress…",
+}
+
+/**
+ * Mastering job progress + failure display (US-21.2). Shows a spinner and a
+ * phase label while the job runs (submitting → queued → processing), and an
+ * error message with a Retry button when it fails. The completed state is owned
+ * by the tab (it swaps in the preview UI), so this never renders "completed".
+ */
+export function MasteringStatus({
+  status,
+  error,
+  onRetry,
+}: {
+  status: MasteringStatusPhase
+  error?: string
+  onRetry?: () => void
+}) {
+  if (status === "failed") {
+    return (
+      <div role="alert" className="flex flex-col items-start gap-3">
+        <p className="flex items-center gap-2 text-sm text-destructive">
+          <HugeiconsIcon icon={Alert01Icon} size={18} />
+          {error || "Mastering failed. Please try again."}
+        </p>
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            <HugeiconsIcon icon={ArrowTurnBackwardIcon} size={16} />
+            Retry
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <p role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
+      <HugeiconsIcon icon={Loading03Icon} size={18} className="animate-spin" />
+      {LABELS[status]}
+    </p>
+  )
+}

--- a/web/components/mastering/mastering-tab.test.tsx
+++ b/web/components/mastering/mastering-tab.test.tsx
@@ -8,6 +8,9 @@ import type { UseMasteringPreviews } from "@/hooks/use-mastering-previews"
 import type { Clip } from "@/lib/workspace-clips"
 
 // --- hook/lib mocks -------------------------------------------------------
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+
 let jobState: MasteringJobState
 const submit = vi.fn()
 const retry = vi.fn()
@@ -124,5 +127,16 @@ describe("MasteringTab", () => {
     expect(
       screen.getByText("Mastered", { selector: "[data-slot='badge']" })
     ).toBeInTheDocument()
+  })
+
+  it("redirects to login when approval is unauthorized", async () => {
+    jobState = { phase: "completed", detail: { job_id: "j1", status: "completed" } }
+    previewsResult = readyPreviews
+    approveMasteringPreview.mockResolvedValue({ status: "unauthorized" })
+    const user = userEvent.setup()
+    render(<MasteringTab selectedClip={clip("c1")} />)
+
+    await user.click(screen.getByRole("button", { name: /approve master/i }))
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/login"))
   })
 })

--- a/web/components/mastering/mastering-tab.test.tsx
+++ b/web/components/mastering/mastering-tab.test.tsx
@@ -129,6 +129,43 @@ describe("MasteringTab", () => {
     ).toBeInTheDocument()
   })
 
+  it("re-shows Approve after approving one preview and selecting another", async () => {
+    jobState = { phase: "completed", detail: { job_id: "j1", status: "completed" } }
+    // Two candidates; start with m1 selected.
+    const two: UseMasteringPreviews = {
+      state: {
+        status: "ready",
+        data: {
+          source_clip_id: "c1",
+          previews: [
+            { preview_id: "m1", audio_url: "u1", loudness_delta: 6 },
+            { preview_id: "m2", audio_url: "u2", loudness_delta: 3 },
+          ],
+        },
+      },
+      selectedId: "m1",
+      select: vi.fn(),
+      reload: vi.fn(),
+    }
+    previewsResult = two
+    approveMasteringPreview.mockResolvedValue({ status: "approved", clipId: "x", audioUrl: "u" })
+    const user = userEvent.setup()
+    const { rerender } = render(<MasteringTab selectedClip={clip("c1")} />)
+
+    await user.click(screen.getByRole("button", { name: /approve master/i }))
+    await waitFor(() =>
+      expect(screen.getByText("Mastered", { selector: "[data-slot='badge']" })).toBeInTheDocument()
+    )
+
+    // The user now selects a different candidate to keep comparing.
+    previewsResult = { ...two, selectedId: "m2" }
+    rerender(<MasteringTab selectedClip={clip("c1")} />)
+
+    // The approval banner is gone; Approve is offered for the new selection.
+    expect(screen.queryByText("Mastered", { selector: "[data-slot='badge']" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /approve master/i })).toBeInTheDocument()
+  })
+
   it("redirects to login when approval is unauthorized", async () => {
     jobState = { phase: "completed", detail: { job_id: "j1", status: "completed" } }
     previewsResult = readyPreviews

--- a/web/components/mastering/mastering-tab.test.tsx
+++ b/web/components/mastering/mastering-tab.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { MasteringTab } from "@/components/mastering/mastering-tab"
+import type { MasteringJobState } from "@/hooks/use-mastering-job"
+import type { UseMasteringPreviews } from "@/hooks/use-mastering-previews"
+import type { Clip } from "@/lib/workspace-clips"
+
+// --- hook/lib mocks -------------------------------------------------------
+let jobState: MasteringJobState
+const submit = vi.fn()
+const retry = vi.fn()
+const reset = vi.fn()
+vi.mock("@/hooks/use-mastering-job", () => ({
+  useMasteringJob: () => ({ state: jobState, submit, retry, reset }),
+}))
+
+let previewsResult: UseMasteringPreviews
+vi.mock("@/hooks/use-mastering-previews", () => ({
+  useMasteringPreviews: () => previewsResult,
+}))
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => ({ accessToken: "tok" }) }))
+
+const approveMasteringPreview = vi.fn()
+vi.mock("@/lib/mastering", async (orig) => {
+  const actual = await orig<typeof import("@/lib/mastering")>()
+  return { ...actual, approveMasteringPreview: (...a: unknown[]) => approveMasteringPreview(...a) }
+})
+
+function clip(id: string): Clip {
+  return {
+    id,
+    workspace_id: "w1",
+    title: id,
+    format: "wav",
+    duration: 60,
+    bpm: null,
+    key: null,
+    style_tags: [],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: null,
+    is_public: false,
+    created_at: "2026-01-01",
+  }
+}
+
+const readyPreviews: UseMasteringPreviews = {
+  state: {
+    status: "ready",
+    data: {
+      source_clip_id: "c1",
+      original_audio_url: "orig",
+      original_metrics: { loudness: -20 },
+      previews: [
+        { preview_id: "m1", audio_url: "u1", profile: "streaming", service: "dolby", loudness_delta: 6, metrics: { loudness: -14 } },
+      ],
+    },
+  },
+  selectedId: "m1",
+  select: vi.fn(),
+  reload: vi.fn(),
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe("MasteringTab", () => {
+  it("prompts to select a song when none is chosen", () => {
+    jobState = { phase: "idle" }
+    previewsResult = { state: { status: "loading" }, selectedId: null, select: vi.fn(), reload: vi.fn() }
+    render(<MasteringTab selectedClip={null} />)
+    expect(screen.getByText(/select a song above/i)).toBeInTheDocument()
+  })
+
+  it("renders the config panel and submits for the selected clip", async () => {
+    jobState = { phase: "idle" }
+    previewsResult = { state: { status: "loading" }, selectedId: null, select: vi.fn(), reload: vi.fn() }
+    const user = userEvent.setup()
+    render(<MasteringTab selectedClip={clip("c1")} />)
+
+    await user.click(screen.getByRole("button", { name: /start mastering/i }))
+    expect(submit).toHaveBeenCalledWith("c1", { profile: "streaming", service: "dolby", format: "wav" })
+  })
+
+  it("shows progress while polling", () => {
+    jobState = { phase: "polling", detail: { job_id: "j1", status: "processing" } }
+    previewsResult = { state: { status: "loading" }, selectedId: null, select: vi.fn(), reload: vi.fn() }
+    render(<MasteringTab selectedClip={clip("c1")} />)
+    expect(screen.getByRole("status")).toHaveTextContent(/in progress/i)
+  })
+
+  it("shows a failure with a working retry", async () => {
+    jobState = { phase: "error", message: "boom" }
+    previewsResult = { state: { status: "loading" }, selectedId: null, select: vi.fn(), reload: vi.fn() }
+    const user = userEvent.setup()
+    render(<MasteringTab selectedClip={clip("c1")} />)
+
+    expect(screen.getByRole("alert")).toHaveTextContent("boom")
+    await user.click(screen.getByRole("button", { name: /retry/i }))
+    expect(retry).toHaveBeenCalled()
+  })
+
+  it("shows previews, the A/B player, and approves a master", async () => {
+    jobState = { phase: "completed", detail: { job_id: "j1", status: "completed" } }
+    previewsResult = readyPreviews
+    approveMasteringPreview.mockResolvedValue({ status: "approved", clipId: "m1", audioUrl: "u" })
+    const user = userEvent.setup()
+    render(<MasteringTab selectedClip={clip("c1")} />)
+
+    // Preview list + A/B player render.
+    expect(screen.getByLabelText(/mastered previews/i)).toBeInTheDocument()
+    expect(screen.getByTestId("preview-audio")).toHaveAttribute("src", "/api/clips/m1/stream")
+
+    await user.click(screen.getByRole("button", { name: /approve master/i }))
+    expect(approveMasteringPreview).toHaveBeenCalledWith("j1", "m1", "tok")
+    await waitFor(() => expect(screen.getByText(/master approved/i)).toBeInTheDocument())
+    // The approval confirmation carries the "Mastered" badge.
+    expect(
+      screen.getByText("Mastered", { selector: "[data-slot='badge']" })
+    ).toBeInTheDocument()
+  })
+})

--- a/web/components/mastering/mastering-tab.tsx
+++ b/web/components/mastering/mastering-tab.tsx
@@ -1,0 +1,189 @@
+"use client"
+
+import { useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { CheckmarkCircle01Icon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { MasteringConfig } from "@/components/mastering/mastering-config"
+import { MasteringMetrics } from "@/components/mastering/mastering-metrics"
+import { MasteringStatus } from "@/components/mastering/mastering-status"
+import { PreviewList } from "@/components/mastering/preview-list"
+import { PreviewPlayer } from "@/components/mastering/preview-player"
+import { useAuth } from "@/hooks/use-auth"
+import { useMasteringJob } from "@/hooks/use-mastering-job"
+import { useMasteringPreviews } from "@/hooks/use-mastering-previews"
+import { approveMasteringPreview } from "@/lib/mastering"
+import type { Clip } from "@/lib/workspace-clips"
+
+/** The approval sub-flow's local state. */
+type ApproveState =
+  | { phase: "idle" }
+  | { phase: "approving" }
+  | { phase: "approved"; clipId: string }
+  | { phase: "error"; message: string }
+
+/**
+ * The mastering tab (US-21.2): the full workflow for one selected song —
+ * configure → submit → track progress → audition previews with A/B compare and
+ * metrics → approve a master. Composed from small components; the job/preview
+ * lifecycle lives in dedicated hooks.
+ */
+export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
+  const { accessToken } = useAuth()
+  const job = useMasteringJob()
+  const jobId =
+    job.state.phase === "completed" ? job.state.detail.job_id : undefined
+  const previews = useMasteringPreviews(jobId)
+  const [approve, setApprove] = useState<ApproveState>({ phase: "idle" })
+
+  async function handleApprove() {
+    if (!jobId || !previews.selectedId) return
+    setApprove({ phase: "approving" })
+    const result = await approveMasteringPreview(
+      jobId,
+      previews.selectedId,
+      accessToken ?? ""
+    )
+    if (result.status === "approved") {
+      setApprove({ phase: "approved", clipId: result.clipId })
+    } else if (result.status === "unauthorized") {
+      setApprove({ phase: "error", message: "Please sign in again to approve." })
+    } else {
+      setApprove({ phase: "error", message: result.detail })
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Mastering</CardTitle>
+        <CardDescription>
+          Choose a profile and service, generate previews, A/B against the
+          original, and approve your master.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>{renderBody()}</CardContent>
+    </Card>
+  )
+
+  function renderBody() {
+    // Configure (idle): needs a selected song first.
+    if (job.state.phase === "idle") {
+      if (!selectedClip) {
+        return (
+          <p className="text-sm text-muted-foreground">
+            Select a song above to start mastering.
+          </p>
+        )
+      }
+      return (
+        <MasteringConfig
+          onStart={(config) => void job.submit(selectedClip.id, config)}
+        />
+      )
+    }
+
+    if (job.state.phase === "submitting") {
+      return <MasteringStatus status="submitting" />
+    }
+
+    if (job.state.phase === "polling") {
+      const status =
+        job.state.detail?.status === "processing" ? "processing" : "queued"
+      return <MasteringStatus status={status} />
+    }
+
+    if (job.state.phase === "error") {
+      return (
+        <MasteringStatus
+          status="failed"
+          error={job.state.message}
+          onRetry={job.retry}
+        />
+      )
+    }
+
+    // Completed → previews / A-B / approve.
+    return renderPreviews()
+  }
+
+  function renderPreviews() {
+    if (previews.state.status === "loading") {
+      return (
+        <p role="status" className="text-sm text-muted-foreground">
+          Loading previews…
+        </p>
+      )
+    }
+    if (previews.state.status === "error") {
+      return (
+        <div className="flex flex-col items-start gap-3">
+          <p className="text-sm text-destructive">Couldn&apos;t load previews.</p>
+          <Button variant="outline" size="sm" onClick={previews.reload}>
+            Try again
+          </Button>
+        </div>
+      )
+    }
+
+    const data = previews.state.data
+    const selected = data.previews.find((p) => p.preview_id === previews.selectedId)
+    const originalClipId = data.source_clip_id ?? selectedClip?.id
+
+    return (
+      <div className="flex flex-col gap-6">
+        <PreviewList
+          previews={data.previews}
+          selectedId={previews.selectedId}
+          onSelect={previews.select}
+        />
+
+        {selected && originalClipId && (
+          <>
+            <PreviewPlayer
+              originalClipId={originalClipId}
+              masteredClipId={selected.preview_id}
+            />
+            <MasteringMetrics
+              metrics={selected.metrics}
+              loudnessDelta={selected.loudness_delta}
+            />
+          </>
+        )}
+
+        {approve.phase === "approved" ? (
+          <p className="flex items-center gap-2 text-sm text-foreground">
+            <HugeiconsIcon
+              icon={CheckmarkCircle01Icon}
+              size={18}
+              className="text-primary"
+            />
+            Master approved.
+            <Badge>Mastered</Badge>
+          </p>
+        ) : (
+          <div className="flex flex-col items-start gap-2">
+            <Button
+              onClick={handleApprove}
+              disabled={!selected || approve.phase === "approving"}
+            >
+              {approve.phase === "approving" ? "Approving…" : "Approve Master"}
+            </Button>
+            {approve.phase === "error" && (
+              <p className="text-sm text-destructive">{approve.message}</p>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+}

--- a/web/components/mastering/mastering-tab.tsx
+++ b/web/components/mastering/mastering-tab.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { CheckmarkCircle01Icon } from "@hugeicons/core-free-icons"
 
@@ -38,6 +39,7 @@ type ApproveState =
  * lifecycle lives in dedicated hooks.
  */
 export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
+  const router = useRouter()
   const { accessToken } = useAuth()
   const job = useMasteringJob()
   const jobId =
@@ -56,7 +58,8 @@ export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
     if (result.status === "approved") {
       setApprove({ phase: "approved", clipId: result.clipId })
     } else if (result.status === "unauthorized") {
-      setApprove({ phase: "error", message: "Please sign in again to approve." })
+      // Token expired mid-session — send to login like the rest of the tab does.
+      router.push("/login")
     } else {
       setApprove({ phase: "error", message: result.detail })
     }

--- a/web/components/mastering/mastering-tab.tsx
+++ b/web/components/mastering/mastering-tab.tsx
@@ -25,11 +25,11 @@ import { useMasteringPreviews } from "@/hooks/use-mastering-previews"
 import { approveMasteringPreview } from "@/lib/mastering"
 import type { Clip } from "@/lib/workspace-clips"
 
-/** The approval sub-flow's local state. */
+/** The approval sub-flow's local state. `previewId` is the candidate approved. */
 type ApproveState =
   | { phase: "idle" }
   | { phase: "approving" }
-  | { phase: "approved"; clipId: string }
+  | { phase: "approved"; previewId: string }
   | { phase: "error"; message: string }
 
 /**
@@ -49,14 +49,11 @@ export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
 
   async function handleApprove() {
     if (!jobId || !previews.selectedId) return
+    const previewId = previews.selectedId
     setApprove({ phase: "approving" })
-    const result = await approveMasteringPreview(
-      jobId,
-      previews.selectedId,
-      accessToken ?? ""
-    )
+    const result = await approveMasteringPreview(jobId, previewId, accessToken ?? "")
     if (result.status === "approved") {
-      setApprove({ phase: "approved", clipId: result.clipId })
+      setApprove({ phase: "approved", previewId })
     } else if (result.status === "unauthorized") {
       // Token expired mid-session — send to login like the rest of the tab does.
       router.push("/login")
@@ -163,7 +160,10 @@ export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
           </>
         )}
 
-        {approve.phase === "approved" ? (
+        {/* The banner only stands for the *approved* candidate — re-selecting a
+            different preview brings the Approve button back for that one. */}
+        {approve.phase === "approved" &&
+        approve.previewId === previews.selectedId ? (
           <p className="flex items-center gap-2 text-sm text-foreground">
             <HugeiconsIcon
               icon={CheckmarkCircle01Icon}

--- a/web/components/mastering/preview-list.test.tsx
+++ b/web/components/mastering/preview-list.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { PreviewList } from "@/components/mastering/preview-list"
+import type { PreviewItem } from "@/lib/mastering"
+
+const items: PreviewItem[] = [
+  { preview_id: "m1", audio_url: "u1", profile: "streaming", service: "dolby", loudness_delta: 6 },
+  { preview_id: "m2", audio_url: "u2", profile: "club", service: "landr", loudness_delta: -2 },
+]
+
+afterEach(() => vi.clearAllMocks())
+
+describe("PreviewList", () => {
+  it("renders an empty state with no previews", () => {
+    render(<PreviewList previews={[]} selectedId={null} onSelect={vi.fn()} />)
+    expect(screen.getByText(/no mastered previews/i)).toBeInTheDocument()
+  })
+
+  it("renders each preview with profile, service, and signed loudness delta", () => {
+    render(<PreviewList previews={items} selectedId="m1" onSelect={vi.fn()} />)
+    expect(screen.getByText("Streaming")).toBeInTheDocument()
+    expect(screen.getByText("Dolby.io")).toBeInTheDocument()
+    expect(screen.getByText("+6.0 dB")).toBeInTheDocument()
+    expect(screen.getByText("-2.0 dB")).toBeInTheDocument()
+  })
+
+  it("marks the selected preview as pressed and reports clicks", async () => {
+    const onSelect = vi.fn()
+    const user = userEvent.setup()
+    render(<PreviewList previews={items} selectedId="m1" onSelect={onSelect} />)
+
+    const buttons = screen.getAllByRole("button")
+    expect(buttons[0]).toHaveAttribute("aria-pressed", "true")
+    expect(buttons[1]).toHaveAttribute("aria-pressed", "false")
+
+    await user.click(buttons[1])
+    expect(onSelect).toHaveBeenCalledWith("m2")
+  })
+})

--- a/web/components/mastering/preview-list.tsx
+++ b/web/components/mastering/preview-list.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import {
+  MASTERING_PROFILES,
+  MASTERING_SERVICES,
+  type PreviewItem,
+} from "@/lib/mastering"
+
+/** Human label for a profile/service key, falling back to the raw value. */
+function profileLabel(value?: string) {
+  return MASTERING_PROFILES.find((p) => p.value === value)?.label ?? value ?? "—"
+}
+function serviceLabel(value?: string) {
+  return MASTERING_SERVICES.find((s) => s.value === value)?.label ?? value ?? "—"
+}
+
+/** Format a loudness delta with a sign (e.g. "+6.0 dB"), or a dash when absent. */
+function formatDelta(delta?: number | null) {
+  if (delta === null || delta === undefined) return "—"
+  const sign = delta > 0 ? "+" : ""
+  return `${sign}${delta.toFixed(1)} dB`
+}
+
+/**
+ * The list of mastered previews (US-21.2). Each is a selectable card showing its
+ * profile, service, and loudness delta vs. the original; the active card is
+ * highlighted and loads into the A/B player. Renders an empty state when the
+ * completed job produced no candidates.
+ */
+export function PreviewList({
+  previews,
+  selectedId,
+  onSelect,
+}: {
+  previews: PreviewItem[]
+  selectedId: string | null
+  onSelect: (previewId: string) => void
+}) {
+  if (previews.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No mastered previews are available for this job.
+      </p>
+    )
+  }
+
+  return (
+    <ul className="flex flex-col gap-2" aria-label="Mastered previews">
+      {previews.map((p) => {
+        const selected = p.preview_id === selectedId
+        return (
+          <li key={p.preview_id}>
+            <button
+              type="button"
+              onClick={() => onSelect(p.preview_id)}
+              aria-pressed={selected}
+              className={cn(
+                "flex w-full items-center justify-between gap-3 rounded-md border p-3 text-left transition-colors",
+                selected
+                  ? "border-primary bg-primary/5"
+                  : "border-input hover:bg-muted/50"
+              )}
+            >
+              <span className="flex flex-col">
+                <span className="text-sm font-medium">
+                  {profileLabel(p.profile)}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {serviceLabel(p.service)}
+                </span>
+              </span>
+              <span className="text-sm tabular-nums text-muted-foreground">
+                {formatDelta(p.loudness_delta)}
+              </span>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/web/components/mastering/preview-player.test.tsx
+++ b/web/components/mastering/preview-player.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { PreviewPlayer } from "@/components/mastering/preview-player"
+
+afterEach(() => vi.clearAllMocks())
+
+describe("PreviewPlayer", () => {
+  it("plays the mastered source by default through the cookie-authed stream proxy", () => {
+    render(<PreviewPlayer originalClipId="c1" masteredClipId="m1" />)
+    const audio = screen.getByTestId("preview-audio")
+    expect(audio.getAttribute("src")).toBe("/api/clips/m1/stream")
+    expect(screen.getByTestId("ab-mode")).toHaveTextContent("Mastered")
+  })
+
+  it("A/B toggle swaps the source to the original and back", async () => {
+    const user = userEvent.setup()
+    render(<PreviewPlayer originalClipId="c1" masteredClipId="m1" />)
+    const audio = screen.getByTestId("preview-audio")
+
+    await user.click(screen.getByRole("button", { name: /compare with original/i }))
+    expect(audio.getAttribute("src")).toBe("/api/clips/c1/stream")
+    expect(screen.getByTestId("ab-mode")).toHaveTextContent("Original")
+
+    await user.click(screen.getByRole("button", { name: /compare with mastered/i }))
+    expect(audio.getAttribute("src")).toBe("/api/clips/m1/stream")
+    expect(screen.getByTestId("ab-mode")).toHaveTextContent("Mastered")
+  })
+
+  it("exposes play/pause and seek controls", () => {
+    render(<PreviewPlayer originalClipId="c1" masteredClipId="m1" />)
+    expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument()
+    expect(screen.getByRole("slider", { name: /seek/i })).toBeInTheDocument()
+  })
+})

--- a/web/components/mastering/preview-player.tsx
+++ b/web/components/mastering/preview-player.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { PauseIcon, PlayIcon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { clipAudioUrl, formatTime } from "@/lib/clips"
+
+type ABMode = "original" | "mastered"
+
+/**
+ * A/B preview player (US-21.2). One `<audio>` element whose source swaps between
+ * the original mix and the selected master, so the two are auditioned at the
+ * same playback position — true A/B comparison.
+ *
+ * Both sources are driven by clip id through the cookie-authed `/stream` proxy
+ * (issue #282): the mastered preview id and the source clip id are both clip
+ * ids, so no raw storage URL is needed. On a toggle the current time + play
+ * state are captured and restored once the new source loads (seamless switch).
+ */
+export function PreviewPlayer({
+  originalClipId,
+  masteredClipId,
+}: {
+  originalClipId: string
+  masteredClipId: string
+}) {
+  const audioRef = useRef<HTMLAudioElement>(null)
+  // Position + play state to restore after a source swap (seamless A/B).
+  const pendingRef = useRef<{ time: number; play: boolean } | null>(null)
+
+  const [mode, setMode] = useState<ABMode>("mastered")
+  const [playing, setPlaying] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+
+  const src = clipAudioUrl(mode === "mastered" ? masteredClipId : originalClipId)
+
+  function safePlay() {
+    // jsdom's play() is a no-op stub; optional-chain the promise so a rejected
+    // autoplay (or the stub) never throws.
+    audioRef.current?.play()?.catch(() => {})
+  }
+
+  function togglePlay() {
+    const audio = audioRef.current
+    if (!audio) return
+    if (audio.paused) safePlay()
+    else audio.pause()
+  }
+
+  function toggleMode() {
+    const audio = audioRef.current
+    if (audio) {
+      pendingRef.current = { time: audio.currentTime, play: !audio.paused }
+    }
+    setMode((m) => (m === "mastered" ? "original" : "mastered"))
+  }
+
+  // Restore position + resume once the swapped-in source is seekable.
+  function handleLoadedMetadata() {
+    const audio = audioRef.current
+    if (!audio) return
+    setDuration(audio.duration || 0)
+    const pending = pendingRef.current
+    if (pending) {
+      audio.currentTime = pending.time
+      if (pending.play) safePlay()
+      pendingRef.current = null
+    }
+  }
+
+  function handleSeek(e: React.ChangeEvent<HTMLInputElement>) {
+    const audio = audioRef.current
+    const t = Number(e.target.value)
+    if (audio) audio.currentTime = t
+    setCurrentTime(t)
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <audio
+        ref={audioRef}
+        src={src}
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+        onLoadedMetadata={handleLoadedMetadata}
+        onTimeUpdate={(e) => setCurrentTime(e.currentTarget.currentTime)}
+        data-testid="preview-audio"
+      />
+
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          size="icon"
+          variant="secondary"
+          onClick={togglePlay}
+          aria-label={playing ? "Pause" : "Play"}
+        >
+          <HugeiconsIcon icon={playing ? PauseIcon : PlayIcon} size={18} />
+        </Button>
+
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {formatTime(currentTime)} / {formatTime(duration)}
+        </span>
+
+        <input
+          type="range"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={currentTime}
+          onChange={handleSeek}
+          aria-label="Seek"
+          className="flex-1 accent-primary"
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-medium">
+          Now playing:{" "}
+          <span data-testid="ab-mode">
+            {mode === "mastered" ? "Mastered" : "Original"}
+          </span>
+        </span>
+        <Button type="button" variant="outline" size="sm" onClick={toggleMode}>
+          Compare with {mode === "mastered" ? "Original" : "Mastered"}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/hooks/use-mastering-job.test.tsx
+++ b/web/hooks/use-mastering-job.test.tsx
@@ -1,0 +1,150 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+import { useMasteringJob } from "@/hooks/use-mastering-job"
+import type { MasteringConfig } from "@/lib/mastering"
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+
+const submitMasteringJob = vi.fn()
+const fetchMasteringStatus = vi.fn()
+vi.mock("@/lib/mastering", () => ({
+  submitMasteringJob: (...a: unknown[]) => submitMasteringJob(...a),
+  fetchMasteringStatus: (...a: unknown[]) => fetchMasteringStatus(...a),
+}))
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+}
+
+const config: MasteringConfig = { profile: "streaming", service: "dolby", format: "wav" }
+
+afterEach(() => vi.clearAllMocks())
+
+describe("useMasteringJob", () => {
+  it("submits, polls, and reaches completed — calling onComplete with the detail", async () => {
+    const detail = { job_id: "j1", status: "completed", mastered_clip_id: "m1" }
+    const onComplete = vi.fn()
+    submitMasteringJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchMasteringStatus.mockResolvedValue({ kind: "completed", detail })
+    const { result } = renderHook(() => useMasteringJob({ onComplete }), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    await waitFor(() => expect(result.current.state.phase).toBe("completed"))
+    expect(onComplete).toHaveBeenCalledWith(detail)
+    // Token comes from auth context, forwarded to the submit + poll.
+    expect(submitMasteringJob).toHaveBeenCalledWith("c1", config, "tok")
+    expect(fetchMasteringStatus).toHaveBeenCalledWith("j1", "tok")
+  })
+
+  it("stays in polling while the job is queued/processing", async () => {
+    submitMasteringJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchMasteringStatus.mockResolvedValue({
+      kind: "pending",
+      detail: { job_id: "j1", status: "processing" },
+    })
+    const { result } = renderHook(() => useMasteringJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    expect(result.current.state).toMatchObject({ phase: "polling" })
+    act(() => result.current.reset())
+  })
+
+  it("surfaces a failed job as an error", async () => {
+    submitMasteringJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchMasteringStatus.mockResolvedValue({ kind: "failed", error: "boom" })
+    const { result } = renderHook(() => useMasteringJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    await waitFor(() =>
+      expect(result.current.state).toEqual({ phase: "error", message: "boom" })
+    )
+  })
+
+  it("surfaces insufficient credits with a readable message", async () => {
+    submitMasteringJob.mockResolvedValue({
+      status: "insufficient_credits",
+      balance: 1,
+      required: 3,
+    })
+    const { result } = renderHook(() => useMasteringJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    expect(result.current.state.phase).toBe("error")
+    if (result.current.state.phase === "error") {
+      expect(result.current.state.message).toMatch(/3 required, 1 available/)
+    }
+  })
+
+  it("redirects to login when submission is unauthorized", async () => {
+    submitMasteringJob.mockResolvedValue({ status: "unauthorized" })
+    const { result } = renderHook(() => useMasteringJob(), { wrapper })
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+    expect(push).toHaveBeenCalledWith("/login")
+  })
+
+  it("redirects to login when a poll returns unauthorized", async () => {
+    submitMasteringJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchMasteringStatus.mockResolvedValue({ kind: "unauthorized" })
+    const { result } = renderHook(() => useMasteringJob(), { wrapper })
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/login"))
+  })
+
+  it("retry replays the last submission", async () => {
+    submitMasteringJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchMasteringStatus.mockResolvedValue({ kind: "failed", error: "boom" })
+    const { result } = renderHook(() => useMasteringJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+    await waitFor(() => expect(result.current.state.phase).toBe("error"))
+
+    await act(async () => {
+      result.current.retry()
+    })
+    expect(submitMasteringJob).toHaveBeenCalledTimes(2)
+    expect(submitMasteringJob).toHaveBeenLastCalledWith("c1", config, "tok")
+  })
+
+  it("reset returns to idle", async () => {
+    submitMasteringJob.mockResolvedValue({ status: "error", detail: "x" })
+    const { result } = renderHook(() => useMasteringJob(), { wrapper })
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+    expect(result.current.state.phase).toBe("error")
+    act(() => result.current.reset())
+    expect(result.current.state).toEqual({ phase: "idle" })
+  })
+})

--- a/web/hooks/use-mastering-job.ts
+++ b/web/hooks/use-mastering-job.ts
@@ -1,0 +1,173 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { useAuth } from "@/hooks/use-auth"
+import {
+  fetchMasteringStatus,
+  submitMasteringJob,
+  type MasteringConfig,
+  type MasteringJobDetail,
+} from "@/lib/mastering"
+
+const POLL_INTERVAL_MS = 2500
+// Cap polling so a stuck/vanished job surfaces an error instead of spinning
+// forever. 240 × 2.5s = 10 min — mastering estimate is ~60s, so this is ample
+// headroom. ponytail: fixed cap; raise if real masters ever run longer.
+const MAX_POLLS = 240
+
+/** The mastering job state machine: idle → submitting → polling → completed|error. */
+export type MasteringJobState =
+  | { phase: "idle" }
+  | { phase: "submitting" }
+  | { phase: "polling"; detail?: MasteringJobDetail }
+  | { phase: "completed"; detail: MasteringJobDetail }
+  | { phase: "error"; message: string }
+
+export type UseMasteringJob = {
+  state: MasteringJobState
+  /** Submit a mastering job for a clip and drive it to completion. */
+  submit: (clipId: string, config: MasteringConfig) => Promise<void>
+  /** Re-run the last submit (for the error/failed state's Retry). No-op if none. */
+  retry: () => void
+  /** Clear back to idle (start a new master after completing/failing). */
+  reset: () => void
+}
+
+/**
+ * Owns one mastering job's lifecycle (US-21.2). After the 202 it polls the job
+ * through the BFF proxy until completed/failed, then surfaces the completed
+ * detail so the tab can load previews. The access token is read from auth
+ * context and kept in a ref (it rotates mid-session, #285) so the poll loop
+ * always uses the latest without re-subscribing. Mirrors use-generation.
+ */
+export function useMasteringJob({
+  onComplete,
+}: { onComplete?: (detail: MasteringJobDetail) => void } = {}): UseMasteringJob {
+  const router = useRouter()
+  const { accessToken } = useAuth()
+  const [state, setState] = useState<MasteringJobState>({ phase: "idle" })
+
+  const tokenRef = useRef(accessToken)
+  useEffect(() => {
+    tokenRef.current = accessToken
+  }, [accessToken])
+
+  // The active job. A ref (not state) so the poll loop reads the latest without
+  // re-subscribing; cleared the moment the job is superseded or terminal.
+  const jobRef = useRef<{ id: string; polls: number } | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The last submission's args, so Retry can replay it verbatim.
+  const lastArgsRef = useRef<{ clipId: string; config: MasteringConfig } | null>(null)
+  const onCompleteRef = useRef(onComplete)
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+  })
+
+  // Holds the latest `poll` so the scheduled timeout can call it without `poll`
+  // referencing itself (hook-immutability lint forbids that).
+  const pollRef = useRef<() => void>(() => {})
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  // Clean up a pending poll if the component unmounts mid-job.
+  useEffect(() => clearTimer, [])
+
+  const poll = useCallback(async () => {
+    const job = jobRef.current
+    if (!job) return
+    const result = await fetchMasteringStatus(job.id, tokenRef.current ?? "")
+    // A reset/retry between the request and its response supersedes this job.
+    if (jobRef.current?.id !== job.id) return
+
+    switch (result.kind) {
+      case "completed":
+        jobRef.current = null
+        clearTimer()
+        setState({ phase: "completed", detail: result.detail })
+        onCompleteRef.current?.(result.detail)
+        return
+      case "failed":
+        jobRef.current = null
+        clearTimer()
+        setState({ phase: "error", message: result.error })
+        return
+      case "unauthorized":
+        jobRef.current = null
+        clearTimer()
+        router.push("/login")
+        return
+      case "pending":
+      case "transient":
+        job.polls += 1
+        if (job.polls >= MAX_POLLS) {
+          jobRef.current = null
+          clearTimer()
+          setState({ phase: "error", message: "Mastering timed out. Please try again." })
+          return
+        }
+        if (result.kind === "pending") {
+          const { detail } = result
+          setState((s) => (s.phase === "polling" ? { ...s, detail } : s))
+        }
+        timerRef.current = setTimeout(() => pollRef.current(), POLL_INTERVAL_MS)
+        return
+    }
+  }, [router])
+
+  useEffect(() => {
+    pollRef.current = poll
+  }, [poll])
+
+  const submit = useCallback(
+    async (clipId: string, config: MasteringConfig) => {
+      lastArgsRef.current = { clipId, config }
+      clearTimer()
+      jobRef.current = null
+      setState({ phase: "submitting" })
+
+      const result = await submitMasteringJob(clipId, config, tokenRef.current ?? "")
+      switch (result.status) {
+        case "accepted":
+          jobRef.current = { id: result.jobId, polls: 0 }
+          setState({ phase: "polling" })
+          // Poll immediately so a fast job doesn't sit idle for the first interval.
+          void poll()
+          return
+        case "unauthorized":
+          router.push("/login")
+          return
+        case "insufficient_credits":
+          setState({
+            phase: "error",
+            message: `Not enough credits — ${result.required} required, ${result.balance} available.`,
+          })
+          return
+        case "invalid":
+        case "error":
+          setState({ phase: "error", message: result.detail })
+          return
+      }
+    },
+    [poll, router]
+  )
+
+  const retry = useCallback(() => {
+    const args = lastArgsRef.current
+    if (args) void submit(args.clipId, args.config)
+  }, [submit])
+
+  const reset = useCallback(() => {
+    clearTimer()
+    jobRef.current = null
+    setState({ phase: "idle" })
+  }, [])
+
+  return { state, submit, retry, reset }
+}

--- a/web/hooks/use-mastering-job.ts
+++ b/web/hooks/use-mastering-job.ts
@@ -76,8 +76,17 @@ export function useMasteringJob({
     }
   }
 
-  // Clean up a pending poll if the component unmounts mid-job.
-  useEffect(() => clearTimer, [])
+  // Clean up on unmount. Nulling jobRef (not just clearing the timer) is what
+  // stops an *in-flight* poll from rescheduling itself after unmount: with no
+  // active job the poll's supersession guard short-circuits before it can
+  // setState or arm a new timer, so no orphaned polling survives navigation.
+  useEffect(
+    () => () => {
+      clearTimer()
+      jobRef.current = null
+    },
+    []
+  )
 
   const poll = useCallback(async () => {
     const job = jobRef.current

--- a/web/hooks/use-mastering-job.ts
+++ b/web/hooks/use-mastering-job.ts
@@ -69,6 +69,14 @@ export function useMasteringJob({
   // referencing itself (hook-immutability lint forbids that).
   const pollRef = useRef<() => void>(() => {})
 
+  // False once unmounted. Both the poll's and the submit's fetches resolve
+  // asynchronously; either can land after the component is gone, so every
+  // post-await branch checks this before it setState/arms a timer/kicks a poll.
+  // Nulling jobRef alone would stop an in-flight *poll*, but a *submit* that
+  // resolves post-unmount re-sets jobRef and would re-arm the loop — this flag
+  // closes that path too (and the shared `retry`).
+  const mountedRef = useRef(true)
+
   const clearTimer = () => {
     if (timerRef.current) {
       clearTimeout(timerRef.current)
@@ -76,22 +84,21 @@ export function useMasteringJob({
     }
   }
 
-  // Clean up on unmount. Nulling jobRef (not just clearing the timer) is what
-  // stops an *in-flight* poll from rescheduling itself after unmount: with no
-  // active job the poll's supersession guard short-circuits before it can
-  // setState or arm a new timer, so no orphaned polling survives navigation.
-  useEffect(
-    () => () => {
+  // Clean up on unmount: mark unmounted, cancel any pending poll, drop the job.
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
       clearTimer()
       jobRef.current = null
-    },
-    []
-  )
+    }
+  }, [])
 
   const poll = useCallback(async () => {
     const job = jobRef.current
     if (!job) return
     const result = await fetchMasteringStatus(job.id, tokenRef.current ?? "")
+    if (!mountedRef.current) return
     // A reset/retry between the request and its response supersedes this job.
     if (jobRef.current?.id !== job.id) return
 
@@ -142,6 +149,9 @@ export function useMasteringJob({
       setState({ phase: "submitting" })
 
       const result = await submitMasteringJob(clipId, config, tokenRef.current ?? "")
+      // Bail if the tab unmounted while the POST was in flight — otherwise the
+      // accepted branch would re-arm jobRef + a poll loop on a dead component.
+      if (!mountedRef.current) return
       switch (result.status) {
         case "accepted":
           jobRef.current = { id: result.jobId, polls: 0 }

--- a/web/hooks/use-mastering-previews.test.tsx
+++ b/web/hooks/use-mastering-previews.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+import { useMasteringPreviews } from "@/hooks/use-mastering-previews"
+import type { PreviewsResponse } from "@/lib/mastering"
+
+const fetchMasteringPreviews = vi.fn()
+vi.mock("@/lib/mastering", () => ({
+  fetchMasteringPreviews: (...a: unknown[]) => fetchMasteringPreviews(...a),
+}))
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+}
+
+const previews: PreviewsResponse = {
+  source_clip_id: "c1",
+  original_audio_url: "orig",
+  original_metrics: { loudness: -20 },
+  previews: [
+    { preview_id: "m1", audio_url: "u1", loudness_delta: 6 },
+    { preview_id: "m2", audio_url: "u2", loudness_delta: 4 },
+  ],
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe("useMasteringPreviews", () => {
+  it("fetches previews for the job and defaults selection to the first", async () => {
+    fetchMasteringPreviews.mockResolvedValue(previews)
+    const { result } = renderHook(() => useMasteringPreviews("j1"), { wrapper })
+
+    await waitFor(() => expect(result.current.state.status).toBe("ready"))
+    expect(fetchMasteringPreviews).toHaveBeenCalledWith("j1", "tok")
+    expect(result.current.selectedId).toBe("m1")
+  })
+
+  it("lets the user select a different preview", async () => {
+    fetchMasteringPreviews.mockResolvedValue(previews)
+    const { result } = renderHook(() => useMasteringPreviews("j1"), { wrapper })
+    await waitFor(() => expect(result.current.state.status).toBe("ready"))
+
+    act(() => result.current.select("m2"))
+    expect(result.current.selectedId).toBe("m2")
+  })
+
+  it("reports an error when the fetch returns null", async () => {
+    fetchMasteringPreviews.mockResolvedValue(null)
+    const { result } = renderHook(() => useMasteringPreviews("j1"), { wrapper })
+    await waitFor(() => expect(result.current.state.status).toBe("error"))
+    expect(result.current.selectedId).toBeNull()
+  })
+
+  it("stays loading when no job id is given", () => {
+    const { result } = renderHook(() => useMasteringPreviews(undefined), { wrapper })
+    expect(result.current.state.status).toBe("loading")
+    expect(fetchMasteringPreviews).not.toHaveBeenCalled()
+  })
+
+  it("reload re-fetches", async () => {
+    fetchMasteringPreviews.mockResolvedValue(previews)
+    const { result } = renderHook(() => useMasteringPreviews("j1"), { wrapper })
+    await waitFor(() => expect(result.current.state.status).toBe("ready"))
+    expect(fetchMasteringPreviews).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      result.current.reload()
+    })
+    await waitFor(() => expect(fetchMasteringPreviews).toHaveBeenCalledTimes(2))
+  })
+})

--- a/web/hooks/use-mastering-previews.ts
+++ b/web/hooks/use-mastering-previews.ts
@@ -1,0 +1,90 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import { fetchMasteringPreviews, type PreviewsResponse } from "@/lib/mastering"
+
+export type PreviewsState =
+  | { status: "loading" }
+  | { status: "ready"; data: PreviewsResponse }
+  | { status: "error" }
+
+/** Fetch outcome tagged with the job id it belongs to (mirrors useClipAudio). */
+type Outcome =
+  | { jobId: string; kind: "ready"; data: PreviewsResponse }
+  | { jobId: string; kind: "error" }
+
+export type UseMasteringPreviews = {
+  state: PreviewsState
+  /** The effective selected preview id: the user's pick, or the first preview. */
+  selectedId: string | null
+  select: (previewId: string) => void
+  /** Re-fetch (e.g. after a transient error). */
+  reload: () => void
+}
+
+/**
+ * Fetch and manage the A/B preview set for a completed mastering job (US-21.2).
+ * Re-fetches when the job id changes; the in-flight request is aborted on
+ * change/unmount and its outcome is tagged with the job id, so a stale response
+ * reads as "loading" under a new id (no flash, no synchronous reset).
+ *
+ * The selected preview is *derived* (explicit pick ?? first preview) rather than
+ * stored, so there's no set-state-in-effect when previews load and the first
+ * candidate is always auditioned by default.
+ */
+export function useMasteringPreviews(
+  jobId: string | undefined
+): UseMasteringPreviews {
+  const { accessToken } = useAuth()
+  const tokenRef = useRef(accessToken)
+  useEffect(() => {
+    tokenRef.current = accessToken
+  }, [accessToken])
+  const hasToken = accessToken !== null
+
+  const [outcome, setOutcome] = useState<Outcome | null>(null)
+  const [explicitId, setExplicitId] = useState<string | null>(null)
+  // Bumped by reload() to retrigger the fetch effect on demand.
+  const [nonce, setNonce] = useState(0)
+
+  useEffect(() => {
+    if (!jobId || !tokenRef.current) return
+    const ctl = new AbortController()
+    fetchMasteringPreviews(jobId, tokenRef.current)
+      .then((data) => {
+        if (ctl.signal.aborted) return
+        setOutcome(
+          data
+            ? { jobId, kind: "ready", data }
+            : { jobId, kind: "error" }
+        )
+      })
+      .catch(() => {
+        if (!ctl.signal.aborted) setOutcome({ jobId, kind: "error" })
+      })
+    return () => ctl.abort()
+  }, [jobId, hasToken, nonce])
+
+  const select = useCallback((previewId: string) => setExplicitId(previewId), [])
+  const reload = useCallback(() => setNonce((n) => n + 1), [])
+
+  const current = outcome?.jobId === jobId ? outcome : null
+  if (!current) {
+    return { state: { status: "loading" }, selectedId: null, select, reload }
+  }
+  if (current.kind === "error") {
+    return { state: { status: "error" }, selectedId: null, select, reload }
+  }
+
+  const previews = current.data.previews
+  // The user's pick wins if it's still in the set; otherwise the first candidate
+  // is auditioned by default (derived, not stored — no set-state-in-effect).
+  const selectedId =
+    (explicitId && previews.some((p) => p.preview_id === explicitId)
+      ? explicitId
+      : previews[0]?.preview_id) ?? null
+
+  return { state: { status: "ready", data: current.data }, selectedId, select, reload }
+}

--- a/web/lib/mastering.test.ts
+++ b/web/lib/mastering.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  approveMasteringPreview,
+  fetchMasteringPreviews,
+  fetchMasteringStatus,
+  submitMasteringJob,
+  type MasteringConfig,
+} from "@/lib/mastering"
+
+const config: MasteringConfig = { profile: "streaming", service: "dolby", format: "wav" }
+
+function jsonRes(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status })
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("submitMasteringJob", () => {
+  it("POSTs clip_id + config with the Bearer token and returns the job id on 202", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonRes({ job_id: "j1", status: "queued" }, 202))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await submitMasteringJob("c1", config, "tok")
+
+    expect(result).toEqual({ status: "accepted", jobId: "j1" })
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/mastering/jobs")
+    expect(opts.method).toBe("POST")
+    expect((opts.headers as Record<string, string>).authorization).toBe("Bearer tok")
+    expect(JSON.parse(opts.body)).toEqual({
+      clip_id: "c1",
+      profile: "streaming",
+      service: "dolby",
+      format: "wav",
+    })
+  })
+
+  it("classifies 401 as unauthorized", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({ detail: "no" }, 401)))
+    expect(await submitMasteringJob("c1", config, "tok")).toEqual({ status: "unauthorized" })
+  })
+
+  it("classifies 402 as insufficient_credits with balance/required", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonRes({ detail: { error: "insufficient_credits", balance: 1, required: 3 } }, 402)
+      )
+    )
+    expect(await submitMasteringJob("c1", config, "tok")).toEqual({
+      status: "insufficient_credits",
+      balance: 1,
+      required: 3,
+    })
+  })
+
+  it("classifies 422 as invalid with the message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonRes({ detail: [{ msg: "target_lufs is required" }] }, 422))
+    )
+    expect(await submitMasteringJob("c1", { ...config, profile: "custom" }, "tok")).toEqual({
+      status: "invalid",
+      detail: "target_lufs is required",
+    })
+  })
+
+  it("returns error on a network failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")))
+    expect((await submitMasteringJob("c1", config, "tok")).status).toBe("error")
+  })
+})
+
+describe("fetchMasteringStatus", () => {
+  it("classifies completed and carries the detail", async () => {
+    const detail = { job_id: "j1", status: "completed", mastered_clip_id: "m1" }
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(detail)))
+    const result = await fetchMasteringStatus("j1", "tok")
+    expect(result.kind).toBe("completed")
+    if (result.kind === "completed") expect(result.detail.mastered_clip_id).toBe("m1")
+  })
+
+  it("classifies queued/processing as pending", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({ job_id: "j1", status: "processing" })))
+    expect((await fetchMasteringStatus("j1", "tok")).kind).toBe("pending")
+  })
+
+  it("classifies failed with the backend error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({ status: "failed", error: "boom" })))
+    expect(await fetchMasteringStatus("j1", "tok")).toEqual({ kind: "failed", error: "boom" })
+  })
+
+  it("treats a 404 as terminal failure, not transient", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({ detail: "gone" }, 404)))
+    expect((await fetchMasteringStatus("j1", "tok")).kind).toBe("failed")
+  })
+
+  it("treats 5xx and network errors as transient", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({}, 503)))
+    expect((await fetchMasteringStatus("j1", "tok")).kind).toBe("transient")
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("net")))
+    expect((await fetchMasteringStatus("j1", "tok")).kind).toBe("transient")
+  })
+
+  it("classifies 401 as unauthorized", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({}, 401)))
+    expect((await fetchMasteringStatus("j1", "tok")).kind).toBe("unauthorized")
+  })
+})
+
+describe("fetchMasteringPreviews", () => {
+  it("returns the preview set on success", async () => {
+    const previews = { previews: [{ preview_id: "m1", audio_url: "u" }] }
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes(previews)))
+    expect(await fetchMasteringPreviews("j1", "tok")).toEqual(previews)
+  })
+
+  it("returns null on error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({}, 404)))
+    expect(await fetchMasteringPreviews("j1", "tok")).toBeNull()
+  })
+})
+
+describe("approveMasteringPreview", () => {
+  it("POSTs the preview id and returns the promoted clip", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonRes({ clip_id: "m1", audio_url: "u" }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await approveMasteringPreview("j1", "m1", "tok")
+
+    expect(result).toEqual({ status: "approved", clipId: "m1", audioUrl: "u" })
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe("/api/mastering/jobs/j1/approve")
+    expect(JSON.parse(opts.body)).toEqual({ preview_id: "m1" })
+  })
+
+  it("classifies 401 as unauthorized", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({}, 401)))
+    expect((await approveMasteringPreview("j1", "m1", "tok")).status).toBe("unauthorized")
+  })
+
+  it("returns error on a 404", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonRes({ detail: "gone" }, 404)))
+    expect((await approveMasteringPreview("j1", "m1", "tok")).status).toBe("error")
+  })
+})

--- a/web/lib/mastering.ts
+++ b/web/lib/mastering.ts
@@ -1,0 +1,287 @@
+// Client-side mastering workflow (US-21.2). The mastering tab submits a job,
+// polls its status, lists the mastered previews, and approves one — each call
+// goes through a same-origin BFF proxy under `/api/mastering/*` that forwards
+// the Bearer token and keeps the backend URL server-side (mirrors lib/generate
+// + lib/job-status). The backend endpoints (US-12.1/12.4) already exist.
+
+/** The five mastering profiles (loudness targets), mirroring the backend Literal. */
+export type MasteringProfile =
+  | "streaming"
+  | "soundcloud"
+  | "club"
+  | "vinyl"
+  | "custom"
+
+/** The mastering service backends, mirroring the backend Literal. */
+export type MasteringService = "dolby" | "landr" | "bakuage"
+
+/** Output container, mirroring the backend Literal. */
+export type MasteringFormat = "wav" | "mp3" | "flac"
+
+/** The backend job lifecycle states (mirrors api JobStatus). */
+export type MasteringStatus = "queued" | "processing" | "completed" | "failed"
+
+/** A profile's display metadata. `lufs` is null for custom (user-specified). */
+export type ProfileOption = {
+  value: MasteringProfile
+  label: string
+  lufs: number | null
+}
+
+/** A service's display metadata (`cost` is the credit price per master). */
+export type ServiceOption = {
+  value: MasteringService
+  label: string
+  cost: number
+}
+
+// Fixed loudness targets per profile (src/acemusic/api/services/mastering.py
+// PROFILE_LUFS_MAP). Custom reveals a user LUFS input constrained to the API's
+// remaster bounds.
+export const MASTERING_PROFILES: ProfileOption[] = [
+  { value: "streaming", label: "Streaming", lufs: -14 },
+  { value: "soundcloud", label: "SoundCloud", lufs: -12 },
+  { value: "club", label: "Club / DJ", lufs: -6 },
+  { value: "vinyl", label: "Vinyl", lufs: -18 },
+  { value: "custom", label: "Custom", lufs: null },
+]
+
+// Per-service credit cost (src/acemusic/api/services/credits.py). dolby is the
+// backend default.
+export const MASTERING_SERVICES: ServiceOption[] = [
+  { value: "dolby", label: "Dolby.io", cost: 3 },
+  { value: "landr", label: "LANDR", cost: 2 },
+  { value: "bakuage", label: "Bakuage", cost: 5 },
+]
+
+// Custom LUFS bounds — the backend rejects anything outside this range (422).
+export const CUSTOM_LUFS_MIN = -70
+export const CUSTOM_LUFS_MAX = -5
+
+/** The mastering configuration a submission carries (clip id is passed separately). */
+export type MasteringConfig = {
+  profile: MasteringProfile
+  service: MasteringService
+  format: MasteringFormat
+  /** Required for the custom profile, forbidden otherwise (backend-validated). */
+  target_lufs?: number
+}
+
+/** A mastering job's status + (once complete) its master + metrics. */
+export type MasteringJobDetail = {
+  job_id: string
+  status: MasteringStatus
+  source_clip_id?: string
+  profile?: string
+  service?: string
+  target_lufs?: number
+  created_at?: string
+  completed_at?: string
+  mastered_clip_id?: string
+  metrics?: MasteringMetrics
+  error?: string
+}
+
+/** Backend mastering metrics. All fields optional — services return partial sets. */
+export type MasteringMetrics = {
+  loudness?: number
+  /** Per-band EQ gains (Dolby returns 16 bands); shape is service-dependent. */
+  eq_bands?: number[]
+  /** Stereo image width/balance (Dolby); absent for loudness-only services. */
+  stereo_width?: number
+  stereo_balance?: number
+}
+
+/** One mastered candidate for A/B comparison against the original. */
+export type PreviewItem = {
+  preview_id: string
+  audio_url: string
+  profile?: string
+  service?: string
+  metrics?: MasteringMetrics
+  /** Mastered-minus-original integrated loudness (dB); null when unavailable. */
+  loudness_delta?: number | null
+}
+
+/** The A/B comparison set: original audio/metrics plus every mastered candidate. */
+export type PreviewsResponse = {
+  source_clip_id?: string
+  original_audio_url?: string
+  original_metrics?: MasteringMetrics
+  previews: PreviewItem[]
+}
+
+/** The outcome of submitting a mastering job, classified for the state machine. */
+export type SubmitMasteringResult =
+  | { status: "accepted"; jobId: string }
+  | { status: "unauthorized" }
+  | { status: "insufficient_credits"; balance: number; required: number }
+  | { status: "invalid"; detail: string }
+  | { status: "error"; detail: string }
+
+/** A single status poll's outcome, classified for the job state machine. */
+export type MasteringPollResult =
+  | { kind: "pending"; detail: MasteringJobDetail }
+  | { kind: "completed"; detail: MasteringJobDetail }
+  | { kind: "failed"; error: string }
+  | { kind: "unauthorized" }
+  // Network blip / 5xx — not a real failure; the poller retries (up to its cap).
+  | { kind: "transient" }
+
+/** The outcome of approving a preview, classified for the approval flow. */
+export type ApproveResult =
+  | { status: "approved"; clipId: string; audioUrl: string }
+  | { status: "unauthorized" }
+  | { status: "error"; detail: string }
+
+/** Pull a human-readable message out of a FastAPI error body (string or 422 list). */
+function extractDetail(body: unknown, fallback: string): string {
+  if (body && typeof body === "object" && "detail" in body) {
+    const detail = (body as { detail: unknown }).detail
+    if (typeof detail === "string") return detail
+    if (Array.isArray(detail) && detail.length > 0) {
+      const first = detail[0]
+      if (first && typeof first === "object" && "msg" in first) {
+        return String((first as { msg: unknown }).msg)
+      }
+    }
+  }
+  return fallback
+}
+
+/** Submit a mastering job through the BFF proxy and classify the response. */
+export async function submitMasteringJob(
+  clipId: string,
+  config: MasteringConfig,
+  accessToken: string
+): Promise<SubmitMasteringResult> {
+  let res: Response
+  try {
+    res = await fetch("/api/mastering/jobs", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ clip_id: clipId, ...config }),
+    })
+  } catch {
+    return { status: "error", detail: "Mastering failed. Please try again." }
+  }
+
+  if (res.status === 202) {
+    const body = (await res.json().catch(() => ({}))) as { job_id?: string }
+    if (!body.job_id) {
+      return { status: "error", detail: "Server returned an unexpected response." }
+    }
+    return { status: "accepted", jobId: body.job_id }
+  }
+  if (res.status === 401) return { status: "unauthorized" }
+
+  const body = await res.json().catch(() => ({}))
+  if (res.status === 402) {
+    // The 402 detail is an object {error, balance, required}.
+    const detail = (body as { detail?: { balance?: number; required?: number } })
+      .detail
+    return {
+      status: "insufficient_credits",
+      balance: detail?.balance ?? 0,
+      required: detail?.required ?? 0,
+    }
+  }
+  if (res.status === 422) {
+    return { status: "invalid", detail: extractDetail(body, "Please check your input.") }
+  }
+  return {
+    status: "error",
+    detail: extractDetail(body, "Mastering failed. Please try again."),
+  }
+}
+
+/** Poll one mastering job's status through the BFF proxy and classify it. */
+export async function fetchMasteringStatus(
+  jobId: string,
+  accessToken: string
+): Promise<MasteringPollResult> {
+  let res: Response
+  try {
+    res = await fetch(`/api/mastering/jobs/${encodeURIComponent(jobId)}`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+  } catch {
+    return { kind: "transient" }
+  }
+
+  if (res.status === 401) return { kind: "unauthorized" }
+  // A 4xx other than 401 is terminal (404 = unknown/not-owned job) — polling
+  // can never recover, so fail fast. 5xx/network stay transient (retried).
+  if (res.status >= 400 && res.status < 500) {
+    return { kind: "failed", error: "Mastering failed. Please try again." }
+  }
+  if (!res.ok) return { kind: "transient" }
+
+  const detail = (await res.json().catch(() => ({}))) as MasteringJobDetail
+  switch (detail.status) {
+    case "completed":
+      return { kind: "completed", detail }
+    case "failed":
+      return { kind: "failed", error: detail.error || "Mastering failed. Please try again." }
+    case "queued":
+    case "processing":
+      return { kind: "pending", detail }
+    default:
+      // Unknown/missing status — transient so one odd body doesn't abort a job.
+      return { kind: "transient" }
+  }
+}
+
+/** Fetch the A/B preview set for a completed job. Null on error/unauthorized. */
+export async function fetchMasteringPreviews(
+  jobId: string,
+  accessToken: string
+): Promise<PreviewsResponse | null> {
+  let res: Response
+  try {
+    res = await fetch(`/api/mastering/jobs/${encodeURIComponent(jobId)}/previews`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+  } catch {
+    return null
+  }
+  if (!res.ok) return null
+  return (await res.json().catch(() => null)) as PreviewsResponse | null
+}
+
+/** Approve (promote) a preview to the final master through the BFF proxy. */
+export async function approveMasteringPreview(
+  jobId: string,
+  previewId: string,
+  accessToken: string
+): Promise<ApproveResult> {
+  let res: Response
+  try {
+    res = await fetch(`/api/mastering/jobs/${encodeURIComponent(jobId)}/approve`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ preview_id: previewId }),
+    })
+  } catch {
+    return { status: "error", detail: "Approval failed. Please try again." }
+  }
+  if (res.status === 401) return { status: "unauthorized" }
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    return { status: "error", detail: extractDetail(body, "Approval failed. Please try again.") }
+  }
+  const { clip_id: clipId, audio_url: audioUrl } = body as {
+    clip_id?: string
+    audio_url?: string
+  }
+  if (!clipId) {
+    return { status: "error", detail: "Server returned an unexpected response." }
+  }
+  return { status: "approved", clipId, audioUrl: audioUrl ?? "" }
+}


### PR DESCRIPTION
## US-21.2: Mastering Workflow

Builds the **Mastering tab** on the `/release` page (the US-21.1 shell). Web-only — the backend mastering endpoints (`/api/v1/mastering/*`, US-12.1/12.4) already exist; this PR is the frontend that drives them.

Closes #221.

### What's included

**API layer (BFF proxy — mirrors the existing `route.ts` pattern)**
- `app/api/mastering/jobs/route.ts` (POST submit), `.../[jobId]/route.ts` (GET status), `.../[jobId]/previews/route.ts` (GET), `.../[jobId]/approve/route.ts` (POST). Each forwards the Bearer token and passes status/body through verbatim, keeping the backend URL server-side.
- `lib/mastering.ts` — typed client (`submitMasteringJob`, `fetchMasteringStatus`, `fetchMasteringPreviews`, `approveMasteringPreview`) with error classification (401/402/404/422/5xx), plus shared profile/service constants.

**Hooks**
- `use-mastering-job` — submit + status-polling state machine (idle → submitting → polling → completed | error), `retry` replays the last config. Mirrors `use-generation`.
- `use-mastering-previews` — fetches previews on completion; the selected preview is *derived* (explicit pick ?? first) so there's no set-state-in-effect.

**Components** (`components/mastering/`) — `mastering-config`, `mastering-status`, `preview-list`, `preview-player` (A/B), `mastering-metrics`, and the `mastering-tab` container, wired into the Release page.

### Notable design decisions (deviations from the CodeRabbit plan, which was stale)

- **No `lib/api/` folder exists** — followed the repo's actual BFF proxy pattern (`app/api/*` route handlers + a thin `lib/` client + hooks).
- **No `Select`/`ToggleGroup` primitive** — both selectors are `RadioGroup`s, inlined into `mastering-config` (no independent consumer).
- **A/B playback drives by clip id**, not the backend `audio_url`: `preview_id` and `source_clip_id` are both clip ids, so the `<audio src>` plays through the cookie-authed `/api/clips/{id}/stream` proxy (issue #282). No raw storage-URL handling.

### Acceptance criteria → evidence

| Criterion | Evidence |
|---|---|
| All five profiles selectable | `mastering-config.test` (renders 5 radios; custom reveals LUFS input) |
| All three services selectable | `mastering-config.test` (renders 3 radios; dolby default) |
| Job submits and shows progress | `use-mastering-job.test` (submit→poll→completed); `mastering-tab.test` (progress + submit wiring) |
| Previews playable when ready | `preview-player.test` (audio src = `/api/clips/{id}/stream`); `mastering-tab.test` |
| A/B toggle switches original↔mastered during playback | `preview-player.test` (src swaps both ways, position/play-state preserved on swap) |
| Approving saves with the correct badge | `mastering-tab.test` (approve → "Mastered" badge; 401 → /login) |

### Verification

- `web` tests: **1337 passed** (60 new for this feature). Typecheck, ESLint, and `next build` all clean.
- Cross-family review (opencode / GLM) run pre-PR: one MAJOR (post-unmount poll reschedule) and one MINOR (approve-401 consistency) found and fixed in the second commit. Two functionally-safe minors (unwired abort signal on the previews fetch; a contrived rapid-double-toggle blip) were reviewed and deliberately not changed — the tagged-outcome guard already prevents stale state.

### Known limitations

- **The mastering worker is a future ticket** — the backend processor doesn't yet claim the mastering `job_type`, so a submitted job stays `queued` locally. The config → submit → progress path is live-runnable; the completed → previews → A/B → approve states are proven by the component/hook tests (they mock the completed state). No live end-to-end master can be produced here yet.
- No Dolby.io credentials in this environment — mastering metrics rendering (EQ/stereo) is exercised via tests, not live provider output.
- `web/` is not in CI (Python-only) — the checks above were run locally.
