### PR TITLE
feat(web): US-21.6 Distribution Status Dashboard and Review Screen (#225)

### DIFF
--- a/web/app/release/page.test.tsx
+++ b/web/app/release/page.test.tsx
@@ -56,6 +56,17 @@ vi.mock("@/components/distribution/TargetSelector", () => ({
     <div data-testid="target-selector">{clip?.id ?? "no-clip"}</div>
   ),
 }))
+// The review screen (US-21.6) has its own tests and renders the submit surface;
+// stub it so the page test stays focused on the Distribute sub-tab wiring.
+vi.mock("@/components/distribution/ReviewScreen", () => ({
+  ReviewScreen: ({ clip }: { clip: { id: string } | null }) => (
+    <div data-testid="review-screen">{clip?.id ?? "no-clip"}</div>
+  ),
+}))
+// The dashboard (US-21.6) polls releases and has its own tests; stub it here.
+vi.mock("@/components/distribution/DashboardList", () => ({
+  DashboardList: () => <div data-testid="dashboard-list" />,
+}))
 vi.mock("@/components/release/SelectedSongSummary", () => ({
   SelectedSongSummary: ({
     clip,
@@ -173,6 +184,30 @@ describe("ReleasePage", () => {
     // The form's Title field is pre-populated from the clip (US-21.4 AC1).
     expect(screen.getByLabelText(/^title/i)).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /save draft/i })).toBeInTheDocument()
+  })
+
+  it("shows the Metadata, Review, and Releases sub-tabs on the Distribute tab", () => {
+    searchParamsRef.current = new URLSearchParams("tab=distribute&clip=c1")
+    useClip.mockReturnValue(foundClip())
+    render(<ReleasePageContent />)
+    expect(screen.getByRole("tab", { name: /metadata/i })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /review/i })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /releases/i })).toBeInTheDocument()
+    // Metadata is the default sub-tab, so the form shows first.
+    expect(screen.getByLabelText(/^title/i)).toBeInTheDocument()
+  })
+
+  it("opens the Review screen and the Releases dashboard from the sub-tabs", async () => {
+    searchParamsRef.current = new URLSearchParams("tab=distribute&clip=c1")
+    useClip.mockReturnValue(foundClip())
+    const user = userEvent.setup()
+    render(<ReleasePageContent />)
+
+    await user.click(screen.getByRole("tab", { name: /review/i }))
+    expect(screen.getByTestId("review-screen")).toHaveTextContent("c1")
+
+    await user.click(screen.getByRole("tab", { name: /releases/i }))
+    expect(screen.getByTestId("dashboard-list")).toBeInTheDocument()
   })
 
   it("preserves unsaved Distribute-tab edits across a tab switch (Radix unmounts the panel)", () => {

--- a/web/app/release/page.tsx
+++ b/web/app/release/page.tsx
@@ -12,7 +12,8 @@ import {
 } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MasteringTab } from "@/components/mastering/mastering-tab"
-import { TargetSelector } from "@/components/distribution/TargetSelector"
+import { DashboardList } from "@/components/distribution/DashboardList"
+import { ReviewScreen } from "@/components/distribution/ReviewScreen"
 import { DistributionForm } from "@/components/release/DistributionForm"
 import { SelectedSongSummary } from "@/components/release/SelectedSongSummary"
 import { SongSelector } from "@/components/release/SongSelector"
@@ -24,7 +25,9 @@ import { useRequireAuth } from "@/hooks/use-require-auth"
 // Mastering", which navigates here with ?clip=), see its summary, then work
 // through the Mastering and Distribute tabs. Mastering (US-21.2) and the
 // distribution metadata form (US-21.4) fill the tab bodies; platform submission
-// lands in US-21.5.
+// lands in US-21.5. The Distribute tab splits into Metadata → Review → Releases
+// sub-tabs (US-21.6): edit, then verify the package and submit, then track every
+// release's per-channel status on the dashboard.
 //
 // Selection is URL-driven (?clip=): the selector writes it and pre-selection
 // reads it, so there's one source of truth and it survives a refresh.
@@ -109,31 +112,50 @@ export function ReleasePageContent() {
           <MasteringTab selectedClip={clip ?? null} />
         </TabsContent>
         <TabsContent value="distribute" className="pt-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Distribution</CardTitle>
-              <CardDescription>
-                Review and edit your release metadata, then save a draft to
-                continue later. Publishing to streaming platforms comes in a
-                later step.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <DistributionForm clip={clip ?? null} />
-            </CardContent>
-          </Card>
-          <Card className="mt-4">
-            <CardHeader>
-              <CardTitle>Distribution targets</CardTitle>
-              <CardDescription>
-                Connect SoundCloud for one-click publishing, or prepare a
-                submission package for a guided store.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <TargetSelector clip={clip ?? null} />
-            </CardContent>
-          </Card>
+          {/* Inner flow (US-21.6): edit metadata → review the package & submit →
+              track releases on the dashboard. Local (not URL-driven) sub-tab —
+              the outer tab already owns the URL; a second param would be noise. */}
+          <Tabs defaultValue="metadata">
+            <TabsList>
+              <TabsTrigger value="metadata">Metadata</TabsTrigger>
+              <TabsTrigger value="review">Review</TabsTrigger>
+              <TabsTrigger value="releases">Releases</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="metadata" className="pt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Distribution</CardTitle>
+                  <CardDescription>
+                    Review and edit your release metadata, then save a draft to
+                    continue later. Review and submit from the Review tab.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <DistributionForm clip={clip ?? null} />
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value="review" className="pt-4">
+              <ReviewScreen clip={clip ?? null} />
+            </TabsContent>
+
+            <TabsContent value="releases" className="pt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Your releases</CardTitle>
+                  <CardDescription>
+                    Track every release across channels. Statuses refresh
+                    automatically while this tab is open.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <DashboardList />
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
         </TabsContent>
       </Tabs>
     </div>

--- a/web/components/distribution/DashboardList.test.tsx
+++ b/web/components/distribution/DashboardList.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { DashboardList } from "@/components/distribution/DashboardList"
+import type { UseReleasesPoll } from "@/hooks/use-releases-poll"
+import type { ReleaseSummary } from "@/lib/releases"
+
+vi.mock("@/hooks/use-releases-poll", () => ({ useReleasesPoll: vi.fn() }))
+import { useReleasesPoll } from "@/hooks/use-releases-poll"
+const mockHook = useReleasesPoll as unknown as ReturnType<typeof vi.fn>
+
+function state(overrides: Partial<UseReleasesPoll>): UseReleasesPoll {
+  return {
+    releases: null,
+    loading: false,
+    error: null,
+    lastUpdated: null,
+    refresh: vi.fn(),
+    ...overrides,
+  }
+}
+
+const rows: ReleaseSummary[] = [
+  {
+    id: "r1",
+    clipId: "c1",
+    title: "Neon Skyline",
+    artist: "A",
+    genre: "G",
+    releaseDate: "2026-06-01",
+    createdAt: "2026-06-01T00:00:00Z",
+    channels: [{ channel: "soundcloud", status: "live", permalink: "https://x" }],
+  },
+]
+
+afterEach(() => vi.clearAllMocks())
+
+describe("DashboardList", () => {
+  it("shows a loading state", () => {
+    mockHook.mockReturnValue(state({ loading: true }))
+    render(<DashboardList />)
+    expect(screen.getByRole("status")).toHaveTextContent(/loading releases/i)
+  })
+
+  it("shows an error with a retry", async () => {
+    const refresh = vi.fn()
+    mockHook.mockReturnValue(state({ error: "nope", refresh }))
+    render(<DashboardList />)
+    expect(screen.getByRole("alert")).toHaveTextContent("nope")
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }))
+    expect(refresh).toHaveBeenCalled()
+  })
+
+  it("keeps the list visible with an inline banner when a poll fails after data loaded", () => {
+    // error set AND releases present = a transient poll failure, not initial.
+    mockHook.mockReturnValue(state({ releases: rows, error: "blip", lastUpdated: Date.now() }))
+    render(<DashboardList />)
+    expect(screen.getByRole("link", { name: "Neon Skyline" })).toBeInTheDocument() // list still shown
+    expect(screen.getByRole("alert")).toHaveTextContent(/showing the last known statuses/i)
+  })
+
+  it("shows an empty state when there are no releases", () => {
+    mockHook.mockReturnValue(state({ releases: [] }))
+    render(<DashboardList />)
+    expect(screen.getByText(/no releases yet/i)).toBeInTheDocument()
+  })
+
+  it("renders a card per release with an updated timestamp", () => {
+    mockHook.mockReturnValue(state({ releases: rows, lastUpdated: Date.now() }))
+    render(<DashboardList />)
+    expect(screen.getByRole("link", { name: "Neon Skyline" })).toBeInTheDocument()
+    expect(screen.getByText(/updated/i)).toBeInTheDocument()
+  })
+})

