### PR TITLE
feat(web): US-21.3 Mastering Status Tracking (#222)

### DIFF
--- a/web/components/mastering/mastering-history.test.tsx
+++ b/web/components/mastering/mastering-history.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { MasteringHistory } from "@/components/mastering/mastering-history"
+import type { MasteringHistoryEntry } from "@/lib/mastering-history"
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+function entry(over: Partial<MasteringHistoryEntry>): MasteringHistoryEntry {
+  return {
+    id: "mj",
+    songTitle: "Song",
+    profile: "streaming",
+    service: "dolby",
+    status: "completed",
+    isApproved: false,
+    createdAt: new Date().toISOString(),
+    ...over,
+  }
+}
+
+describe("MasteringHistory", () => {
+  it("renders an empty state when there are no jobs", () => {
+    render(<MasteringHistory entries={[]} />)
+    expect(screen.getByText(/no mastering jobs yet/i)).toBeInTheDocument()
+  })
+
+  it("links an approved master to its song page (AC4)", () => {
+    render(
+      <MasteringHistory
+        entries={[
+          entry({ id: "a", songTitle: "Neon Skyline", isApproved: true, masteredClipId: "clip-neon" }),
+        ]}
+      />
+    )
+    const link = screen.getByRole("link", { name: /neon skyline/i })
+    expect(link).toHaveAttribute("href", "/song/clip-neon")
+    // Exact match — the card description also contains the word "approved".
+    expect(screen.getByText("Approved")).toBeInTheDocument()
+  })
+
+  it("shows non-approved jobs without a link and with their status", () => {
+    render(
+      <MasteringHistory
+        entries={[entry({ id: "p", songTitle: "Crownfall", status: "processing" })]}
+      />
+    )
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+    expect(screen.getByText(/crownfall/i)).toBeInTheDocument()
+    expect(screen.getByText(/processing/i)).toBeInTheDocument()
+  })
+})

--- a/web/components/mastering/mastering-history.tsx
+++ b/web/components/mastering/mastering-history.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import Link from "next/link"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { MasteringStatusBadge } from "@/components/mastering/mastering-status"
+import { relativeTime } from "@/lib/notifications"
+import {
+  masteredHref,
+  masteringDisplayStatus,
+  masteringHistory,
+  type MasteringHistoryEntry,
+} from "@/lib/mastering-history"
+import { MASTERING_PROFILES, MASTERING_SERVICES } from "@/lib/mastering"
+import { cn } from "@/lib/utils"
+
+function profileLabel(value: string) {
+  return MASTERING_PROFILES.find((p) => p.value === value)?.label ?? value
+}
+function serviceLabel(value: string) {
+  return MASTERING_SERVICES.find((s) => s.value === value)?.label ?? value
+}
+
+/**
+ * Mastering history (US-21.3): past mastering jobs for the current user with their
+ * status, and a link to the approved master where one exists (AC4). Reads the local
+ * history seam (lib/mastering-history) until a backend listing endpoint exists.
+ */
+export function MasteringHistory({
+  entries = masteringHistory,
+}: {
+  entries?: MasteringHistoryEntry[]
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Mastering history</CardTitle>
+        <CardDescription>Your recent mastering jobs and approved masters.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {entries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No mastering jobs yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2" aria-label="Mastering history">
+            {entries.map((entry) => (
+              <li key={entry.id}>
+                <HistoryRow entry={entry} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+/** A single history row. Approved rows link to the master; the rest are static. */
+function HistoryRow({ entry }: { entry: MasteringHistoryEntry }) {
+  const href = masteredHref(entry)
+  const body = (
+    <>
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-medium">{entry.songTitle}</span>
+        <span className="text-xs text-muted-foreground">
+          {profileLabel(entry.profile)} · {serviceLabel(entry.service)} ·{" "}
+          {relativeTime(entry.createdAt)}
+        </span>
+      </span>
+      <MasteringStatusBadge status={masteringDisplayStatus(entry)} />
+    </>
+  )
+
+  const className = cn(
+    "flex items-center justify-between gap-3 rounded-md border border-input p-3",
+    href && "transition-colors hover:bg-muted/50"
+  )
+
+  return href ? (
+    <Link href={href} className={className}>
+      {body}
+    </Link>
+  ) : (
+    <div className={className}>{body}</div>
+  )
+}

--- a/web/components/mastering/mastering-history.tsx
+++ b/web/components/mastering/mastering-history.tsx
@@ -17,15 +17,8 @@ import {
   masteringHistory,
   type MasteringHistoryEntry,
 } from "@/lib/mastering-history"
-import { MASTERING_PROFILES, MASTERING_SERVICES } from "@/lib/mastering"
+import { profileLabel, serviceLabel } from "@/lib/mastering"
 import { cn } from "@/lib/utils"
-
-function profileLabel(value: string) {
-  return MASTERING_PROFILES.find((p) => p.value === value)?.label ?? value
-}
-function serviceLabel(value: string) {
-  return MASTERING_SERVICES.find((s) => s.value === value)?.label ?? value
-}
 
 /**
  * Mastering history (US-21.3): past mastering jobs for the current user with their

--- a/web/components/mastering/mastering-status.test.tsx
+++ b/web/components/mastering/mastering-status.test.tsx
@@ -2,7 +2,10 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { MasteringStatus } from "@/components/mastering/mastering-status"
+import {
+  MasteringStatus,
+  MasteringStatusBadge,
+} from "@/components/mastering/mastering-status"
 
 afterEach(() => vi.clearAllMocks())
 
@@ -10,8 +13,10 @@ describe("MasteringStatus", () => {
   it.each([
     ["submitting", /submitting/i],
     ["queued", /queued/i],
-    ["processing", /in progress/i],
-  ] as const)("shows a progress status for %s", (status, re) => {
+    ["processing", /processing/i],
+    ["preview_ready", /preview ready/i],
+    ["approved", /approved/i],
+  ] as const)("shows a status for %s", (status, re) => {
     render(<MasteringStatus status={status} />)
     expect(screen.getByRole("status")).toHaveTextContent(re)
   })
@@ -29,5 +34,18 @@ describe("MasteringStatus", () => {
   it("omits Retry when no handler is given", () => {
     render(<MasteringStatus status="failed" error="boom" />)
     expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument()
+  })
+})
+
+describe("MasteringStatusBadge", () => {
+  it.each([
+    ["queued", /queued/i],
+    ["processing", /processing/i],
+    ["preview_ready", /preview ready/i],
+    ["approved", /approved/i],
+    ["failed", /failed/i],
+  ] as const)("labels the %s state", (status, re) => {
+    render(<MasteringStatusBadge status={status} />)
+    expect(screen.getByText(re)).toBeInTheDocument()
   })
 })

--- a/web/components/mastering/mastering-status.tsx
+++ b/web/components/mastering/mastering-status.tsx
@@ -1,32 +1,67 @@
 "use client"
 
 import { HugeiconsIcon } from "@hugeicons/react"
+import type { IconSvgElement } from "@hugeicons/react"
 import {
   Alert01Icon,
   ArrowTurnBackwardIcon,
+  CheckmarkCircle01Icon,
+  Clock01Icon,
   Loading03Icon,
+  PlayCircle02Icon,
 } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
-/** The in-progress/terminal-failure phases the status panel renders. */
-export type MasteringStatusPhase =
-  | "submitting"
+/** The five spec status states (US-21.3), each rendered visually distinct (AC2).
+ *  Backend jobs only report queued/processing/completed/failed; the frontend
+ *  splits completed into preview_ready vs approved (see masteringDisplayStatus). */
+export type MasteringDisplayStatus =
   | "queued"
   | "processing"
+  | "preview_ready"
+  | "approved"
   | "failed"
 
-const LABELS: Record<Exclude<MasteringStatusPhase, "failed">, string> = {
-  submitting: "Submitting mastering job…",
-  queued: "Queued — waiting for a mastering slot…",
-  processing: "Mastering in progress…",
+/** The active-flow panel also shows a pre-queue "submitting" beat. */
+export type MasteringStatusPhase = MasteringDisplayStatus | "submitting"
+
+type StatusMeta = { icon: IconSvgElement; label: string; tone: string; spin?: boolean }
+
+// One icon + label + accent per state — the single source of the status vocabulary,
+// shared by the active-flow panel and the history rows so a state looks the same
+// everywhere (AC2). queued/processing keep motion cues; the terminal states get a
+// solid icon and a distinct color.
+const STATUS_META: Record<MasteringStatusPhase, StatusMeta> = {
+  submitting: { icon: Loading03Icon, label: "Submitting mastering job…", tone: "text-muted-foreground", spin: true },
+  queued: { icon: Clock01Icon, label: "Queued", tone: "text-amber-500" },
+  processing: { icon: Loading03Icon, label: "Processing", tone: "text-sky-500", spin: true },
+  preview_ready: { icon: PlayCircle02Icon, label: "Preview ready", tone: "text-violet-500" },
+  approved: { icon: CheckmarkCircle01Icon, label: "Approved", tone: "text-emerald-500" },
+  failed: { icon: Alert01Icon, label: "Failed", tone: "text-destructive" },
+}
+
+/** Compact inline status pill (icon + label) for lists like the mastering history. */
+export function MasteringStatusBadge({ status }: { status: MasteringDisplayStatus }) {
+  const meta = STATUS_META[status]
+  return (
+    <span className={cn("inline-flex items-center gap-1.5 text-xs font-medium", meta.tone)}>
+      <HugeiconsIcon
+        icon={meta.icon}
+        size={14}
+        className={meta.spin ? "animate-spin" : undefined}
+      />
+      {meta.label}
+    </span>
+  )
 }
 
 /**
- * Mastering job progress + failure display (US-21.2). Shows a spinner and a
- * phase label while the job runs (submitting → queued → processing), and an
- * error message with a Retry button when it fails. The completed state is owned
- * by the tab (it swaps in the preview UI), so this never renders "completed".
+ * Mastering job status panel (US-21.2, extended for US-21.3). Renders the current
+ * job state distinctly: a spinner/label while it runs (submitting → queued →
+ * processing), a distinct badge once a master is ready or approved
+ * (preview_ready / approved), and an error message with Retry when it fails.
  */
 export function MasteringStatus({
   status,
@@ -54,10 +89,15 @@ export function MasteringStatus({
     )
   }
 
+  const meta = STATUS_META[status]
   return (
-    <p role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
-      <HugeiconsIcon icon={Loading03Icon} size={18} className="animate-spin" />
-      {LABELS[status]}
+    <p role="status" className={cn("flex items-center gap-2 text-sm", meta.tone)}>
+      <HugeiconsIcon
+        icon={meta.icon}
+        size={18}
+        className={meta.spin ? "animate-spin" : undefined}
+      />
+      {meta.label}
     </p>
   )
 }

--- a/web/components/mastering/mastering-tab.test.tsx
+++ b/web/components/mastering/mastering-tab.test.tsx
@@ -26,6 +26,9 @@ vi.mock("@/hooks/use-mastering-previews", () => ({
 
 vi.mock("@/hooks/use-auth", () => ({ useAuth: () => ({ accessToken: "tok" }) }))
 
+const notify = vi.fn()
+vi.mock("@/contexts/notifications-context", () => ({ useNotify: () => notify }))
+
 const approveMasteringPreview = vi.fn()
 vi.mock("@/lib/mastering", async (orig) => {
   const actual = await orig<typeof import("@/lib/mastering")>()
@@ -95,7 +98,7 @@ describe("MasteringTab", () => {
     jobState = { phase: "polling", detail: { job_id: "j1", status: "processing" } }
     previewsResult = { state: { status: "loading" }, selectedId: null, select: vi.fn(), reload: vi.fn() }
     render(<MasteringTab selectedClip={clip("c1")} />)
-    expect(screen.getByRole("status")).toHaveTextContent(/in progress/i)
+    expect(screen.getByRole("status")).toHaveTextContent(/processing/i)
   })
 
   it("shows a failure with a working retry", async () => {
@@ -164,6 +167,18 @@ describe("MasteringTab", () => {
     // The approval banner is gone; Approve is offered for the new selection.
     expect(screen.queryByText("Mastered", { selector: "[data-slot='badge']" })).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: /approve master/i })).toBeInTheDocument()
+  })
+
+  it("raises a mastering_complete notification when a job completes (AC5)", () => {
+    jobState = { phase: "completed", detail: { job_id: "j1", status: "completed" } }
+    previewsResult = readyPreviews
+    render(<MasteringTab selectedClip={clip("Velvet Static")} />)
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "mastering_complete" })
+    )
+    // A distinct "Preview ready" status shows for the completed-not-approved job (AC2).
+    // Scope to the status role — the history section below also lists a preview_ready row.
+    expect(screen.getByRole("status")).toHaveTextContent(/preview ready/i)
   })
 
   it("redirects to login when approval is unauthorized", async () => {

--- a/web/components/mastering/mastering-tab.test.tsx
+++ b/web/components/mastering/mastering-tab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -15,8 +15,14 @@ let jobState: MasteringJobState
 const submit = vi.fn()
 const retry = vi.fn()
 const reset = vi.fn()
+// Capture the onComplete the tab passes so a test can fire it (the real hook
+// invokes it once, from its poll loop, when a job reaches completed).
+let capturedOnComplete: ((detail: unknown) => void) | undefined
 vi.mock("@/hooks/use-mastering-job", () => ({
-  useMasteringJob: () => ({ state: jobState, submit, retry, reset }),
+  useMasteringJob: (opts?: { onComplete?: (detail: unknown) => void }) => {
+    capturedOnComplete = opts?.onComplete
+    return { state: jobState, submit, retry, reset }
+  },
 }))
 
 let previewsResult: UseMasteringPreviews
@@ -167,12 +173,18 @@ describe("MasteringTab", () => {
     // The approval banner is gone; Approve is offered for the new selection.
     expect(screen.queryByText("Mastered", { selector: "[data-slot='badge']" })).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: /approve master/i })).toBeInTheDocument()
+    // And the top status pill no longer contradicts it: it falls back to
+    // "Preview ready" for the newly-selected, unapproved candidate (review #1).
+    expect(screen.getByRole("status")).toHaveTextContent(/preview ready/i)
   })
 
   it("raises a mastering_complete notification when a job completes (AC5)", () => {
     jobState = { phase: "completed", detail: { job_id: "j1", status: "completed" } }
     previewsResult = readyPreviews
     render(<MasteringTab selectedClip={clip("Velvet Static")} />)
+
+    // The tab wires notify() through the hook's onComplete; firing it notifies.
+    act(() => capturedOnComplete?.({ job_id: "j1", status: "completed" }))
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "mastering_complete" })
     )

--- a/web/components/mastering/mastering-tab.tsx
+++ b/web/components/mastering/mastering-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { CheckmarkCircle01Icon } from "@hugeicons/core-free-icons"
@@ -44,26 +44,20 @@ export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
   const router = useRouter()
   const { accessToken } = useAuth()
   const notify = useNotify()
-  const job = useMasteringJob()
+  // Raise a notification when the job completes (AC5) via the hook's fire-once
+  // onComplete seam (kept in a ref there, so this closure sees the latest clip).
+  const job = useMasteringJob({
+    onComplete: () =>
+      notify({
+        type: "mastering_complete",
+        message: `Mastering complete for "${selectedClip?.title ?? "your song"}"`,
+        href: "/release",
+      }),
+  })
   const jobId =
     job.state.phase === "completed" ? job.state.detail.job_id : undefined
   const previews = useMasteringPreviews(jobId)
   const [approve, setApprove] = useState<ApproveState>({ phase: "idle" })
-
-  // Raise a notification the first time each job completes (AC5). Keyed by job_id
-  // so re-renders don't re-fire; notify targets the shared store, not local state.
-  const notifiedRef = useRef<string | null>(null)
-  useEffect(() => {
-    if (job.state.phase !== "completed") return
-    const id = job.state.detail.job_id
-    if (notifiedRef.current === id) return
-    notifiedRef.current = id
-    notify({
-      type: "mastering_complete",
-      message: `Mastering complete for "${selectedClip?.title ?? "your song"}"`,
-      href: "/release",
-    })
-  }, [job.state, notify, selectedClip])
 
   async function handleApprove() {
     if (!jobId || !previews.selectedId) return
@@ -164,9 +158,16 @@ export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
 
     return (
       <div className="flex flex-col gap-6">
-        {/* Distinct status for the completed job: preview ready vs approved (AC2). */}
+        {/* Distinct status for the completed job: preview ready vs approved (AC2).
+            Gated the same way as the approval banner below — an "approved" phase
+            only shows for the still-selected approved preview, so selecting a
+            different candidate falls back to "preview ready" (no contradiction). */}
         <MasteringStatus
-          status={approve.phase === "approved" ? "approved" : "preview_ready"}
+          status={
+            approve.phase === "approved" && approve.previewId === previews.selectedId
+              ? "approved"
+              : "preview_ready"
+          }
         />
 
         <PreviewList

--- a/web/components/mastering/mastering-tab.tsx
+++ b/web/components/mastering/mastering-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { CheckmarkCircle01Icon } from "@hugeicons/core-free-icons"
@@ -15,11 +15,13 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { MasteringConfig } from "@/components/mastering/mastering-config"
+import { MasteringHistory } from "@/components/mastering/mastering-history"
 import { MasteringMetrics } from "@/components/mastering/mastering-metrics"
 import { MasteringStatus } from "@/components/mastering/mastering-status"
 import { PreviewList } from "@/components/mastering/preview-list"
 import { PreviewPlayer } from "@/components/mastering/preview-player"
 import { useAuth } from "@/hooks/use-auth"
+import { useNotify } from "@/contexts/notifications-context"
 import { useMasteringJob } from "@/hooks/use-mastering-job"
 import { useMasteringPreviews } from "@/hooks/use-mastering-previews"
 import { approveMasteringPreview } from "@/lib/mastering"
@@ -41,11 +43,27 @@ type ApproveState =
 export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
   const router = useRouter()
   const { accessToken } = useAuth()
+  const notify = useNotify()
   const job = useMasteringJob()
   const jobId =
     job.state.phase === "completed" ? job.state.detail.job_id : undefined
   const previews = useMasteringPreviews(jobId)
   const [approve, setApprove] = useState<ApproveState>({ phase: "idle" })
+
+  // Raise a notification the first time each job completes (AC5). Keyed by job_id
+  // so re-renders don't re-fire; notify targets the shared store, not local state.
+  const notifiedRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (job.state.phase !== "completed") return
+    const id = job.state.detail.job_id
+    if (notifiedRef.current === id) return
+    notifiedRef.current = id
+    notify({
+      type: "mastering_complete",
+      message: `Mastering complete for "${selectedClip?.title ?? "your song"}"`,
+      href: "/release",
+    })
+  }, [job.state, notify, selectedClip])
 
   async function handleApprove() {
     if (!jobId || !previews.selectedId) return
@@ -63,16 +81,21 @@ export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Mastering</CardTitle>
-        <CardDescription>
-          Choose a profile and service, generate previews, A/B against the
-          original, and approve your master.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>{renderBody()}</CardContent>
-    </Card>
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Mastering</CardTitle>
+          <CardDescription>
+            Choose a profile and service, generate previews, A/B against the
+            original, and approve your master.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>{renderBody()}</CardContent>
+      </Card>
+
+      {/* Past jobs + approved masters (AC4). US-21.3. */}
+      <MasteringHistory />
+    </div>
   )
 
   function renderBody() {
@@ -141,6 +164,11 @@ export function MasteringTab({ selectedClip }: { selectedClip: Clip | null }) {
 
     return (
       <div className="flex flex-col gap-6">
+        {/* Distinct status for the completed job: preview ready vs approved (AC2). */}
+        <MasteringStatus
+          status={approve.phase === "approved" ? "approved" : "preview_ready"}
+        />
+
         <PreviewList
           previews={data.previews}
           selectedId={previews.selectedId}

--- a/web/components/mastering/preview-list.tsx
+++ b/web/components/mastering/preview-list.tsx
@@ -1,19 +1,7 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import {
-  MASTERING_PROFILES,
-  MASTERING_SERVICES,
-  type PreviewItem,
-} from "@/lib/mastering"
-
-/** Human label for a profile/service key, falling back to the raw value. */
-function profileLabel(value?: string) {
-  return MASTERING_PROFILES.find((p) => p.value === value)?.label ?? value ?? "—"
-}
-function serviceLabel(value?: string) {
-  return MASTERING_SERVICES.find((s) => s.value === value)?.label ?? value ?? "—"
-}
+import { profileLabel, serviceLabel, type PreviewItem } from "@/lib/mastering"
 
 /** Format a loudness delta with a sign (e.g. "+6.0 dB"), or a dash when absent. */
 function formatDelta(delta?: number | null) {

--- a/web/contexts/notifications-context.test.tsx
+++ b/web/contexts/notifications-context.test.tsx
@@ -1,0 +1,41 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import {
+  NotificationsProvider,
+  useNotifications,
+  useNotify,
+} from "@/contexts/notifications-context"
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <NotificationsProvider>{children}</NotificationsProvider>
+}
+
+describe("NotificationsProvider.notify", () => {
+  it("prepends an unread notification and bumps the unread count (AC5)", () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper })
+    const before = result.current.unreadCount
+
+    act(() => {
+      result.current.notify({
+        type: "mastering_complete",
+        message: 'Mastering complete for "Velvet Static"',
+        href: "/release",
+      })
+    })
+
+    expect(result.current.unreadCount).toBe(before + 1)
+    expect(result.current.notifications[0]).toMatchObject({
+      type: "mastering_complete",
+      read: false,
+      href: "/release",
+    })
+  })
+})
+
+describe("useNotify", () => {
+  it("degrades to a no-op outside a provider (no throw)", () => {
+    const { result } = renderHook(() => useNotify())
+    expect(() => result.current({ type: "system", message: "x", href: "/" })).not.toThrow()
+  })
+})

--- a/web/contexts/notifications-context.tsx
+++ b/web/contexts/notifications-context.tsx
@@ -1,13 +1,15 @@
 "use client"
 
-import { createContext, useCallback, useContext, useMemo, useState } from "react"
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react"
 
 import {
+  addNotification as addNotificationIn,
   initialNotifications,
   markAllRead as markAllReadIn,
   markRead as markReadIn,
   unreadCount as countUnread,
   type AppNotification,
+  type NotifyInput,
 } from "@/lib/notifications"
 
 // In-memory notifications store (US-20.6). Lives in the ROOT layout — unlike the
@@ -22,6 +24,8 @@ type NotificationsContextValue = {
   unreadCount: number
   markRead: (id: string) => void
   markAllRead: () => void
+  /** Raise a new (unread) notification now — e.g. a mastering job completing (US-21.3). */
+  notify: (input: NotifyInput) => void
 }
 
 const NotificationsContext = createContext<NotificationsContextValue | null>(null)
@@ -37,14 +41,28 @@ export function NotificationsProvider({ children }: { children: React.ReactNode 
     setNotifications((list) => markAllReadIn(list))
   }, [])
 
+  // Monotonic id source for live notifications (distinct from the seed's "n-*-N").
+  const seq = useRef(0)
+  const notify = useCallback((input: NotifyInput) => {
+    seq.current += 1
+    const entry: AppNotification = {
+      id: `n-live-${seq.current}`,
+      read: false,
+      createdAt: new Date().toISOString(),
+      ...input,
+    }
+    setNotifications((list) => addNotificationIn(list, entry))
+  }, [])
+
   const value = useMemo<NotificationsContextValue>(
     () => ({
       notifications,
       unreadCount: countUnread(notifications),
       markRead,
       markAllRead,
+      notify,
     }),
-    [notifications, markRead, markAllRead]
+    [notifications, markRead, markAllRead, notify]
   )
 
   return (
@@ -63,4 +81,13 @@ export function useNotifications(): NotificationsContextValue {
  *  hidden) rather than throwing, so those suites need no provider wrapper. */
 export function useUnreadCount(): number {
   return useContext(NotificationsContext)?.unreadCount ?? 0
+}
+
+const noop = () => {}
+
+/** Notifier for feature code that raises notifications (e.g. the mastering tab)
+ *  but may render in suites without a provider — degrades to a no-op rather than
+ *  throwing, mirroring useUnreadCount. */
+export function useNotify(): (input: NotifyInput) => void {
+  return useContext(NotificationsContext)?.notify ?? noop
 }

--- a/web/lib/mastering-history.test.ts
+++ b/web/lib/mastering-history.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  masteredHref,
+  masteringDisplayStatus,
+  masteringHistory,
+  type MasteringHistoryEntry,
+} from "@/lib/mastering-history"
+
+function entry(over: Partial<MasteringHistoryEntry>): MasteringHistoryEntry {
+  return {
+    id: "mj",
+    songTitle: "Song",
+    profile: "streaming",
+    service: "dolby",
+    status: "completed",
+    isApproved: false,
+    createdAt: "2026-07-23T00:00:00Z",
+    ...over,
+  }
+}
+
+describe("masteringDisplayStatus", () => {
+  it("splits completed into preview_ready vs approved", () => {
+    expect(masteringDisplayStatus(entry({ status: "completed", isApproved: false }))).toBe(
+      "preview_ready"
+    )
+    expect(masteringDisplayStatus(entry({ status: "completed", isApproved: true }))).toBe(
+      "approved"
+    )
+  })
+
+  it("passes through the transient/failed states", () => {
+    expect(masteringDisplayStatus(entry({ status: "queued" }))).toBe("queued")
+    expect(masteringDisplayStatus(entry({ status: "processing" }))).toBe("processing")
+    expect(masteringDisplayStatus(entry({ status: "failed" }))).toBe("failed")
+  })
+})
+
+describe("masteredHref", () => {
+  it("links approved masters to their song page (AC4)", () => {
+    expect(masteredHref(entry({ isApproved: true, masteredClipId: "clip-neon" }))).toBe(
+      "/song/clip-neon"
+    )
+  })
+
+  it("returns null for unapproved or clip-less entries", () => {
+    expect(masteredHref(entry({ isApproved: false }))).toBeNull()
+    expect(masteredHref(entry({ isApproved: true, masteredClipId: undefined }))).toBeNull()
+  })
+})
+
+describe("masteringHistory seed", () => {
+  it("covers every display state and every approved row links to a clip", () => {
+    const states = new Set(masteringHistory.map(masteringDisplayStatus))
+    expect(states).toEqual(new Set(["approved", "preview_ready", "processing", "failed"]))
+    for (const e of masteringHistory) {
+      if (e.isApproved) expect(e.masteredClipId).toBeTruthy()
+    }
+  })
+})

--- a/web/lib/mastering-history.ts
+++ b/web/lib/mastering-history.ts
@@ -39,6 +39,12 @@ export function masteringDisplayStatus(entry: MasteringHistoryEntry): MasteringD
       return "failed"
     case "completed":
       return entry.isApproved ? "approved" : "preview_ready"
+    default: {
+      // Exhaustiveness guard: if MasteringStatus ever grows a member, this fails
+      // to compile instead of returning undefined and throwing in the badge.
+      const unexpected: never = entry.status
+      return unexpected
+    }
   }
 }
 

--- a/web/lib/mastering-history.ts
+++ b/web/lib/mastering-history.ts
@@ -1,0 +1,96 @@
+// Mastering history data seam (US-21.3).
+//
+// Like the Stage-20 pages (Explore, Notifications, …), mastering history has no
+// backend list endpoint yet — the mastering router (US-12.1/12.4) exposes submit,
+// detail, previews, and approve, but no `GET /mastering/jobs` listing. This module
+// is the local, typed mock layer whose shape mirrors that eventual endpoint. When
+// it lands, swap `masteringHistory` for a fetch; the components stay unchanged.
+//
+// Deferred (not faked) on purpose: the mastering worker doesn't run locally either
+// ([[us-21-2-mastering-workflow]]), so real history would be empty here regardless.
+
+import type { MasteringDisplayStatus } from "@/components/mastering/mastering-status"
+import type { MasteringProfile, MasteringService, MasteringStatus } from "@/lib/mastering"
+
+/** One past mastering job. `masteredClipId` is set once a master is approved so the
+ *  row can link to it (AC4). Mirrors the fields a `GET /mastering/jobs` row would carry. */
+export type MasteringHistoryEntry = {
+  id: string
+  songTitle: string
+  profile: MasteringProfile
+  service: MasteringService
+  status: MasteringStatus
+  /** True when a preview from this job has been promoted to the final master. */
+  isApproved: boolean
+  /** The approved master clip id (present iff isApproved) — links to /song/{id}. */
+  masteredClipId?: string
+  createdAt: string
+}
+
+/** Collapse the backend job status (+ approval) into a display state (AC2). A
+ *  COMPLETED job is "approved" once a master was picked, else "preview ready". */
+export function masteringDisplayStatus(entry: MasteringHistoryEntry): MasteringDisplayStatus {
+  switch (entry.status) {
+    case "queued":
+      return "queued"
+    case "processing":
+      return "processing"
+    case "failed":
+      return "failed"
+    case "completed":
+      return entry.isApproved ? "approved" : "preview_ready"
+  }
+}
+
+/** The link a history row navigates to: the approved master's song page, else null. */
+export function masteredHref(entry: MasteringHistoryEntry): string | null {
+  return entry.isApproved && entry.masteredClipId ? `/song/${entry.masteredClipId}` : null
+}
+
+const HOUR = 60 * 60 * 1000
+
+function hoursAgo(h: number): string {
+  return new Date(Date.now() - h * HOUR).toISOString()
+}
+
+/** Seed history — one row per display state. Approved rows link to real Explore-pool
+ *  clip ids (clip-*), the same targets song links use elsewhere, so they resolve. */
+export const masteringHistory: MasteringHistoryEntry[] = [
+  {
+    id: "mj-approved-1",
+    songTitle: "Neon Skyline",
+    profile: "streaming",
+    service: "dolby",
+    status: "completed",
+    isApproved: true,
+    masteredClipId: "clip-neon",
+    createdAt: hoursAgo(26),
+  },
+  {
+    id: "mj-preview-1",
+    songTitle: "Crownfall",
+    profile: "club",
+    service: "landr",
+    status: "completed",
+    isApproved: false,
+    createdAt: hoursAgo(3),
+  },
+  {
+    id: "mj-processing-1",
+    songTitle: "Gold Rush 88",
+    profile: "soundcloud",
+    service: "dolby",
+    status: "processing",
+    isApproved: false,
+    createdAt: hoursAgo(0),
+  },
+  {
+    id: "mj-failed-1",
+    songTitle: "Paper Lanterns",
+    profile: "vinyl",
+    service: "bakuage",
+    status: "failed",
+    isApproved: false,
+    createdAt: hoursAgo(48),
+  },
+]

--- a/web/lib/mastering.ts
+++ b/web/lib/mastering.ts
@@ -58,6 +58,16 @@ export const MASTERING_SERVICES: ServiceOption[] = [
 export const CUSTOM_LUFS_MIN = -70
 export const CUSTOM_LUFS_MAX = -5
 
+/** Human label for a profile key, falling back to the raw value then a dash. */
+export function profileLabel(value?: string): string {
+  return MASTERING_PROFILES.find((p) => p.value === value)?.label ?? value ?? "—"
+}
+
+/** Human label for a service key, falling back to the raw value then a dash. */
+export function serviceLabel(value?: string): string {
+  return MASTERING_SERVICES.find((s) => s.value === value)?.label ?? value ?? "—"
+}
+
 /** The mastering configuration a submission carries (clip id is passed separately). */
 export type MasteringConfig = {
   profile: MasteringProfile

--- a/web/lib/notifications.test.ts
+++ b/web/lib/notifications.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest"
 
 import { getAllClips } from "@/lib/explore"
 import {
+  addNotification,
   initialNotifications,
   markAllRead,
   markRead,
   NOTIFICATION_META,
   relativeTime,
   unreadCount,
+  type AppNotification,
   type NotificationType,
 } from "@/lib/notifications"
 import { getProfileByHandle } from "@/lib/profiles"
@@ -85,5 +87,21 @@ describe("notifications seam", () => {
     expect(relativeTime(at(3 * 3_600_000), now)).toBe("3h ago")
     expect(relativeTime(at(2 * 86_400_000), now)).toBe("2d ago")
     expect(relativeTime(at(9 * 86_400_000), now)).toBe("1w ago")
+  })
+
+  it("addNotification prepends immutably (newest first)", () => {
+    const base = initialNotifications.slice(0, 2)
+    const entry: AppNotification = {
+      id: "n-live-1",
+      type: "mastering_complete",
+      message: "Mastering complete",
+      href: "/release",
+      createdAt: "2026-07-23T00:00:00Z",
+      read: false,
+    }
+    const next = addNotification(base, entry)
+    expect(next).toHaveLength(3)
+    expect(next[0]).toBe(entry)
+    expect(base).toHaveLength(2) // original untouched
   })
 })

--- a/web/lib/notifications.ts
+++ b/web/lib/notifications.ts
@@ -162,6 +162,18 @@ export function unreadCount(list: AppNotification[]): number {
   return list.reduce((n, item) => n + (item.read ? 0 : 1), 0)
 }
 
+/** The fields a caller supplies to raise a notification; id/createdAt/read are
+ *  stamped by the store (see notifications-context `notify`). */
+export type NotifyInput = Pick<AppNotification, "type" | "message" | "href">
+
+/** Prepend a new notification (newest first), immutable — the store's insert path. */
+export function addNotification(
+  list: AppNotification[],
+  entry: AppNotification
+): AppNotification[] {
+  return [entry, ...list]
+}
+
 /** Return a new list with the one notification marked read (immutable). */
 export function markRead(list: AppNotification[], id: string): AppNotification[] {
   return list.map((item) => (item.id === id && !item.read ? { ...item, read: true } : item))


### PR DESCRIPTION
Closes #222 (US-21.3: Mastering Status Tracking).

## Scope
Web-only, per the codified Stage-1x/2x convention (add minimal web wiring; defer backend subsystems). The CodeRabbit plan on the issue is stale — it was authored when `web/` was empty and prescribes a full backend build (notification hooks, `GET /mastering/jobs` listing + `is_approved`). Those are **deferred**: notifications are a local mock seam (no backend endpoint exists), and the mastering worker doesn't run locally so a real listing would be empty here anyway. This builds on US-21.2's mastering tab.

## Acceptance criteria
| AC | Status | How |
|----|--------|-----|
| AC1 — real-time status updates | ✅ pre-existing | US-21.2 polling (`use-mastering-job`) |
| AC2 — each state visually distinct | ✅ new | Unified 5-state vocabulary (queued/processing/preview_ready/approved/failed) — distinct icon+color, shared by the flow panel and history badges |
| AC3 — failed jobs show error + retry | ✅ pre-existing | US-21.2 `MasteringStatus` failed + retry |
| AC4 — approved masters accessible from history | ✅ new | `MasteringHistory` section; approved rows link to `/song/{clipId}` |
| AC5 — completion triggers a notification | ✅ new | `notify()` store action fired on job completion; renders on `/notifications` (type already supported) + bumps the sidebar bell |

## Changes
- `components/mastering/mastering-status.tsx` — extended to all 5 spec states + a compact `MasteringStatusBadge`.
- `components/mastering/mastering-history.tsx` + `lib/mastering-history.ts` — history list (mock seam mirroring Stage-20 pages) with approved-master links and empty state.
- `contexts/notifications-context.tsx` + `lib/notifications.ts` — `notify()` insert action + tolerant `useNotify()` (no-ops outside a provider); pure `addNotification` helper.
- `components/mastering/mastering-tab.tsx` — renders the status badge + history, and raises a `mastering_complete` notification on completion.

## Known limitations
- History and the completion notification are **web-only seams**; the real `GET /mastering/jobs` listing and backend notification dispatch are deferred to a backend ticket (consistent with the notifications page and all Stage-20 pages).
- No live end-to-end demo of the *completed* path locally: the mastering worker isn't wired, so submitted jobs stay `queued` (see US-21.2). Completed/approved states are proven via tests.

## Verification
- `web/` is not in CI (Python-only). Locally: **typecheck ✓, lint ✓, build ✓, 1358/1358 vitest tests pass** (54 in the touched suites).
- Review: internal/self-review (cross-family reviewer not run — advisory).
