### PR TITLE
feat(web): US-21.5 Distribution Target Selection and SoundCloud OAuth (#224)

### DIFF
--- a/web/app/api/distribution/soundcloud/callback/route.ts
+++ b/web/app/api/distribution/soundcloud/callback/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+import { clearScLinkCookies, collectScLinkCookies } from "@/lib/distribution-server"
+
+const TARGET = `${BACKEND_URL}/api/v1/distribution/soundcloud/callback`
+
+// Finish the SoundCloud link: forward the Bearer token plus the per-flow PKCE
+// cookies + code/state to the backend, then clear the single-use cookies.
+// Mirrors app/api/auth/callback/[provider].
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+
+  const { code, state } = (await request.json().catch(() => ({}))) as {
+    code?: string
+    state?: string
+  }
+  if (!code || !state) {
+    return NextResponse.json({ detail: "Missing code or state." }, { status: 400 })
+  }
+
+  const cookieHeader = collectScLinkCookies(request)
+  let res: Response
+  try {
+    res = await fetch(TARGET, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: auth,
+        ...(cookieHeader ? { cookie: cookieHeader } : {}),
+      },
+      body: JSON.stringify({ code, state }),
+    })
+  } catch {
+    return NextResponse.json({ detail: "SoundCloud is unavailable." }, { status: 502 })
+  }
+
+  const body = await res.json().catch(() => ({}))
+  const out = NextResponse.json(body, { status: res.status })
+  clearScLinkCookies(request, out)
+  return out
+}

--- a/web/app/api/distribution/soundcloud/connect/route.test.ts
+++ b/web/app/api/distribution/soundcloud/connect/route.test.ts
@@ -1,0 +1,72 @@
+import { NextRequest } from "next/server"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { DELETE, POST } from "./route"
+
+function post(auth: boolean): NextRequest {
+  const req = new NextRequest(
+    new URL("http://localhost:3000/api/distribution/soundcloud/connect"),
+    { method: "POST" }
+  )
+  if (auth) req.headers.set("authorization", "Bearer tok")
+  return req
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("soundcloud connect route", () => {
+  it("401s without an Authorization header, without calling the backend", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    const res = await POST(post(false))
+    expect(res.status).toBe(401)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("returns the authorize URL and re-emits the backend PKCE cookies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ authorization_url: "https://soundcloud.com/connect?x=1" }),
+        headers: {
+          getSetCookie: () => [
+            "sc_link_nonce_abc=nonceval; Path=/api/v1/distribution; HttpOnly",
+            "sc_link_verifier_abc=verval; Path=/api/v1/distribution; HttpOnly",
+          ],
+        },
+      }))
+    )
+    const res = await POST(post(true))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      authorization_url: "https://soundcloud.com/connect?x=1",
+    })
+    const setCookie = res.headers.get("set-cookie") ?? ""
+    expect(setCookie).toContain("sc_link_nonce_abc=nonceval")
+    expect(setCookie).toContain("sc_link_verifier_abc=verval")
+    // Re-scoped to `/` so the callback route on a different path can read them back.
+    expect(setCookie).toContain("Path=/")
+  })
+
+  it("passes a backend 503 (not configured) straight through", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 503,
+        json: async () => ({ detail: "SoundCloud is not configured." }),
+        headers: { getSetCookie: () => [] },
+      }))
+    )
+    const res = await POST(post(true))
+    expect(res.status).toBe(503)
+  })
+
+  it("forwards a DELETE disconnect and preserves the 204", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 204 })))
+    const res = await DELETE(post(true))
+    expect(res.status).toBe(204)
+  })
+})

--- a/web/app/api/distribution/soundcloud/connect/route.ts
+++ b/web/app/api/distribution/soundcloud/connect/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+import { reemitScLinkCookies } from "@/lib/distribution-server"
+
+const TARGET = `${BACKEND_URL}/api/v1/distribution/soundcloud/connect`
+
+// Begin the SoundCloud link: forward the Bearer token, ask the backend for the
+// authorize URL, and re-emit its per-flow PKCE cookies under a path the BFF
+// callback route can read back. Mirrors app/api/auth/login/[provider].
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+
+  let res: Response
+  try {
+    res = await fetch(TARGET, { method: "POST", headers: { authorization: auth } })
+  } catch {
+    return NextResponse.json({ detail: "SoundCloud is unavailable." }, { status: 502 })
+  }
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) return NextResponse.json(body, { status: res.status })
+  if (!body.authorization_url) {
+    return NextResponse.json({ detail: "Malformed SoundCloud response." }, { status: 502 })
+  }
+
+  const out = NextResponse.json({ authorization_url: body.authorization_url })
+  reemitScLinkCookies(out, res.headers.getSetCookie())
+  return out
+}
+
+// Unlink the SoundCloud account (idempotent — the backend 204s even if unlinked).
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+
+  let res: Response
+  try {
+    res = await fetch(TARGET, { method: "DELETE", headers: { authorization: auth } })
+  } catch {
+    return NextResponse.json({ detail: "SoundCloud is unavailable." }, { status: 502 })
+  }
+  if (res.status === 204) return new NextResponse(null, { status: 204 })
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/distribution/soundcloud/status/route.ts
+++ b/web/app/api/distribution/soundcloud/status/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+const TARGET = `${BACKEND_URL}/api/v1/distribution/soundcloud/status`
+
+// Report whether the user has a linked SoundCloud account (forwards the Bearer token).
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+
+  let res: Response
+  try {
+    res = await fetch(TARGET, { headers: { authorization: auth } })
+  } catch {
+    return NextResponse.json({ detail: "SoundCloud is unavailable." }, { status: 502 })
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/auth/soundcloud/callback/page.tsx
+++ b/web/app/auth/soundcloud/callback/page.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { Suspense, useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Alert01Icon, Loading03Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { completeSoundCloudCallback } from "@/lib/distribution"
+import { useAuth } from "@/hooks/use-auth"
+
+const RETURN_TO = "/release?tab=distribute"
+
+function CallbackHandler() {
+  const { accessToken, isLoading, isAuthenticated } = useAuth()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [failed, setFailed] = useState(false)
+  const started = useRef(false)
+
+  const code = searchParams.get("code")
+  const state = searchParams.get("state")
+  // Once auth has settled without a session, the link can't complete (the backend
+  // endpoints are gated) — surface the error instead of spinning forever.
+  const sessionLost = !isLoading && !isAuthenticated
+  const broken = failed || sessionLost || !code || !state
+
+  useEffect(() => {
+    // Exchange exactly once, and only after the access token is available (the
+    // backend link endpoints are auth-gated).
+    if (started.current || !code || !state || !accessToken) return
+    started.current = true
+    completeSoundCloudCallback(code, state, accessToken)
+      .then((result) => {
+        if (result.kind === "ok") router.replace(RETURN_TO)
+        else setFailed(true)
+      })
+      .catch(() => setFailed(true))
+  }, [accessToken, code, state, router])
+
+  if (broken) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
+        <HugeiconsIcon icon={Alert01Icon} size={32} className="text-destructive" />
+        <p role="alert" className="text-sm text-muted-foreground">
+          Could not connect your SoundCloud account.
+        </p>
+        <Button asChild variant="outline">
+          <Link href={RETURN_TO}>Back to distribution</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <HugeiconsIcon icon={Loading03Icon} size={32} className="animate-spin" />
+      <p className="text-sm text-muted-foreground">Connecting your SoundCloud account…</p>
+    </div>
+  )
+}
+
+export default function SoundCloudCallbackPage() {
+  return (
+    <Suspense fallback={null}>
+      <CallbackHandler />
+    </Suspense>
+  )
+}

--- a/web/app/release/page.test.tsx
+++ b/web/app/release/page.test.tsx
@@ -48,6 +48,14 @@ vi.mock("@/components/mastering/mastering-tab", () => ({
     <div data-testid="mastering-tab">{selectedClip?.id ?? "no-clip"}</div>
   ),
 }))