--- a/web/components/distribution/DashboardList.tsx
+++ b/web/components/distribution/DashboardList.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Alert01Icon, RefreshIcon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import { ReleaseCard } from "@/components/distribution/ReleaseCard"
+import { useReleasesPoll } from "@/hooks/use-releases-poll"
+import { relativeTime } from "@/lib/notifications"
+
+/**
+ * Distribution status dashboard (US-21.6, spec §42.5): lists every release with
+ * per-channel status badges, external links, and rejection reasons, refreshed by
+ * a visibility-gated poll so status changes from the platforms surface without a
+ * page reload. Loading/empty/error states mirror the rest of the app (muted text
+ * and a role="alert"; no Skeleton/Alert primitives exist in web/).
+ */
+export function DashboardList() {
+  const { releases, loading, error, lastUpdated, refresh } = useReleasesPoll()
+
+  if (loading) {
+    return (
+      <p role="status" className="text-sm text-muted-foreground">
+        Loading releases…
+      </p>
+    )
+  }
+
+  // Full error state only before any data has loaded. Once we have releases, a
+  // transient poll failure must NOT wipe the visible list — show an inline stale
+  // banner over the last-good data instead (a background blip shouldn't blank the
+  // whole dashboard for 30s until the next poll).
+  if (error && !releases) {
+    return (
+      <div role="alert" className="flex flex-col items-start gap-3">
+        <p className="flex items-center gap-2 text-sm text-destructive">
+          <HugeiconsIcon icon={Alert01Icon} size={18} />
+          {error}
+        </p>
+        <Button variant="outline" size="sm" onClick={refresh}>
+          <HugeiconsIcon icon={RefreshIcon} size={16} />
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (!releases || releases.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No releases yet. Prepare one from the Review tab to get started.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {error && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-amber-600"
+        >
+          <HugeiconsIcon icon={Alert01Icon} size={14} />
+          Couldn’t refresh — showing the last known statuses.
+        </div>
+      )}
+      <div className="flex items-center justify-between">
+        {lastUpdated && (
+          <p className="text-xs text-muted-foreground" suppressHydrationWarning>
+            Updated {relativeTime(new Date(lastUpdated).toISOString())}
+          </p>
+        )}
+        <Button variant="ghost" size="sm" onClick={refresh}>
+          <HugeiconsIcon icon={RefreshIcon} size={16} />
+          Refresh
+        </Button>
+      </div>
+      {releases.map((release) => (
+        <ReleaseCard key={release.id} release={release} />
+      ))}
+    </div>
+  )
+}

--- a/web/components/distribution/ReleaseCard.test.tsx
+++ b/web/components/distribution/ReleaseCard.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ReleaseCard } from "@/components/distribution/ReleaseCard"
+import type { ReleaseSummary } from "@/lib/releases"
+
+function make(overrides: Partial<ReleaseSummary> = {}): ReleaseSummary {
+  return {
+    id: "rel-1",
+    clipId: "clip-1",
+    title: "Neon Skyline",
+    artist: "Ivory Lanes",
+    genre: "Synthwave",
+    releaseDate: "2026-06-01",
+    isrc: "US-AMS-26-00012",
+    upc: "0885686000121",
+    createdAt: new Date().toISOString(),
+    channels: [{ channel: "soundcloud", status: "live", permalink: "https://sc/x" }],
+    ...overrides,
+  }
+}
+
+describe("ReleaseCard", () => {
+  it("shows title, artist, and identifiers", () => {
+    render(<ReleaseCard release={make()} />)
+    expect(screen.getByRole("link", { name: "Neon Skyline" })).toHaveAttribute("href", "/song/clip-1")
+    expect(screen.getByText(/Ivory Lanes/)).toBeInTheDocument()
+    expect(screen.getByText(/ISRC US-AMS-26-00012/)).toBeInTheDocument()
+    expect(screen.getByText(/UPC 0885686000121/)).toBeInTheDocument()
+  })
+
+  it("links live channels to the external platform in a new tab", () => {
+    render(<ReleaseCard release={make()} />)
+    const link = screen.getByRole("link", { name: /View on SoundCloud/i })
+    expect(link).toHaveAttribute("href", "https://sc/x")
+    expect(link).toHaveAttribute("target", "_blank")
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"))
+  })
+
+  it("shows the rejection reason for a rejected channel", () => {
+    render(
+      <ReleaseCard
+        release={make({ channels: [{ channel: "distrokid", status: "rejected", rejectionReason: "Bad art." }] })}
+      />
+    )
+    expect(screen.getByText("Bad art.")).toBeInTheDocument()
+  })
+
+  it("falls back to 'Reason unavailable' when a rejected channel has no reason", () => {
+    render(
+      <ReleaseCard release={make({ channels: [{ channel: "distrokid", status: "rejected" }] })} />
+    )
+    expect(screen.getByText(/Reason unavailable/i)).toBeInTheDocument()
+  })
+
+  it("shows no external link for non-live channels", () => {
+    render(<ReleaseCard release={make({ channels: [{ channel: "landr", status: "submitted" }] })} />)
+    expect(screen.queryByRole("link", { name: /View on/i })).not.toBeInTheDocument()
+  })
+})

