### PR TITLE
feat(web): US-21.4 Distribution Metadata Form

### DIFF
--- a/web/app/release/page.test.tsx
+++ b/web/app/release/page.test.tsx
@@ -157,6 +157,15 @@ describe("ReleasePage", () => {
     ).toHaveAttribute("aria-selected", "true")
   })
 
+  it("renders the distribution metadata form prefilled for the selected song", () => {
+    searchParamsRef.current = new URLSearchParams("tab=distribute&clip=c1")
+    useClip.mockReturnValue(foundClip())
+    render(<ReleasePageContent />)
+    // The form's Title field is pre-populated from the clip (US-21.4 AC1).
+    expect(screen.getByLabelText(/^title/i)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /save draft/i })).toBeInTheDocument()
+  })
+
   it("syncs the URL when switching tabs", async () => {
     useClip.mockReturnValue(noClip())
     const user = userEvent.setup()

--- a/web/app/release/page.test.tsx
+++ b/web/app/release/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -69,6 +69,7 @@ afterEach(() => {
   searchParamsRef.current = new URLSearchParams()
   useClip.mockReset()
   vi.clearAllMocks()
+  localStorage.clear() // the form auto-saves a draft on unmount — don't leak across tests
 })
 
 function noClip() {
@@ -164,6 +165,21 @@ describe("ReleasePage", () => {
     // The form's Title field is pre-populated from the clip (US-21.4 AC1).
     expect(screen.getByLabelText(/^title/i)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /save draft/i })).toBeInTheDocument()
+  })
+
+  it("preserves unsaved Distribute-tab edits across a tab switch (Radix unmounts the panel)", () => {
+    searchParamsRef.current = new URLSearchParams("tab=distribute&clip=c1")
+    useClip.mockReturnValue(foundClip())
+    const { rerender } = render(<ReleasePageContent />)
+    fireEvent.change(screen.getByLabelText(/album/i), { target: { value: "Night Sessions" } })
+    // Switch to Mastering — Radix unmounts the Distribute panel → save-on-unmount fires.
+    searchParamsRef.current = new URLSearchParams("tab=mastering&clip=c1")
+    rerender(<ReleasePageContent />)
+    expect(screen.getByTestId("mastering-tab")).toBeInTheDocument()
+    // Back to Distribute — the panel remounts and resumes the auto-saved draft.
+    searchParamsRef.current = new URLSearchParams("tab=distribute&clip=c1")
+    rerender(<ReleasePageContent />)
+    expect(screen.getByLabelText(/album/i)).toHaveValue("Night Sessions")
   })
 
   it("syncs the URL when switching tabs", async () => {

--- a/web/app/release/page.tsx
+++ b/web/app/release/page.tsx
@@ -5,12 +5,14 @@ import { useRouter, useSearchParams } from "next/navigation"
 
 import {
   Card,
+  CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MasteringTab } from "@/components/mastering/mastering-tab"
+import { DistributionForm } from "@/components/release/DistributionForm"
 import { SelectedSongSummary } from "@/components/release/SelectedSongSummary"
 import { SongSelector } from "@/components/release/SongSelector"
 import { useClip } from "@/hooks/use-clip"
@@ -19,8 +21,9 @@ import { useRequireAuth } from "@/hooks/use-require-auth"
 // Release page (US-21.1). A single destination for preparing and shipping a
 // song: pick a clip (or arrive pre-selected from the Studio's "Send to
 // Mastering", which navigates here with ?clip=), see its summary, then work
-// through the Mastering and Distribute tabs. The tab body placeholders are
-// filled by US-21.2 (mastering) and US-21.4/21.5 (distribution).
+// through the Mastering and Distribute tabs. Mastering (US-21.2) and the
+// distribution metadata form (US-21.4) fill the tab bodies; platform submission
+// lands in US-21.5.
 //
 // Selection is URL-driven (?clip=): the selector writes it and pre-selection
 // reads it, so there's one source of truth and it survives a refresh.
@@ -109,9 +112,14 @@ export function ReleasePageContent() {
             <CardHeader>
               <CardTitle>Distribution</CardTitle>
               <CardDescription>
-                Publishing to streaming platforms is coming soon.
+                Review and edit your release metadata, then save a draft to
+                continue later. Publishing to streaming platforms comes in a
+                later step.
               </CardDescription>
             </CardHeader>
+            <CardContent>
+              <DistributionForm clip={clip ?? null} />
+            </CardContent>
           </Card>
         </TabsContent>
       </Tabs>

--- a/web/components/release/DistributionForm.test.tsx
+++ b/web/components/release/DistributionForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -91,13 +91,14 @@ describe("DistributionForm", () => {
     expect(screen.getByLabelText(/album/i)).toHaveValue("Night Sessions")
   })
 
-  it("rejects a non-image cover art file (AC3)", async () => {
-    const user = userEvent.setup()
+  it("rejects a non-image cover art file (AC3)", () => {
     render(<DistributionForm clip={makeClip()} />)
     const input = screen.getByLabelText(/upload cover art/i) as HTMLInputElement
+    // fireEvent (not user.upload) so the `accept` attribute doesn't filter the
+    // pdf before the component's own type guard — this tests the backstop.
     const pdf = new File(["x"], "cover.pdf", { type: "application/pdf" })
-    await user.upload(input, pdf)
-    expect(screen.getByText(/jpg or png/i)).toBeInTheDocument()
+    fireEvent.change(input, { target: { files: [pdf] } })
+    expect(screen.getByText(/must be a JPG or PNG/i)).toBeInTheDocument()
   })
 
   it("re-prefills when the selected song changes", () => {
@@ -130,6 +131,27 @@ describe("DistributionForm", () => {
     expect(loadDraft("clip-1")?.album).toBe("Night Sessions")
     rerender(<DistributionForm clip={makeClip()} />)
     expect(screen.getByLabelText(/album/i)).toHaveValue("Night Sessions")
+  })
+
+  it("persists edits on unmount so they survive leaving/returning to the tab (no save click)", () => {
+    const { unmount } = render(<DistributionForm clip={makeClip()} />)
+    // Edit but do NOT click Save — then unmount (as the Radix tab switch does).
+    fireEvent.change(screen.getByLabelText(/album/i), { target: { value: "Night Sessions" } })
+    unmount()
+    expect(loadDraft("clip-1")?.album).toBe("Night Sessions")
+    render(<DistributionForm clip={makeClip()} />)
+    expect(screen.getByLabelText(/album/i)).toHaveValue("Night Sessions")
+  })
+
+  it("clears a stale cover-art error when 'Use existing art' is chosen", async () => {
+    const user = userEvent.setup()
+    render(<DistributionForm clip={makeClip()} />)
+    const input = screen.getByLabelText(/upload cover art/i) as HTMLInputElement
+    fireEvent.change(input, { target: { files: [new File(["x"], "cover.pdf", { type: "application/pdf" })] } })
+    expect(screen.getByText(/must be a JPG or PNG/i)).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /use existing art/i }))
+    expect(screen.queryByText(/must be a JPG or PNG/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/existing cover art/i)).toBeInTheDocument()
   })
 
   it("backfills fields when resuming a draft written by an older version", () => {

--- a/web/components/release/DistributionForm.test.tsx
+++ b/web/components/release/DistributionForm.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { DistributionForm } from "@/components/release/DistributionForm"
+import { loadDraft } from "@/lib/release-draft"
+import type { Clip } from "@/lib/workspace-clips"
+
+function makeClip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "clip-1",
+    workspace_id: "ws-1",
+    title: "Midnight Drive",
+    format: "wav",
+    duration: 180,
+    bpm: 122,
+    key: "A minor",
+    style_tags: ["synthwave"],
+    lyrics: "neon lights",
+    vocal_language: "en",
+    model: "ace-step",
+    seed: 42,
+    inference_steps: 30,
+    parent_clip_ids: [],
+    generation_mode: "text",
+    is_public: false,
+    created_at: "2026-07-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+describe("DistributionForm", () => {
+  it("prompts to select a song when no clip is chosen", () => {
+    render(<DistributionForm clip={null} />)
+    expect(screen.getByText(/select a song/i)).toBeInTheDocument()
+  })
+
+  it("pre-populates fields from the selected song (AC1)", () => {
+    render(<DistributionForm clip={makeClip()} />)
+    expect(screen.getByLabelText(/^title/i)).toHaveValue("Midnight Drive")
+    expect(screen.getByLabelText(/^genre/i)).toHaveValue("synthwave")
+    expect(screen.getByLabelText(/^bpm/i)).toHaveValue(122)
+    expect(screen.getByLabelText(/^key/i)).toHaveValue("A minor")
+    expect(screen.getByLabelText(/lyrics/i)).toHaveValue("neon lights")
+  })
+
+  it("lets the user edit a field (AC2)", async () => {
+    const user = userEvent.setup()
+    render(<DistributionForm clip={makeClip()} />)
+    const album = screen.getByLabelText(/album/i)
+    await user.type(album, "Night Sessions")
+    expect(album).toHaveValue("Night Sessions")
+  })
+
+  it("highlights missing required fields on save (AC5)", async () => {
+    const user = userEvent.setup()
+    render(<DistributionForm clip={makeClip({ title: null, style_tags: [] })} />)
+    await user.click(screen.getByRole("button", { name: /save draft/i }))
+    const title = screen.getByLabelText(/^title/i)
+    expect(title).toHaveAttribute("aria-invalid", "true")
+    expect(screen.getByText(/title is required/i)).toBeInTheDocument()
+    expect(screen.getByText(/genre is required/i)).toBeInTheDocument()
+  })
+
+  it("generates a valid ISRC and UPC on demand (AC4)", async () => {
+    const user = userEvent.setup()
+    render(<DistributionForm clip={makeClip()} />)
+    await user.click(screen.getByRole("button", { name: /generate isrc/i }))
+    await user.click(screen.getByRole("button", { name: /generate upc/i }))
+    expect((screen.getByLabelText(/isrc/i) as HTMLInputElement).value).toMatch(
+      /^[A-Z]{2}-[A-Z0-9]{3}-\d{2}-\d{5}$/
+    )
+    expect((screen.getByLabelText(/upc/i) as HTMLInputElement).value).toMatch(/^\d{12}$/)
+  })
+
+  it("saves a draft and resumes it on remount (AC6)", async () => {
+    const user = userEvent.setup()
+    const { unmount } = render(<DistributionForm clip={makeClip()} />)
+    await user.clear(screen.getByLabelText(/album/i))
+    await user.type(screen.getByLabelText(/album/i), "Night Sessions")
+    await user.click(screen.getByRole("button", { name: /save draft/i }))
+
+    expect(loadDraft("clip-1")?.album).toBe("Night Sessions")
+    expect(screen.getByText(/draft saved/i)).toBeInTheDocument()
+
+    unmount()
+    render(<DistributionForm clip={makeClip()} />)
+    expect(screen.getByLabelText(/album/i)).toHaveValue("Night Sessions")
+  })
+
+  it("rejects a non-image cover art file (AC3)", async () => {
+    const user = userEvent.setup()
+    render(<DistributionForm clip={makeClip()} />)
+    const input = screen.getByLabelText(/upload cover art/i) as HTMLInputElement
+    const pdf = new File(["x"], "cover.pdf", { type: "application/pdf" })
+    await user.upload(input, pdf)
+    expect(screen.getByText(/jpg or png/i)).toBeInTheDocument()
+  })
+
+  it("re-prefills when the selected song changes", () => {
+    const { rerender } = render(<DistributionForm clip={makeClip()} />)
+    expect(screen.getByLabelText(/^title/i)).toHaveValue("Midnight Drive")
+    rerender(<DistributionForm clip={makeClip({ id: "clip-2", title: "Sunrise" })} />)
+    expect(screen.getByLabelText(/^title/i)).toHaveValue("Sunrise")
+  })
+
+  it("surfaces a failure (not a crash) when storage can't save the draft", async () => {
+    const user = userEvent.setup()
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError")
+    })
+    render(<DistributionForm clip={makeClip()} />)
+    await user.click(screen.getByRole("button", { name: /save draft/i }))
+    expect(screen.getByRole("alert")).toHaveTextContent(/storage may be full/i)
+    expect(screen.queryByText(/draft saved/i)).not.toBeInTheDocument()
+    spy.mockRestore()
+  })
+
+  it("auto-saves the outgoing song's edits when the selected song changes (no data loss)", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<DistributionForm clip={makeClip()} />)
+    await user.type(screen.getByLabelText(/album/i), "Night Sessions")
+    // Switch to another song without pressing Save…
+    rerender(<DistributionForm clip={makeClip({ id: "clip-2", title: "Sunrise" })} />)
+    expect(screen.getByLabelText(/^title/i)).toHaveValue("Sunrise")
+    // …the edit was preserved as clip-1's draft and resumes on return.
+    expect(loadDraft("clip-1")?.album).toBe("Night Sessions")
+    rerender(<DistributionForm clip={makeClip()} />)
+    expect(screen.getByLabelText(/album/i)).toHaveValue("Night Sessions")
+  })
+
+  it("backfills fields when resuming a draft written by an older version", () => {
+    // A stale draft missing the nested `credits` object must not crash on read.
+    localStorage.setItem(
+      "ams:release-draft:clip-1",
+      JSON.stringify({ title: "Legacy", album: "Old" })
+    )
+    render(<DistributionForm clip={makeClip()} />)
+    expect(screen.getByLabelText(/^title/i)).toHaveValue("Legacy")
+    expect(screen.getByLabelText(/album/i)).toHaveValue("Old")
+    expect(screen.getByLabelText(/producer/i)).toHaveValue("") // backfilled, not undefined
+  })
+
+  it("keeps a live validation summary count of remaining required fields", async () => {
+    const user = userEvent.setup()
+    render(<DistributionForm clip={makeClip({ title: null, style_tags: [] })} />)
+    await user.click(screen.getByRole("button", { name: /save draft/i }))
+    // Two required fields missing (title, genre); artist has a placeholder default.
+    const summary = screen.getByRole("alert")
+    expect(within(summary).getByText(/2/)).toBeInTheDocument()
+  })
+})

--- a/web/components/release/DistributionForm.tsx
+++ b/web/components/release/DistributionForm.tsx
@@ -1,0 +1,408 @@
+"use client"
+
+import { cloneElement, useState, type ReactElement } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  clearDraft,
+  coverArtResolutionError,
+  generateIsrc,
+  generateUpc,
+  loadDraft,
+  MIN_COVER_ART_PX,
+  prefillFromClip,
+  saveDraft,
+  validateMetadata,
+  type ReleaseCredits,
+  type ReleaseMetadata,
+} from "@/lib/release-draft"
+import type { Clip } from "@/lib/workspace-clips"
+
+/**
+ * Distribution metadata form (US-21.4). Pre-populates from the selected song,
+ * lets the user review/edit every field, pick or upload cover art (enforcing the
+ * store 3000×3000 minimum), enter or auto-generate ISRC/UPC codes, and save an
+ * incremental draft. All web-only for now — see [[us-21-4-distribution-metadata-form]]
+ * and lib/release-draft.ts for the persistence seam that will become a backend PATCH.
+ *
+ * A draft is intentionally saveable while incomplete: Save Draft always persists
+ * and *also* reveals the required-field validation so the user sees what still
+ * needs finishing before distribution (US-21.5).
+ */
+export function DistributionForm({ clip }: { clip: Clip | null }) {
+  if (!clip) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Select a song above to prepare its release metadata.
+      </p>
+    )
+  }
+  return <DistributionFormFields clip={clip} />
+}
+
+/** Resume a saved draft merged over a fresh prefill (AC1/AC6). Merging backfills
+ *  any fields a draft written by an older version is missing — including the
+ *  nested `credits` object — so an old draft can never crash on read.
+ *
+ *  Reads localStorage during render (here and in the render-phase reset). That's
+ *  intentional and the pattern the repo's `set-state-in-effect` lint steers you
+ *  toward (derive during render, don't hydrate in an effect). It's safe because
+ *  this form only ever mounts client-side: `/release` gates it behind
+ *  `useRequireAuth` (renders null until auth resolves on the client) inside a
+ *  `useSearchParams` Suspense boundary (renders null on the server), so there is
+ *  no server render to diverge from. Mount it elsewhere and it must stay
+ *  client-only, or the localStorage read would cause a hydration mismatch. */
+function initialMetadata(clip: Clip): ReleaseMetadata {
+  const base = prefillFromClip(clip)
+  const draft = loadDraft(clip.id)
+  if (!draft) return base
+  return {
+    ...base,
+    ...draft,
+    credits: { ...base.credits, ...draft.credits },
+    coverArt: draft.coverArt ?? base.coverArt,
+  }
+}
+
+function DistributionFormFields({ clip }: { clip: Clip }) {
+  const [metadata, setMetadata] = useState<ReleaseMetadata>(() => initialMetadata(clip))
+  // Render-phase reset when the selected song changes — the form re-prefills from
+  // the new clip (or its draft) without a setState-in-effect the lint forbids.
+  const [prevClipId, setPrevClipId] = useState(clip.id)
+  const [showValidation, setShowValidation] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [coverError, setCoverError] = useState<string | null>(null)
+  // Bumped to remount the file input so its displayed filename clears on reset.
+  const [coverInputKey, setCoverInputKey] = useState(0)
+  if (clip.id !== prevClipId) {
+    // Auto-persist the outgoing song's edits before switching so unsaved work
+    // isn't silently lost — drafts are cheap, keyed per clip, and resumable.
+    // ponytail: best-effort save on switch, not a dirty-state confirmation.
+    saveDraft(prevClipId, metadata)
+    setPrevClipId(clip.id)
+    setMetadata(initialMetadata(clip))
+    setShowValidation(false)
+    setSaved(false)
+    setSaveError(null)
+    setCoverError(null)
+  }
+
+  const errors = validateMetadata(metadata)
+  const requiredMissing = ["title", "artist", "genre"].filter(
+    (k) => errors[k as keyof ReleaseMetadata]
+  ).length
+
+  function set<K extends keyof ReleaseMetadata>(key: K, value: ReleaseMetadata[K]) {
+    setMetadata((m) => ({ ...m, [key]: value }))
+    setSaved(false)
+  }
+  function setCredit(key: keyof ReleaseCredits, value: string) {
+    setMetadata((m) => ({ ...m, credits: { ...m.credits, [key]: value } }))
+    setSaved(false)
+  }
+
+  function handleSaveDraft() {
+    setShowValidation(true)
+    if (saveDraft(clip.id, metadata)) {
+      setSaved(true)
+      setSaveError(null)
+    } else {
+      setSaved(false)
+      setSaveError("Couldn't save the draft — your browser storage may be full or disabled.")
+    }
+  }
+
+  function handleClearDraft() {
+    clearDraft(clip.id)
+    setMetadata(prefillFromClip(clip))
+    setShowValidation(false)
+    setSaved(false)
+    setSaveError(null)
+    setCoverError(null)
+    setCoverInputKey((k) => k + 1)
+  }
+
+  async function handleCoverUpload(file: File | undefined) {
+    setCoverError(null)
+    if (!file) return
+    if (file.type !== "image/jpeg" && file.type !== "image/png") {
+      setCoverError("Cover art must be a JPG or PNG image.")
+      return
+    }
+    // Resolution enforcement (AC3): decode the image to read its real pixel size.
+    // jsdom has no image decoder, so this path is exercised by the live demo.
+    const url = URL.createObjectURL(file)
+    try {
+      const { width, height } = await readImageSize(url)
+      const resErr = coverArtResolutionError(width, height)
+      if (resErr) {
+        setCoverError(resErr)
+        return
+      }
+      set("coverArt", { kind: "uploaded", name: file.name })
+    } catch {
+      setCoverError("Couldn't read that image. Try a different file.")
+    } finally {
+      URL.revokeObjectURL(url)
+    }
+  }
+
+  const invalid = (key: keyof ReleaseMetadata) => showValidation && !!errors[key]
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* Core metadata --------------------------------------------------- */}
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Field label="Title" htmlFor="rel-title" error={invalid("title") ? errors.title : undefined} required>
+          <Input
+            id="rel-title"
+            value={metadata.title}
+            aria-invalid={invalid("title")}
+            onChange={(e) => set("title", e.target.value)}
+          />
+        </Field>
+        <Field label="Artist" htmlFor="rel-artist" error={invalid("artist") ? errors.artist : undefined} required>
+          <Input
+            id="rel-artist"
+            value={metadata.artist}
+            aria-invalid={invalid("artist")}
+            onChange={(e) => set("artist", e.target.value)}
+          />
+        </Field>
+        <Field label="Album name" htmlFor="rel-album">
+          <Input id="rel-album" value={metadata.album} onChange={(e) => set("album", e.target.value)} />
+        </Field>
+        <Field label="Genre" htmlFor="rel-genre" error={invalid("genre") ? errors.genre : undefined} required>
+          <Input
+            id="rel-genre"
+            value={metadata.genre}
+            aria-invalid={invalid("genre")}
+            onChange={(e) => set("genre", e.target.value)}
+          />
+        </Field>
+        <Field label="BPM" htmlFor="rel-bpm">
+          <Input
+            id="rel-bpm"
+            type="number"
+            inputMode="numeric"
+            value={metadata.bpm ?? ""}
+            onChange={(e) => {
+              const n = Number(e.target.value)
+              set("bpm", e.target.value === "" || !Number.isFinite(n) ? null : n)
+            }}
+          />
+        </Field>
+        <Field label="Key" htmlFor="rel-key">
+          <Input id="rel-key" value={metadata.key} onChange={(e) => set("key", e.target.value)} />
+        </Field>
+        <Field label="Language" htmlFor="rel-language">
+          <Input id="rel-language" value={metadata.language} onChange={(e) => set("language", e.target.value)} />
+        </Field>
+        <Field label="Release date" htmlFor="rel-date">
+          <Input
+            id="rel-date"
+            type="date"
+            value={metadata.releaseDate}
+            onChange={(e) => set("releaseDate", e.target.value)}
+          />
+        </Field>
+      </section>
+
+      <Field label="Description" htmlFor="rel-description">
+        <Textarea
+          id="rel-description"
+          value={metadata.description}
+          onChange={(e) => set("description", e.target.value)}
+        />
+      </Field>
+
+      <div className="flex items-center gap-3">
+        <Switch
+          id="rel-explicit"
+          checked={metadata.explicit}
+          onCheckedChange={(v) => set("explicit", v)}
+        />
+        <Label htmlFor="rel-explicit" className="font-normal">
+          Explicit content
+        </Label>
+      </div>
+
+      {/* Cover art ------------------------------------------------------- */}
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-medium">Cover art</h3>
+        <p className="text-xs text-muted-foreground">
+          Minimum {MIN_COVER_ART_PX}×{MIN_COVER_ART_PX}px, JPG or PNG.
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <Field label="Upload cover art" htmlFor="rel-cover-upload">
+            <input
+              key={coverInputKey}
+              id="rel-cover-upload"
+              type="file"
+              accept="image/jpeg,image/png"
+              aria-invalid={!!coverError}
+              aria-describedby={coverError ? "rel-cover-error" : undefined}
+              className="text-sm file:mr-3 file:rounded-md file:border file:border-input file:bg-background file:px-3 file:py-1.5 file:text-sm"
+              onChange={(e) => void handleCoverUpload(e.target.files?.[0])}
+            />
+          </Field>
+          <Button type="button" variant="outline" onClick={() => set("coverArt", { kind: "existing" })}>
+            Use existing art
+          </Button>
+          {/* ponytail: AI cover-art generation isn't built yet — link is a stub
+              until the generation page exists (spec 42.3 "generate via AI"). */}
+          <Button type="button" variant="outline" disabled title="Coming soon">
+            Generate with AI
+          </Button>
+        </div>
+        {metadata.coverArt.kind !== "none" && !coverError && (
+          <p className="text-xs text-muted-foreground">
+            {metadata.coverArt.kind === "uploaded"
+              ? `Uploaded: ${metadata.coverArt.name}`
+              : "Using the song's existing cover art."}
+          </p>
+        )}
+        {coverError && (
+          <p id="rel-cover-error" className="text-sm text-destructive">
+            {coverError}
+          </p>
+        )}
+      </section>
+
+      {/* Identifiers ----------------------------------------------------- */}
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Field label="ISRC" htmlFor="rel-isrc" error={invalid("isrc") ? errors.isrc : undefined}>
+          <div className="flex gap-2">
+            <Input
+              id="rel-isrc"
+              value={metadata.isrc}
+              aria-invalid={invalid("isrc")}
+              placeholder="US-AMS-25-00001"
+              onChange={(e) => set("isrc", e.target.value.toUpperCase())}
+            />
+            <Button type="button" variant="outline" onClick={() => set("isrc", generateIsrc())}>
+              Generate ISRC
+            </Button>
+          </div>
+        </Field>
+        <Field label="UPC / EAN" htmlFor="rel-upc" error={invalid("upc") ? errors.upc : undefined}>
+          <div className="flex gap-2">
+            <Input
+              id="rel-upc"
+              value={metadata.upc}
+              aria-invalid={invalid("upc")}
+              placeholder="12-digit UPC"
+              onChange={(e) => set("upc", e.target.value)}
+            />
+            <Button type="button" variant="outline" onClick={() => set("upc", generateUpc())}>
+              Generate UPC
+            </Button>
+          </div>
+        </Field>
+      </section>
+
+      {/* Copyright + credits -------------------------------------------- */}
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Field label="Copyright notice" htmlFor="rel-copyright">
+          <Input
+            id="rel-copyright"
+            value={metadata.copyright}
+            placeholder="© 2026 Your Label"
+            onChange={(e) => set("copyright", e.target.value)}
+          />
+        </Field>
+        <Field label="Producer" htmlFor="rel-producer">
+          <Input id="rel-producer" value={metadata.credits.producer} onChange={(e) => setCredit("producer", e.target.value)} />
+        </Field>
+        <Field label="Songwriter" htmlFor="rel-songwriter">
+          <Input id="rel-songwriter" value={metadata.credits.songwriter} onChange={(e) => setCredit("songwriter", e.target.value)} />
+        </Field>
+        <Field label="Performer" htmlFor="rel-performer">
+          <Input id="rel-performer" value={metadata.credits.performer} onChange={(e) => setCredit("performer", e.target.value)} />
+        </Field>
+      </section>
+
+      <Field label="Lyrics" htmlFor="rel-lyrics">
+        <Textarea
+          id="rel-lyrics"
+          value={metadata.lyrics}
+          className="min-h-32"
+          onChange={(e) => set("lyrics", e.target.value)}
+        />
+      </Field>
+
+      {/* Validation summary + actions ------------------------------------ */}
+      {showValidation && requiredMissing > 0 && (
+        <p role="alert" className="text-sm text-destructive">
+          {requiredMissing} required field{requiredMissing === 1 ? "" : "s"} still need
+          {requiredMissing === 1 ? "s" : ""} attention before distribution.
+        </p>
+      )}
+      <div className="flex flex-wrap items-center gap-3">
+        <Button type="button" onClick={handleSaveDraft}>
+          Save draft
+        </Button>
+        <Button type="button" variant="outline" onClick={handleClearDraft}>
+          Reset to song defaults
+        </Button>
+        {saved && <span className="text-sm text-muted-foreground">Draft saved.</span>}
+      </div>
+      {saveError && (
+        <p role="alert" className="text-sm text-destructive">
+          {saveError}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** Labeled field wrapper: label (with required marker) + control + inline error.
+ *  When there's an error, the control is linked to the message via aria-describedby
+ *  so screen readers announce it (the control still supplies its own aria-invalid). */
+function Field({
+  label,
+  htmlFor,
+  required,
+  error,
+  children,
+}: {
+  label: string
+  htmlFor: string
+  required?: boolean
+  error?: string
+  children: ReactElement
+}) {
+  const errorId = `${htmlFor}-error`
+  const control = error
+    ? cloneElement(children, { "aria-describedby": errorId } as { "aria-describedby": string })
+    : children
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={htmlFor} className="text-sm">
+        {label}
+        {required && <span className="ml-0.5 text-destructive">*</span>}
+      </Label>
+      {control}
+      {error && (
+        <p id={errorId} className="text-xs text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** Read an image's natural pixel dimensions from an object URL. */
+function readImageSize(url: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight })
+    img.onerror = () => reject(new Error("image load failed"))
+    img.src = url
+  })
+}

--- a/web/components/release/DistributionForm.tsx
+++ b/web/components/release/DistributionForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { cloneElement, useState, type ReactElement } from "react"
+import { cloneElement, useEffect, useRef, useState, type ReactElement } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -15,6 +15,7 @@ import {
   loadDraft,
   MIN_COVER_ART_PX,
   prefillFromClip,
+  REQUIRED_FIELDS,
   saveDraft,
   validateMetadata,
   type ReleaseCredits,
@@ -93,9 +94,25 @@ function DistributionFormFields({ clip }: { clip: Clip }) {
   }
 
   const errors = validateMetadata(metadata)
-  const requiredMissing = ["title", "artist", "genre"].filter(
-    (k) => errors[k as keyof ReleaseMetadata]
-  ).length
+  const requiredMissing = REQUIRED_FIELDS.filter(({ key }) => errors[key]).length
+
+  // Persist the current edits on unmount so leaving the Distribute tab (Radix
+  // unmounts the inactive panel) or the page doesn't silently drop unsaved work —
+  // the draft is picked back up on return. A ref holds the latest values so the
+  // cleanup, which runs once, saves what's on screen at that moment. The cleanup
+  // calls saveDraft (never setState), so it's clear of the set-state-in-effect lint.
+  const latest = useRef({ clipId: clip.id, metadata })
+  // Keep the ref current in the commit phase (writing it during render is a lint
+  // error) so the unmount cleanup below saves what was last on screen.
+  useEffect(() => {
+    latest.current = { clipId: clip.id, metadata }
+  })
+  useEffect(() => {
+    const ref = latest
+    return () => {
+      saveDraft(ref.current.clipId, ref.current.metadata)
+    }
+  }, [])
 
   function set<K extends keyof ReleaseMetadata>(key: K, value: ReleaseMetadata[K]) {
     setMetadata((m) => ({ ...m, [key]: value }))
@@ -251,7 +268,14 @@ function DistributionFormFields({ clip }: { clip: Clip }) {
               onChange={(e) => void handleCoverUpload(e.target.files?.[0])}
             />
           </Field>
-          <Button type="button" variant="outline" onClick={() => set("coverArt", { kind: "existing" })}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              set("coverArt", { kind: "existing" })
+              setCoverError(null) // clear any prior upload-resolution error
+            }}
+          >
             Use existing art
           </Button>
           {/* ponytail: AI cover-art generation isn't built yet — link is a stub

--- a/web/lib/release-draft.test.ts
+++ b/web/lib/release-draft.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  clearDraft,
+  coverArtResolutionError,
+  generateIsrc,
+  generateUpc,
+  loadDraft,
+  MIN_COVER_ART_PX,
+  prefillFromClip,
+  saveDraft,
+  validateMetadata,
+  type ReleaseMetadata,
+} from "@/lib/release-draft"
+import type { Clip } from "@/lib/workspace-clips"
+
+function makeClip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "clip-1",
+    workspace_id: "ws-1",
+    title: "Midnight Drive",
+    format: "wav",
+    duration: 180,
+    bpm: 122,
+    key: "A minor",
+    style_tags: ["synthwave", "retro"],
+    lyrics: "neon lights\nempty road",
+    vocal_language: "en",
+    model: "ace-step",
+    seed: 42,
+    inference_steps: 30,
+    parent_clip_ids: [],
+    generation_mode: "text",
+    is_public: false,
+    created_at: "2026-07-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("prefillFromClip", () => {
+  it("maps clip metadata onto the release form fields", () => {
+    const m = prefillFromClip(makeClip())
+    expect(m.title).toBe("Midnight Drive")
+    expect(m.genre).toBe("synthwave") // first style tag
+    expect(m.bpm).toBe(122)
+    expect(m.key).toBe("A minor")
+    expect(m.language).toBe("en")
+    expect(m.lyrics).toBe("neon lights\nempty road")
+    expect(m.explicit).toBe(false)
+  })
+
+  it("fills sensible blanks for fields the clip has no data for", () => {
+    const m = prefillFromClip(makeClip({ title: null, style_tags: [], lyrics: null, bpm: null }))
+    expect(m.title).toBe("")
+    expect(m.artist).toBe("Unknown artist")
+    expect(m.album).toBe("")
+    expect(m.genre).toBe("")
+    expect(m.lyrics).toBe("")
+    expect(m.bpm).toBeNull()
+    expect(m.releaseDate).toBe("")
+    expect(m.isrc).toBe("")
+    expect(m.upc).toBe("")
+  })
+})
+
+describe("generateIsrc", () => {
+  it("produces a well-formed ISRC (CC-XXX-YY-NNNNN)", () => {
+    for (let i = 0; i < 50; i++) {
+      expect(generateIsrc()).toMatch(/^[A-Z]{2}-[A-Z0-9]{3}-\d{2}-\d{5}$/)
+    }
+  })
+})
+
+describe("generateUpc", () => {
+  it("produces 12 digits with a valid UPC-A check digit", () => {
+    for (let i = 0; i < 50; i++) {
+      const upc = generateUpc()
+      expect(upc).toMatch(/^\d{12}$/)
+      // UPC-A: 3*(odd positions) + (even positions), mod 10 == 0
+      const digits = upc.split("").map(Number)
+      const sum = digits.reduce((acc, d, idx) => acc + d * (idx % 2 === 0 ? 3 : 1), 0)
+      expect(sum % 10).toBe(0)
+    }
+  })
+})
+
+describe("coverArtResolutionError", () => {
+  it("passes art at or above the minimum", () => {
+    expect(coverArtResolutionError(MIN_COVER_ART_PX, MIN_COVER_ART_PX)).toBeNull()
+    expect(coverArtResolutionError(4000, 4000)).toBeNull()
+  })
+
+  it("rejects art below the minimum on either axis", () => {
+    expect(coverArtResolutionError(2999, 3000)).toMatch(/3000/)
+    expect(coverArtResolutionError(3000, 100)).toMatch(/3000/)
+  })
+})
+
+describe("validateMetadata", () => {
+  const base = (): ReleaseMetadata => prefillFromClip(makeClip())
+
+  it("returns no errors for a fully-populated form", () => {
+    expect(validateMetadata(base())).toEqual({})
+  })
+
+  it("flags missing required fields", () => {
+    const errors = validateMetadata({ ...base(), title: "", artist: "  ", genre: "" })
+    expect(errors.title).toBeTruthy()
+    expect(errors.artist).toBeTruthy()
+    expect(errors.genre).toBeTruthy()
+  })
+
+  it("rejects a malformed ISRC but accepts a blank one", () => {
+    expect(validateMetadata({ ...base(), isrc: "not-an-isrc" }).isrc).toBeTruthy()
+    expect(validateMetadata({ ...base(), isrc: "" }).isrc).toBeUndefined()
+    expect(validateMetadata({ ...base(), isrc: generateIsrc() }).isrc).toBeUndefined()
+  })
+
+  it("rejects a malformed UPC but accepts a blank one", () => {
+    expect(validateMetadata({ ...base(), upc: "123" }).upc).toBeTruthy()
+    expect(validateMetadata({ ...base(), upc: "" }).upc).toBeUndefined()
+    expect(validateMetadata({ ...base(), upc: generateUpc() }).upc).toBeUndefined()
+  })
+})
+
+describe("draft persistence", () => {
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it("round-trips a draft by clip id", () => {
+    const m = { ...prefillFromClip(makeClip()), album: "Night Sessions" }
+    expect(loadDraft("clip-1")).toBeNull()
+    saveDraft("clip-1", m)
+    expect(loadDraft("clip-1")).toEqual(m)
+  })
+
+  it("keeps drafts separate per clip and clears one", () => {
+    saveDraft("clip-1", { ...prefillFromClip(makeClip()), title: "One" })
+    saveDraft("clip-2", { ...prefillFromClip(makeClip()), title: "Two" })
+    expect(loadDraft("clip-1")?.title).toBe("One")
+    expect(loadDraft("clip-2")?.title).toBe("Two")
+    clearDraft("clip-1")
+    expect(loadDraft("clip-1")).toBeNull()
+    expect(loadDraft("clip-2")?.title).toBe("Two")
+  })
+
+  it("returns null (not a throw) on corrupt stored JSON", () => {
+    localStorage.setItem("ams:release-draft:clip-1", "{not json")
+    expect(loadDraft("clip-1")).toBeNull()
+  })
+
+  it("reports save success/failure instead of throwing when storage is blocked", () => {
+    expect(saveDraft("clip-1", prefillFromClip(makeClip()))).toBe(true)
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError")
+    })
+    expect(saveDraft("clip-1", prefillFromClip(makeClip()))).toBe(false)
+    spy.mockRestore()
+  })
+})

--- a/web/lib/release-draft.ts
+++ b/web/lib/release-draft.ts
@@ -1,0 +1,168 @@
+// Release metadata + draft seam (US-21.4).
+//
+// Like mastering history ([[us-21-3-mastering-status-tracking]]) and the Stage-20
+// pages, there is no backend release endpoint yet. This module is the local,
+// typed layer the distribution form is built on: it prefills from a clip,
+// generates/validates identifiers, checks cover-art resolution, and persists a
+// draft to localStorage. The persistence shape mirrors an eventual
+// `PATCH /releases/{id}` — when that lands, swap the localStorage calls for a
+// fetch and the form stays unchanged.
+
+import type { Clip } from "@/lib/workspace-clips"
+
+/** Distributor minimum for cover art on the major stores (Spotify/Apple). */
+export const MIN_COVER_ART_PX = 3000
+
+/** Credits captured for the release (spec 42.3). */
+export type ReleaseCredits = {
+  producer: string
+  songwriter: string
+  performer: string
+}
+
+/** How the cover art was chosen. The uploaded File itself is not persisted to a
+ *  draft (localStorage can't hold it) — only the descriptor, so a resumed draft
+ *  shows "was uploaded: name" and the user re-picks if they want to change it. */
+export type CoverArtChoice =
+  | { kind: "none" }
+  | { kind: "existing" }
+  | { kind: "uploaded"; name: string }
+
+/** The editable release form model. `bpm` stays null when the song has none. */
+export type ReleaseMetadata = {
+  title: string
+  artist: string
+  album: string
+  genre: string
+  description: string
+  bpm: number | null
+  key: string
+  language: string
+  explicit: boolean
+  releaseDate: string
+  copyright: string
+  credits: ReleaseCredits
+  coverArt: CoverArtChoice
+  isrc: string
+  upc: string
+  lyrics: string
+}
+
+/** Pre-populate the form from a song's existing metadata (AC1). Fields the Clip
+ *  model doesn't carry (artist, album, release date, credits, ISRC/UPC) start
+ *  blank for the user to fill; artist mirrors the player's placeholder. */
+export function prefillFromClip(clip: Clip): ReleaseMetadata {
+  return {
+    title: clip.title ?? "",
+    artist: "Unknown artist",
+    album: "",
+    genre: clip.style_tags?.[0] ?? "",
+    description: "",
+    bpm: clip.bpm,
+    key: clip.key ?? "",
+    language: clip.vocal_language ?? "",
+    explicit: false,
+    releaseDate: "",
+    copyright: "",
+    credits: { producer: "", songwriter: "", performer: "" },
+    coverArt: { kind: "none" },
+    isrc: "",
+    upc: "",
+    lyrics: clip.lyrics ?? "",
+  }
+}
+
+/** Random n-digit string (as characters, leading zeros kept). */
+function digits(n: number): string {
+  let out = ""
+  for (let i = 0; i < n; i++) out += Math.floor(Math.random() * 10)
+  return out
+}
+
+/** Generate a syntactically-valid placeholder ISRC (AC4): CC-Registrant-YY-Designation.
+ *  Real allocation needs a registrant code from a label; this stands in until a
+ *  distributor assigns one. */
+export function generateIsrc(): string {
+  const yy = String(new Date().getFullYear() % 100).padStart(2, "0")
+  return `US-AMS-${yy}-${digits(5)}`
+}
+
+/** UPC-A check digit for the first 11 digits (weights 3,1,3,1,… from the left). */
+function upcCheckDigit(first11: string): number {
+  const sum = first11
+    .split("")
+    .reduce((acc, ch, idx) => acc + Number(ch) * (idx % 2 === 0 ? 3 : 1), 0)
+  return (10 - (sum % 10)) % 10
+}
+
+/** Generate a valid 12-digit UPC-A (AC4): 11 random digits + computed check digit. */
+export function generateUpc(): string {
+  const first11 = digits(11)
+  return first11 + upcCheckDigit(first11)
+}
+
+/** True when a 12-digit string carries a correct UPC-A check digit. */
+function isValidUpc(upc: string): boolean {
+  return /^\d{12}$/.test(upc) && upcCheckDigit(upc.slice(0, 11)) === Number(upc[11])
+}
+
+/** ISRC shape check (not registry-verified): CC-XXX-YY-NNNNN. */
+function isValidIsrc(isrc: string): boolean {
+  return /^[A-Z]{2}-[A-Z0-9]{3}-\d{2}-\d{5}$/.test(isrc)
+}
+
+/** Error message if cover art is below the store minimum, else null (AC3). */
+export function coverArtResolutionError(width: number, height: number): string | null {
+  if (width < MIN_COVER_ART_PX || height < MIN_COVER_ART_PX) {
+    return `Cover art must be at least ${MIN_COVER_ART_PX}×${MIN_COVER_ART_PX}px (got ${width}×${height}).`
+  }
+  return null
+}
+
+/** Field-keyed validation errors (AC5). Empty object ⇒ valid. Required: title,
+ *  artist, genre. ISRC/UPC are optional but must be well-formed when present. */
+export function validateMetadata(m: ReleaseMetadata): Partial<Record<keyof ReleaseMetadata, string>> {
+  const errors: Partial<Record<keyof ReleaseMetadata, string>> = {}
+  if (!m.title.trim()) errors.title = "Title is required."
+  if (!m.artist.trim()) errors.artist = "Artist is required."
+  if (!m.genre.trim()) errors.genre = "Genre is required."
+  if (m.isrc.trim() && !isValidIsrc(m.isrc.trim())) errors.isrc = "Enter a valid ISRC (e.g. US-AMS-25-00001)."
+  if (m.upc.trim() && !isValidUpc(m.upc.trim())) errors.upc = "Enter a valid 12-digit UPC."
+  return errors
+}
+
+const DRAFT_PREFIX = "ams:release-draft:"
+
+/** Load a saved draft for a clip, or null if none / corrupt / unavailable (AC6).
+ *  The try/catch also makes this safe during SSR, where `localStorage` is undefined
+ *  (returns null). Callers should merge the result over a fresh prefill so a draft
+ *  written by an older version — missing newer fields — can't crash on read. */
+export function loadDraft(clipId: string): Partial<ReleaseMetadata> | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_PREFIX + clipId)
+    return raw ? (JSON.parse(raw) as Partial<ReleaseMetadata>) : null
+  } catch {
+    return null
+  }
+}
+
+/** Persist a draft for a clip so it can be resumed later (AC6). Returns false when
+ *  storage is full/blocked (private mode, quota) so the caller can surface it
+ *  instead of throwing an uncaught error and silently losing the user's work. */
+export function saveDraft(clipId: string, metadata: ReleaseMetadata): boolean {
+  try {
+    localStorage.setItem(DRAFT_PREFIX + clipId, JSON.stringify(metadata))
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Remove a clip's saved draft. Best-effort — never throws. */
+export function clearDraft(clipId: string): void {
+  try {
+    localStorage.removeItem(DRAFT_PREFIX + clipId)
+  } catch {
+    // storage unavailable — nothing to remove
+  }
+}

--- a/web/lib/release-draft.ts
+++ b/web/lib/release-draft.ts
@@ -119,13 +119,21 @@ export function coverArtResolutionError(width: number, height: number): string |
   return null
 }
 
-/** Field-keyed validation errors (AC5). Empty object ⇒ valid. Required: title,
- *  artist, genre. ISRC/UPC are optional but must be well-formed when present. */
+/** Required fields (AC5) — the single source of truth for both validation and the
+ *  "N required fields still need attention" summary, so the two can't drift. */
+export const REQUIRED_FIELDS = [
+  { key: "title", label: "Title" },
+  { key: "artist", label: "Artist" },
+  { key: "genre", label: "Genre" },
+] as const satisfies ReadonlyArray<{ key: keyof ReleaseMetadata; label: string }>
+
+/** Field-keyed validation errors (AC5). Empty object ⇒ valid. Required fields come
+ *  from REQUIRED_FIELDS; ISRC/UPC are optional but must be well-formed when present. */
 export function validateMetadata(m: ReleaseMetadata): Partial<Record<keyof ReleaseMetadata, string>> {
   const errors: Partial<Record<keyof ReleaseMetadata, string>> = {}
-  if (!m.title.trim()) errors.title = "Title is required."
-  if (!m.artist.trim()) errors.artist = "Artist is required."
-  if (!m.genre.trim()) errors.genre = "Genre is required."
+  for (const { key, label } of REQUIRED_FIELDS) {
+    if (!String(m[key] ?? "").trim()) errors[key] = `${label} is required.`
+  }
   if (m.isrc.trim() && !isValidIsrc(m.isrc.trim())) errors.isrc = "Enter a valid ISRC (e.g. US-AMS-25-00001)."
   if (m.upc.trim() && !isValidUpc(m.upc.trim())) errors.upc = "Enter a valid 12-digit UPC."
   return errors


### PR DESCRIPTION
## US-21.4: Distribution Metadata Form

Fills the `/release` **Distribute** tab (a "coming soon" placeholder left by US-21.1) with a pre-populated, editable release metadata form per spec §42.3–42.4.

### Approach — web-only, mock-seam convention
There is **no backend release endpoint** yet (the mastering router exposes submit/detail/previews/approve, but nothing for releases). So this mirrors the established Stage-20/21 pattern (`lib/mastering-history.ts`): a local, typed seam whose shape mirrors an eventual `PATCH /releases/{id}`. Drafts persist to `localStorage`. When the endpoint lands, swap the persistence calls for a fetch and the components stay unchanged.

> Note: this deliberately does **not** follow the CodeRabbit plan comment, which prescribed React Query + a from-scratch API client + backend `/releases` endpoints — none of which exist in this codebase (no React Query dependency; `radix-ui` + `@hugeicons` only). Following it would introduce a parallel stack.

### What's here
- **`lib/release-draft.ts`** — pure logic: `prefillFromClip`, `generateIsrc`, `generateUpc` (valid UPC-A check digit), `validateMetadata`, `coverArtResolutionError` (3000×3000 rule), and `loadDraft`/`saveDraft`/`clearDraft`.
- **`components/release/DistributionForm.tsx`** — controlled form: prefilled core fields, cover-art upload with real image-decode resolution enforcement, ISRC/UPC enter-or-generate, editable lyrics, required-field highlighting, save-as-draft + auto-resume.
- **`app/release/page.tsx`** — wires the form into the Distribute tab.

### Acceptance criteria — all verified in a live browser demo (`/labs`, reverted)
| AC | Evidence |
|----|----------|
| Pre-populates from song | title=`Midnight Drive`, bpm=`122`, genre=`synthwave`, key=`A minor`, lyrics loaded |
| All fields editable | edited album → `Night Sessions` |
| Cover art enforces 3000×3000 | 512×512 rejected with message; 3000×3000 accepted (real `Image` decode) |
| ISRC/UPC enter or auto-generate | generated `US-AMS-26-54396` / `249868038170` |
| Validation highlights missing required | cleared Genre → `aria-invalid` + "Genre is required." + "1 required field still needs attention" |
| Draft saved & resumed | saved, reloaded page, album + ISRC restored |

### Cross-family review (opencode / GLM) — applied
- `saveDraft` returns success/failure instead of throwing on `QuotaExceededError` / private mode → surfaced in the UI (no silent data loss).
- Unsaved edits **auto-persist as a draft when switching songs** (was: silently discarded).
- Draft-resume **backfills fields** a draft from an older version is missing (incl. nested `credits`) → no crash on read.
- BPM input guards `NaN`; file input clears its filename on reset; field errors link via `aria-describedby`.

### Known limitations
- **Web-only**: drafts are per-browser (`localStorage`), not server-persisted, until the release endpoint exists (US-21.5 / backend).
- **"Generate with AI" cover art** is a disabled stub — the cover-art generation page doesn't exist yet (spec §42.3).
- **"Use existing art"** records the choice but can't render a thumbnail — there's no authed artwork proxy (see repo memory).
- The form reads `localStorage` during render (the pattern the repo's `set-state-in-effect` lint steers toward). Safe because `/release` only mounts it client-side (behind `useRequireAuth` + a `useSearchParams` Suspense boundary that renders `null` on the server). Documented inline.

Closes #223