+// The distribution target selector (US-21.5) fetches SoundCloud status via useAuth
+// and has its own tests; stub it so this page test stays focused on selection/URL
+// wiring (mirrors the mastering-tab stub above).
+vi.mock("@/components/distribution/TargetSelector", () => ({
+  TargetSelector: ({ clip }: { clip: { id: string } | null }) => (
+    <div data-testid="target-selector">{clip?.id ?? "no-clip"}</div>
+  ),
+}))
 vi.mock("@/components/release/SelectedSongSummary", () => ({
   SelectedSongSummary: ({
     clip,

--- a/web/app/release/page.tsx
+++ b/web/app/release/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MasteringTab } from "@/components/mastering/mastering-tab"
+import { TargetSelector } from "@/components/distribution/TargetSelector"
 import { DistributionForm } from "@/components/release/DistributionForm"
 import { SelectedSongSummary } from "@/components/release/SelectedSongSummary"
 import { SongSelector } from "@/components/release/SongSelector"
@@ -119,6 +120,18 @@ export function ReleasePageContent() {
             </CardHeader>
             <CardContent>
               <DistributionForm clip={clip ?? null} />
+            </CardContent>
+          </Card>
+          <Card className="mt-4">
+            <CardHeader>
+              <CardTitle>Distribution targets</CardTitle>
+              <CardDescription>
+                Connect SoundCloud for one-click publishing, or prepare a
+                submission package for a guided store.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <TargetSelector clip={clip ?? null} />
             </CardContent>
           </Card>
         </TabsContent>

--- a/web/components/distribution/GuidedFlowModal.test.tsx
+++ b/web/components/distribution/GuidedFlowModal.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { GuidedFlowModal } from "@/components/distribution/GuidedFlowModal"
+import type { ReleaseMetadata } from "@/lib/release-draft"
+
+function metadata(overrides: Partial<ReleaseMetadata> = {}): ReleaseMetadata {
+  return {
+    title: "Nightfall",
+    artist: "AMS",
+    album: "",
+    genre: "House",
+    description: "",
+    bpm: 124,
+    key: "Am",
+    language: "",
+    explicit: false,
+    releaseDate: "",
+    copyright: "",
+    credits: { producer: "", songwriter: "", performer: "" },
+    coverArt: { kind: "existing" },
+    isrc: "US-AMS-25-00001",
+    upc: "012345678905",
+    lyrics: "",
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", { ...URL, createObjectURL: () => "blob:pkg", revokeObjectURL: vi.fn() })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe("GuidedFlowModal", () => {
+  it("disables Prepare when no song is selected", () => {
+    render(<GuidedFlowModal target="landr" ready={false} resolveMetadata={() => null} />)
+    expect(screen.getByRole("button", { name: /prepare package/i })).toBeDisabled()
+  })
+
+  it("resolves the metadata fresh when the modal opens", async () => {
+    const resolveMetadata = vi.fn(() => metadata())
+    render(<GuidedFlowModal target="landr" ready resolveMetadata={resolveMetadata} />)
+    expect(resolveMetadata).not.toHaveBeenCalled() // not read until opened
+    await userEvent.click(screen.getByRole("button", { name: /prepare package/i }))
+    await screen.findByRole("dialog")
+    expect(resolveMetadata).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows an open-in-new-tab link to LANDR when every check passes", async () => {
+    render(<GuidedFlowModal target="landr" ready resolveMetadata={() => metadata()} />)
+    await userEvent.click(screen.getByRole("button", { name: /prepare package/i }))
+
+    const dialog = await screen.findByRole("dialog")
+    const openLink = within(dialog).getByRole("link", { name: /open landr/i })
+    expect(openLink).toHaveAttribute("href", expect.stringMatching(/landr\.com/))
+    expect(openLink).toHaveAttribute("target", "_blank")
+    // The bundle is downloadable.
+    expect(within(dialog).getByRole("link", { name: /download package/i })).toHaveAttribute(
+      "download"
+    )
+  })
+
+  it("withholds the bundle and lists failed checks for incomplete metadata", async () => {
+    render(
+      <GuidedFlowModal
+        target="distrokid"
+        ready
+        resolveMetadata={() => metadata({ coverArt: { kind: "none" } })}
+      />
+    )
+    await userEvent.click(screen.getByRole("button", { name: /prepare package/i }))
+
+    const dialog = await screen.findByRole("dialog")
+    expect(within(dialog).queryByRole("link", { name: /download package/i })).toBeNull()
+    expect(within(dialog).getByText("Cover art")).toBeInTheDocument()
+  })
+})

--- a/web/components/distribution/GuidedFlowModal.tsx
+++ b/web/components/distribution/GuidedFlowModal.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Cancel01Icon,
+  CheckmarkCircle01Icon,
+  Download04Icon,
+  LinkSquare02Icon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  prepareDistribution,
+  targetById,
+  type GuidedTarget,
+  type PreparedPackage,
+} from "@/lib/distribution"
+import type { ReleaseMetadata } from "@/lib/release-draft"
+import { useNotify } from "@/contexts/notifications-context"
+
+type Props = {
+  target: GuidedTarget
+  /** Whether a song is selected; false disables the flow. */
+  ready: boolean
+  /**
+   * Resolve the release metadata to package, read fresh when the modal opens so
+   * the package reflects the latest saved draft rather than a mount-time snapshot.
+   * Returns null when no song is selected.
+   */
+  resolveMetadata: () => ReleaseMetadata | null
+}
+
+/** Guided LANDR/DistroKid flow (US-21.5): prepare a package, then upload it manually. */
+export function GuidedFlowModal({ target, ready, resolveMetadata }: Props) {
+  const notify = useNotify()
+  const info = targetById(target)!
+  const [open, setOpen] = useState(false)
+  const [pkg, setPkg] = useState<PreparedPackage | null>(null)
+  const [submitted, setSubmitted] = useState(false)
+  // Track the live bundle object URL so it's revoked on close AND on unmount
+  // (Radix only fires onOpenChange for an actual close, not an unmount).
+  const bundleUrl = useRef<string | null>(null)
+
+  function revokeBundle() {
+    if (bundleUrl.current) {
+      URL.revokeObjectURL(bundleUrl.current)
+      bundleUrl.current = null
+    }
+  }
+
+  useEffect(() => revokeBundle, [])
+
+  function handleOpenChange(next: boolean) {
+    if (next) {
+      const metadata = resolveMetadata()
+      if (!metadata) return
+      // Compute the package in the open transition (not an effect) so the bundle
+      // object URL is created once per open. Revoke any prior one first.
+      revokeBundle()
+      const prepared = prepareDistribution(target, metadata)
+      bundleUrl.current = prepared.bundleUrl
+      setPkg(prepared)
+      setSubmitted(false)
+    } else {
+      revokeBundle()
+      setPkg(null)
+    }
+    setOpen(next)
+  }
+
+  function markSubmitted() {
+    setSubmitted(true)
+    // Seam: no real release_id yet, so record the submission locally + notify.
+    // Swaps to POST /releases/{id}/submit/{target} when release-creation lands.
+    notify({
+      type: "distribution_update",
+      message: `${info.label} submission marked as sent.`,
+      href: "/release?tab=distribute",
+    })
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={!ready}
+        onClick={() => handleOpenChange(true)}
+      >
+        Prepare package
+      </Button>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Prepare for {info.label}</DialogTitle>
+            <DialogDescription>
+              {pkg?.allChecksPassed
+                ? "Your release is ready. Download the package and upload it on " +
+                  info.label +
+                  "."
+                : "Resolve the items below on the metadata tab, then reopen this to prepare."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {pkg && (
+            <div className="flex flex-col gap-4">
+              <ul className="flex flex-col gap-2">
+                {pkg.checklist.map((c) => (
+                  <li key={c.item} className="flex items-start gap-2 text-sm">
+                    <HugeiconsIcon
+                      icon={c.passed ? CheckmarkCircle01Icon : Cancel01Icon}
+                      size={16}
+                      className={
+                        c.passed
+                          ? "mt-0.5 shrink-0 text-emerald-500"
+                          : "mt-0.5 shrink-0 text-destructive"
+                      }
+                    />
+                    <span>
+                      <span className="font-medium">{c.item}</span>
+                      <span className="block text-xs text-muted-foreground">{c.message}</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+
+              {pkg.allChecksPassed && (
+                <>
+                  <pre className="max-h-40 overflow-auto rounded-md bg-muted/50 p-3 text-xs whitespace-pre-wrap text-muted-foreground">
+                    {pkg.instructions}
+                  </pre>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Button asChild variant="outline" size="sm">
+                      <a href={pkg.bundleUrl!} download={`${target}-release-package.json`}>
+                        <HugeiconsIcon icon={Download04Icon} size={16} />
+                        Download package
+                      </a>
+                    </Button>
+                    {info.portalUrl && (
+                      <Button asChild size="sm">
+                        <a href={info.portalUrl} target="_blank" rel="noopener noreferrer">
+                          <HugeiconsIcon icon={LinkSquare02Icon} size={16} />
+                          Open {info.label}
+                        </a>
+                      </Button>
+                    )}
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="self-start"
+                    disabled={submitted}
+                    onClick={markSubmitted}
+                  >
+                    {submitted ? (
+                      <>
+                        <HugeiconsIcon
+                          icon={CheckmarkCircle01Icon}
+                          size={16}
+                          className="text-emerald-500"
+                        />
+                        Marked as submitted
+                      </>
+                    ) : (
+                      "Mark as submitted"
+                    )}
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/web/components/distribution/SoundCloudCard.test.tsx
+++ b/web/components/distribution/SoundCloudCard.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { SoundCloudCard } from "@/components/distribution/SoundCloudCard"
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => ({ accessToken: "tok" }) }))
+
+const getSoundCloudStatus = vi.fn()
+const connectSoundCloud = vi.fn()
+const disconnectSoundCloud = vi.fn()
+vi.mock("@/lib/distribution", () => ({
+  getSoundCloudStatus: (...a: unknown[]) => getSoundCloudStatus(...a),
+  connectSoundCloud: (...a: unknown[]) => connectSoundCloud(...a),
+  disconnectSoundCloud: (...a: unknown[]) => disconnectSoundCloud(...a),
+}))
+
+beforeEach(() => {
+  push.mockReset()
+  getSoundCloudStatus.mockReset()
+  connectSoundCloud.mockReset()
+  disconnectSoundCloud.mockReset()
+})
+afterEach(() => vi.restoreAllMocks())
+
+const disconnected = {
+  kind: "ok" as const,
+  status: { connected: false, username: null, connectedAt: null, tokenValid: null },
+}
+const connected = {
+  kind: "ok" as const,
+  status: {
+    connected: true,
+    username: "dj_ams",
+    connectedAt: "2026-07-01T00:00:00Z",
+    tokenValid: true,
+  },
+}
+
+describe("SoundCloudCard", () => {
+  it("shows a Connect button when disconnected", async () => {
+    getSoundCloudStatus.mockResolvedValue(disconnected)
+    render(<SoundCloudCard />)
+    expect(await screen.findByRole("button", { name: /connect soundcloud/i })).toBeInTheDocument()
+  })
+
+  it("redirects to the SoundCloud authorize URL on connect", async () => {
+    getSoundCloudStatus.mockResolvedValue(disconnected)
+    connectSoundCloud.mockResolvedValue({
+      kind: "ok",
+      authorizationUrl: "https://soundcloud.com/connect?x=1",
+    })
+    // window.location.href assignment — capture instead of navigating.
+    const location = { href: "" }
+    Object.defineProperty(window, "location", { value: location, writable: true })
+
+    render(<SoundCloudCard />)
+    await userEvent.click(await screen.findByRole("button", { name: /connect soundcloud/i }))
+    await waitFor(() => expect(location.href).toBe("https://soundcloud.com/connect?x=1"))
+  })
+
+  it("shows the username, an initials avatar and Disconnect when connected", async () => {
+    getSoundCloudStatus.mockResolvedValue(connected)
+    render(<SoundCloudCard />)
+    expect(await screen.findByText("dj_ams")).toBeInTheDocument()
+    expect(screen.getByText("DA")).toBeInTheDocument() // initials placeholder avatar
+    expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument()
+  })
+
+  it("disconnects after confirming in the dialog", async () => {
+    getSoundCloudStatus.mockResolvedValue(connected)
+    disconnectSoundCloud.mockResolvedValue({ kind: "ok" })
+    render(<SoundCloudCard />)
+
+    await userEvent.click(await screen.findByRole("button", { name: /^disconnect$/i }))
+    // Confirm inside the dialog (the trigger button has the same label).
+    const dialog = await screen.findByRole("dialog")
+    await userEvent.click(within(dialog).getByRole("button", { name: /^disconnect$/i }))
+
+    await waitFor(() => expect(disconnectSoundCloud).toHaveBeenCalledWith("tok"))
+    expect(await screen.findByText(/soundcloud disconnected/i)).toBeInTheDocument()
+  })
+})

--- a/web/components/distribution/SoundCloudCard.tsx
+++ b/web/components/distribution/SoundCloudCard.tsx
@@ -1,0 +1,233 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Alert01Icon,
+  Cancel01Icon,
+  CheckmarkCircle01Icon,
+  Loading03Icon,
+} from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  connectSoundCloud,
+  disconnectSoundCloud,
+  getSoundCloudStatus,
+  type SoundCloudStatus,
+} from "@/lib/distribution"
+import { useAuth } from "@/hooks/use-auth"
+
+type Phase = "loading" | "ready" | "error"
+type Message = { tone: "error" | "success"; text: string } | null
+
+/** First letters of the username, for the placeholder avatar (no avatar_url from backend). */
+function initials(username: string | null): string {
+  if (!username) return "SC"
+  const parts = username.trim().split(/[\s_-]+/).filter(Boolean)
+  const chars = (parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")
+  return (chars || username.slice(0, 2)).toUpperCase()
+}
+
+/** SoundCloud account linking (US-21.5): connect, show the linked account, disconnect. */
+export function SoundCloudCard() {
+  const { accessToken } = useAuth()
+  const router = useRouter()
+  const [phase, setPhase] = useState<Phase>("loading")
+  const [status, setStatus] = useState<SoundCloudStatus | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [message, setMessage] = useState<Message>(null)
+  // Bumped by Retry to re-run the status effect (mirrors use-clip's mount fetch:
+  // state is set only inside the promise callback, never synchronously).
+  const [reloadKey, setReloadKey] = useState(0)
+
+  useEffect(() => {
+    if (!accessToken) return
+    let active = true
+    getSoundCloudStatus(accessToken)
+      .then((res) => {
+        if (!active) return
+        if (res.kind === "unauthorized") return router.push("/login")
+        if (res.kind === "error") {
+          setPhase("error")
+          return
+        }
+        setStatus(res.status)
+        setPhase("ready")
+      })
+      .catch(() => {
+        if (active) setPhase("error")
+      })
+    return () => {
+      active = false
+    }
+  }, [accessToken, reloadKey, router])
+
+  async function handleConnect() {
+    if (!accessToken) return
+    setBusy(true)
+    setMessage(null)
+    const res = await connectSoundCloud(accessToken)
+    if (res.kind === "ok") {
+      // Leave the app for SoundCloud's consent screen; we return via the callback page.
+      window.location.href = res.authorizationUrl
+      return
+    }
+    if (res.kind === "unauthorized") return router.push("/login")
+    setBusy(false)
+    setMessage({
+      tone: "error",
+      text:
+        res.kind === "unavailable"
+          ? "SoundCloud connection isn't configured yet. Try again later."
+          : res.detail,
+    })
+  }
+
+  async function handleDisconnect() {
+    if (!accessToken) return
+    setBusy(true)
+    setMessage(null)
+    const res = await disconnectSoundCloud(accessToken)
+    setConfirmOpen(false)
+    setBusy(false)
+    if (res.kind === "unauthorized") return router.push("/login")
+    if (res.kind === "error") {
+      setMessage({ tone: "error", text: res.detail })
+      return
+    }
+    setStatus({ connected: false, username: null, connectedAt: null, tokenValid: null })
+    setMessage({ tone: "success", text: "SoundCloud disconnected." })
+  }
+
+  const connected = status?.connected ?? false
+
+  return (
+    <div className="flex flex-col gap-3">
+      {phase === "loading" ? (
+        <p role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
+          <HugeiconsIcon icon={Loading03Icon} size={16} className="animate-spin" />
+          Checking SoundCloud connection…
+        </p>
+      ) : phase === "error" ? (
+        <div className="flex flex-col items-start gap-2">
+          <p role="alert" className="text-sm text-destructive">
+            Couldn&apos;t load your SoundCloud status.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setPhase("loading")
+              setReloadKey((k) => k + 1)
+            }}
+          >
+            Retry
+          </Button>
+        </div>
+      ) : connected ? (
+        <div className="flex items-center gap-3">
+          <div
+            aria-hidden
+            className="flex size-10 shrink-0 items-center justify-center rounded-full bg-sky-500/15 text-sm font-semibold text-sky-600"
+          >
+            {initials(status?.username ?? null)}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">
+              {status?.username ?? "Connected account"}
+            </p>
+            <p className="flex items-center gap-1 text-xs text-muted-foreground">
+              <HugeiconsIcon
+                icon={CheckmarkCircle01Icon}
+                size={13}
+                className="text-emerald-500"
+              />
+              Connected{status?.connectedAt ? ` · ${formatDate(status.connectedAt)}` : ""}
+              {status?.tokenValid === false ? " · reauthorize to publish" : ""}
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={busy}
+            onClick={() => setConfirmOpen(true)}
+          >
+            Disconnect
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col items-start gap-3">
+          <p className="text-sm text-muted-foreground">
+            Connect your SoundCloud account to publish masters in a single click.
+          </p>
+          <Button size="sm" disabled={busy} onClick={handleConnect}>
+            {busy ? (
+              <>
+                <HugeiconsIcon icon={Loading03Icon} size={16} className="animate-spin" />
+                Connecting…
+              </>
+            ) : (
+              "Connect SoundCloud"
+            )}
+          </Button>
+        </div>
+      )}
+
+      {message && (
+        <p
+          role={message.tone === "error" ? "alert" : "status"}
+          className={
+            message.tone === "error"
+              ? "flex items-center gap-1 text-sm text-destructive"
+              : "flex items-center gap-1 text-sm text-emerald-600"
+          }
+        >
+          <HugeiconsIcon
+            icon={message.tone === "error" ? Alert01Icon : CheckmarkCircle01Icon}
+            size={14}
+          />
+          {message.text}
+        </p>
+      )}
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Disconnect SoundCloud?</DialogTitle>
+            <DialogDescription>
+              You&apos;ll need to reconnect before you can publish to SoundCloud again.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={busy}>
+              <HugeiconsIcon icon={Cancel01Icon} size={16} />
+              Keep connected
+            </Button>
+            <Button variant="destructive" onClick={handleDisconnect} disabled={busy}>
+              Disconnect
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+/** Short, locale-independent date for the connection timestamp. */
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime())
+    ? ""
+    : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })
+}

--- a/web/components/distribution/TargetSelector.test.tsx
+++ b/web/components/distribution/TargetSelector.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import { TargetSelector } from "@/components/distribution/TargetSelector"
+import type { Clip } from "@/lib/workspace-clips"
+
+// SoundCloudCard fetches status on mount; mock useAuth + the SoundCloud calls so
+// the selector renders without an AuthProvider or real network.
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => ({ accessToken: "tok" }) }))
+vi.mock("@/lib/distribution", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/distribution")>()
+  return {
+    ...actual,
+    getSoundCloudStatus: vi.fn(async () => ({
+      kind: "ok",
+      status: { connected: false, username: null, connectedAt: null, tokenValid: null },
+    })),
+  }
+})
+
+function clip(): Clip {
+  return {
+    id: "clip-1",
+    workspace_id: null,
+    title: "Nightfall",
+    bpm: 124,
+    key: "Am",
+    style_tags: ["House"],
+  } as Clip
+}
+
+beforeEach(() => localStorage.clear())
+afterEach(() => vi.restoreAllMocks())
+
+describe("TargetSelector", () => {
+  it("renders all three distribution targets with a kind badge each", () => {
+    render(<TargetSelector clip={clip()} />)
+    expect(screen.getByText("SoundCloud")).toBeInTheDocument()
+    expect(screen.getByText("LANDR")).toBeInTheDocument()
+    expect(screen.getByText("DistroKid")).toBeInTheDocument()
+    expect(screen.getByText("Automated")).toBeInTheDocument()
+    expect(screen.getAllByText("Guided")).toHaveLength(2)
+  })
+
+  it("shows a Requirements disclosure for every target", () => {
+    render(<TargetSelector clip={clip()} />)
+    expect(screen.getAllByText("Requirements")).toHaveLength(3)
+  })
+
+  it("enables the guided Prepare buttons when a song is selected", () => {
+    render(<TargetSelector clip={clip()} />)
+    const prepare = screen.getAllByRole("button", { name: /prepare package/i })
+    expect(prepare).toHaveLength(2)
+    prepare.forEach((btn) => expect(btn).toBeEnabled())
+  })
+
+  it("disables guided actions when no song is selected", () => {
+    render(<TargetSelector clip={null} />)
+    screen
+      .getAllByRole("button", { name: /prepare package/i })
+      .forEach((btn) => expect(btn).toBeDisabled())
+  })
+})

--- a/web/components/distribution/TargetSelector.tsx
+++ b/web/components/distribution/TargetSelector.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { GuidedFlowModal } from "@/components/distribution/GuidedFlowModal"
+import { SoundCloudCard } from "@/components/distribution/SoundCloudCard"
+import {
+  DISTRIBUTION_TARGETS,
+  type DistributionTarget,
+  type GuidedTarget,
+} from "@/lib/distribution"
+import { loadDraft, prefillFromClip, type ReleaseMetadata } from "@/lib/release-draft"
+import type { Clip } from "@/lib/workspace-clips"
+
+type Props = {
+  /** The selected song; null shows a prompt and disables guided actions. */
+  clip: Clip | null
+}
+
+/** Effective release metadata = clip prefill with any saved draft layered on top. */
+function effectiveMetadata(clip: Clip): ReleaseMetadata {
+  return { ...prefillFromClip(clip), ...loadDraft(clip.id) }
+}
+
+/** Requirements list, collapsed by default via the native <details> element. */
+function Requirements({ items }: { items: string[] }) {
+  return (
+    <details className="group text-sm">
+      <summary className="flex cursor-pointer list-none items-center gap-1 text-muted-foreground hover:text-foreground">
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          size={14}
+          className="transition-transform group-open:rotate-180"
+        />
+        Requirements
+      </summary>
+      <ul className="mt-2 ml-1 flex list-disc flex-col gap-1 pl-4 text-xs text-muted-foreground">
+        {items.map((r) => (
+          <li key={r}>{r}</li>
+        ))}
+      </ul>
+    </details>
+  )
+}
+
+function TargetCard({
+  target,
+  clip,
+}: {
+  target: DistributionTarget
+  clip: Clip | null
+}) {
+  return (
+    <Card className="flex flex-col">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle>{target.label}</CardTitle>
+          <Badge variant={target.kind === "auto" ? "default" : "secondary"}>
+            {target.kind === "auto" ? "Automated" : "Guided"}
+          </Badge>
+        </div>
+        <CardDescription>{target.blurb}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4">
+        {target.kind === "auto" ? (
+          <SoundCloudCard />
+        ) : (
+          <div className="flex flex-col items-start gap-3">
+            {!clip && (
+              <p className="text-sm text-muted-foreground">
+                Select a song to prepare a package.
+              </p>
+            )}
+            <GuidedFlowModal
+              target={target.id as GuidedTarget}
+              ready={!!clip}
+              // Read the draft fresh on open so the package reflects the latest
+              // saved edits (the form persists on change), not a mount snapshot.
+              resolveMetadata={() => (clip ? effectiveMetadata(clip) : null)}
+            />
+          </div>
+        )}
+        <div className="mt-auto">
+          <Requirements items={target.requirements} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Distribution target selection grid (US-21.5): SoundCloud + guided LANDR/DistroKid. */
+export function TargetSelector({ clip }: Props) {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {DISTRIBUTION_TARGETS.map((target) => (
+        <TargetCard key={target.id} target={target} clip={clip} />
+      ))}
+    </div>
+  )
+}

--- a/web/components/release/DistributionForm.test.tsx
+++ b/web/components/release/DistributionForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -53,6 +53,16 @@ describe("DistributionForm", () => {
     const album = screen.getByLabelText(/album/i)
     await user.type(album, "Night Sessions")
     expect(album).toHaveValue("Night Sessions")
+  })
+
+  it("auto-persists edits to the draft as the user types, so the US-21.5 guided flow reads current metadata", async () => {
+    const user = userEvent.setup()
+    render(<DistributionForm clip={makeClip()} />)
+    await user.type(screen.getByLabelText(/album/i), "Night Sessions")
+    // Debounced save (no unmount / song-switch) keeps localStorage current.
+    await waitFor(() => expect(loadDraft("clip-1")?.album).toBe("Night Sessions"), {
+      timeout: 2000,
+    })
   })
 
   it("highlights missing required fields on save (AC5)", async () => {

--- a/web/components/release/DistributionForm.tsx
+++ b/web/components/release/DistributionForm.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { cloneElement, useEffect, useRef, useState, type ReactElement } from "react"
+import {
+  cloneElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -21,6 +28,7 @@ import {
   type ReleaseCredits,
   type ReleaseMetadata,
 } from "@/lib/release-draft"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import type { Clip } from "@/lib/workspace-clips"
 
 /**
@@ -113,6 +121,18 @@ function DistributionFormFields({ clip }: { clip: Clip }) {
       saveDraft(ref.current.clipId, ref.current.metadata)
     }
   }, [])
+
+  // Persist edits as they happen (debounced), keeping localStorage the current
+  // source of truth so a sibling reading the draft — the distribution guided flow
+  // (US-21.5) packages metadata.json from it — never sees a stale, pre-save
+  // snapshot. The clipId is paired with the metadata so a song-switch (which
+  // resets both in the same render) can't misfile one song's edits under another.
+  // Silent: saveDraft only writes storage, never setState, so no "saved" message.
+  const editSnapshot = useMemo(() => ({ clipId: clip.id, metadata }), [clip.id, metadata])
+  const debouncedSnapshot = useDebouncedValue(editSnapshot, 400)
+  useEffect(() => {
+    saveDraft(debouncedSnapshot.clipId, debouncedSnapshot.metadata)
+  }, [debouncedSnapshot])
 
   function set<K extends keyof ReleaseMetadata>(key: K, value: ReleaseMetadata[K]) {
     setMetadata((m) => ({ ...m, [key]: value }))

--- a/web/lib/distribution-server.ts
+++ b/web/lib/distribution-server.ts
@@ -1,0 +1,59 @@
+// Server-only helpers for the SoundCloud BFF routes. Imports next/server, so
+// never pull this into a client component. Mirrors lib/auth-server, but for the
+// SoundCloud link's PKCE cookies (sc_link_nonce_* / sc_link_verifier_*) which the
+// backend sets at /connect and reads back at /callback.
+import type { NextRequest, NextResponse } from "next/server"
+
+import { cookieOptions, STATE_MAX_AGE } from "@/lib/auth-server"
+
+/** Prefixes of the backend's per-flow SoundCloud link cookies. */
+export const SC_LINK_PREFIXES = ["sc_link_nonce_", "sc_link_verifier_"] as const
+
+function isScLinkCookie(name: string): boolean {
+  return SC_LINK_PREFIXES.some((p) => name.startsWith(p))
+}
+
+/**
+ * Pull the sc_link_* cookies out of a backend Set-Cookie header list, returning
+ * just name/value so the BFF can re-emit them under its own path. Cookie
+ * attributes (the backend's `/api/v1/distribution` path, secure, etc.) are
+ * intentionally dropped — the BFF re-scopes them to `/` so its callback route
+ * can read them back. Mirrors auth.parseStateSetCookies.
+ */
+export function parseScLinkSetCookies(
+  setCookies: string[]
+): { name: string; value: string }[] {
+  const out: { name: string; value: string }[] = []
+  for (const raw of setCookies) {
+    const pair = raw.split(";", 1)[0]
+    const eq = pair.indexOf("=")
+    if (eq === -1) continue
+    const name = pair.slice(0, eq).trim()
+    const value = pair.slice(eq + 1).trim()
+    if (isScLinkCookie(name) && value) out.push({ name, value })
+  }
+  return out
+}
+
+/** Re-emit the backend's link cookies on the BFF response, scoped so /callback reads them. */
+export function reemitScLinkCookies(response: NextResponse, setCookies: string[]): void {
+  for (const { name, value } of parseScLinkSetCookies(setCookies)) {
+    response.cookies.set(name, value, cookieOptions(STATE_MAX_AGE))
+  }
+}
+
+/** Build a `Cookie` header of the sc_link_* cookies to forward back to the backend. */
+export function collectScLinkCookies(request: NextRequest): string {
+  return request.cookies
+    .getAll()
+    .filter((c) => isScLinkCookie(c.name))
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ")
+}
+
+/** Expire the sc_link_* cookies once the link flow is consumed. */
+export function clearScLinkCookies(request: NextRequest, response: NextResponse): void {
+  for (const c of request.cookies.getAll()) {
+    if (isScLinkCookie(c.name)) response.cookies.set(c.name, "", cookieOptions(0))
+  }
+}

--- a/web/lib/distribution.test.ts
+++ b/web/lib/distribution.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  completeSoundCloudCallback,
+  connectSoundCloud,
+  disconnectSoundCloud,
+  DISTRIBUTION_TARGETS,
+  getSoundCloudStatus,
+  prepareDistribution,
+  targetById,
+} from "@/lib/distribution"
+import type { ReleaseMetadata } from "@/lib/release-draft"
+
+function metadata(overrides: Partial<ReleaseMetadata> = {}): ReleaseMetadata {
+  return {
+    title: "Nightfall",
+    artist: "AMS",
+    album: "",
+    genre: "House",
+    description: "",
+    bpm: 124,
+    key: "Am",
+    language: "",
+    explicit: false,
+    releaseDate: "",
+    copyright: "",
+    credits: { producer: "", songwriter: "", performer: "" },
+    coverArt: { kind: "existing" },
+    isrc: "US-AMS-25-00001",
+    upc: "012345678905",
+    lyrics: "",
+    ...overrides,
+  }
+}
+
+function ok(body: unknown, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+beforeEach(() => {
+  // jsdom has no URL.createObjectURL; stub it so bundle-building is observable.
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:metadata"),
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe("target catalogue", () => {
+  it("offers SoundCloud (auto) plus two guided targets with portal URLs", () => {
+    expect(DISTRIBUTION_TARGETS.map((t) => t.id)).toEqual([
+      "soundcloud",
+      "landr",
+      "distrokid",
+    ])
+    expect(targetById("soundcloud")?.kind).toBe("auto")
+    expect(targetById("landr")?.portalUrl).toMatch(/landr\.com/)
+    expect(targetById("distrokid")?.portalUrl).toMatch(/distrokid\.com/)
+  })
+})
+
+describe("prepareDistribution", () => {
+  it("passes every check and builds a bundle for complete metadata", () => {
+    const pkg = prepareDistribution("landr", metadata())
+    expect(pkg.allChecksPassed).toBe(true)
+    expect(pkg.checklist.every((c) => c.passed)).toBe(true)
+    expect(pkg.bundleUrl).toBe("blob:metadata")
+    expect(pkg.instructions).toMatch(/LANDR/)
+  })
+
+  it("fails and withholds the bundle when required metadata is missing", () => {
+    const pkg = prepareDistribution("distrokid", metadata({ title: "", genre: "" }))
+    expect(pkg.allChecksPassed).toBe(false)
+    expect(pkg.bundleUrl).toBeNull()
+    expect(pkg.checklist.find((c) => c.item === "Required metadata")?.passed).toBe(false)
+  })
+
+  it("fails the cover-art check when no art is attached", () => {
+    const pkg = prepareDistribution("landr", metadata({ coverArt: { kind: "none" } }))
+    expect(pkg.checklist.find((c) => c.item === "Cover art")?.passed).toBe(false)
+    expect(pkg.allChecksPassed).toBe(false)
+  })
+
+  it("fails the ISRC check on a malformed identifier", () => {
+    const pkg = prepareDistribution("landr", metadata({ isrc: "not-an-isrc" }))
+    expect(pkg.checklist.find((c) => c.item === "ISRC")?.passed).toBe(false)
+  })
+})
+
+describe("SoundCloud client", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("maps a connected status response into camelCase", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        ok({
+          connected: true,
+          soundcloud_username: "dj-ams",
+          connected_at: "2026-07-01T00:00:00Z",
+          token_valid: true,
+        })
+      )
+    )
+    const res = await getSoundCloudStatus("tok")
+    expect(res).toEqual({
+      kind: "ok",
+      status: {
+        connected: true,
+        username: "dj-ams",
+        connectedAt: "2026-07-01T00:00:00Z",
+        tokenValid: true,
+      },
+    })
+  })
+
+  it("classifies 401 as unauthorized", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ok({ detail: "no" }, 401)))
+    expect((await getSoundCloudStatus("tok")).kind).toBe("unauthorized")
+  })
+
+  it("returns the authorize URL from connect", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ok({ authorization_url: "https://soundcloud.com/connect?x=1" }))
+    )
+    const res = await connectSoundCloud("tok")
+    expect(res).toEqual({
+      kind: "ok",
+      authorizationUrl: "https://soundcloud.com/connect?x=1",
+    })
+  })
+
+  it("surfaces a 503 from connect as unavailable", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ok({ detail: "not configured" }, 503)))
+    const res = await connectSoundCloud("tok")
+    expect(res.kind).toBe("unavailable")
+  })
+
+  it("classifies a 400 callback as invalid state", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ok({ detail: "bad" }, 400)))
+    expect((await completeSoundCloudCallback("c", "s", "tok")).kind).toBe("invalid")
+  })
+
+  it("treats a 204 disconnect as ok", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 204, json: async () => ({}) })))
+    expect((await disconnectSoundCloud("tok")).kind).toBe("ok")
+  })
+})

