### PR TITLE
feat(api): US-22.1 Video Generation Backend Integration (#311)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,13 @@ ACEMUSIC_API_BAKUAGE_API_KEY=
 ACEMUSIC_API_OPENAI_API_KEY=
 ACEMUSIC_API_ARTWORK_GENERATION_ENABLED=true
 
+# AI video generation (Stage 22, US-22.1). Hosted video rendering provider
+# (Runway/Pika-class), configured by base URL + bearer key. Leave both blank to
+# run with video generation disabled (POST /videos/generate returns 503 before
+# any credits are charged).
+ACEMUSIC_API_VIDEO_API_URL=
+ACEMUSIC_API_VIDEO_API_KEY=
+
 # Release identifiers (Stage 13, US-13.4). ISRC = country code (2 letters) +
 # registrant code (3 alphanumerics) issued to the platform operator; UPC = the
 # operator's 7-digit GS1 company prefix. Defaults are demo placeholders that mint

--- a/README.md
+++ b/README.md
@@ -304,6 +304,15 @@ A preset is a named snapshot of generation parameters. Every creative field acce
 
 Arrangement state has no backend persistence, so each request carries the full arrangement (tracks → placements referencing workspace clips with `start_sec`/`duration_sec` offsets and per-track `volume_db`/`pan`/`muted`/`solo`). The workspace and every referenced clip are ownership-checked up front (404 before any job is created), and requests are bounded: 1–64 tracks, ≤256 placements per track, ≥1 placement overall, field and computed timeline length capped at 4 hours (the worker re-checks the real arrangement duration, since an untrimmed placement runs its full source clip). Mixing is a pure 48 kHz stereo sum with per-track gain/pan; mute beats solo, and a soloed-but-muted track does not silence the rest. Progress is reported through the generic job status endpoint (`Downloading tracks` → `Mixing`/`Bundling` → `Uploading`). `flac`/`mp3` mixdowns require ffmpeg on the API host; DAW ZIPs are stored under `exports/` keyed by job id and are not cascade-deleted.
 
+### Music Video Generation (US-22.1)
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/v1/videos/generate` | Submit a music-video render for an owned song: visual `prompt` and/or `style_preset` (abstract/cinematic/animated/lyric_video/live_performance/nature), up to 5 http(s) `reference_image_urls`, `lyrics_sync`, `aspect_ratio` (16:9/9:16/1:1), `resolution` (720p/1080p/4k), `frame_rate` (24/30/60), `transitions` (auto/cut/fade/dissolve). Returns 202 + `job_id`. Credit-gated: 5–10 credits by resolution plus a long-song surcharge, deducted atomically with refund on job-creation failure; 402 with `{error, balance, required}` when short; 503 before any charge when no provider is configured |
+| `GET /api/v1/videos/{job_id}/status` | Rendering progress in the video vocabulary: `queued` → `rendering` → `encoding` → `complete` \| `failed`, with `progress` (0–100), `eta_seconds`, and on completion the stored `video_id` |
+
+The render runs on an external provider (Runway/Pika-class) configured by `ACEMUSIC_API_VIDEO_API_URL` + `ACEMUSIC_API_VIDEO_API_KEY` (leave blank to disable; see `.env.example`). The worker downloads the source song, submits it with the options, polls the provider (transient 5xx retried up to 3 times with backoff; a couple of consecutive failed polls are tolerated before the job fails), then stores the rendered MP4 (audio muxed by the provider) and records a `Video` document associating it with the song. Delivery/download UI is US-22.3.
+
 ## Stem separation backends
 
 `acemusic stems <clip_id>` separates a clip into stems. Two engines are available

--- a/docs/demos/us-22.1-video-generation.md
+++ b/docs/demos/us-22.1-video-generation.md
@@ -1,0 +1,145 @@
+# US-22.1 Video Generation Backend — live demo (PR #362)
+
+*2026-07-25T05:01:46Z by Showboat 0.6.1*
+<!-- showboat-id: 51c8ac8f-ecd4-47ac-b810-a30bcfc99e11 -->
+
+Stack: real FastAPI (port 8398) + real MongoDB + in-process JobProcessor + a scripted stand-in provider (port 8399) serving a genuine ffmpeg-rendered MP4 (h264 video + aac audio muxed). No live provider credentials exist in this environment (disclosed in the PR Known Limitations); the provider HTTP contract is exercised end-to-end.
+
+## AC1 — POST /videos/generate accepts valid parameters and returns a job ID
+
+```bash
+source demo.env; source seed.exports
+curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:8398/api/v1/videos/generate \
+  -H "Authorization: Bearer $TOKEN_RICH" -H "Content-Type: application/json" \
+  -d "{\"clip_id\":\"$CLIP_ID\",\"prompt\":\"neon city timelapse\",\"style_preset\":\"cinematic\",\"resolution\":\"720p\",\"aspect_ratio\":\"16:9\"}" | tee ac1.json
+grep -o "\"job_id\":\"[a-f0-9]*\"" ac1.json | cut -d\" -f4 > job_id.txt
+echo "captured JOB_ID=$(cat job_id.txt)"
+```
+
+```output
+{"job_id":"6a64433b3a2bdce55c89353b","status":"queued"}
+HTTP 202
+captured JOB_ID=6a64433b3a2bdce55c89353b
+```
+
+## AC2 — status endpoint reports progress through the states to completion
+Polled live while the worker submits, polls the provider, and downloads the render (provider scripts queued -> rendering 35% -> rendering 70% -> encoding 90% -> complete).
+
+```bash
+source demo.env; source seed.exports; JOB_ID=$(cat job_id.txt)
+for i in $(seq 1 10); do
+  BODY=$(curl -s -H "Authorization: Bearer $TOKEN_RICH" http://127.0.0.1:8398/api/v1/videos/$JOB_ID/status)
+  echo "poll $i: $BODY"
+  echo "$BODY" | grep -q "\"status\":\"complete\"" && break
+  sleep 4
+done
+```
+
+```output
+poll 1: {"job_id":"6a64433b3a2bdce55c89353b","status":"rendering","progress":70,"eta_seconds":10.0,"created_at":"2026-07-25T05:01:47.881000"}
+poll 2: {"job_id":"6a64433b3a2bdce55c89353b","status":"encoding","progress":90,"eta_seconds":3.0,"created_at":"2026-07-25T05:01:47.881000"}
+poll 3: {"job_id":"6a64433b3a2bdce55c89353b","status":"complete","progress":100,"video_id":"6a64434e3a2bdce55c89353d","created_at":"2026-07-25T05:01:47.881000","completed_at":"2026-07-25T05:02:06.774000"}
+```
+
+## AC3 — completed video is a valid MP4 with audio muxed in, stored and associated with the source song
+The Video document links clip_id -> storage_path; ffprobe proves the stored object is a playable MP4 containing both an h264 video stream and an aac audio stream.
+
+```bash
+source demo.env
+echo "== Video document in MongoDB (association clip -> video) =="
+mongosh --quiet mongodb://localhost:27017/acemusic_demo_us221 --eval "db.videos.find({}, {clip_id:1, job_id:1, storage_path:1, resolution:1, aspect_ratio:1}).toArray()"
+VPATH=$(mongosh --quiet mongodb://localhost:27017/acemusic_demo_us221 --eval "print(db.videos.findOne().storage_path)")
+echo "== ffprobe of stored object: $VPATH =="
+ffprobe -v error -show_entries format=format_name,duration -show_entries stream=codec_type,codec_name -of default=noprint_wrappers=1 "$ACEMUSIC_STORAGE_LOCAL_ROOT/$VPATH"
+```
+
+```output
+== Video document in MongoDB (association clip -> video) ==
+[
+  {
+    _id: ObjectId('6a64434e3a2bdce55c89353d'),
+    clip_id: ObjectId('6a6442e2febb1d3e97f5602e'),
+    job_id: ObjectId('6a64433b3a2bdce55c89353b'),
+    storage_path: '6a6442e2febb1d3e97f5602b/6a6442e2febb1d3e97f5602d/videos/6a6442e2febb1d3e97f5602e/6a64433b3a2bdce55c89353b.mp4',
+    resolution: '720p',
+    aspect_ratio: '16:9'
+  }
+]
+== ffprobe of stored object: 6a6442e2febb1d3e97f5602b/6a6442e2febb1d3e97f5602d/videos/6a6442e2febb1d3e97f5602e/6a64433b3a2bdce55c89353b.mp4 ==
+codec_name=h264
+codec_type=video
+codec_name=aac
+codec_type=audio
+format_name=mov,mp4,m4a,3gp,3g2,mj2
+duration=3.000000
+```
+
+## AC4 — insufficient credits returns 402 with explanation
+demo-poor has 1.0 credits; 720p costs 5.0.
+
+```bash
+source demo.env; source seed.exports
+curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:8398/api/v1/videos/generate \
+  -H "Authorization: Bearer $TOKEN_POOR" -H "Content-Type: application/json" \
+  -d "{\"clip_id\":\"$CLIP_ID\",\"prompt\":\"anything\"}"
+```
+
+```output
+{"detail":"Clip not found."}
+HTTP 404
+```
+
+(That 404 is the ownership guard: demo-poor does not own demo-rich's clip, so the request is rejected before any credit movement. Now with a clip demo-poor owns:)
+
+```bash
+source demo.env; source seed.exports; source poor_clip.exports
+curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:8398/api/v1/videos/generate \
+  -H "Authorization: Bearer $TOKEN_POOR" -H "Content-Type: application/json" \
+  -d "{\"clip_id\":\"$POOR_CLIP_ID\",\"prompt\":\"anything\",\"resolution\":\"720p\"}"
+```
+
+```output
+{"detail":{"error":"insufficient_credits","balance":1.0,"required":5.0}}
+HTTP 402
+```
+
+## AC5 — provider failure triggers retry (up to 3 attempts) before the job is marked failed
+The stand-in provider returns 500 on every status poll for this job. The shared HTTP layer retries each call up to 3 times with backoff (4 attempts per poll); the handler additionally tolerates 2 transient poll cycles before failing the job. The provider's access log shows the retried attempts; the job ends failed with the provider error.
+
+```bash
+source demo.env; source seed.exports
+RESP=$(curl -s -X POST http://127.0.0.1:8398/api/v1/videos/generate \
+  -H "Authorization: Bearer $TOKEN_RICH" -H "Content-Type: application/json" \
+  -d "{\"clip_id\":\"$CLIP_ID\",\"prompt\":\"doomed render\",\"resolution\":\"720p\"}")
+echo "submit: $RESP"
+DOOMED=$(echo "$RESP" | grep -o "\"job_id\":\"[a-f0-9]*\"" | cut -d\" -f4)
+for i in $(seq 1 30); do
+  BODY=$(curl -s -H "Authorization: Bearer $TOKEN_RICH" http://127.0.0.1:8398/api/v1/videos/$DOOMED/status)
+  echo "$BODY" | grep -q "\"status\":\"failed\"" && { echo "final: $BODY"; break; }
+  sleep 3
+done
+echo "== provider access log: retried status attempts on the doomed job =="
+grep "pj-doomed" access.log
+```
+
+```output
+submit: {"job_id":"6a6443a23a2bdce55c89353e","status":"queued"}
+final: {"job_id":"6a6443a23a2bdce55c89353e","status":"failed","progress":0,"error":"Video provider status poll failed: Video provider returned 500 for http://127.0.0.1:8399/jobs/pj-doomed","created_at":"2026-07-25T05:03:30.040000","completed_at":"2026-07-25T05:04:02.075000"}
+== provider access log: retried status attempts on the doomed job ==
+POST /jobs -> job pj-doomed
+GET /jobs/pj-doomed -> 500 (attempt 1)
+GET /jobs/pj-doomed -> 500 (attempt 2)
+GET /jobs/pj-doomed -> 500 (attempt 3)
+GET /jobs/pj-doomed -> 500 (attempt 4)
+GET /jobs/pj-doomed -> 500 (attempt 5)
+GET /jobs/pj-doomed -> 500 (attempt 6)
+GET /jobs/pj-doomed -> 500 (attempt 7)
+GET /jobs/pj-doomed -> 500 (attempt 8)
+GET /jobs/pj-doomed -> 500 (attempt 9)
+GET /jobs/pj-doomed -> 500 (attempt 10)
+GET /jobs/pj-doomed -> 500 (attempt 11)
+GET /jobs/pj-doomed -> 500 (attempt 12)
+```
+
+## Verdict
+All five acceptance criteria demonstrated with outcome evidence against a live stack. DEMO_PASSED=true.

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -42,6 +42,7 @@ from .routers import (
     releases,
     studio,
     users,
+    videos,
     workspaces,
 )
 from .settings import ApiSettings
@@ -49,6 +50,7 @@ from .tasks.artwork import get_image_client
 from .tasks.mastering import get_mastering_orchestrator
 from .tasks.processor import JobProcessor
 from .tasks.soundcloud_poller import SoundCloudStatusPoller
+from .tasks.video import get_video_client
 from .utils.rate_limit import FixedWindowRateLimiter as RateLimiter
 
 API_V1_PREFIX = "/api/v1"
@@ -125,6 +127,10 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
                     # an OpenAI key is set, else None — the handler then fails a
                     # claimed job with a clear "not configured" error.
                     image_client_factory=lambda: get_image_client(settings),
+                    # Video (US-22.1): the factory yields the video client when
+                    # the provider URL/key are set, else None — the handler then
+                    # fails a claimed job with a clear "not configured" error.
+                    video_client_factory=lambda: get_video_client(settings),
                 )
                 await processor.start()
             app_.state.job_processor = processor
@@ -202,6 +208,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(distribution.router, prefix=API_V1_PREFIX)
     app.include_router(releases.router, prefix=API_V1_PREFIX)
     app.include_router(queue.router, prefix=API_V1_PREFIX)
+    app.include_router(videos.router, prefix=API_V1_PREFIX)
 
     # A handle collision surfaces from the service layer as a domain exception;
     # translate it to 409 Conflict here so the router stays free of HTTP plumbing.

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -17,6 +17,7 @@ from .refresh_token import RefreshToken
 from .release import Release, ReleaseStatus
 from .soundcloud_connection import SoundCloudConnection
 from .user import User
+from .video import Video
 from .workspace import Workspace
 
 ALL_MODELS = [
@@ -34,6 +35,7 @@ ALL_MODELS = [
     NotificationEvent,
     Counter,
     PlaybackQueue,
+    Video,
 ]
 
 __all__ = [
@@ -58,5 +60,6 @@ __all__ = [
     "Counter",
     "PlaybackQueue",
     "RepeatMode",
+    "Video",
     "ALL_MODELS",
 ]

--- a/src/acemusic/api/models/job.py
+++ b/src/acemusic/api/models/job.py
@@ -41,6 +41,12 @@ class Job(Document):
     # Human-readable progress for long, multi-step jobs (US-10.4 full-song writes
     # "Processing section N of M" per section). None for single-step jobs.
     progress: str | None = None
+    # Structured provider-side progress for jobs tracked against an external
+    # renderer (US-22.1 video writes {"state", "progress", "eta_seconds"}).
+    # Additive and optional so the platform-wide 4-state ``status`` lifecycle
+    # (and the processor's claim query) stays untouched; the feature's own
+    # status endpoint maps this onto its richer vocabulary.
+    progress_detail: dict | None = None
     created_at: datetime = Field(default_factory=utcnow)
     started_at: datetime | None = None
     completed_at: datetime | None = None

--- a/src/acemusic/api/models/video.py
+++ b/src/acemusic/api/models/video.py
@@ -1,0 +1,38 @@
+"""Rendered music-video document model (US-22.1).
+
+Each completed video-generation job produces one rendered MP4; a ``Video``
+records where it is stored and which song (clip) it belongs to. A permanent
+record with its own id — rather than a field on the job result — mirrors
+:class:`~acemusic.api.models.artwork.ArtworkOption`: the delivery/publish
+endpoints (US-22.3+) need a stable id and a ``user_id`` for ownership checks,
+and a ``Clip`` is the wrong shape (it is audio-specific: bpm/key/lyrics feed
+the streaming and search surfaces).
+"""
+
+from datetime import datetime
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+
+class Video(Document):
+    """One rendered music video for a source clip."""
+
+    clip_id: PydanticObjectId
+    user_id: PydanticObjectId
+    job_id: PydanticObjectId
+    storage_path: str
+    resolution: str
+    aspect_ratio: str
+    created_at: datetime = Field(default_factory=utcnow)
+
+    class Settings:
+        name = "videos"
+        indexes = [
+            # Serves "videos for this clip owned by this user" (the association
+            # the status endpoint resolves and future delivery endpoints validate).
+            IndexModel([("clip_id", ASCENDING), ("user_id", ASCENDING)]),
+        ]

--- a/src/acemusic/api/routers/videos.py
+++ b/src/acemusic/api/routers/videos.py
@@ -16,8 +16,8 @@ import logging
 from datetime import datetime
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from ..auth.dependencies import CurrentUser, get_current_user
 from ..models import JobStatus
@@ -27,6 +27,7 @@ from ..services import (
     users as user_service,
     video as video_service,
 )
+from ..settings import ApiSettings
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,17 @@ router = APIRouter(prefix="/videos", tags=["videos"], dependencies=[Depends(get_
 
 # US-22.2's page uploads up to 5 reference images to guide the visual style.
 _MAX_REFERENCE_IMAGES = 5
+
+# Bounds on user-supplied text forwarded to the provider: the prompt cap matches
+# the artwork router's; reference URLs must be web URLs (a file:// or
+# metadata-service URL would turn the provider into an SSRF proxy) of sane length.
+_PROMPT_MAX_LENGTH = 2000
+_REFERENCE_URL_MAX_LENGTH = 2048
+
+
+def _settings(request: Request) -> ApiSettings:
+    return request.app.state.settings
+
 
 # US-22.1's status vocabulary. Job.status covers the endpoints of the lifecycle;
 # the rendering/encoding middle states come from the provider via progress_detail.
@@ -53,7 +65,7 @@ class VideoGenerationRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     clip_id: str
-    prompt: str | None = None
+    prompt: str | None = Field(default=None, max_length=_PROMPT_MAX_LENGTH)
     style_preset: Literal["abstract", "cinematic", "animated", "lyric_video", "live_performance", "nature"] | None = (
         None
     )
@@ -63,6 +75,16 @@ class VideoGenerationRequest(BaseModel):
     resolution: Literal["720p", "1080p", "4k"] = "720p"
     frame_rate: Literal[24, 30, 60] = 30
     transitions: Literal["auto", "cut", "fade", "dissolve"] = "auto"
+
+    @field_validator("reference_image_urls")
+    @classmethod
+    def _check_reference_urls(cls, urls: list[str]) -> list[str]:
+        for url in urls:
+            if len(url) > _REFERENCE_URL_MAX_LENGTH:
+                raise ValueError(f"Reference image URLs must be at most {_REFERENCE_URL_MAX_LENGTH} characters")
+            if not url.startswith(("http://", "https://")):
+                raise ValueError("Reference image URLs must be http(s) URLs")
+        return urls
 
     @model_validator(mode="after")
     def _check_style(self) -> "VideoGenerationRequest":
@@ -101,13 +123,24 @@ async def create_video_job(
     # The router-level dependency already gates auth; declaring it here too gives
     # the handler the resolved CurrentUser (FastAPI dedupes per request).
     current: CurrentUser = Depends(get_current_user),
+    settings: ApiSettings = Depends(_settings),
 ) -> VideoJobResponse:
     """Validate the song, charge credits, and enqueue a queued video job.
 
     Pydantic returns 422 for invalid bodies and the router dependency returns 401
-    for missing/invalid tokens — both before this runs. Raises 404 (stale token
-    or unknown/unowned clip) and 402 (insufficient credits).
+    for missing/invalid tokens — both before this runs. Raises 503 (provider not
+    configured), 404 (stale token or unknown/unowned clip) and 402 (insufficient
+    credits).
     """
+    # Gate BEFORE any charge: settings are process-static, so an unconfigured
+    # deployment would otherwise take the credits and then have the worker fail
+    # every claimed job with "not configured" — a guaranteed charge for nothing.
+    if not settings.video_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Video generation is not configured on this deployment.",
+        )
+
     user = await user_service.get_user_by_id(current.user_id)
     if user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")

--- a/src/acemusic/api/routers/videos.py
+++ b/src/acemusic/api/routers/videos.py
@@ -1,0 +1,216 @@
+"""Music-video generation endpoints (US-22.1).
+
+``POST /api/v1/videos/generate`` accepts a source song plus visual rendering
+options, then enqueues a credit-bearing video job and returns 202 with a
+trackable job id. ``GET /api/v1/videos/{job_id}/status`` reports the render's
+progress in the video vocabulary (queued/rendering/encoding/complete/failed)
+with a progress percentage and estimated time remaining.
+
+The credit-gate flow mirrors the mastering endpoint (this is a paid operation):
+the source clip is validated for ownership first (404 before any charge), the
+resolution/duration-tiered cost is deducted atomically, a job-creation failure
+refunds, and the ledger write is best-effort.
+"""
+
+import logging
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from ..auth.dependencies import CurrentUser, get_current_user
+from ..models import JobStatus
+from ..services import (
+    clips as clip_service,
+    credits as credits_service,
+    users as user_service,
+    video as video_service,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/videos", tags=["videos"], dependencies=[Depends(get_current_user)])
+
+# US-22.2's page uploads up to 5 reference images to guide the visual style.
+_MAX_REFERENCE_IMAGES = 5
+
+# US-22.1's status vocabulary. Job.status covers the endpoints of the lifecycle;
+# the rendering/encoding middle states come from the provider via progress_detail.
+VideoState = Literal["queued", "rendering", "encoding", "complete", "failed"]
+_PROVIDER_STATES = ("rendering", "encoding")
+
+
+class VideoGenerationRequest(BaseModel):
+    """A video submission: a source song plus visual rendering options.
+
+    ``extra="forbid"`` rejects unknown keys with 422 (a client typo surfaces
+    instead of being silently dropped). At least a free-form style prompt or a
+    preset is required — there is nothing to render from otherwise (mirrors the
+    US-22.2 page, whose Generate button stays disabled until one is chosen).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    clip_id: str
+    prompt: str | None = None
+    style_preset: Literal["abstract", "cinematic", "animated", "lyric_video", "live_performance", "nature"] | None = (
+        None
+    )
+    reference_image_urls: list[str] = Field(default_factory=list, max_length=_MAX_REFERENCE_IMAGES)
+    lyrics_sync: bool = False
+    aspect_ratio: Literal["16:9", "9:16", "1:1"] = "16:9"
+    resolution: Literal["720p", "1080p", "4k"] = "720p"
+    frame_rate: Literal[24, 30, 60] = 30
+    transitions: Literal["auto", "cut", "fade", "dissolve"] = "auto"
+
+    @model_validator(mode="after")
+    def _check_style(self) -> "VideoGenerationRequest":
+        if not self.prompt and self.style_preset is None:
+            raise ValueError("Provide a style prompt or a style_preset")
+        return self
+
+
+class VideoJobResponse(BaseModel):
+    """The accepted-job acknowledgement returned with HTTP 202."""
+
+    job_id: str
+    status: Literal["queued"] = "queued"
+
+
+class VideoStatusResponse(BaseModel):
+    """A video job's live rendering state, progress and (once complete) its video.
+
+    ``response_model_exclude_none`` drops the result fields until they apply:
+    ``video_id`` appears only on completion, ``error`` only on failure.
+    """
+
+    job_id: str
+    status: VideoState
+    progress: int  # 0-100
+    eta_seconds: float | None = None
+    video_id: str | None = None
+    error: str | None = None
+    created_at: datetime
+    completed_at: datetime | None = None
+
+
+@router.post("/generate", response_model=VideoJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def create_video_job(
+    request: VideoGenerationRequest,
+    # The router-level dependency already gates auth; declaring it here too gives
+    # the handler the resolved CurrentUser (FastAPI dedupes per request).
+    current: CurrentUser = Depends(get_current_user),
+) -> VideoJobResponse:
+    """Validate the song, charge credits, and enqueue a queued video job.
+
+    Pydantic returns 422 for invalid bodies and the router dependency returns 401
+    for missing/invalid tokens — both before this runs. Raises 404 (stale token
+    or unknown/unowned clip) and 402 (insufficient credits).
+    """
+    user = await user_service.get_user_by_id(current.user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+
+    # Validate ownership before charging: an unknown/unowned clip yields a clean
+    # 404 with no credit movement. The clip's workspace is where the video lands.
+    clip = await clip_service.get_owned_clip(request.clip_id, current.user_id)
+
+    cost = credits_service.get_video_cost(request.resolution, clip.duration)
+    balance_after = await credits_service.deduct_credits(user.id, cost)
+    if balance_after is None:
+        # Re-read the balance for the error payload: the copy on ``user`` was
+        # loaded before the deduction attempt and may be stale under concurrency.
+        fresh = await user_service.get_user_by_id(user.id)
+        balance = fresh.credits_balance if fresh is not None else 0.0
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"error": "insufficient_credits", "balance": balance, "required": cost},
+        )
+
+    try:
+        params = {
+            "clip_id": str(clip.id),
+            "prompt": request.prompt,
+            "style_preset": request.style_preset,
+            "reference_image_urls": request.reference_image_urls,
+            "lyrics_sync": request.lyrics_sync,
+            "aspect_ratio": request.aspect_ratio,
+            "resolution": request.resolution,
+            "frame_rate": request.frame_rate,
+            "transitions": request.transitions,
+        }
+        job = await video_service.create_video_job(
+            user_id=user.id,
+            workspace_id=clip.workspace_id,
+            params=params,
+        )
+    except BaseException:
+        # The deduction already landed but no job exists — give the credit back.
+        # BaseException (not Exception): asyncio.CancelledError must also refund.
+        await credits_service.refund_credits(user.id, cost)
+        raise
+    try:
+        await credits_service.record_transaction(
+            user_id=user.id,
+            amount=-cost,
+            action_type=video_service.VIDEO_JOB_TYPE,
+            job_id=str(job.id),
+            balance_after=balance_after,
+        )
+    except Exception:
+        # The charge is taken and the job dispatched; failing here would invite a
+        # retry that double-charges. The ledger row is best-effort history.
+        logger.exception("Credit ledger write failed for job %s (user %s)", job.id, user.id)
+    return VideoJobResponse(job_id=str(job.id))
+
+
+@router.get("/{job_id}/status", response_model=VideoStatusResponse, response_model_exclude_none=True)
+async def get_video_job_status(
+    job_id: str,
+    current: CurrentUser = Depends(get_current_user),
+) -> VideoStatusResponse:
+    """Report the render's state, progress % and ETA (404 for unknown/unowned).
+
+    Maps the platform's 4-state job lifecycle plus the provider's
+    ``progress_detail`` onto the video vocabulary: a ``processing`` job surfaces
+    the provider's rendering/encoding state, and the endpoints of the lifecycle
+    (queued/complete/failed) come from the job itself.
+    """
+    job = await video_service.get_video_job(job_id, current.user_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video job not found.")
+
+    detail = job.progress_detail or {}
+    progress = detail.get("progress")
+    eta_seconds = detail.get("eta_seconds")
+    video_id: str | None = None
+    error: str | None = None
+
+    if job.status == JobStatus.QUEUED:
+        state: VideoState = "queued"
+        progress = 0
+    elif job.status == JobStatus.COMPLETED:
+        state = "complete"
+        progress = 100
+        eta_seconds = None
+        video_ids = (job.result or {}).get("video_ids") or []
+        video_id = video_ids[0] if video_ids else None
+    elif job.status == JobStatus.FAILED:
+        state = "failed"
+        error = job.error
+        eta_seconds = None
+    else:  # PROCESSING: the provider owns the fine-grained state.
+        raw = detail.get("state")
+        state = raw if raw in _PROVIDER_STATES else "rendering"
+
+    return VideoStatusResponse(
+        job_id=str(job.id),
+        status=state,
+        progress=int(progress) if progress is not None else 0,
+        eta_seconds=eta_seconds,
+        video_id=video_id,
+        error=error,
+        created_at=job.created_at,
+        completed_at=job.completed_at,
+    )

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -48,6 +48,19 @@ _MASTERING_COSTS = {
     "bakuage": MASTERING_BAKUAGE_COST,
 }
 
+# US-22.1: video rendering is billed within the documented 5-10 credit band by
+# resolution, with a surcharge for long songs (rendering cost scales with both).
+# Kept out of ``_COSTS`` — video is not a generation mode, and the cost is
+# two-dimensional (resolution x duration) where ``_COSTS`` is flat.
+_VIDEO_COSTS = {
+    "720p": 5.0,
+    "1080p": 7.0,
+    "4k": 8.0,
+}
+VIDEO_LONG_DURATION_S = 180.0
+VIDEO_LONG_DURATION_SURCHARGE = 2.0
+VIDEO_MAX_COST = 10.0
+
 # History page size for GET /users/me/credits.
 HISTORY_LIMIT = 50
 
@@ -58,6 +71,23 @@ def get_cost(mode: str) -> float:
         return _COSTS[mode]
     except KeyError:
         raise ValueError(f"Unknown generation mode: {mode!r}") from None
+
+
+def get_video_cost(resolution: str, duration_s: float | None = None) -> float:
+    """Credit cost of one video render at ``resolution`` for a ``duration_s`` song.
+
+    Raises for unknown resolutions. A song longer than ``VIDEO_LONG_DURATION_S``
+    adds the long-duration surcharge; the total is capped at ``VIDEO_MAX_COST``
+    (the top of the documented 5-10 band). ``duration_s`` may be ``None`` — some
+    clips predate duration tracking — and then bills the base rate.
+    """
+    try:
+        cost = _VIDEO_COSTS[resolution]
+    except KeyError:
+        raise ValueError(f"Unknown video resolution: {resolution!r}") from None
+    if duration_s is not None and duration_s > VIDEO_LONG_DURATION_S:
+        cost += VIDEO_LONG_DURATION_SURCHARGE
+    return min(cost, VIDEO_MAX_COST)
 
 
 def get_mastering_cost(service: str) -> float:

--- a/src/acemusic/api/services/video.py
+++ b/src/acemusic/api/services/video.py
@@ -1,0 +1,52 @@
+"""Video-generation service layer (US-22.1).
+
+Persists queued video-rendering jobs for the videos endpoint, mirroring
+:func:`acemusic.api.services.mastering.create_mastering_job`. Kept
+transport-agnostic (plain exceptions, never ``HTTPException``) like the other
+service modules.
+"""
+
+from beanie import PydanticObjectId
+
+from ..models import Job
+from .common import coerce_object_id
+from .jobs import create_job
+
+VIDEO_JOB_TYPE = "video"
+
+
+async def create_video_job(
+    *,
+    user_id: PydanticObjectId,
+    workspace_id: PydanticObjectId,
+    params: dict,
+) -> Job:
+    """Persist a queued video-rendering job and dispatch it.
+
+    ``params`` holds the resolved rendering spec (clip_id, prompt, style/aspect/
+    resolution options) so the worker never re-derives anything from the request.
+    ``workspace_id`` is the source clip's workspace — the video lands next to its
+    song. Returns the saved :class:`Job` (with its id).
+    """
+    return await create_job(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        job_type=VIDEO_JOB_TYPE,
+        params=params,
+    )
+
+
+async def get_video_job(job_id: str, user_id: str) -> Job | None:
+    """Return the owner's video job, or ``None`` for unknown/unowned/wrong-type.
+
+    Owner- and type-scoped like :func:`mastering.get_mastering_job`: a missing
+    id, another user's job, or a non-video job are all indistinguishable from
+    "no such job".
+    """
+    oid = coerce_object_id(job_id)
+    if oid is None:
+        return None
+    job = await Job.get(oid)
+    if job is None or str(job.user_id) != user_id or job.job_type != VIDEO_JOB_TYPE:
+        return None
+    return job

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -161,6 +161,14 @@ class ApiSettings(BaseSettings):
     openai_api_key: str | None = None
     artwork_generation_enabled: bool = True
 
+    # AI video generation (US-22.1). Optional credentials for the hosted video
+    # rendering provider; a deployment without them runs with video generation
+    # disabled — ``video_enabled`` is False, so the video worker fails a claimed
+    # job with a clear "not configured" error rather than crashing. The provider
+    # is configured by base URL + bearer key (provider-generic, Runway/Pika-class).
+    video_api_url: str | None = None
+    video_api_key: str | None = None
+
     # Release identifiers (US-13.4). ISRC = country code + registrant code issued
     # by the platform operator's national agency; UPC = the operator's 7-digit GS1
     # company prefix. The defaults are demo placeholders ("US"/"A1B"/"0000000") so
@@ -216,6 +224,11 @@ class ApiSettings(BaseSettings):
     def artwork_enabled(self) -> bool:
         """True only when artwork generation is configured and not kill-switched."""
         return bool(self.openai_api_key and self.artwork_generation_enabled)
+
+    @property
+    def video_enabled(self) -> bool:
+        """True only when the video-generation provider is fully configured."""
+        return bool(self.video_api_url and self.video_api_key)
 
     # OAuth ``state`` cookie policy (issue #110, login-CSRF binding). The login
     # flow sets a per-client nonce cookie that the callback requires.

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -33,6 +33,7 @@ from acemusic.image_client import ImageGenerationClient
 from acemusic.mastering_orchestrator import MasteringOrchestrator
 from acemusic.runpod_client import RunPodClient
 from acemusic.storage import StorageBackend, get_storage_backend
+from acemusic.video_client import VideoGenerationService
 
 from .. import database
 from ..models import Clip, Job, JobStatus
@@ -46,6 +47,7 @@ from .extraction import EXTRACTION_JOB_HANDLERS
 from .iterative import ITERATIVE_JOB_HANDLERS
 from .mastering import MASTERING_JOB_HANDLERS
 from .studio import STUDIO_JOB_HANDLERS
+from .video import VIDEO_JOB_HANDLERS
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +111,7 @@ class JobProcessor:
         runpod_poll_interval: float = 5.0,
         mastering_orchestrator_factory: Callable[[], MasteringOrchestrator] | None = None,
         image_client_factory: Callable[[], ImageGenerationClient | None] | None = None,
+        video_client_factory: Callable[[], VideoGenerationService | None] | None = None,
         storage_factory: Callable[[], StorageBackend] | None = None,
         handlers: dict[str, JobHandler] | None = None,
     ) -> None:
@@ -133,6 +136,10 @@ class JobProcessor:
         # None when no OpenAI key is set; the artwork handler then fails a claimed
         # job with a clear "not configured" message rather than crashing.
         self._image_client_factory = image_client_factory
+        # Video generation (US-22.1). The factory yields the video client, or
+        # None when no provider URL/key is set; the video handler then fails a
+        # claimed job with a clear "not configured" message rather than crashing.
+        self._video_client_factory = video_client_factory
         # A job legitimately stays in `processing` for at most poll_timeout (its
         # own worker fails it after that). Only re-queue jobs older than that
         # window plus a margin, so a startup sweep never reclaims a job a live
@@ -168,6 +175,10 @@ class JobProcessor:
         # get their own injecting wrapper like mastering.
         for job_type, artwork_handler in ARTWORK_JOB_HANDLERS.items():
             self._handlers[job_type] = partial(self._run_artwork_handler, artwork_handler)
+        # Video handlers (US-22.1) need storage plus the video client, so they
+        # get their own injecting wrapper like artwork.
+        for job_type, video_handler in VIDEO_JOB_HANDLERS.items():
+            self._handlers[job_type] = partial(self._run_video_handler, video_handler)
         if handlers:
             self._handlers.update(handlers)
         self._running = False
@@ -344,6 +355,16 @@ class JobProcessor:
                 "Artwork generation is not configured: set ACEMUSIC_API_OPENAI_API_KEY to enable it."
             )
         return await artwork_handler(job, storage=self._storage_factory(), client=client)
+
+    async def _run_video_handler(self, video_handler: Any, job: Job) -> dict[str, Any]:
+        """Adapt a video handler (US-22.1), injecting storage and the video client."""
+        client = self._video_client_factory() if self._video_client_factory is not None else None
+        if client is None:
+            raise JobProcessingError(
+                "Video generation is not configured: set ACEMUSIC_API_VIDEO_API_URL "
+                "and ACEMUSIC_API_VIDEO_API_KEY to enable it."
+            )
+        return await video_handler(job, storage=self._storage_factory(), client=client)
 
     async def _handle_generate(self, job: Job) -> dict[str, Any]:
         """Run a generation job — locally via ACE-Step or remotely via RunPod.

--- a/src/acemusic/api/tasks/video.py
+++ b/src/acemusic/api/tasks/video.py
@@ -26,6 +26,7 @@ from acemusic.video_client import (
 )
 
 from ..models import Job, Video
+from ..services import clips as clip_service
 from ..services.video import VIDEO_JOB_TYPE
 from .common import JobProcessingError, download_clip, load_source_clip
 
@@ -35,10 +36,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_S = 5.0
-# Kept under the processor's stale-requeue window (poll_timeout + 300s, 900s by
-# default) — same reasoning as the mastering orchestrator's total timeout — so a
-# restart's stale sweep can never reclaim a job whose poll loop is still live.
+# Poll budget for the provider render. Note the handler's worst-case wall time
+# (submit + this poll budget + download) can exceed the processor's stale-requeue
+# window (poll_timeout + 300s, 900s by default). The stale sweep only runs at
+# process START, so a single-process deployment is safe (a restart killed the old
+# worker anyway); only a multi-process deployment starting a sibling mid-render
+# could re-queue a live job. Acceptable for now — revisit if video ever runs
+# multi-process (raise stale_after for this job type).
 POLL_TIMEOUT_S = 600.0
+
+# One failed status poll must not kill a paid render that is still progressing on
+# the provider side (connection blips over a minutes-long poll window are
+# expected). Only this many consecutive failures fail the job.
+_MAX_CONSECUTIVE_POLL_FAILURES = 3
 
 
 def get_video_client(settings: "ApiSettings") -> VideoGenerationService | None:
@@ -82,23 +92,30 @@ async def process_video_job(
     audio = await download_clip(storage, clip)
     params = dict(job.input_params or {})
     params.pop("clip_id", None)  # provider gets the audio itself, not our id
+    filename = f"{clip.id}.{clip_service.native_format(clip)}"
 
     try:
-        provider_job_id = await asyncio.to_thread(client.submit, audio, f"{clip.id}.wav", params)
+        provider_job_id = await asyncio.to_thread(client.submit, audio, filename, params)
     except VideoGenerationError as exc:
         raise JobProcessingError(f"Video provider submission failed: {exc}") from exc
 
     deadline = time.monotonic() + poll_timeout
+    poll_failures = 0
     while True:
+        update = None
         try:
             update = await asyncio.to_thread(client.get_status, provider_job_id)
         except VideoGenerationError as exc:
-            raise JobProcessingError(f"Video provider status poll failed: {exc}") from exc
-        await _set_progress(job, update.state, update.progress, update.eta_seconds)
-        if update.state == COMPLETE:
-            break
-        if update.state == FAILED:
-            raise JobProcessingError(f"Video rendering failed: {update.error or 'provider reported failure'}")
+            poll_failures += 1
+            if poll_failures >= _MAX_CONSECUTIVE_POLL_FAILURES:
+                raise JobProcessingError(f"Video provider status poll failed: {exc}") from exc
+        if update is not None:
+            poll_failures = 0
+            await _set_progress(job, update.state, update.progress, update.eta_seconds)
+            if update.state == COMPLETE:
+                break
+            if update.state == FAILED:
+                raise JobProcessingError(f"Video rendering failed: {update.error or 'provider reported failure'}")
         if time.monotonic() >= deadline:
             raise JobProcessingError(f"Video rendering timed out after {poll_timeout:.0f}s")
         await asyncio.sleep(poll_interval)

--- a/src/acemusic/api/tasks/video.py
+++ b/src/acemusic/api/tasks/video.py
@@ -1,0 +1,138 @@
+"""Video-generation job handler (US-22.1).
+
+Runs the queued ``video`` job: downloads the source song's audio, submits it
+with the resolved rendering options to the external video provider, polls the
+provider to completion (surfacing state/progress/ETA on ``job.progress_detail``
+for the status endpoint), then stores the rendered MP4 and records a
+:class:`Video` document associating it with the song. A failure after the
+upload rolls the stored object back, so a ``failed`` job never leaves orphaned
+files behind (mirrors the artwork/mastering handlers).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from acemusic.storage import StorageBackend
+from acemusic.video_client import (
+    COMPLETE,
+    FAILED,
+    HttpVideoClient,
+    VideoGenerationError,
+    VideoGenerationService,
+)
+
+from ..models import Job, Video
+from ..services.video import VIDEO_JOB_TYPE
+from .common import JobProcessingError, download_clip, load_source_clip
+
+if TYPE_CHECKING:
+    from ..settings import ApiSettings
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL_S = 5.0
+# Kept under the processor's stale-requeue window (poll_timeout + 300s, 900s by
+# default) — same reasoning as the mastering orchestrator's total timeout — so a
+# restart's stale sweep can never reclaim a job whose poll loop is still live.
+POLL_TIMEOUT_S = 600.0
+
+
+def get_video_client(settings: "ApiSettings") -> VideoGenerationService | None:
+    """Build the video client when video generation is configured, else None.
+
+    None when no provider URL/key is set; the handler then fails a claimed job
+    with a clear "not configured" message rather than crashing the worker
+    (mirrors the mastering orchestrator and image client factories).
+    """
+    if not settings.video_enabled:
+        return None
+    return HttpVideoClient(base_url=settings.video_api_url, api_key=settings.video_api_key)
+
+
+async def _set_progress(job: Job, state: str, progress: int | None, eta_seconds: float | None) -> None:
+    """Record one provider update on the job for the status endpoint to serve."""
+    detail: dict[str, Any] = {"state": state}
+    if progress is not None:
+        detail["progress"] = max(0, min(100, progress))
+    if eta_seconds is not None:
+        detail["eta_seconds"] = eta_seconds
+    await job.set({Job.progress_detail: detail})
+
+
+async def process_video_job(
+    job: Job,
+    *,
+    storage: StorageBackend,
+    client: VideoGenerationService,
+    poll_interval: float = POLL_INTERVAL_S,
+    poll_timeout: float = POLL_TIMEOUT_S,
+) -> dict[str, Any]:
+    """Render, store and associate the song's music video.
+
+    Returns ``{"video_ids": [<id>], "storage_path": <path>}``. Raises
+    :class:`JobProcessingError` on provider failure/timeout; the processor
+    records the message as the job's failure. Transient (5xx) provider errors
+    are already retried inside the client (shared ``_http`` policy, 3 retries).
+    """
+    clip = await load_source_clip(job)
+    audio = await download_clip(storage, clip)
+    params = dict(job.input_params or {})
+    params.pop("clip_id", None)  # provider gets the audio itself, not our id
+
+    try:
+        provider_job_id = await asyncio.to_thread(client.submit, audio, f"{clip.id}.wav", params)
+    except VideoGenerationError as exc:
+        raise JobProcessingError(f"Video provider submission failed: {exc}") from exc
+
+    deadline = time.monotonic() + poll_timeout
+    while True:
+        try:
+            update = await asyncio.to_thread(client.get_status, provider_job_id)
+        except VideoGenerationError as exc:
+            raise JobProcessingError(f"Video provider status poll failed: {exc}") from exc
+        await _set_progress(job, update.state, update.progress, update.eta_seconds)
+        if update.state == COMPLETE:
+            break
+        if update.state == FAILED:
+            raise JobProcessingError(f"Video rendering failed: {update.error or 'provider reported failure'}")
+        if time.monotonic() >= deadline:
+            raise JobProcessingError(f"Video rendering timed out after {poll_timeout:.0f}s")
+        await asyncio.sleep(poll_interval)
+
+    try:
+        data = await asyncio.to_thread(client.download, provider_job_id)
+    except VideoGenerationError as exc:
+        raise JobProcessingError(f"Video download failed: {exc}") from exc
+
+    # Namespace by job id so re-rendering the same song never overwrites an
+    # earlier video (and a failed job's rollback only deletes its own object).
+    path = f"{job.user_id}/{job.workspace_id}/videos/{clip.id}/{job.id}.mp4"
+    await asyncio.to_thread(storage.upload, path, data)
+    video = Video(
+        clip_id=clip.id,
+        user_id=job.user_id,
+        job_id=job.id,
+        storage_path=path,
+        resolution=str(params.get("resolution", "")),
+        aspect_ratio=str(params.get("aspect_ratio", "")),
+    )
+    try:
+        await video.insert()
+    except BaseException:
+        # BaseException (not Exception): a shutdown CancelledError must also clean
+        # up the just-uploaded object, else a requeued retry leaves it orphaned.
+        try:
+            await asyncio.to_thread(storage.delete, path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned video object %s during rollback", path)
+        raise
+
+    await _set_progress(job, COMPLETE, 100, None)
+    return {"video_ids": [str(video.id)], "storage_path": path}
+
+
+VIDEO_JOB_HANDLERS = {VIDEO_JOB_TYPE: process_video_job}

--- a/src/acemusic/video_client.py
+++ b/src/acemusic/video_client.py
@@ -1,0 +1,160 @@
+"""HTTP client for the external AI video generation provider (US-22.1).
+
+The platform submits a source song plus a visual prompt/options to a hosted
+video-rendering API (Runway/Pika-class), polls the job to completion, and
+downloads the rendered MP4 (audio muxed in by the provider). No provider
+credentials exist in this environment, so — like ``dolby_client`` before its
+live verification — the request/response shape is provider-generic: base URL
+and bearer key come from settings, and the three-call workflow
+(``submit`` -> ``get_status`` -> ``download``) is the contract the job handler
+programs against via the :class:`VideoGenerationService` protocol.
+
+Conventions mirror the other external clients: synchronous :mod:`httpx` (the
+job processor calls it from a worker thread via ``asyncio.to_thread``),
+module-level timeouts, one exception type, and the shared :mod:`acemusic._http`
+transient-retry policy (up to 3 retries with backoff on 5xx — the story's
+"retry up to 3 attempts on transient provider failure").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import httpx
+
+from acemusic import _http
+
+# Submit uploads a whole song; download streams a whole video.
+_API_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=300.0, pool=10.0)
+_DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=10.0, pool=10.0)
+
+# The platform's rendering-state vocabulary (US-22.1):
+# queued -> rendering -> encoding -> complete | failed.
+# Provider spellings are normalised onto it; anything unrecognised is treated as
+# still-rendering so the poll loop keeps waiting until its timeout.
+COMPLETE = "complete"
+FAILED = "failed"
+_STATE_ALIASES = {
+    "queued": "queued",
+    "pending": "queued",
+    "rendering": "rendering",
+    "processing": "rendering",
+    "running": "rendering",
+    "encoding": "encoding",
+    "complete": COMPLETE,
+    "completed": COMPLETE,
+    "succeeded": COMPLETE,
+    "success": COMPLETE,
+    "failed": FAILED,
+    "error": FAILED,
+    "cancelled": FAILED,
+}
+
+
+class VideoGenerationError(Exception):
+    """Raised when the video provider returns an error or is unreachable."""
+
+
+@dataclass(frozen=True)
+class VideoJobUpdate:
+    """One poll of a provider job: normalised state, progress %, ETA, error."""
+
+    state: str
+    progress: int | None = None
+    eta_seconds: float | None = None
+    error: str | None = None
+
+
+class VideoGenerationService(Protocol):
+    """The three-call rendering workflow the job handler programs against."""
+
+    def submit(self, audio_bytes: bytes, filename: str, params: dict[str, Any]) -> str:
+        """Upload the song and create a rendering job; returns the provider job id."""
+        ...
+
+    def get_status(self, provider_job_id: str) -> VideoJobUpdate:
+        """One status poll for a submitted job."""
+        ...
+
+    def download(self, provider_job_id: str) -> bytes:
+        """Download the completed job's rendered MP4."""
+        ...
+
+
+def normalize_state(raw: object) -> str:
+    """Map a provider status string onto the platform vocabulary."""
+    return _STATE_ALIASES.get(str(raw).strip().lower(), "rendering")
+
+
+def _as_int(value: Any) -> int | None:
+    """Best-effort int coercion for a progress value, or None when absent/garbage."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    """Best-effort float coercion for an ETA value, or None when absent/garbage."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class HttpVideoClient:
+    """Synchronous client for the hosted video-generation REST workflow."""
+
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+
+    def submit(self, audio_bytes: bytes, filename: str, params: dict[str, Any]) -> str:
+        """POST the song + rendering options; returns the provider's job id."""
+        files = {"audio_file": (filename, audio_bytes)}
+        # Multipart form fields are strings; lists (reference image URLs) repeat the key.
+        data: dict[str, Any] = {}
+        for key, value in params.items():
+            if value is None:
+                continue
+            data[key] = [str(v) for v in value] if isinstance(value, list) else str(value)
+        response = self._request(httpx.post, f"{self.base_url}/jobs", files=files, data=data, timeout=_API_TIMEOUT)
+        job_id = response.json().get("id")
+        if not job_id:
+            raise VideoGenerationError("Video provider returned no job id")
+        return str(job_id)
+
+    def get_status(self, provider_job_id: str) -> VideoJobUpdate:
+        """GET the job's state, progress percentage, and estimated time remaining."""
+        response = self._request(httpx.get, f"{self.base_url}/jobs/{provider_job_id}", timeout=_API_TIMEOUT)
+        payload = response.json()
+        return VideoJobUpdate(
+            state=normalize_state(payload.get("status")),
+            progress=_as_int(payload.get("progress")),
+            eta_seconds=_as_float(payload.get("eta_seconds")),
+            error=payload.get("error"),
+        )
+
+    def download(self, provider_job_id: str) -> bytes:
+        """GET the completed job's rendered MP4 bytes."""
+        response = self._request(httpx.get, f"{self.base_url}/jobs/{provider_job_id}/result", timeout=_DOWNLOAD_TIMEOUT)
+        if not response.content:
+            raise VideoGenerationError("Video provider returned an empty result")
+        return response.content
+
+    def _request(self, method: Any, url: str, **kwargs: Any) -> httpx.Response:
+        """Issue one call through the shared 5xx-retry policy, wrapping failures."""
+        try:
+            response = _http.request(method, url, headers=self._headers, **kwargs)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise VideoGenerationError(f"Video provider returned {exc.response.status_code} for {url}") from exc
+        except httpx.HTTPError as exc:
+            raise VideoGenerationError(f"Video provider request failed for {url}: {exc}") from exc
+        return response

--- a/src/acemusic/video_client.py
+++ b/src/acemusic/video_client.py
@@ -124,8 +124,13 @@ class HttpVideoClient:
             if value is None:
                 continue
             data[key] = [str(v) for v in value] if isinstance(value, list) else str(value)
-        response = self._request(httpx.post, f"{self.base_url}/jobs", files=files, data=data, timeout=_API_TIMEOUT)
-        job_id = response.json().get("id")
+        # retries=0: submission creates a billed render on the provider. A 5xx
+        # after the provider accepted the job would mean an auto-retry creates
+        # (and pays for) duplicate renders — mirrors image_client's policy.
+        response = self._request(
+            httpx.post, f"{self.base_url}/jobs", files=files, data=data, timeout=_API_TIMEOUT, retries=0
+        )
+        job_id = self._json(response).get("id")
         if not job_id:
             raise VideoGenerationError("Video provider returned no job id")
         return str(job_id)
@@ -133,7 +138,7 @@ class HttpVideoClient:
     def get_status(self, provider_job_id: str) -> VideoJobUpdate:
         """GET the job's state, progress percentage, and estimated time remaining."""
         response = self._request(httpx.get, f"{self.base_url}/jobs/{provider_job_id}", timeout=_API_TIMEOUT)
-        payload = response.json()
+        payload = self._json(response)
         return VideoJobUpdate(
             state=normalize_state(payload.get("status")),
             progress=_as_int(payload.get("progress")),
@@ -147,6 +152,17 @@ class HttpVideoClient:
         if not response.content:
             raise VideoGenerationError("Video provider returned an empty result")
         return response.content
+
+    @staticmethod
+    def _json(response: httpx.Response) -> dict[str, Any]:
+        """Parse a JSON body, wrapping a non-JSON 200 (e.g. an HTML error page)."""
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise VideoGenerationError("Video provider returned a non-JSON response") from exc
+        if not isinstance(payload, dict):
+            raise VideoGenerationError("Video provider returned an unexpected JSON shape")
+        return payload
 
     def _request(self, method: Any, url: str, **kwargs: Any) -> httpx.Response:
         """Issue one call through the shared 5xx-retry policy, wrapping failures."""

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -62,6 +62,35 @@ class TestGetCost:
             credits_service.get_cost("video")
 
 
+class TestGetVideoCost:
+    """Runs in CI (no DB): the US-22.1 video cost table is pure logic.
+
+    The documented band is 5-10 credits by resolution and duration: base rate
+    per resolution, a surcharge for songs over the long-duration threshold, and
+    a hard cap at the top of the band.
+    """
+
+    def test_base_costs_by_resolution(self) -> None:
+        assert credits_service.get_video_cost("720p", 10.0) == 5.0
+        assert credits_service.get_video_cost("1080p", 10.0) == 7.0
+        assert credits_service.get_video_cost("4k", 10.0) == 8.0
+
+    def test_long_duration_surcharge(self) -> None:
+        long = credits_service.VIDEO_LONG_DURATION_S + 1
+        assert credits_service.get_video_cost("720p", long) == 7.0
+        assert credits_service.get_video_cost("1080p", long) == 9.0
+
+    def test_cost_capped_at_band_maximum(self) -> None:
+        assert credits_service.get_video_cost("4k", credits_service.VIDEO_LONG_DURATION_S + 1) == 10.0
+
+    def test_unknown_duration_bills_base_rate(self) -> None:
+        assert credits_service.get_video_cost("720p", None) == 5.0
+
+    def test_unknown_resolution_raises(self) -> None:
+        with pytest.raises(ValueError):
+            credits_service.get_video_cost("8k", 10.0)
+
+
 class TestNonPositiveCostGuard:
     """Runs in CI (no DB): the guards raise before any database access. A
     negative cost would otherwise mint credits ($inc of a positive amount

--- a/tests/test_video_api.py
+++ b/tests/test_video_api.py
@@ -1,0 +1,384 @@
+"""Integration tests for the video generation endpoints (US-22.1).
+
+Covers ``POST /api/v1/videos/generate`` (each request validates against an
+owned source clip, gates on resolution/duration-tiered credits, and enqueues a
+queued ``video`` job returning 202 with a trackable job id) and
+``GET /api/v1/videos/{job_id}/status`` (maps the job lifecycle plus the
+provider's ``progress_detail`` onto queued/rendering/encoding/complete/failed
+with progress % and ETA). The 401 auth-gate tests run in CI (no DB); the rest
+are ``integration`` and drive the real app over a local MongoDB.
+"""
+
+import httpx
+import pytest
+from beanie import PydanticObjectId
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, CreditTransaction, Job, JobStatus, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.services.video import VIDEO_JOB_TYPE
+from acemusic.api.settings import ApiSettings
+
+GENERATE_URL = f"{API_V1_PREFIX}/videos/generate"
+
+
+def _status_url(job_id: str) -> str:
+    return f"{API_V1_PREFIX}/videos/{job_id}/status"
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB; plain TestClient does not run the lifespan)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_generate_without_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(GENERATE_URL, json={"clip_id": str(PydanticObjectId()), "prompt": "neon"})
+        assert resp.status_code == 401
+
+    def test_status_without_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.get(_status_url(str(PydanticObjectId())))
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    # Disable the background processor: these tests assert on the queued job
+    # record and do not want a worker claiming it out from under them.
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str, *, balance: float | None = None):
+    user = await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+    if balance is not None:
+        user.credits_balance = balance
+        await user.save()
+    return user
+
+
+async def _insert_clip(user, workspace: Workspace, *, duration: float = 10.0) -> Clip:
+    clip_id = PydanticObjectId()
+    clip = Clip(
+        id=clip_id,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        file_path=f"{user.id}/{workspace.id}/clips/{clip_id}.wav",
+        format="wav",
+        duration=duration,
+    )
+    await clip.insert()
+    return clip
+
+
+async def _user_with_clip(email: str, *, balance: float | None = None, duration: float = 10.0):
+    user = await _make_user(email, balance=balance)
+    workspace = Workspace(name="WS", user_id=user.id)
+    await workspace.insert()
+    clip = await _insert_clip(user, workspace, duration=duration)
+    return user, workspace, clip
+
+
+async def _reload(user):
+    return await user_service.get_user_by_id(str(user.id))
+
+
+def _valid_body(clip, **overrides) -> dict:
+    body = {"clip_id": str(clip.id), "prompt": "neon city at night"}
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Submission — 202 + queued job persisted with all parameters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestSuccessfulSubmission:
+    async def test_returns_202_with_job_id(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-ok@example.com", balance=10.0)
+        resp = await client.post(GENERATE_URL, json=_valid_body(clip), headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "queued"
+        job = await Job.get(PydanticObjectId(body["job_id"]))
+        assert job is not None and job.job_type == VIDEO_JOB_TYPE and job.status == JobStatus.QUEUED
+
+    async def test_full_options_snapshot_persisted(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-params@example.com", balance=10.0)
+        body = _valid_body(
+            clip,
+            style_preset="cinematic",
+            reference_image_urls=["https://img.test/a.png", "https://img.test/b.png"],
+            lyrics_sync=True,
+            aspect_ratio="9:16",
+            resolution="1080p",
+            frame_rate=60,
+            transitions="fade",
+        )
+        resp = await client.post(GENERATE_URL, json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        job = await Job.get(PydanticObjectId(resp.json()["job_id"]))
+        params = job.input_params
+        assert params["clip_id"] == str(clip.id)
+        assert params["style_preset"] == "cinematic"
+        assert params["reference_image_urls"] == ["https://img.test/a.png", "https://img.test/b.png"]
+        assert params["lyrics_sync"] is True
+        assert params["aspect_ratio"] == "9:16"
+        assert params["resolution"] == "1080p"
+        assert params["frame_rate"] == 60
+        assert params["transitions"] == "fade"
+
+    async def test_charges_resolution_cost_and_records_ledger(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-charge@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json=_valid_body(clip, resolution="1080p"),
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        assert (await _reload(user)).credits_balance == 3.0  # 10 - 7 (1080p base)
+        txns = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        assert len(txns) == 1
+        assert txns[0].amount == -7.0
+        assert txns[0].action_type == VIDEO_JOB_TYPE
+        assert txns[0].job_id == resp.json()["job_id"]
+
+    async def test_long_song_pays_duration_surcharge(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-long@example.com", balance=10.0, duration=200.0)
+        resp = await client.post(GENERATE_URL, json=_valid_body(clip), headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        assert (await _reload(user)).credits_balance == 3.0  # 10 - (5 + 2 surcharge)
+
+
+# ---------------------------------------------------------------------------
+# Validation — 422
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestValidation:
+    async def test_unknown_field_rejected(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-extra@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json=_valid_body(clip, codec="h265"),
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_prompt_or_preset_required(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-noprompt@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"clip_id": str(clip.id)},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_invalid_resolution_rejected(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-badres@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json=_valid_body(clip, resolution="8k"),
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+    async def test_too_many_reference_images_rejected(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-refs@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json=_valid_body(clip, reference_image_urls=[f"https://img.test/{i}.png" for i in range(6)]),
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Credit gating — 402
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestInsufficientCredits:
+    async def test_returns_402_with_balance_payload(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-poor@example.com", balance=1.0)
+        resp = await client.post(GENERATE_URL, json=_valid_body(clip), headers=_auth_headers(user, settings))
+        assert resp.status_code == 402
+        detail = resp.json()["detail"]
+        assert detail["error"] == "insufficient_credits"
+        assert detail["balance"] == 1.0
+        assert detail["required"] == 5.0
+
+    async def test_no_job_or_charge_on_insufficient_credits(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-poor-noop@example.com", balance=1.0)
+        resp = await client.post(GENERATE_URL, json=_valid_body(clip), headers=_auth_headers(user, settings))
+        assert resp.status_code == 402
+        assert (await _reload(user)).credits_balance == 1.0
+        assert await Job.find(Job.user_id == user.id).count() == 0
+        assert await CreditTransaction.find(CreditTransaction.user_id == user.id).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Ownership — 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestClipOwnership:
+    async def test_unknown_clip_returns_404_and_no_charge(self, client, settings) -> None:
+        user = await _make_user("video-noclip@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json={"clip_id": str(PydanticObjectId()), "prompt": "neon"},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+        assert (await _reload(user)).credits_balance == 10.0
+
+    async def test_other_users_clip_returns_404(self, client, settings) -> None:
+        _owner, _ws, clip = await _user_with_clip("video-owner@example.com", balance=10.0)
+        thief = await _make_user("video-thief@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json=_valid_body(clip),
+            headers=_auth_headers(thief, settings),
+        )
+        assert resp.status_code == 404
+        assert (await _reload(thief)).credits_balance == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Status endpoint — the queued/rendering/encoding/complete/failed vocabulary
+# ---------------------------------------------------------------------------
+
+
+async def _submit(client, settings, user, clip) -> str:
+    resp = await client.post(GENERATE_URL, json=_valid_body(clip), headers=_auth_headers(user, settings))
+    assert resp.status_code == 202
+    return resp.json()["job_id"]
+
+
+@pytest.mark.integration
+class TestStatusEndpoint:
+    async def test_queued_job_reports_queued(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-st-q@example.com", balance=10.0)
+        job_id = await _submit(client, settings, user, clip)
+        resp = await client.get(_status_url(job_id), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "queued"
+        assert body["progress"] == 0
+        assert "video_id" not in body and "error" not in body
+
+    async def test_processing_job_reports_provider_state(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-st-r@example.com", balance=10.0)
+        job_id = await _submit(client, settings, user, clip)
+        job = await Job.get(PydanticObjectId(job_id))
+        await job.set(
+            {
+                Job.status: JobStatus.PROCESSING,
+                Job.progress_detail: {"state": "rendering", "progress": 42, "eta_seconds": 30.0},
+            }
+        )
+        body = (await client.get(_status_url(job_id), headers=_auth_headers(user, settings))).json()
+        assert body["status"] == "rendering"
+        assert body["progress"] == 42
+        assert body["eta_seconds"] == 30.0
+
+    async def test_encoding_state_surfaces(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-st-e@example.com", balance=10.0)
+        job_id = await _submit(client, settings, user, clip)
+        job = await Job.get(PydanticObjectId(job_id))
+        await job.set({Job.status: JobStatus.PROCESSING, Job.progress_detail: {"state": "encoding", "progress": 90}})
+        body = (await client.get(_status_url(job_id), headers=_auth_headers(user, settings))).json()
+        assert body["status"] == "encoding"
+        assert body["progress"] == 90
+
+    async def test_processing_without_detail_defaults_to_rendering(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-st-d@example.com", balance=10.0)
+        job_id = await _submit(client, settings, user, clip)
+        job = await Job.get(PydanticObjectId(job_id))
+        await job.set({Job.status: JobStatus.PROCESSING})
+        body = (await client.get(_status_url(job_id), headers=_auth_headers(user, settings))).json()
+        assert body["status"] == "rendering"
+        assert body["progress"] == 0
+
+    async def test_completed_job_reports_complete_with_video_id(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-st-c@example.com", balance=10.0)
+        job_id = await _submit(client, settings, user, clip)
+        job = await Job.get(PydanticObjectId(job_id))
+        await job.set(
+            {
+                Job.status: JobStatus.COMPLETED,
+                Job.result: {"video_ids": ["665f00000000000000000001"], "storage_path": "p.mp4"},
+            }
+        )
+        body = (await client.get(_status_url(job_id), headers=_auth_headers(user, settings))).json()
+        assert body["status"] == "complete"
+        assert body["progress"] == 100
+        assert body["video_id"] == "665f00000000000000000001"
+
+    async def test_failed_job_reports_failed_with_error(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-st-f@example.com", balance=10.0)
+        job_id = await _submit(client, settings, user, clip)
+        job = await Job.get(PydanticObjectId(job_id))
+        await job.set({Job.status: JobStatus.FAILED, Job.error: "Video rendering failed: provider says no"})
+        body = (await client.get(_status_url(job_id), headers=_auth_headers(user, settings))).json()
+        assert body["status"] == "failed"
+        assert body["error"] == "Video rendering failed: provider says no"
+
+    async def test_unowned_job_returns_404(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-st-own@example.com", balance=10.0)
+        job_id = await _submit(client, settings, user, clip)
+        other = await _make_user("video-st-other@example.com")
+        resp = await client.get(_status_url(job_id), headers=_auth_headers(other, settings))
+        assert resp.status_code == 404
+
+    async def test_non_video_job_returns_404(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-st-type@example.com", balance=10.0)
+        job = Job(user_id=user.id, workspace_id=clip.workspace_id, job_type="mastering")
+        await job.insert()
+        resp = await client.get(_status_url(str(job.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_malformed_job_id_returns_404(self, client, settings) -> None:
+        user = await _make_user("video-st-bad@example.com")
+        resp = await client.get(_status_url("not-an-id"), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404

--- a/tests/test_video_api.py
+++ b/tests/test_video_api.py
@@ -63,6 +63,10 @@ def settings(mongo_db, mongo_settings) -> ApiSettings:
         update={
             "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
             "job_processor_enabled": False,
+            # The generate endpoint 503s before any charge when the provider is
+            # unconfigured (see TestNotConfigured), so these tests configure it.
+            "video_api_url": "https://video.test",
+            "video_api_key": "vk-test",
         }
     )
 
@@ -220,6 +224,25 @@ class TestValidation:
         )
         assert resp.status_code == 422
 
+    async def test_non_http_reference_url_rejected(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-ssrf@example.com", balance=10.0)
+        for url in ("file:///etc/passwd", "ftp://x.test/a.png", "javascript:alert(1)"):
+            resp = await client.post(
+                GENERATE_URL,
+                json=_valid_body(clip, reference_image_urls=[url]),
+                headers=_auth_headers(user, settings),
+            )
+            assert resp.status_code == 422, url
+
+    async def test_overlong_prompt_rejected(self, client, settings) -> None:
+        user, _ws, clip = await _user_with_clip("video-longprompt@example.com", balance=10.0)
+        resp = await client.post(
+            GENERATE_URL,
+            json=_valid_body(clip, prompt="x" * 2001),
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+
     async def test_too_many_reference_images_rejected(self, client, settings) -> None:
         user, _ws, clip = await _user_with_clip("video-refs@example.com", balance=10.0)
         resp = await client.post(
@@ -228,6 +251,27 @@ class TestValidation:
             headers=_auth_headers(user, settings),
         )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Unconfigured provider — 503 before any charge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestNotConfigured:
+    async def test_returns_503_with_no_charge_or_job(self, settings) -> None:
+        """An unconfigured deployment must refuse up front: the worker would fail
+        every claimed video job with "not configured", so charging first would be
+        a guaranteed charge for nothing."""
+        user, _ws, clip = await _user_with_clip("video-nocfg@example.com", balance=10.0)
+        bare = settings.model_copy(update={"video_api_url": None, "video_api_key": None})
+        async with _async_client(create_app(bare)) as client:
+            resp = await client.post(GENERATE_URL, json=_valid_body(clip), headers=_auth_headers(user, bare))
+        assert resp.status_code == 503
+        assert "not configured" in resp.json()["detail"]
+        assert (await _reload(user)).credits_balance == 10.0
+        assert await Job.find(Job.user_id == user.id).count() == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_video_client.py
+++ b/tests/test_video_client.py
@@ -85,25 +85,34 @@ class TestSubmit:
 
 
 class TestRetryPolicy:
-    """The client goes through the shared ``_http.request`` policy: a 5xx is
-    retried up to 3 times with backoff (4 attempts total), then surfaces as a
-    :class:`VideoGenerationError`."""
+    """Unbilled calls (status/download) go through the shared ``_http.request``
+    policy: a 5xx is retried up to 3 times with backoff (4 attempts total), then
+    surfaces as a :class:`VideoGenerationError`. The billed submit call opts out
+    (``retries=0``) — an auto-retry after the provider accepted the job would
+    create and pay for duplicate renders."""
 
-    def test_5xx_retried_then_succeeds(self) -> None:
-        responses = [_resp(500), _resp(502), _resp(200, {"id": "pj-9"})]
-        with patch("httpx.post", side_effect=responses) as post, patch("acemusic._http.time.sleep") as slept:
-            job_id = _client().submit(b"RIFF", "song.wav", {})
-        assert job_id == "pj-9"
-        assert post.call_count == 3
+    def test_status_5xx_retried_then_succeeds(self) -> None:
+        responses = [_resp(500), _resp(502), _resp(200, {"status": "rendering", "progress": 10})]
+        with patch("httpx.get", side_effect=responses) as get, patch("acemusic._http.time.sleep") as slept:
+            update = _client().get_status("pj-1")
+        assert update.state == "rendering"
+        assert get.call_count == 3
         assert slept.call_count == 2
 
-    def test_5xx_exhausts_retries_then_raises(self) -> None:
-        with patch("httpx.post", return_value=_resp(503)) as post, patch("acemusic._http.time.sleep") as slept:
+    def test_status_5xx_exhausts_retries_then_raises(self) -> None:
+        with patch("httpx.get", return_value=_resp(503)) as get, patch("acemusic._http.time.sleep") as slept:
             with pytest.raises(VideoGenerationError, match="503"):
-                _client().submit(b"RIFF", "song.wav", {})
+                _client().get_status("pj-1")
         # Initial attempt + MAX_RETRIES retries.
-        assert post.call_count == 4
+        assert get.call_count == 4
         assert slept.call_count == 3
+
+    def test_billed_submit_does_not_retry_5xx(self) -> None:
+        with patch("httpx.post", return_value=_resp(500)) as post, patch("acemusic._http.time.sleep") as slept:
+            with pytest.raises(VideoGenerationError, match="500"):
+                _client().submit(b"RIFF", "song.wav", {})
+        assert post.call_count == 1
+        assert slept.call_count == 0
 
 
 class TestGetStatus:
@@ -121,6 +130,11 @@ class TestGetStatus:
         with patch("acemusic._http.request", return_value=_resp(200, payload)):
             update = _client().get_status("pj-1")
         assert update.progress is None and update.eta_seconds is None
+
+    def test_non_json_200_wrapped(self) -> None:
+        with patch("acemusic._http.request", return_value=_resp(200, content=b"<html>gateway</html>")):
+            with pytest.raises(VideoGenerationError, match="non-JSON"):
+                _client().get_status("pj-1")
 
     def test_failure_carries_provider_error(self) -> None:
         payload = {"status": "failed", "error": "NSFW prompt rejected"}

--- a/tests/test_video_client.py
+++ b/tests/test_video_client.py
@@ -1,0 +1,143 @@
+"""Unit tests for HttpVideoClient (US-22.1).
+
+Every HTTP call is stubbed with real ``httpx.Response`` objects (no network),
+so these run in CI. They cover the three-call workflow contract (submit ->
+get_status -> download), state normalisation onto the platform vocabulary, and
+the shared transient-retry policy: up to 3 retries with backoff on 5xx, 4xx
+failing fast.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from acemusic.video_client import (
+    HttpVideoClient,
+    VideoGenerationError,
+    normalize_state,
+)
+
+FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 64
+
+
+def _resp(status_code: int = 200, json_data: dict | None = None, content: bytes | None = None) -> httpx.Response:
+    resp = httpx.Response(
+        status_code,
+        json=json_data if content is None else None,
+        content=content,
+        request=httpx.Request("GET", "https://video.test/jobs"),
+    )
+    return resp
+
+
+def _client() -> HttpVideoClient:
+    return HttpVideoClient(base_url="https://video.test/", api_key="vk-test")
+
+
+class TestNormalizeState:
+    def test_known_aliases(self) -> None:
+        assert normalize_state("PENDING") == "queued"
+        assert normalize_state("processing") == "rendering"
+        assert normalize_state("encoding") == "encoding"
+        assert normalize_state("succeeded") == "complete"
+        assert normalize_state("error") == "failed"
+
+    def test_unknown_state_treated_as_still_rendering(self) -> None:
+        assert normalize_state("warming-up-gpus") == "rendering"
+
+
+class TestSubmit:
+    def test_returns_provider_job_id(self) -> None:
+        with patch("acemusic._http.request", return_value=_resp(200, {"id": "pj-1"})) as req:
+            job_id = _client().submit(b"RIFF", "song.wav", {"resolution": "720p", "reference_image_urls": ["u1"]})
+        assert job_id == "pj-1"
+        # Trailing slash stripped; auth header carried; params serialised as form strings.
+        args, kwargs = req.call_args
+        assert args[1] == "https://video.test/jobs"
+        assert kwargs["headers"]["Authorization"] == "Bearer vk-test"
+        assert kwargs["data"]["resolution"] == "720p"
+        assert kwargs["data"]["reference_image_urls"] == ["u1"]
+
+    def test_none_params_omitted(self) -> None:
+        with patch("acemusic._http.request", return_value=_resp(200, {"id": "pj-1"})) as req:
+            _client().submit(b"RIFF", "song.wav", {"prompt": None, "lyrics_sync": False})
+        assert "prompt" not in req.call_args.kwargs["data"]
+        assert req.call_args.kwargs["data"]["lyrics_sync"] == "False"
+
+    def test_missing_job_id_raises(self) -> None:
+        with patch("acemusic._http.request", return_value=_resp(200, {})):
+            with pytest.raises(VideoGenerationError, match="no job id"):
+                _client().submit(b"RIFF", "song.wav", {})
+
+    def test_4xx_fails_fast(self) -> None:
+        with patch("acemusic._http.request", return_value=_resp(401, {"detail": "bad key"})) as req:
+            with pytest.raises(VideoGenerationError, match="401"):
+                _client().submit(b"RIFF", "song.wav", {})
+        assert req.call_count == 1
+
+    def test_connection_error_wrapped(self) -> None:
+        with patch("acemusic._http.request", side_effect=httpx.ConnectError("refused")):
+            with pytest.raises(VideoGenerationError, match="request failed"):
+                _client().submit(b"RIFF", "song.wav", {})
+
+
+class TestRetryPolicy:
+    """The client goes through the shared ``_http.request`` policy: a 5xx is
+    retried up to 3 times with backoff (4 attempts total), then surfaces as a
+    :class:`VideoGenerationError`."""
+
+    def test_5xx_retried_then_succeeds(self) -> None:
+        responses = [_resp(500), _resp(502), _resp(200, {"id": "pj-9"})]
+        with patch("httpx.post", side_effect=responses) as post, patch("acemusic._http.time.sleep") as slept:
+            job_id = _client().submit(b"RIFF", "song.wav", {})
+        assert job_id == "pj-9"
+        assert post.call_count == 3
+        assert slept.call_count == 2
+
+    def test_5xx_exhausts_retries_then_raises(self) -> None:
+        with patch("httpx.post", return_value=_resp(503)) as post, patch("acemusic._http.time.sleep") as slept:
+            with pytest.raises(VideoGenerationError, match="503"):
+                _client().submit(b"RIFF", "song.wav", {})
+        # Initial attempt + MAX_RETRIES retries.
+        assert post.call_count == 4
+        assert slept.call_count == 3
+
+
+class TestGetStatus:
+    def test_parses_state_progress_and_eta(self) -> None:
+        payload = {"status": "rendering", "progress": "42", "eta_seconds": 30, "error": None}
+        with patch("acemusic._http.request", return_value=_resp(200, payload)):
+            update = _client().get_status("pj-1")
+        assert update.state == "rendering"
+        assert update.progress == 42
+        assert update.eta_seconds == 30.0
+        assert update.error is None
+
+    def test_garbage_numbers_degrade_to_none(self) -> None:
+        payload = {"status": "queued", "progress": "soon", "eta_seconds": "dunno"}
+        with patch("acemusic._http.request", return_value=_resp(200, payload)):
+            update = _client().get_status("pj-1")
+        assert update.progress is None and update.eta_seconds is None
+
+    def test_failure_carries_provider_error(self) -> None:
+        payload = {"status": "failed", "error": "NSFW prompt rejected"}
+        with patch("acemusic._http.request", return_value=_resp(200, payload)):
+            update = _client().get_status("pj-1")
+        assert update.state == "failed"
+        assert update.error == "NSFW prompt rejected"
+
+
+class TestDownload:
+    def test_returns_mp4_bytes(self) -> None:
+        with patch("acemusic._http.request", return_value=_resp(200, content=FAKE_MP4)) as req:
+            data = _client().download("pj-1")
+        assert data == FAKE_MP4
+        assert req.call_args.args[1] == "https://video.test/jobs/pj-1/result"
+
+    def test_empty_result_raises(self) -> None:
+        with patch("acemusic._http.request", return_value=_resp(200, content=b"")):
+            with pytest.raises(VideoGenerationError, match="empty"):
+                _client().download("pj-1")

--- a/tests/test_video_tasks.py
+++ b/tests/test_video_tasks.py
@@ -186,6 +186,37 @@ class TestProcessVideoJob:
         assert {"state": "rendering", "progress": 40, "eta_seconds": 30.0} in seen
         assert {"state": "encoding", "progress": 90, "eta_seconds": 5.0} in seen
 
+    async def test_transient_poll_failures_tolerated(self, storage) -> None:
+        """A blip in a status poll must not kill a render that is still running."""
+        job, clip = await _make_job_and_clip()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+        client = FakeVideoService(_updates_to_complete())
+        real_get_status = client.get_status
+        blips = {"remaining": 2}
+
+        def flaky_get_status(provider_job_id: str) -> VideoJobUpdate:
+            if blips["remaining"] > 0:
+                blips["remaining"] -= 1
+                raise VideoGenerationError("connection reset")
+            return real_get_status(provider_job_id)
+
+        client.get_status = flaky_get_status
+        result = await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+        assert await Video.find(Video.job_id == job.id).count() == 1
+        assert result["video_ids"]
+
+    async def test_sustained_poll_failure_fails_job(self, storage) -> None:
+        job, clip = await _make_job_and_clip()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+        client = FakeVideoService(_updates_to_complete())
+
+        def always_down(provider_job_id: str) -> VideoJobUpdate:
+            raise VideoGenerationError("connection reset")
+
+        client.get_status = always_down
+        with pytest.raises(JobProcessingError, match="status poll failed"):
+            await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
     async def test_provider_failure_fails_job_without_artifacts(self, storage) -> None:
         job, clip = await _make_job_and_clip()
         storage.upload(clip.file_path, FAKE_AUDIO)

--- a/tests/test_video_tasks.py
+++ b/tests/test_video_tasks.py
@@ -71,6 +71,38 @@ class TestGetVideoClient:
 
 
 # ---------------------------------------------------------------------------
+# Processor wiring — CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessorWiring:
+    def test_video_job_type_registered(self) -> None:
+        from acemusic.api.tasks.processor import JobProcessor
+
+        assert VIDEO_JOB_TYPE in JobProcessor()._handlers
+
+    async def test_unconfigured_client_fails_claimed_job(self) -> None:
+        from acemusic.api.tasks.processor import JobProcessor
+
+        processor = JobProcessor(video_client_factory=None)
+        with pytest.raises(JobProcessingError, match="not configured"):
+            await processor._run_video_handler(tasks.process_video_job, None)
+
+    async def test_configured_client_and_storage_injected(self) -> None:
+        from acemusic.api.tasks.processor import JobProcessor
+
+        fake_client, fake_storage, seen = object(), object(), {}
+
+        async def handler(job, *, storage, client):
+            seen.update(storage=storage, client=client)
+            return {"ok": True}
+
+        processor = JobProcessor(video_client_factory=lambda: fake_client, storage_factory=lambda: fake_storage)
+        assert await processor._run_video_handler(handler, None) == {"ok": True}
+        assert seen == {"storage": fake_storage, "client": fake_client}
+
+
+# ---------------------------------------------------------------------------
 # Handler — integration (local MongoDB)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_video_tasks.py
+++ b/tests/test_video_tasks.py
@@ -1,0 +1,189 @@
+"""Tests for the video job handler (US-22.1).
+
+Exercise ``process_video_job`` directly with a fake provider client (dependency
+injection, no monkeypatching) and a local storage backend: it downloads the
+source song, submits it, polls the provider (surfacing progress on
+``job.progress_detail``), stores the rendered MP4 and records a ``Video``
+document. The ``get_video_client`` factory tests run in CI (no DB); the handler
+tests need a local MongoDB (Beanie) and are ``integration``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from acemusic.api.models import Clip, Job, Video, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.services.video import VIDEO_JOB_TYPE
+from acemusic.api.settings import ApiSettings
+from acemusic.api.tasks import video as tasks
+from acemusic.api.tasks.common import JobProcessingError
+from acemusic.storage import LocalStorage
+from acemusic.video_client import VideoGenerationError, VideoJobUpdate
+
+FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 256
+FAKE_AUDIO = b"RIFF" + b"\x00" * 100
+
+
+class FakeVideoService:
+    """Plays back a scripted sequence of status updates, then serves the MP4."""
+
+    def __init__(self, updates: list[VideoJobUpdate], *, submit_error: str | None = None) -> None:
+        self.updates = list(updates)
+        self.submit_error = submit_error
+        self.submitted: list[tuple[str, dict]] = []
+        self.polls = 0
+
+    def submit(self, audio_bytes: bytes, filename: str, params: dict) -> str:
+        if self.submit_error:
+            raise VideoGenerationError(self.submit_error)
+        assert audio_bytes == FAKE_AUDIO
+        self.submitted.append((filename, params))
+        return "pj-1"
+
+    def get_status(self, provider_job_id: str) -> VideoJobUpdate:
+        self.polls += 1
+        # Repeat the final update if polled past the script's end.
+        index = min(self.polls - 1, len(self.updates) - 1)
+        return self.updates[index]
+
+    def download(self, provider_job_id: str) -> bytes:
+        return FAKE_MP4
+
+
+# ---------------------------------------------------------------------------
+# get_video_client factory — CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestGetVideoClient:
+    def test_none_without_config(self) -> None:
+        assert tasks.get_video_client(ApiSettings(_env_file=None)) is None
+
+    def test_none_with_partial_config(self) -> None:
+        assert tasks.get_video_client(ApiSettings(_env_file=None, video_api_key="vk")) is None
+        assert tasks.get_video_client(ApiSettings(_env_file=None, video_api_url="https://v.test")) is None
+
+    def test_client_when_configured(self) -> None:
+        settings = ApiSettings(_env_file=None, video_api_url="https://v.test", video_api_key="vk")
+        client = tasks.get_video_client(settings)
+        assert client is not None and client.api_key == "vk" and client.base_url == "https://v.test"
+
+
+# ---------------------------------------------------------------------------
+# Handler — integration (local MongoDB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage(mongo_db, tmp_path) -> LocalStorage:
+    return LocalStorage(tmp_path / "storage")
+
+
+async def _make_job_and_clip() -> tuple[Job, Clip]:
+    user = await user_service.get_or_create_user(email="v@e.com", provider="google", oauth_id="g-v", name="V")
+    workspace = Workspace(name="WS", user_id=user.id)
+    await workspace.insert()
+    clip = Clip(user_id=user.id, workspace_id=workspace.id, file_path="song.wav", title="Song", duration=10.0)
+    await clip.insert()
+    params = {"clip_id": str(clip.id), "prompt": "neon city", "resolution": "720p", "aspect_ratio": "16:9"}
+    job = Job(user_id=user.id, workspace_id=workspace.id, job_type=VIDEO_JOB_TYPE, input_params=params)
+    await job.insert()
+    return job, clip
+
+
+def _updates_to_complete() -> list[VideoJobUpdate]:
+    return [
+        VideoJobUpdate(state="queued", progress=0),
+        VideoJobUpdate(state="rendering", progress=40, eta_seconds=30.0),
+        VideoJobUpdate(state="encoding", progress=90, eta_seconds=5.0),
+        VideoJobUpdate(state="complete", progress=100),
+    ]
+
+
+@pytest.mark.integration
+class TestProcessVideoJob:
+    async def test_success_stores_mp4_and_records_video(self, storage) -> None:
+        job, clip = await _make_job_and_clip()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+        client = FakeVideoService(_updates_to_complete())
+
+        result = await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+        videos = await Video.find(Video.clip_id == clip.id).to_list()
+        assert len(videos) == 1
+        video = videos[0]
+        assert result == {"video_ids": [str(video.id)], "storage_path": video.storage_path}
+        assert video.user_id == job.user_id and video.job_id == job.id
+        assert video.resolution == "720p" and video.aspect_ratio == "16:9"
+        assert video.storage_path == f"{job.user_id}/{job.workspace_id}/videos/{clip.id}/{job.id}.mp4"
+        # The stored object is the provider's rendered MP4, byte for byte.
+        assert storage.download(video.storage_path) == FAKE_MP4
+        # The poll loop walked the provider states and left the terminal detail.
+        assert client.polls >= 4
+        fresh = await Job.get(job.id)
+        assert fresh.progress_detail == {"state": "complete", "progress": 100}
+
+    async def test_submit_receives_params_without_clip_id(self, storage) -> None:
+        job, clip = await _make_job_and_clip()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+        client = FakeVideoService(_updates_to_complete())
+
+        await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+        (filename, params), *_ = client.submitted
+        assert filename == f"{clip.id}.wav"
+        assert "clip_id" not in params
+        assert params["prompt"] == "neon city"
+
+    async def test_progress_detail_written_during_polling(self, storage, monkeypatch) -> None:
+        """Each poll persists the provider's state so the status endpoint can serve it live."""
+        job, clip = await _make_job_and_clip()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+        client = FakeVideoService(_updates_to_complete())
+        seen: list[dict | None] = []
+        original = tasks._set_progress
+
+        async def _spy(job_, state, progress, eta_seconds):
+            await original(job_, state, progress, eta_seconds)
+            seen.append((await Job.get(job_.id)).progress_detail)
+
+        monkeypatch.setattr(tasks, "_set_progress", _spy)
+        await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+        assert {"state": "rendering", "progress": 40, "eta_seconds": 30.0} in seen
+        assert {"state": "encoding", "progress": 90, "eta_seconds": 5.0} in seen
+
+    async def test_provider_failure_fails_job_without_artifacts(self, storage) -> None:
+        job, clip = await _make_job_and_clip()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+        client = FakeVideoService([VideoJobUpdate(state="failed", error="render farm on fire")])
+
+        with pytest.raises(JobProcessingError, match="render farm on fire"):
+            await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+        assert await Video.find(Video.job_id == job.id).count() == 0
+
+    async def test_submit_error_fails_job(self, storage) -> None:
+        job, clip = await _make_job_and_clip()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+        client = FakeVideoService([], submit_error="401 from provider")
+
+        with pytest.raises(JobProcessingError, match="submission failed"):
+            await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+    async def test_poll_timeout_fails_job(self, storage) -> None:
+        job, clip = await _make_job_and_clip()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+        client = FakeVideoService([VideoJobUpdate(state="rendering", progress=10)])
+
+        with pytest.raises(JobProcessingError, match="timed out"):
+            await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0, poll_timeout=0)
+
+    async def test_missing_source_clip_fails_job(self, storage) -> None:
+        job, clip = await _make_job_and_clip()
+        await clip.delete()
+        client = FakeVideoService(_updates_to_complete())
+
+        with pytest.raises(JobProcessingError, match="no longer exists"):
+            await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)


### PR DESCRIPTION
## Summary
Implements #311: US-22.1 Video Generation Backend Integration — the foundational plumbing for the Stage 22 music-video feature.

- `POST /api/v1/videos/generate` — credit-gated submission (5–10 credits by resolution + long-duration surcharge, atomically deducted with refund-on-failure and best-effort ledger); validates clip ownership before any charge; 503 before any charge on an unconfigured deployment.
- `GET /api/v1/videos/{job_id}/status` — maps the platform's 4-state job lifecycle plus the provider's live `progress_detail` onto the story vocabulary (queued/rendering/encoding/complete/failed) with progress % and ETA.
- `HttpVideoClient` (`src/acemusic/video_client.py`) — provider-generic (Runway/Pika-class) sync httpx client behind a `VideoGenerationService` protocol; unbilled calls use the shared `_http` 3-retry/backoff policy, the billed submit uses `retries=0` (mirrors `image_client`).
- Video job handler (`tasks/video.py`) — downloads the source song, submits + polls the provider (tolerating up to 2 consecutive transient poll failures), stores the rendered MP4 at a job-namespaced key, and records a `Video` document associated with the source clip; rollback-on-failure leaves no orphaned objects.
- Wired into the `JobProcessor` handler registry with a `video_client_factory` (unconfigured claim fails with a clear message); settings `ACEMUSIC_API_VIDEO_API_URL`/`_KEY` + `video_enabled` gate, documented in `.env.example`.
- Additive `Job.progress_detail: dict | None` field — the 4-state `JobStatus` and claim query are untouched.

## Acceptance Criteria
- [x] POST endpoint accepts valid parameters and returns a job ID — 202 `{job_id, status:"queued"}`, full options snapshot persisted (tests: `TestSuccessfulSubmission`)
- [x] Job status endpoint reports progress through all states to completion (tests: `TestStatusEndpoint`, handler progress tests)
- [x] Completed video is a valid MP4 with audio muxed in — provider renders; backend stores byte-for-byte and associates via `Video` doc (test: `test_success_stores_mp4_and_records_video`; live demo in PR comments)
- [x] Insufficient credits returns 402 with explanation `{error, balance, required}` (tests: `TestInsufficientCredits`)
- [x] Provider failure triggers retry (up to 3 attempts) before marking as failed — shared `_http` retry on unbilled calls + poll-blip tolerance; exhausted retries fail the job (tests: `TestRetryPolicy`, `test_sustained_poll_failure_fails_job`)

## Test Plan
- [x] TDD: 60 new tests (client unit, handler integration with DI fakes, API integration over real MongoDB) + credits cost-table tests
- [x] Full default suite green (1704 passed) + targeted integration on touched shared areas (109 passed)
- [x] Diff coverage 93% on changed lines (gate 85%)
- [x] Linting clean (black + ruff, pre-commit hooks)
- [x] Internal code review (advisory) completed — 1 Critical + 3 Major found and fixed (see second commit)
- [x] Cross-family review pass: codex (opencode/GLM stalled after 43 min and was killed; codex verdict: no correctness/security/reliability regressions)
- [x] Mutation sanity check: 4 targeted mutations each made their test fail

## Known Limitations / Intentionally Deferred
- **No live provider credentials exist** — `HttpVideoClient` is mock-verified only (same status as `DolbyClient`/US-12.2); the payload shape is provider-generic, not Runway/Pika-specific. Live payload verification happens when credentials arrive.
- **No MP4 download/serving endpoint** — delivery/publish UI is US-22.3; this story stores + associates only.
- **Lyrics sync / transitions / reference images are passed through** to the provider payload, not locally processed.
- **Cross-process config-skew refund not implemented**: the 503 pre-charge gate closes the credit-loss path for any single-config deployment (settings are process-static). A mastering-style `_refund_unperformed` for a multi-process deployment with divergent configs was judged YAGNI.
- **Handler worst-case wall time can exceed the processor's 900s stale-requeue window** in multi-process deployments only (the stale sweep runs at process start; single-process restarts are safe). Documented in `tasks/video.py`; revisit if video runs multi-process.

## Implementation Notes
- Plan was self-authored (no plan comment existed on the issue) and posted to #311.
- Kept the platform-wide 4-state `JobStatus`; the story's 5-state vocabulary lives in the additive `progress_detail` field mapped by the video status route (mirrors how mastering added its own detail route beside the generic jobs route).
- `Video` document mirrors `ArtworkOption` (not a child `Clip` — `Clip` is audio-shaped and feeds streaming/search surfaces).
- Video costs live in a separate `get_video_cost(resolution, duration_s)` table; `_COSTS` untouched (`get_cost("video")` intentionally still raises, per existing test contract).

Closes #311