--- a/web/components/distribution/ReleaseCard.tsx
+++ b/web/components/distribution/ReleaseCard.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import Link from "next/link"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Alert01Icon, LinkSquare02Icon, MusicNote01Icon } from "@hugeicons/core-free-icons"
+
+import { Card, CardContent } from "@/components/ui/card"
+import { StatusBadge } from "@/components/distribution/StatusBadge"
+import { channelLabel, externalLink, type ReleaseSummary } from "@/lib/releases"
+
+/** Format an ISO date as a short, locale-stable label (UTC to avoid SSR drift). */
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric", timeZone: "UTC" })
+}
+
+/**
+ * One release row for the distribution dashboard (US-21.6). Shows the cover
+ * (music-glyph placeholder — no artwork proxy in web/), title/artist, release
+ * date, identifiers, a per-channel StatusBadge, a live external link, and the
+ * rejection reason when a channel was rejected.
+ */
+export function ReleaseCard({ release }: { release: ReleaseSummary }) {
+  return (
+    <Card>
+      <CardContent className="flex items-start gap-4 p-4">
+        <span className="flex size-16 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <HugeiconsIcon icon={MusicNote01Icon} size={24} />
+        </span>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex flex-col gap-0.5">
+            <Link
+              href={`/song/${release.clipId}`}
+              className="truncate text-base font-semibold hover:underline"
+            >
+              {release.title}
+            </Link>
+            <p className="truncate text-sm text-muted-foreground">
+              {release.artist} · {release.genre} · {formatDate(release.releaseDate)}
+            </p>
+            {(release.isrc || release.upc) && (
+              <p className="text-xs text-muted-foreground tabular-nums">
+                {release.isrc && <span>ISRC {release.isrc}</span>}
+                {release.isrc && release.upc && <span> · </span>}
+                {release.upc && <span>UPC {release.upc}</span>}
+              </p>
+            )}
+          </div>
+
+          <ul className="flex flex-col gap-1.5">
+            {release.channels.map((ch) => {
+              const link = externalLink(ch)
+              return (
+                <li key={ch.channel} className="flex flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <StatusBadge status={ch.status} channel={ch.channel} />
+                    {link && (
+                      <a
+                        href={link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-xs font-medium text-sky-500 hover:underline"
+                      >
+                        <HugeiconsIcon icon={LinkSquare02Icon} size={13} />
+                        View on {channelLabel(ch.channel)}
+                      </a>
+                    )}
+                  </div>
+                  {ch.status === "rejected" && (
+                    <p className="flex items-start gap-1 text-xs text-destructive">
+                      <HugeiconsIcon icon={Alert01Icon} size={13} className="mt-0.5 shrink-0" />
+                      {ch.rejectionReason || "Reason unavailable."}
+                    </p>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/components/distribution/ReviewScreen.test.tsx
+++ b/web/components/distribution/ReviewScreen.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ReviewScreen } from "@/components/distribution/ReviewScreen"
+import type { Clip } from "@/lib/workspace-clips"
+
+// Stub the submit surface — it pulls in auth/SoundCloud wiring we don't exercise
+// here; this test is about the review summary itself.
+vi.mock("@/components/distribution/TargetSelector", () => ({
+  TargetSelector: () => <div data-testid="target-selector" />,
+}))
+
+function makeClip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "clip-1",
+    workspace_id: "ws-1",
+    title: "Neon Skyline",
+    format: "wav",
+    duration: 185,
+    bpm: 128,
+    key: "A minor",
+    style_tags: ["Synthwave"],
+    lyrics: null,
+    vocal_language: null,
+    model: null,
+    seed: null,
+    inference_steps: null,
+    parent_clip_ids: [],
+    generation_mode: null,
+    is_public: false,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe("ReviewScreen", () => {
+  it("prompts to pick a song when none is selected", () => {
+    render(<ReviewScreen clip={null} />)
+    expect(screen.getByText(/select a song to review/i)).toBeInTheDocument()
+  })
+
+  it("summarizes metadata and audio details from the clip", () => {
+    render(<ReviewScreen clip={makeClip()} />)
+    expect(screen.getAllByText("Neon Skyline").length).toBeGreaterThan(0)
+    expect(screen.getByText("Synthwave")).toBeInTheDocument() // genre from style_tags
+    expect(screen.getByText("WAV")).toBeInTheDocument() // format upper-cased
+    expect(screen.getByText("128")).toBeInTheDocument() // bpm
+    expect(screen.getByText("A minor")).toBeInTheDocument() // key
+    expect(screen.getByText("3:05")).toBeInTheDocument() // 185s duration
+  })
+
+  it("warns about missing required fields and cover art before submission", () => {
+    // Prefill leaves genre blank when the clip has no style tags.
+    render(<ReviewScreen clip={makeClip({ style_tags: [] })} />)
+    const alert = screen.getByRole("alert")
+    expect(alert).toHaveTextContent(/Genre is required/i)
+    expect(alert).toHaveTextContent(/Cover art is required/i)
+  })
+
+  it("renders the per-target submit surface", () => {
+    render(<ReviewScreen clip={makeClip()} />)
+    expect(screen.getByTestId("target-selector")).toBeInTheDocument()
+  })
+})

--- a/web/components/distribution/ReviewScreen.tsx
+++ b/web/components/distribution/ReviewScreen.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Alert01Icon, MusicNote01Icon } from "@hugeicons/core-free-icons"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { TargetSelector } from "@/components/distribution/TargetSelector"
+import { formatTime } from "@/lib/clips"
+import {
+  loadDraft,
+  prefillFromClip,
+  REQUIRED_FIELDS,
+  validateMetadata,
+  type ReleaseMetadata,
+} from "@/lib/release-draft"
+import type { Clip } from "@/lib/workspace-clips"
+
+/** Effective release metadata = clip prefill with any saved draft layered on top
+ *  (same merge TargetSelector uses, so the review matches what will be submitted). */
+function effectiveMetadata(clip: Clip): ReleaseMetadata {
+  return { ...prefillFromClip(clip), ...loadDraft(clip.id) }
+}
+
+function coverArtLabel(m: ReleaseMetadata): string {
+  switch (m.coverArt.kind) {
+    case "uploaded":
+      return `Uploaded (${m.coverArt.name})`
+    case "existing":
+      return "Using the song's artwork"
+    case "none":
+      return "None — add cover art before submitting"
+  }
+}
+
+/** A label/value row; renders a muted "—" when the value is empty. */
+function Row({ label, value }: { label: string; value: string | null | undefined }) {
+  const shown = value && String(value).trim() ? value : "—"
+  return (
+    <div className="flex justify-between gap-4 py-1 text-sm">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 truncate text-right font-medium">{shown}</dd>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      <dl className="divide-y divide-border">{children}</dl>
+    </div>
+  )
+}
+
+/**
+ * Release review / summary screen (US-21.6, spec §42.4 step 7). Presents the
+ * complete package — metadata, identifiers, audio details, cover art, and any
+ * validation warnings — for a final check, then hands off submission to the
+ * per-target workflows (TargetSelector) below. A missing-song state mirrors the
+ * rest of the Distribute tab.
+ */
+export function ReviewScreen({ clip }: { clip: Clip | null }) {
+  if (!clip) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Select a song to review its release package.
+      </p>
+    )
+  }
+
+  const m = effectiveMetadata(clip)
+  const errors = validateMetadata(m)
+  // Blocking warnings: any required field still missing, plus no cover art.
+  const warnings = [
+    ...REQUIRED_FIELDS.filter(({ key }) => errors[key]).map(({ label }) => `${label} is required.`),
+    ...(m.coverArt.kind === "none" ? ["Cover art is required for most stores."] : []),
+    ...(errors.isrc ? [errors.isrc] : []),
+    ...(errors.upc ? [errors.upc] : []),
+  ]
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Review your release</CardTitle>
+          <CardDescription>
+            Check everything below before submitting. This is your last chance to
+            catch issues before the release goes out.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-6">
+          {warnings.length > 0 && (
+            <div role="alert" className="flex flex-col gap-1 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+              <p className="flex items-center gap-2 text-sm font-medium text-destructive">
+                <HugeiconsIcon icon={Alert01Icon} size={16} />
+                {warnings.length} item{warnings.length > 1 ? "s" : ""} to fix
+              </p>
+              <ul className="ml-6 list-disc text-sm text-destructive">
+                {warnings.map((w) => (
+                  <li key={w}>{w}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="flex items-center gap-4">
+            <span className="flex size-20 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+              <HugeiconsIcon icon={MusicNote01Icon} size={28} />
+            </span>
+            <div className="min-w-0">
+              <p className="truncate text-lg font-semibold">{m.title || "Untitled"}</p>
+              <p className="truncate text-sm text-muted-foreground">{m.artist || "Unknown artist"}</p>
+              <p className="text-xs text-muted-foreground">{coverArtLabel(m)}</p>
+            </div>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Section title="Metadata">
+              <Row label="Title" value={m.title} />
+              <Row label="Artist" value={m.artist} />
+              <Row label="Genre" value={m.genre} />
+              <Row label="Album" value={m.album} />
+              <Row label="Release date" value={m.releaseDate} />
+              <Row label="Language" value={m.language} />
+              <Row label="Explicit" value={m.explicit ? "Yes" : "No"} />
+            </Section>
+
+            <Section title="Identifiers">
+              <Row label="ISRC" value={m.isrc} />
+              <Row label="UPC" value={m.upc} />
+              <Row label="Copyright" value={m.copyright} />
+            </Section>
+
+            <Section title="Audio">
+              <Row label="Format" value={clip.format?.toUpperCase()} />
+              <Row label="Duration" value={clip.duration ? formatTime(clip.duration) : null} />
+              <Row label="BPM" value={m.bpm != null ? String(m.bpm) : null} />
+              <Row label="Key" value={m.key} />
+            </Section>
+
+            {m.description.trim() && (
+              <Section title="Description">
+                <p className="py-1 text-sm">{m.description}</p>
+              </Section>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Submit</CardTitle>
+          <CardDescription>
+            Publish to a connected platform, or prepare a package for a guided
+            store. Each target runs its own submission workflow.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <TargetSelector clip={clip} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/web/components/distribution/StatusBadge.test.tsx
+++ b/web/components/distribution/StatusBadge.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { StatusBadge } from "@/components/distribution/StatusBadge"
+
+describe("StatusBadge", () => {
+  it.each([
+    ["draft", /draft/i],
+    ["ready", /ready/i],
+    ["submitted", /submitted/i],
+    ["in_review", /in review/i],
+    ["live", /live/i],
+    ["rejected", /rejected/i],
+  ] as const)("labels the %s state", (status, re) => {
+    render(<StatusBadge status={status} />)
+    expect(screen.getByText(re)).toBeInTheDocument()
+  })
+
+  it("prefixes the channel name when given", () => {
+    render(<StatusBadge status="live" channel="soundcloud" />)
+    expect(screen.getByText(/SoundCloud · Live/)).toBeInTheDocument()
+  })
+})

--- a/web/components/distribution/StatusBadge.tsx
+++ b/web/components/distribution/StatusBadge.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import type { IconSvgElement } from "@hugeicons/react"
+import {
+  Cancel01Icon,
+  Clock01Icon,
+  Edit02Icon,
+  Globe02Icon,
+  Tick02Icon,
+  Upload04Icon,
+} from "@hugeicons/core-free-icons"
+
+import { channelLabel, type DistributionStatus } from "@/lib/releases"
+import { cn } from "@/lib/utils"
+
+type StatusMeta = { icon: IconSvgElement; label: string; tone: string }
+
+// One icon + label + accent per distribution status — the single source of the
+// dashboard's status vocabulary (mirrors mastering-status' STATUS_META). Neutral
+// tone for the pre-submission states, semantic colour for the outcomes: sky for
+// ready, violet for submitted, amber (waiting) for in_review, green for live,
+// destructive for rejected.
+const STATUS_META: Record<DistributionStatus, StatusMeta> = {
+  draft: { icon: Edit02Icon, label: "Draft", tone: "text-muted-foreground" },
+  ready: { icon: Tick02Icon, label: "Ready", tone: "text-sky-500" },
+  submitted: { icon: Upload04Icon, label: "Submitted", tone: "text-violet-500" },
+  in_review: { icon: Clock01Icon, label: "In Review", tone: "text-amber-500" },
+  live: { icon: Globe02Icon, label: "Live", tone: "text-emerald-500" },
+  rejected: { icon: Cancel01Icon, label: "Rejected", tone: "text-destructive" },
+}
+
+/** Compact status pill (icon + label). When `channel` is given it prefixes the
+ *  channel name ("SoundCloud · Live") so per-channel rows read unambiguously.
+ *  A plain span (not role="status"): these are persistent labels, and a
+ *  dashboard of them must not become a dozen aria-live regions that re-announce
+ *  on every poll (mirrors MasteringStatusBadge). */
+export function StatusBadge({
+  status,
+  channel,
+}: {
+  status: DistributionStatus
+  channel?: string
+}) {
+  const meta = STATUS_META[status]
+  const label = channel ? `${channelLabel(channel)} · ${meta.label}` : meta.label
+  return (
+    <span className={cn("inline-flex items-center gap-1.5 text-xs font-medium", meta.tone)}>
+      <HugeiconsIcon icon={meta.icon} size={14} />
+      {label}
+    </span>
+  )
+}

--- a/web/hooks/use-releases-poll.test.tsx
+++ b/web/hooks/use-releases-poll.test.tsx
@@ -1,0 +1,116 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useReleasesPoll } from "@/hooks/use-releases-poll"
+import type { ReleaseSummary } from "@/lib/releases"
+
+// Mock the seam so we control resolution + count calls. Types are erased at
+// runtime, so dropping the other exports is harmless.
+vi.mock("@/lib/releases", () => ({ fetchReleases: vi.fn() }))
+import { fetchReleases } from "@/lib/releases"
+const mockFetch = fetchReleases as unknown as ReturnType<typeof vi.fn>
+
+const sample: ReleaseSummary[] = [
+  {
+    id: "r1",
+    clipId: "c1",
+    title: "T",
+    artist: "A",
+    genre: "G",
+    releaseDate: "2026-01-01",
+    createdAt: "2026-01-01T00:00:00Z",
+    channels: [{ channel: "soundcloud", status: "live", permalink: "https://x" }],
+  },
+]
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  Object.defineProperty(document, "hidden", { value: false, configurable: true })
+})
+
+describe("useReleasesPoll", () => {
+  it("loads releases on mount and clears loading", async () => {
+    mockFetch.mockResolvedValue(sample)
+    const { result } = renderHook(() => useReleasesPoll(1000))
+
+    expect(result.current.loading).toBe(true)
+    await waitFor(() => expect(result.current.releases).toEqual(sample))
+    expect(result.current.loading).toBe(false)
+    expect(result.current.lastUpdated).not.toBeNull()
+  })
+
+  it("surfaces an error when the fetch rejects", async () => {
+    mockFetch.mockRejectedValue(new Error("boom"))
+    const { result } = renderHook(() => useReleasesPoll(1000))
+    await waitFor(() => expect(result.current.error).toMatch(/could not load/i))
+    expect(result.current.loading).toBe(false)
+  })
+
+  it("re-polls on the interval while visible", async () => {
+    mockFetch.mockResolvedValue(sample)
+    vi.useFakeTimers()
+    renderHook(() => useReleasesPoll(1000))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0) // flush the mount load
+    })
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("skips polling while the tab is hidden", async () => {
+    mockFetch.mockResolvedValue(sample)
+    vi.useFakeTimers()
+    renderHook(() => useReleasesPoll(1000))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, "hidden", { value: true, configurable: true })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    expect(mockFetch).toHaveBeenCalledTimes(1) // no extra polls while hidden
+  })
+
+  it("ignores a stale (out-of-order) resolution", async () => {
+    // load #1 (mount) stays pending; load #2 (refresh) resolves with newer data
+    // first; then #1 resolves late and must NOT overwrite the newer result.
+    let resolveStale: (v: ReleaseSummary[]) => void = () => {}
+    const stalePromise = new Promise<ReleaseSummary[]>((r) => (resolveStale = r))
+    const newer: ReleaseSummary[] = [{ ...sample[0], id: "newer" }]
+    mockFetch.mockReturnValueOnce(stalePromise).mockResolvedValueOnce(newer)
+
+    const { result } = renderHook(() => useReleasesPoll(60_000))
+    await act(async () => {}) // flush the mount microtask → load #1 starts, pending
+
+    await act(async () => {
+      result.current.refresh() // load #2 resolves with `newer`
+    })
+    await waitFor(() => expect(result.current.releases?.[0].id).toBe("newer"))
+
+    await act(async () => {
+      resolveStale([{ ...sample[0], id: "stale" }]) // late #1
+    })
+    expect(result.current.releases?.[0].id).toBe("newer") // not overwritten
+  })
+
+  it("refresh() forces an immediate reload", async () => {
+    mockFetch.mockResolvedValue(sample)
+    const { result } = renderHook(() => useReleasesPoll(60_000))
+    await waitFor(() => expect(result.current.releases).toEqual(sample))
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      result.current.refresh()
+    })
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+  })
+})

--- a/web/hooks/use-releases-poll.ts
+++ b/web/hooks/use-releases-poll.ts
@@ -1,0 +1,93 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { fetchReleases, type ReleaseSummary } from "@/lib/releases"
+
+/** Default poll cadence — matches the spec's "real-time-ish" status refresh. */
+export const DEFAULT_POLL_INTERVAL_MS = 30_000
+
+export type UseReleasesPoll = {
+  releases: ReleaseSummary[] | null
+  loading: boolean
+  error: string | null
+  /** Epoch ms of the last successful load, or null before the first. */
+  lastUpdated: number | null
+  /** Force an immediate reload (e.g. after a submit). */
+  refresh: () => void
+}
+
+/**
+ * Polls the release listing for live status updates (US-21.6, AC: "status
+ * updates via real-time polling"). Refetches every `intervalMs`, but only while
+ * the tab is visible (Page Visibility API) so a backgrounded dashboard doesn't
+ * poll needlessly — and refetches once immediately when the tab regains focus so
+ * a returning user sees fresh state without waiting a full interval.
+ *
+ * Today `fetchReleases` returns a local seam; the transport is real, so when the
+ * backend `GET /releases` is wired in there, live transitions flow through here
+ * unchanged. Mirrors use-mastering-job's mounted-ref/timer discipline.
+ */
+export function useReleasesPoll(intervalMs: number = DEFAULT_POLL_INTERVAL_MS): UseReleasesPoll {
+  const [releases, setReleases] = useState<ReleaseSummary[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null)
+
+  // False once unmounted; every post-await branch checks it before setState.
+  const mountedRef = useRef(true)
+  // Monotonic request id: load() fires from four sources (mount, interval,
+  // visibilitychange, refresh) with nothing serializing them, so a slower older
+  // fetch could resolve after a newer one. Each call captures its id and drops
+  // its result if a newer load has since started — no stale overwrite.
+  const seqRef = useRef(0)
+
+  const load = useCallback(async () => {
+    const seq = ++seqRef.current
+    try {
+      const list = await fetchReleases()
+      if (!mountedRef.current || seq !== seqRef.current) return
+      setReleases(list)
+      setError(null)
+      setLastUpdated(Date.now())
+    } catch {
+      if (!mountedRef.current || seq !== seqRef.current) return
+      setError("Could not load releases. Please try again.")
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    // Kick the first load off the effect body: a direct call trips
+    // react-hooks/set-state-in-effect (the rule can't see the setState is
+    // post-await). A microtask still runs before paint.
+    queueMicrotask(() => void load())
+
+    const timer = setInterval(() => {
+      // Only poll when the tab is visible.
+      if (typeof document !== "undefined" && document.hidden) return
+      void load()
+    }, intervalMs)
+
+    // Refetch immediately on returning to the tab (don't wait a full interval).
+    const onVisible = () => {
+      if (!document.hidden) void load()
+    }
+    document.addEventListener("visibilitychange", onVisible)
+
+    return () => {
+      mountedRef.current = false
+      clearInterval(timer)
+      document.removeEventListener("visibilitychange", onVisible)
+    }
+  }, [load, intervalMs])
+
+  const refresh = useCallback(() => void load(), [load])
+
+  return {
+    releases,
+    loading: releases === null && error === null,
+    error,
+    lastUpdated,
+    refresh,
+  }
+}

--- a/web/lib/releases.test.ts
+++ b/web/lib/releases.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  channelLabel,
+  externalLink,
+  fetchReleases,
+  type ChannelDistribution,
+} from "@/lib/releases"
+
+describe("channelLabel", () => {
+  it("maps known channel ids to display names", () => {
+    expect(channelLabel("soundcloud")).toBe("SoundCloud")
+    expect(channelLabel("landr")).toBe("LANDR")
+    expect(channelLabel("distrokid")).toBe("DistroKid")
+    expect(channelLabel("tunecore")).toBe("TuneCore")
+  })
+
+  it("title-cases an unknown id rather than dropping it", () => {
+    expect(channelLabel("bandcamp")).toBe("Bandcamp")
+  })
+})
+
+describe("externalLink", () => {
+  const base: ChannelDistribution = { channel: "soundcloud", status: "live" }
+
+  it("returns the permalink only when live and present", () => {
+    expect(externalLink({ ...base, permalink: "https://x" })).toBe("https://x")
+  })
+
+  it("is null when live but no permalink", () => {
+    expect(externalLink({ ...base, permalink: null })).toBeNull()
+  })
+
+  it("is null for non-live statuses even with a permalink", () => {
+    expect(externalLink({ channel: "soundcloud", status: "submitted", permalink: "https://x" })).toBeNull()
+  })
+})
+
+describe("fetchReleases", () => {
+  it("returns rows spanning every distribution status", async () => {
+    const releases = await fetchReleases()
+    const statuses = new Set(releases.flatMap((r) => r.channels.map((c) => c.status)))
+    for (const s of ["draft", "ready", "submitted", "in_review", "live", "rejected"]) {
+      expect(statuses).toContain(s)
+    }
+  })
+
+  it("orders newest first", async () => {
+    const releases = await fetchReleases()
+    const times = releases.map((r) => r.createdAt)
+    expect(times).toEqual([...times].sort((a, b) => b.localeCompare(a)))
+  })
+
+  it("carries a live permalink and a rejection reason on the relevant rows", async () => {
+    const releases = await fetchReleases()
+    const live = releases.flatMap((r) => r.channels).find((c) => c.status === "live")
+    const rejected = releases.flatMap((r) => r.channels).find((c) => c.status === "rejected")
+    expect(live?.permalink).toMatch(/^https:\/\//)
+    expect(rejected?.rejectionReason).toBeTruthy()
+  })
+
+  it("returns a defensive copy the caller can't use to mutate the seed", async () => {
+    const first = await fetchReleases()
+    first[0].channels[0].status = "draft"
+    const second = await fetchReleases()
+    expect(second.some((r) => r.channels.some((c) => c.status === "live"))).toBe(true)
+  })
+})

--- a/web/lib/releases.test.ts
+++ b/web/lib/releases.test.ts
@@ -34,6 +34,13 @@ describe("externalLink", () => {
   it("is null for non-live statuses even with a permalink", () => {
     expect(externalLink({ channel: "soundcloud", status: "submitted", permalink: "https://x" })).toBeNull()
   })
+
+  it("rejects non-http(s) schemes (XSS guard) and malformed URLs", () => {
+    expect(externalLink({ ...base, permalink: "javascript:alert(document.cookie)" })).toBeNull()
+    expect(externalLink({ ...base, permalink: "data:text/html,<script>x</script>" })).toBeNull()
+    expect(externalLink({ ...base, permalink: "not a url" })).toBeNull()
+    expect(externalLink({ ...base, permalink: "http://ok" })).toBe("http://ok")
+  })
 })
 
 describe("fetchReleases", () => {

--- a/web/lib/releases.ts
+++ b/web/lib/releases.ts
@@ -70,9 +70,18 @@ export function channelLabel(channel: string): string {
   return known[channel] ?? channel.charAt(0).toUpperCase() + channel.slice(1)
 }
 
-/** The live external link for a channel, or null when it isn't live / has no URL. */
+/** The live external link for a channel, or null when it isn't live / has no URL.
+ *  `permalink` is backend/external-sourced and rendered as an `<a href>`, so only
+ *  an absolute http(s) URL is allowed through — a `javascript:`/`data:` scheme
+ *  would be an XSS sink (mirrors the repo's other URL-sink guards). */
 export function externalLink(channel: ChannelDistribution): string | null {
-  return channel.status === "live" && channel.permalink ? channel.permalink : null
+  if (channel.status !== "live" || !channel.permalink) return null
+  try {
+    const { protocol } = new URL(channel.permalink)
+    return protocol === "http:" || protocol === "https:" ? channel.permalink : null
+  } catch {
+    return null
+  }
 }
 
 const HOUR = 60 * 60 * 1000

--- a/web/lib/releases.ts
+++ b/web/lib/releases.ts
@@ -1,0 +1,188 @@
+// Release listing + distribution-status seam (US-21.6).
+//
+// The backend release API is fully built (US-13.x): `GET /releases` lists a
+// user's releases with per-channel `channel_statuses`, and `/status`,
+// `/prepare`, `/submit` round it out. But the web app has no release-creation
+// flow yet — the Distribute tab only persists a localStorage draft
+// ([[us-21-4-distribution-metadata-form]]) — so `GET /releases` returns an empty
+// list for every web user today, and the dashboard would have nothing to show.
+//
+// So, like mastering history ([[us-21-3-mastering-status-tracking]]) and the
+// Stage-20 pages, this is a typed seam seeded across every status state. Its
+// shape mirrors the backend `ReleaseListResponse` / `ReleaseResponse` /
+// `channel_statuses` so it swaps cleanly: when web release-creation lands, replace
+// `fetchReleases`'s body with a BFF fetch to `GET /releases` (mirroring
+// lib/distribution's SoundCloud proxy) and the hook + components stay unchanged.
+//
+// Two forward-compat fields the backend Release model does NOT carry yet live on
+// the per-channel status here: `permalink` (the live external URL, e.g.
+// SoundCloud's `permalink_url`) and `rejectionReason`. They are the minimal
+// backend additions US-21.6 implies; the UI reads them now so the wiring is ready.
+
+/** Per-channel distribution lifecycle — matches backend DistributionStatus
+ *  (`draft → ready → submitted → in_review → live | rejected`). */
+export type DistributionStatus =
+  | "draft"
+  | "ready"
+  | "submitted"
+  | "in_review"
+  | "live"
+  | "rejected"
+
+/** One channel's status for a release (mirrors backend ChannelStatus, plus the
+ *  two forward-compat fields the backend must add: external link + reason). */
+export type ChannelDistribution = {
+  /** Channel id: "soundcloud", "landr", "distrokid", "tunecore", … */
+  channel: string
+  status: DistributionStatus
+  /** Live external URL, present when `status === "live"` (else null). */
+  permalink?: string | null
+  /** Why the platform rejected it, present when `status === "rejected"` (else null). */
+  rejectionReason?: string | null
+}
+
+/** A release summary row for the dashboard (mirrors backend ReleaseResponse). */
+export type ReleaseSummary = {
+  id: string
+  clipId: string
+  title: string
+  artist: string
+  genre: string
+  /** ISO date. */
+  releaseDate: string
+  album?: string | null
+  isrc?: string | null
+  upc?: string | null
+  /** Per-channel status across every engaged channel. */
+  channels: ChannelDistribution[]
+  /** ISO timestamp; drives newest-first ordering. */
+  createdAt: string
+}
+
+/** Human label for a channel id (falls back to a Title-cased id). */
+export function channelLabel(channel: string): string {
+  const known: Record<string, string> = {
+    soundcloud: "SoundCloud",
+    landr: "LANDR",
+    distrokid: "DistroKid",
+    tunecore: "TuneCore",
+  }
+  return known[channel] ?? channel.charAt(0).toUpperCase() + channel.slice(1)
+}
+
+/** The live external link for a channel, or null when it isn't live / has no URL. */
+export function externalLink(channel: ChannelDistribution): string | null {
+  return channel.status === "live" && channel.permalink ? channel.permalink : null
+}
+
+const HOUR = 60 * 60 * 1000
+
+function hoursAgo(h: number): string {
+  return new Date(Date.now() - h * HOUR).toISOString()
+}
+
+// Seed — one release per DistributionStatus so the dashboard demonstrates every
+// badge, plus a live-with-permalink row (external link AC) and a
+// rejected-with-reason row (rejection AC). clipId uses real Explore-pool ids
+// (clip-*) so a ReleaseCard's "song" link resolves like everywhere else.
+const SEED: ReleaseSummary[] = [
+  {
+    id: "rel-live-1",
+    clipId: "clip-neon",
+    title: "Neon Skyline",
+    artist: "Ivory Lanes",
+    genre: "Synthwave",
+    releaseDate: "2026-06-01",
+    isrc: "US-AMS-26-00012",
+    upc: "0885686000121",
+    createdAt: hoursAgo(2),
+    channels: [
+      {
+        channel: "soundcloud",
+        status: "live",
+        permalink: "https://soundcloud.com/ivory-lanes/neon-skyline",
+      },
+    ],
+  },
+  {
+    id: "rel-review-1",
+    clipId: "clip-crown",
+    title: "Crownfall",
+    artist: "Ivory Lanes",
+    genre: "Drum & Bass",
+    releaseDate: "2026-06-10",
+    isrc: "US-AMS-26-00019",
+    upc: "0885686000190",
+    createdAt: hoursAgo(20),
+    channels: [
+      { channel: "distrokid", status: "in_review" },
+      { channel: "soundcloud", status: "live", permalink: "https://soundcloud.com/ivory-lanes/crownfall" },
+    ],
+  },
+  {
+    id: "rel-submitted-1",
+    clipId: "clip-gold",
+    title: "Gold Rush 88",
+    artist: "Ivory Lanes",
+    genre: "House",
+    releaseDate: "2026-06-14",
+    isrc: "US-AMS-26-00021",
+    upc: "0885686000213",
+    createdAt: hoursAgo(30),
+    channels: [{ channel: "landr", status: "submitted" }],
+  },
+  {
+    id: "rel-rejected-1",
+    clipId: "clip-paper",
+    title: "Paper Lanterns",
+    artist: "Ivory Lanes",
+    genre: "Ambient",
+    releaseDate: "2026-05-28",
+    isrc: "US-AMS-26-00007",
+    upc: "0885686000077",
+    createdAt: hoursAgo(50),
+    channels: [
+      {
+        channel: "distrokid",
+        status: "rejected",
+        rejectionReason: "Cover art is below the 3000×3000px minimum.",
+      },
+    ],
+  },
+  {
+    id: "rel-ready-1",
+    clipId: "clip-velvet",
+    title: "Velvet Static",
+    artist: "Ivory Lanes",
+    genre: "Downtempo",
+    releaseDate: "2026-06-20",
+    isrc: "US-AMS-26-00025",
+    upc: "0885686000251",
+    createdAt: hoursAgo(70),
+    channels: [{ channel: "soundcloud", status: "ready" }],
+  },
+  {
+    id: "rel-draft-1",
+    clipId: "clip-mid",
+    title: "Midnight Payload",
+    artist: "Ivory Lanes",
+    genre: "Techno",
+    releaseDate: "2026-07-01",
+    createdAt: hoursAgo(96),
+    channels: [{ channel: "soundcloud", status: "draft" }],
+  },
+]
+
+/**
+ * Fetch the user's releases, newest first (AC: dashboard shows all releases).
+ *
+ * Async on purpose so the polling hook is real transport: swap this body for a
+ * BFF fetch to `GET /releases` when web release-creation lands, mapping
+ * `channel_statuses` → `channels`. Callers won't change. Returns a fresh copy so
+ * a consumer can't mutate the seed.
+ */
+export async function fetchReleases(): Promise<ReleaseSummary[]> {
+  return SEED.map((r) => ({ ...r, channels: r.channels.map((c) => ({ ...c })) })).sort(
+    (a, b) => b.createdAt.localeCompare(a.createdAt)
+  )
+}


### PR DESCRIPTION
## US-21.6 — Distribution Status Dashboard & Release Review Screen

Closes #225. Builds the distribution status dashboard (spec §42.5) and the review/summary screen (§42.4 step 7) into the `/release` **Distribute** tab, now split into **Metadata → Review → Releases** sub-tabs (edit → verify & submit → track).

### What's here
- **`lib/releases.ts`** — typed seam mirroring the backend `GET /releases` shape (`channel_statuses`), seeded across all six `DistributionStatus` states. Async `fetchReleases()` so the poll hook is real transport. Carries two forward-compat per-channel fields — `permalink` (live external URL) and `rejectionReason` — the minimal additions the backend `Release` model needs when web release-creation lands.
- **`StatusBadge`** — single-source vocabulary for the six states (draft / ready / submitted / in_review / live / rejected).
- **`ReleaseCard`** — per-channel badges, live external link, rejection reason (with "Reason unavailable" fallback), music-glyph placeholder art.
- **`DashboardList` + `useReleasesPoll`** — visibility-gated 30s polling; a transient poll failure shows an inline "showing last known statuses" banner over the last-good list instead of blanking it; a sequence guard drops out-of-order resolutions.
- **`ReviewScreen`** — complete package summary (metadata, identifiers, audio details, cover art, validation warnings) reusing `TargetSelector` as the per-target submit surface (SoundCloud auto / LANDR + DistroKid guided).

### Acceptance criteria → evidence
| AC | Evidence |
|----|----------|
| Review screen shows the complete package | `ReviewScreen.test` + demo screenshot (metadata/identifiers/audio/warnings) |
| Submission triggers the correct workflow per target | Review reuses `TargetSelector` (auto vs guided), tested in US-21.5 |
| Dashboard shows all releases with correct badges | `releases.test` (seed spans all 6 states), `StatusBadge.test`, `DashboardList.test`, demo |
| Status updates via polling | `useReleasesPoll` interval + visibility-gating tests |
| Rejected releases show the reason | `ReleaseCard.test` (reason + fallback), demo (Paper Lanterns) |
| Live releases link to the external platform | `ReleaseCard.test` (href/target/rel), demo (View on SoundCloud) |

Verified live in a browser (dashboard + review rendered on a temp `/labs` mount, reverted before commit).

### Design decisions (differs from the CodeRabbit plan)
Web-only, consistent with US-21.1–21.5 — **no backend changes**:
- The backend release API (`GET /releases`, `/status`, `/prepare`, `/submit`) already exists (US-13.x) and is *reachable*, but the web app has no release-creation flow yet, so it returns an empty list for every web user. The dashboard is therefore built on the seam (seeded across states) so the ACs are demonstrable, documented to swap to a BFF fetch when release-creation lands.
- CodeRabbit proposed adding `soundcloud_permalink` / `rejection_reason` to the backend `Release` model. Deferred: nothing populates them (no web flow reaches them, the poller doesn't run locally), and CI is Python-only, so a backend change would risk the Python suite for dead fields. They live on the web seam instead, ready to map from the backend when it grows them.
- CodeRabbit's `<img src=.../artwork>` and React Query/SWR were declined — there's no authed artwork proxy in `web/` (music-glyph placeholders everywhere), and neither RQ nor SWR is a project dependency (used the existing hook + `setInterval` pattern).

### Quality gates
- ✅ `vitest` — full suite green (1452 tests); 49 new/updated tests for this change
- ✅ `tsc --noEmit`, ✅ `eslint`, ✅ `next build` (`/release` prerenders)
- ✅ Cross-family review (opencode / GLM): 3 findings, all fixed — transient-error list wipe, `role="status"` live-region flooding, out-of-order poll resolution.

### Known limitations
- Dashboard data is the **seam seed**, not live releases — the web app can't create releases yet, so real `GET /releases` is empty here. Swap `fetchReleases`'s body for a BFF fetch when web release-creation ships.
- `permalink` / `rejectionReason` are read from the seam; the backend `Release` model must add them (one small field each) for real data to carry links/reasons.
- "Submit" runs the existing US-21.5 workflows (SoundCloud linking is real; upload/guided submission needs a real `release_id`, so it stays a seam until release-creation lands).
- CI is Python-only — the web typecheck/lint/test/build above were run locally.