--- a/web/lib/distribution.ts
+++ b/web/lib/distribution.ts
@@ -1,0 +1,338 @@
+// Distribution client + guided-flow seam (US-21.5).
+//
+// Two halves, split by whether the backend is reachable from the current web state:
+//
+// 1. SoundCloud account linking is wired to the REAL backend. Its endpoints
+//    (`/api/v1/distribution/soundcloud/*`) are usable without a release, so each
+//    call goes through a same-origin BFF proxy under `/api/distribution/soundcloud/*`
+//    that forwards the Bearer token and carries the PKCE state cookies (mirrors
+//    lib/mastering + the OAuth callback BFF).
+//
+// 2. The guided LANDR/DistroKid flow is a local seam, like release-draft
+//    ([[us-21-4-distribution-metadata-form]]) and mastering-history. The backend
+//    `POST /releases/{id}/prepare/{target}` exists but needs a real release_id,
+//    and the web app has no release-creation yet (only a localStorage draft). So
+//    `prepareDistribution` computes the same checklist the backend would, from the
+//    draft, and builds a real metadata.json package client-side. The response shape
+//    mirrors the backend PrepareResponse — when release-creation lands, swap the
+//    body of prepareDistribution for a fetch to the BFF prepare route and callers
+//    won't change.
+
+import { validateMetadata, type ReleaseMetadata } from "@/lib/release-draft"
+
+// --- target catalogue -------------------------------------------------------
+
+/** Guided targets that use the package-and-upload-manually flow. */
+export type GuidedTarget = "landr" | "distrokid"
+
+/** Every selectable distribution channel. */
+export type DistributionTargetId = "soundcloud" | GuidedTarget
+
+/** "auto" = one-click via a connected account; "guided" = prepare + manual upload. */
+export type DistributionKind = "auto" | "guided"
+
+export type DistributionTarget = {
+  id: DistributionTargetId
+  label: string
+  kind: DistributionKind
+  /** One-line pitch shown on the target card. */
+  blurb: string
+  /** Where the guided flow opens in a new tab (null for the automated target). */
+  portalUrl: string | null
+  /** Static requirements listed under each card (validation runs server-side). */
+  requirements: string[]
+}
+
+const COMMON_STORE_REQUIREMENTS = [
+  "Lossless master (WAV or FLAC)",
+  "Square cover art, at least 3000×3000px",
+  "Title, artist and genre",
+  "ISRC and UPC (auto-generated if you have none)",
+]
+
+/** The three channels US-21.5 offers, in display order. */
+export const DISTRIBUTION_TARGETS: DistributionTarget[] = [
+  {
+    id: "soundcloud",
+    label: "SoundCloud",
+    kind: "auto",
+    blurb: "Connect your account once and publish in a single click.",
+    portalUrl: null,
+    requirements: [
+      "Title, genre and description",
+      "BPM and musical key",
+      "ISRC (optional)",
+      "Square artwork",
+    ],
+  },
+  {
+    id: "landr",
+    label: "LANDR",
+    kind: "guided",
+    blurb: "Prepare a submission package, then upload it on LANDR.",
+    portalUrl: "https://www.landr.com/digital-music-distribution/",
+    requirements: COMMON_STORE_REQUIREMENTS,
+  },
+  {
+    id: "distrokid",
+    label: "DistroKid",
+    kind: "guided",
+    blurb: "Prepare a submission package, then upload it on DistroKid.",
+    portalUrl: "https://distrokid.com/",
+    requirements: COMMON_STORE_REQUIREMENTS,
+  },
+]
+
+/** Look a target up by id (undefined if unknown). */
+export function targetById(id: string): DistributionTarget | undefined {
+  return DISTRIBUTION_TARGETS.find((t) => t.id === id)
+}
+
+// --- guided-flow seam -------------------------------------------------------
+
+/** One pass/fail line in a preparation checklist (mirrors backend ChecklistItem). */
+export type ChecklistItem = { item: string; passed: boolean; message: string }
+
+/** Result of preparing a guided submission (mirrors backend PrepareResponse). */
+export type PreparedPackage = {
+  target: GuidedTarget
+  checklist: ChecklistItem[]
+  allChecksPassed: boolean
+  /** Object URL of the client-built metadata.json, or null until every check passes. */
+  bundleUrl: string | null
+  instructions: string
+}
+
+function instructionsFor(target: GuidedTarget): string {
+  const label = targetById(target)?.label ?? target
+  const portal = target === "landr" ? "landr.com" : "distrokid.com"
+  return [
+    `Submitting to ${label}:`,
+    "1. Download the package and unzip your master and artwork.",
+    `2. Sign in to ${portal} and start a new release.`,
+    "3. Upload the audio and cover art, and copy the fields from metadata.json.",
+    `4. Submit on ${label}, then mark the release submitted here.`,
+  ].join("\n")
+}
+
+/**
+ * Build a guided-submission checklist for a target from the release metadata,
+ * mirroring what the backend `prepare/{target}` validates. When every item
+ * passes, a real metadata.json package is produced as an object URL.
+ */
+export function prepareDistribution(
+  target: GuidedTarget,
+  metadata: ReleaseMetadata
+): PreparedPackage {
+  const errors = validateMetadata(metadata)
+  const has = (v: string) => v.trim().length > 0
+
+  const checklist: ChecklistItem[] = [
+    {
+      item: "Required metadata",
+      passed: !errors.title && !errors.artist && !errors.genre,
+      message:
+        !errors.title && !errors.artist && !errors.genre
+          ? "Title, artist and genre are set."
+          : "Title, artist and genre are all required.",
+    },
+    {
+      item: "Cover art",
+      passed: metadata.coverArt.kind !== "none",
+      message:
+        metadata.coverArt.kind !== "none"
+          ? "Cover art is attached."
+          : "Attach square cover art of at least 3000×3000px.",
+    },
+    {
+      item: "ISRC",
+      passed: has(metadata.isrc) && !errors.isrc,
+      message: errors.isrc
+        ? errors.isrc
+        : has(metadata.isrc)
+          ? "ISRC is set."
+          : "Add an ISRC (generate one on the metadata tab).",
+    },
+    {
+      item: "UPC",
+      passed: has(metadata.upc) && !errors.upc,
+      message: errors.upc
+        ? errors.upc
+        : has(metadata.upc)
+          ? "UPC is set."
+          : "Add a UPC (generate one on the metadata tab).",
+    },
+  ]
+
+  const allChecksPassed = checklist.every((c) => c.passed)
+  return {
+    target,
+    checklist,
+    allChecksPassed,
+    bundleUrl: allChecksPassed ? buildPackageUrl(metadata) : null,
+    instructions: instructionsFor(target),
+  }
+}
+
+/** Serialise the release metadata to a downloadable metadata.json object URL. */
+function buildPackageUrl(metadata: ReleaseMetadata): string {
+  const blob = new Blob([JSON.stringify(metadata, null, 2)], {
+    type: "application/json",
+  })
+  return URL.createObjectURL(blob)
+}
+
+// --- SoundCloud client (real backend via BFF) -------------------------------
+
+/** A user's SoundCloud link state (mirrors backend StatusResponse, camelCased). */
+export type SoundCloudStatus = {
+  connected: boolean
+  username: string | null
+  connectedAt: string | null
+  tokenValid: boolean | null
+}
+
+const DISCONNECTED: SoundCloudStatus = {
+  connected: false,
+  username: null,
+  connectedAt: null,
+  tokenValid: null,
+}
+
+/** Shape the raw backend StatusResponse into our camelCased status. */
+function toStatus(body: unknown): SoundCloudStatus {
+  const b = (body ?? {}) as {
+    connected?: boolean
+    soundcloud_username?: string | null
+    connected_at?: string | null
+    token_valid?: boolean | null
+  }
+  return {
+    connected: Boolean(b.connected),
+    username: b.soundcloud_username ?? null,
+    connectedAt: b.connected_at ?? null,
+    tokenValid: b.token_valid ?? null,
+  }
+}
+
+/** Pull a human-readable message out of a FastAPI error body. */
+function extractDetail(body: unknown, fallback: string): string {
+  if (body && typeof body === "object" && "detail" in body) {
+    const detail = (body as { detail: unknown }).detail
+    if (typeof detail === "string") return detail
+  }
+  return fallback
+}
+
+export type StatusResult =
+  | { kind: "ok"; status: SoundCloudStatus }
+  | { kind: "unauthorized" }
+  | { kind: "error"; detail: string }
+
+export type ConnectResult =
+  | { kind: "ok"; authorizationUrl: string }
+  | { kind: "unauthorized" }
+  | { kind: "unavailable"; detail: string }
+  | { kind: "error"; detail: string }
+
+export type CallbackResult =
+  | { kind: "ok"; status: SoundCloudStatus }
+  | { kind: "unauthorized" }
+  | { kind: "invalid" }
+  | { kind: "error"; detail: string }
+
+export type DisconnectResult =
+  | { kind: "ok" }
+  | { kind: "unauthorized" }
+  | { kind: "error"; detail: string }
+
+function authHeaders(accessToken: string): HeadersInit {
+  return { authorization: `Bearer ${accessToken}` }
+}
+
+/** Fetch the current SoundCloud link status through the BFF proxy. */
+export async function getSoundCloudStatus(accessToken: string): Promise<StatusResult> {
+  let res: Response
+  try {
+    res = await fetch("/api/distribution/soundcloud/status", {
+      headers: authHeaders(accessToken),
+    })
+  } catch {
+    return { kind: "error", detail: "Could not reach SoundCloud. Please try again." }
+  }
+  if (res.status === 401) return { kind: "unauthorized" }
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    return { kind: "error", detail: extractDetail(body, "Could not load SoundCloud status.") }
+  }
+  // 404 is impossible here (status always 200 with connected:false), so any ok
+  // body is a status. A blank body degrades to disconnected rather than erroring.
+  const body = await res.json().catch(() => DISCONNECTED)
+  return { kind: "ok", status: toStatus(body) }
+}
+
+/** Begin the OAuth link: returns the SoundCloud authorize URL to redirect to. */
+export async function connectSoundCloud(accessToken: string): Promise<ConnectResult> {
+  let res: Response
+  try {
+    res = await fetch("/api/distribution/soundcloud/connect", {
+      method: "POST",
+      headers: authHeaders(accessToken),
+    })
+  } catch {
+    return { kind: "error", detail: "Could not start the SoundCloud connection." }
+  }
+  if (res.status === 401) return { kind: "unauthorized" }
+  const body = await res.json().catch(() => ({}))
+  if (res.status === 503) {
+    return { kind: "unavailable", detail: extractDetail(body, "SoundCloud is not configured.") }
+  }
+  if (!res.ok || !(body as { authorization_url?: string }).authorization_url) {
+    return { kind: "error", detail: extractDetail(body, "Could not start the SoundCloud connection.") }
+  }
+  return { kind: "ok", authorizationUrl: (body as { authorization_url: string }).authorization_url }
+}
+
+/** Complete the OAuth link by exchanging the code+state through the BFF proxy. */
+export async function completeSoundCloudCallback(
+  code: string,
+  state: string,
+  accessToken: string
+): Promise<CallbackResult> {
+  let res: Response
+  try {
+    res = await fetch("/api/distribution/soundcloud/callback", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...authHeaders(accessToken) },
+      body: JSON.stringify({ code, state }),
+    })
+  } catch {
+    return { kind: "error", detail: "Could not complete the SoundCloud connection." }
+  }
+  if (res.status === 401) return { kind: "unauthorized" }
+  if (res.status === 400) return { kind: "invalid" }
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    return { kind: "error", detail: extractDetail(body, "Could not complete the SoundCloud connection.") }
+  }
+  return { kind: "ok", status: toStatus(body) }
+}
+
+/** Unlink the SoundCloud account through the BFF proxy (idempotent). */
+export async function disconnectSoundCloud(accessToken: string): Promise<DisconnectResult> {
+  let res: Response
+  try {
+    res = await fetch("/api/distribution/soundcloud/connect", {
+      method: "DELETE",
+      headers: authHeaders(accessToken),
+    })
+  } catch {
+    return { kind: "error", detail: "Could not disconnect SoundCloud. Please try again." }
+  }
+  if (res.status === 401) return { kind: "unauthorized" }
+  if (!res.ok && res.status !== 204) {
+    const body = await res.json().catch(() => ({}))
+    return { kind: "error", detail: extractDetail(body, "Could not disconnect SoundCloud.") }
+  }
+  return { kind: "ok" }
+}


### PR DESCRIPTION
## US-21.5: Distribution Target Selection and SoundCloud OAuth

Closes #224.

Adds the distribution-target selection UI to the `/release` **Distribute** tab: connect a SoundCloud account for one-click publishing, and prepare guided submission packages for LANDR / DistroKid.

### What's here
- **SoundCloud OAuth (real backend, BFF-proxied).** `Connect` starts the backend's OAuth 2.1 **PKCE** flow, the callback page finishes the link, and the card shows the connected username with an initials avatar, connection date, and a confirm-gated **Disconnect**. Three same-origin BFF routes under `/api/distribution/soundcloud/*` forward the Bearer token and carry the backend's per-flow `sc_link_*` cookies (re-emit on connect, forward + clear on callback) — mirroring the existing Google/Discord OAuth infra.
- **Guided LANDR / DistroKid flow.** `Prepare package` runs a preparation checklist against the release metadata, and when every item passes, builds a downloadable `metadata.json` package and an **Open {store}** button that launches the store in a new tab. Includes the backend's submission instructions and a **Mark as submitted** acknowledgement.
- **Target selector grid** with an Automated/Guided badge and a collapsible **Requirements** disclosure (native `<details>`) per channel.

### Design decisions
- **Seam vs. real backend follows the codebase's reachability convention.** SoundCloud's endpoints are usable without a release, so they're wired to the real backend. `prepare/{target}` needs a real `release_id`, but the web app has no release-creation yet (only the `release-draft` localStorage seam from US-21.4) — so the guided flow computes the same checklist client-side and builds the package locally. `lib/distribution.ts` mirrors the backend `PrepareResponse` shape; when release-creation lands, swap `prepareDistribution`'s body for a BFF fetch and callers won't change (a `// ponytail:` marker notes the swap point). This matches US-21.2 (real) vs US-21.3/21.4 (seam).
- **Avatar** is an initials placeholder — the backend `StatusResponse` carries no `avatar_url`.

### Acceptance criteria
- [x] SoundCloud OAuth connect flow completes and stores credentials — BFF connect/callback routes + callback page.
- [x] Connected SoundCloud account shows username and avatar — connected card state (initials avatar).
- [x] SoundCloud can be disconnected — confirm dialog → `DELETE` route.
- [x] LANDR guided flow prepares package and opens LANDR in a new tab — `GuidedFlowModal` + `prepareDistribution`.
- [x] Target-specific requirements displayed for each channel — `<details>` per target card.

### Tests
5 new test files: client/seam classification, BFF connect cookie re-emit + 503 passthrough + DELETE, and the three components (connect/connected/disconnect, guided checklist + open-in-new-tab, selector grid/requirements/enablement), plus a save-on-change test on `DistributionForm`. `tsc --noEmit`, `eslint`, full `vitest run` (180 files) green locally.

### Cross-family review (opencode / GLM)
A GLM review confirmed the security posture (SameSite=lax survives the OAuth round-trip, PKCE cookies are single-use, no SSRF / open-redirect / token leakage) and found three defects, all fixed in this PR:
- **Stale package (correctness):** the guided flow read the release draft memoized on `clip`, but `DistributionForm` only persisted on unmount/song-switch — so an in-tab edit could package a stale `metadata.json`. Fixed by a debounced save-on-change in the form (localStorage stays current; also survives crashes) + the guided flow reading the draft fresh on open.
- **Infinite spinner:** the callback page could spin forever for a visitor whose session couldn't be restored. Fixed by surfacing the error once auth settles unauthenticated.
- **Object-URL leak:** the bundle URL is now revoked on unmount and before re-creation, not only on dialog close.

### Known limitations
- **No live SoundCloud e2e** — the backend `/soundcloud/connect` 503s until real SoundCloud app credentials are configured (consistent with US-21.2's mastering-worker gap). Card states, disconnect, callback, and the guided flow are verified via unit tests and a `/labs` mount.
- **Guided prepare/submit are client seams** — no real `release_id` in the web flow yet; swap to the backend `prepare`/`submit` routes when release-creation lands.
- Requires the backend's SoundCloud OAuth `redirect_uri` to point at `/auth/soundcloud/callback` (backend config, unchanged here).

_Frontend is not in CI — verified locally: typecheck, lint, full test suite, and `next build`._
