### PR TITLE
feat(web): US-22.2 Video Creation Page (#312)

### DIFF
--- a/docs/demos/us-22.2-video-creation-page.md
+++ b/docs/demos/us-22.2-video-creation-page.md
@@ -1,0 +1,79 @@
+# US-22.2 Video Creation Page — live demo (PR #363)
+
+*2026-07-25, driven by Playwright (chromium) against the full local stack.*
+
+Stack: next dev (port 3000, BFF proxies) → real FastAPI (port 8000) with the
+in-process JobProcessor → real MongoDB → a scripted stand-in video provider
+(port 8399) serving an ffmpeg-rendered MP4 and a scripted status sequence
+(rendering 35% → rendering 70% → encoding 90% → complete). No live provider
+credentials exist in this environment (same disclosure as US-22.1). Auth via
+minted single-use refresh cookies for two seeded users: `demo-free` (free
+tier) and `demo-pro` (pro tier), each with 50.0 credits and an owned clip.
+
+## Driver transcript (every assertion is against the live page)
+
+```
+PASS AC1 — heading Neon Nights visible
+PASS AC1 — duration 0:30 visible
+PASS AC1 — style tag synthwave visible
+PASS AC1 — play button visible
+PASS AC1 — style prompt visible
+PASS AC1 — preset group visible
+PASS AC1 — reference images input visible
+PASS AC1 — lyrics sync switch visible
+PASS AC1 — aspect ratio group visible
+PASS AC1 — resolution group visible
+PASS AC1 — frame rate group visible
+PASS AC1 — transitions group visible
+PASS AC1 — generate button visible
+PASS AC1 — credit estimate visible
+PASS AC2 — Generate disabled before any style input
+PASS AC2 — preset seeded prompt: "Cinematic film scenes with dramatic lighting and sweeping ca…"
+PASS AC2 — Generate enabled after preset
+PASS AC3 — two Pro badges (1080p, 4K)
+PASS AC3 — 1080p radio disabled on free tier
+PASS AC3 — 4K radio disabled on free tier
+PASS AC3 — upgrade prompt shown
+PASS AC5 — combination selectable: 16:9 Landscape x 720p
+PASS AC5 — combination selectable: 16:9 Landscape x 1080p Pro
+PASS AC5 — combination selectable: 16:9 Landscape x 4K Pro
+PASS AC5 — combination selectable: 9:16 Vertical x 720p
+PASS AC5 — combination selectable: 9:16 Vertical x 1080p Pro
+PASS AC5 — combination selectable: 9:16 Vertical x 4K Pro
+PASS AC5 — combination selectable: 1:1 Square x 720p
+PASS AC5 — combination selectable: 1:1 Square x 1080p Pro
+PASS AC5 — combination selectable: 1:1 Square x 4K Pro
+PASS AC5 — 4K estimate reflects tier pricing: "Estimated cost: 8 credits"
+PASS AC4 — progress view replaced the form after submit
+PASS AC4 — live provider states observed: [queued, rendering, encoding, ready]
+PASS AC4 — render completed — 'ready' shown
+ALL ACCEPTANCE CRITERIA PASSED
+```
+
+## Backend outcome evidence (the submit was real, not visual)
+
+```
+pro user credits_balance: 45 (seeded 50, 720p costs 5)
+video doc: {"clip_id":"6a656e5018a46724e357ddd0","resolution":"720p",
+  "aspect_ratio":"1:1","storage_path":".../videos/6a656e5018a46724e357ddd0/6a656ed311342689d17c28d9.mp4"}
+job: {"_id":"6a656ed311342689d17c28d9","status":"completed"}
+```
+
+The UI's last-selected aspect ratio (`1:1`) flowed through the form → BFF
+proxy → `POST /api/v1/videos/generate` params → stored `Video` document, the
+5.0-credit charge landed atomically, and the page's poll loop surfaced the
+provider's rendering/encoding states live before showing completion.
+
+## Acceptance-criteria map
+
+| Criterion | Evidence |
+|---|---|
+| Page loads with song metadata and all controls | 14 AC1 assertions + `ac1-page-loaded.png` |
+| Presets populate the style prompt | AC2 assertions (exact seeded text) |
+| Pro badge + upgrade prompt for Free users on 1080p/4K | AC3 assertions + `ac3-pro-gating.png` |
+| Generate submits and transitions to a progress view | AC4 assertions + credits/job/Video Mongo evidence |
+| All aspect × resolution combinations selectable | 9 AC5 assertions (pro user) |
+
+Screenshots captured to the session scratchpad (`ac1`–`ac5` PNGs); driver
+script: `drive_us222.js` (Playwright, refresh-cookie auth per the proven
+web-demo recipe).

--- a/web/README.md
+++ b/web/README.md
@@ -304,6 +304,31 @@ once) so both the timeline and the panel observe the same `AudioContext`.
   -6 dB ceiling caps a near-0 dBFS tone at ≈ -2 dBFS rather than exactly -6.
   Exact adherence needs an AudioWorklet limiter (deferred by design).
 
+## Video Creation Page (US-22.2)
+
+The `/video/[songId]` route configures and submits a music-video render over
+the US-22.1 backend. Reached from the song menu's Pro-only "Create Music
+Video" action (`create-video` in `lib/song-actions.ts`, `workflow:
+"navigation"`).
+
+- `app/video/[songId]/page.tsx` — thin route shim; delegates to `VideoCreator`.
+- `components/video/VideoCreator.tsx` — auth guard, `useClip` load/not-found,
+  and the form ⇄ progress swap (the form unmounts the moment a job submits).
+- `components/video/VideoForm.tsx` — style prompt + preset chips that seed it,
+  reference-image picker (local previews only — the backend takes hosted
+  http(s) URLs and no hosting endpoint exists yet, so submissions omit them),
+  lyrics-sync switch, RadioGroup-fieldset pickers (aspect ratio, resolution,
+  frame rate, transitions), live credit estimate, and UI Pro-gating on
+  1080p/4K (lock badge + upgrade copy; server enforcement is Stage 26).
+- `components/video/VideoProgress.tsx` — minimal progress view (state label,
+  bar, ETA, error/retry); the rich delivery UX is US-22.3.
+- `components/video/SourceSongCard.tsx` — title/duration/style tags with
+  play/pause through the cookie-authed `/api/clips/{id}/stream` proxy.
+- `hooks/use-video-job.ts` — submit → poll state machine (mirrors
+  `use-mastering-job`); `lib/video.ts` — typed client + option tables +
+  `estimateVideoCost` (client mirror of `credits.get_video_cost`); BFF proxies
+  under `app/api/videos/`.
+
 ## Adding components
 
 To add components to your app, run the following command:

--- a/web/app/api/videos/[jobId]/status/route.ts
+++ b/web/app/api/videos/[jobId]/status/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/videos/{job_id}/status (US-22.2). The video
+// page polls this after a 202 to drive queued → rendering/encoding →
+// complete/failed. Status/body pass through verbatim (200 with the job detail,
+// 401, 404 when the job is unknown or not owned).
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ jobId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { jobId } = await ctx.params
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/videos/${encodeURIComponent(jobId)}/status`,
+      { headers: { authorization: auth, accept: "application/json" } }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Video service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/videos/generate/route.ts
+++ b/web/app/api/videos/generate/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for POST /api/v1/videos/generate (US-22.2). The client
+// holds the access token in memory and sends it as a Bearer header; this route
+// forwards it so the backend URL stays server-side. Status/body pass through
+// verbatim: 202 (queued), 401, 402 (insufficient credits), 404, 422, 503.
+
+const TARGET = `${BACKEND_URL}/api/v1/videos/generate`
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  let res: Response
+  try {
+    res = await fetch(TARGET, {
+      method: "POST",
+      headers: {
+        authorization: auth,
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: await request.text(),
+    })
+  } catch {
+    return NextResponse.json(
+      { detail: "Video service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/video/[songId]/page.tsx
+++ b/web/app/video/[songId]/page.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { useParams } from "next/navigation"
+
+import { VideoCreator } from "@/components/video/VideoCreator"
+
+// Video creation page (US-22.2). Thin shim over VideoCreator (editor/[id]
+// idiom) so the content is testable without a navigation mock.
+export default function VideoPage() {
+  const params = useParams<{ songId: string }>()
+  const songId = params?.songId
+  if (!songId) return null
+  return <VideoCreator songId={songId} />
+}

--- a/web/components/video/SourceSongCard.test.tsx
+++ b/web/components/video/SourceSongCard.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { SourceSongCard } from "@/components/video/SourceSongCard"
+import type { Clip } from "@/lib/workspace-clips"
+
+const clip = {
+  id: "c1",
+  workspace_id: "w1",
+  title: "Neon Nights",
+  format: "wav",
+  duration: 125,
+  bpm: 120,
+  key: "C",
+  style_tags: ["synthwave", "retro"],
+  lyrics: null,
+  vocal_language: null,
+  model: null,
+  seed: null,
+  inference_steps: null,
+  parent_clip_ids: [],
+  generation_mode: null,
+  is_public: false,
+  created_at: "2026-01-01T00:00:00Z",
+} as Clip
+
+describe("SourceSongCard", () => {
+  it("shows title, duration, and style tags", () => {
+    render(<SourceSongCard clip={clip} />)
+    expect(screen.getByRole("heading", { name: "Neon Nights" })).toBeInTheDocument()
+    expect(screen.getByText("2:05")).toBeInTheDocument()
+    expect(screen.getByText("synthwave")).toBeInTheDocument()
+    expect(screen.getByText("retro")).toBeInTheDocument()
+  })
+
+  it("streams the clip through the cookie-authed proxy and toggles play", () => {
+    render(<SourceSongCard clip={clip} />)
+    const audio = screen.getByTestId("source-audio") as HTMLAudioElement
+    expect(audio).toHaveAttribute("src", "/api/clips/c1/stream")
+
+    fireEvent.click(screen.getByRole("button", { name: /play/i }))
+    // jsdom's play() is a stub that doesn't fire events; simulate the browser.
+    fireEvent.play(audio)
+    expect(screen.getByRole("button", { name: /pause/i })).toBeInTheDocument()
+    fireEvent.pause(audio)
+    expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument()
+  })
+})

--- a/web/components/video/SourceSongCard.tsx
+++ b/web/components/video/SourceSongCard.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { MusicNote01Icon, PauseIcon, PlayIcon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { clipAudioUrl, formatTime } from "@/lib/clips"
+import type { Clip } from "@/lib/workspace-clips"
+
+/**
+ * Source-song card for the video page (US-22.2): music-glyph thumbnail (no
+ * artwork proxy exists in web/), title, duration, style tags, and play/pause
+ * driven by the cookie-authed `/stream` proxy (preview-player idiom).
+ */
+export function SourceSongCard({ clip }: { clip: Clip }) {
+  const audioRef = useRef<HTMLAudioElement>(null)
+  const [playing, setPlaying] = useState(false)
+
+  function togglePlay() {
+    const audio = audioRef.current
+    if (!audio) return
+    // jsdom's play() is a no-op stub; optional-chain the promise so a rejected
+    // autoplay (or the stub) never throws.
+    if (audio.paused) audio.play()?.catch(() => {})
+    else audio.pause()
+  }
+
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-4 p-4">
+        <audio
+          ref={audioRef}
+          src={clipAudioUrl(clip.id)}
+          onPlay={() => setPlaying(true)}
+          onPause={() => setPlaying(false)}
+          onEnded={() => setPlaying(false)}
+          data-testid="source-audio"
+        />
+
+        <span className="flex size-16 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+          <HugeiconsIcon icon={MusicNote01Icon} size={24} />
+        </span>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <h2 className="truncate text-lg font-semibold">
+            {clip.title ?? "Untitled"}
+          </h2>
+          <p className="text-sm text-muted-foreground tabular-nums">
+            {formatTime(clip.duration ?? 0)}
+          </p>
+          {clip.style_tags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1 pt-1">
+              {clip.style_tags.map((tag) => (
+                <Badge key={tag} variant="secondary">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <Button
+          type="button"
+          size="icon"
+          variant="secondary"
+          onClick={togglePlay}
+          aria-label={playing ? "Pause" : "Play"}
+        >
+          <HugeiconsIcon icon={playing ? PauseIcon : PlayIcon} size={18} />
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/components/video/VideoCreator.test.tsx
+++ b/web/components/video/VideoCreator.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { VideoCreator } from "@/components/video/VideoCreator"
+import type { VideoJobState } from "@/hooks/use-video-job"
+import type { Clip } from "@/lib/workspace-clips"
+
+vi.mock("@/hooks/use-require-auth", () => ({
+  useRequireAuth: () => ({ isLoading: false, isAuthenticated: true }),
+}))
+
+const clip = {
+  id: "c1",
+  workspace_id: "w1",
+  title: "Neon Nights",
+  duration: 120,
+  style_tags: [],
+  parent_clip_ids: [],
+  is_public: false,
+  created_at: "2026-01-01T00:00:00Z",
+} as unknown as Clip
+
+let clipResult: { clip: Clip | null; loading: boolean; notFound: boolean }
+vi.mock("@/hooks/use-clip", () => ({
+  useClip: () => clipResult,
+}))
+
+let jobState: VideoJobState
+const submit = vi.fn()
+vi.mock("@/hooks/use-video-job", () => ({
+  useVideoJob: () => ({ state: jobState, submit, retry: vi.fn(), reset: vi.fn() }),
+}))
+
+// Sibling components own their behavior tests; stub them to isolate composition.
+vi.mock("@/components/video/SourceSongCard", () => ({
+  SourceSongCard: ({ clip: c }: { clip: Clip }) => (
+    <div data-testid="source-card">{c.title}</div>
+  ),
+}))
+vi.mock("@/components/video/VideoForm", () => ({
+  VideoForm: ({ onGenerate }: { onGenerate: (c: unknown) => void }) => (
+    <button onClick={() => onGenerate({ prompt: "x" })}>mock-generate</button>
+  ),
+}))
+
+beforeEach(() => {
+  clipResult = { clip, loading: false, notFound: false }
+  jobState = { phase: "idle" }
+})
+
+afterEach(() => vi.clearAllMocks())
+
+describe("VideoCreator", () => {
+  it("renders the source card and the form for a loaded song", () => {
+    render(<VideoCreator songId="c1" />)
+    expect(screen.getByTestId("source-card")).toHaveTextContent("Neon Nights")
+    expect(screen.getByRole("button", { name: "mock-generate" })).toBeInTheDocument()
+  })
+
+  it("submits the config for the routed song id", () => {
+    render(<VideoCreator songId="c1" />)
+    fireEvent.click(screen.getByRole("button", { name: "mock-generate" }))
+    expect(submit).toHaveBeenCalledWith("c1", { prompt: "x" })
+  })
+
+  it("swaps the form for the progress view once a job is running", () => {
+    jobState = {
+      phase: "polling",
+      detail: { job_id: "j1", status: "rendering", progress: 10 },
+    }
+    render(<VideoCreator songId="c1" />)
+    expect(
+      screen.queryByRole("button", { name: "mock-generate" })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("status")).toHaveTextContent(/rendering/i)
+  })
+
+  it("shows a loading state while the song loads", () => {
+    clipResult = { clip: null, loading: true, notFound: false }
+    render(<VideoCreator songId="c1" />)
+    expect(screen.getByRole("status")).toHaveTextContent(/loading song/i)
+  })
+
+  it("shows not-found for an unknown song", () => {
+    clipResult = { clip: null, loading: false, notFound: true }
+    render(<VideoCreator songId="nope" />)
+    expect(screen.getByText(/song not found/i)).toBeInTheDocument()
+  })
+})

--- a/web/components/video/VideoCreator.tsx
+++ b/web/components/video/VideoCreator.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import Link from "next/link"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { SourceSongCard } from "@/components/video/SourceSongCard"
+import { VideoForm } from "@/components/video/VideoForm"
+import { VideoProgress } from "@/components/video/VideoProgress"
+import { useClip } from "@/hooks/use-clip"
+import { useRequireAuth } from "@/hooks/use-require-auth"
+import { useVideoJob } from "@/hooks/use-video-job"
+import type { VideoConfig } from "@/lib/video"
+
+/**
+ * Video creation page content (US-22.2): the source song, the render
+ * configuration form, and — once submitted — the progress view. The form and
+ * progress swap in place; submitting is a one-way transition until the job
+ * completes, fails, or is reset.
+ */
+export function VideoCreator({ songId }: { songId: string }) {
+  const { isLoading: authLoading, isAuthenticated } = useRequireAuth()
+  const { clip, loading, notFound } = useClip(songId)
+  const { state, submit, retry, reset } = useVideoJob()
+
+  // Render nothing until authed — useRequireAuth redirects otherwise (mirrors
+  // app/release/page.tsx).
+  if (authLoading || !isAuthenticated) return null
+
+  function handleGenerate(config: VideoConfig) {
+    void submit(songId, config)
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-8">
+      <h1 className="text-2xl font-semibold">Create Music Video</h1>
+
+      {loading ? (
+        <p role="status" className="text-sm text-muted-foreground">
+          Loading song…
+        </p>
+      ) : notFound || !clip ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Song not found</CardTitle>
+            <CardDescription>
+              That song is unavailable.{" "}
+              <Link
+                href="/dashboard"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Back to your songs
+              </Link>
+              .
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <>
+          <SourceSongCard clip={clip} />
+          <Card>
+            <CardHeader>
+              <CardTitle>Visual settings</CardTitle>
+              <CardDescription>
+                Describe the look of your video, or start from a preset.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {state.phase === "idle" ? (
+                <VideoForm clip={clip} onGenerate={handleGenerate} />
+              ) : (
+                <VideoProgress state={state} onRetry={retry} onReset={reset} />
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/components/video/VideoForm.test.tsx
+++ b/web/components/video/VideoForm.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { VideoForm } from "@/components/video/VideoForm"
+import type { Clip } from "@/lib/workspace-clips"
+
+let tier = { tier: "free", isFreeTier: true, isLoading: false }
+vi.mock("@/hooks/use-subscription-tier", () => ({
+  useSubscriptionTier: () => tier,
+}))
+
+const clip = {
+  id: "c1",
+  workspace_id: "w1",
+  title: "Neon Nights",
+  format: "wav",
+  duration: 120,
+  bpm: 120,
+  key: "C",
+  style_tags: ["synthwave"],
+  lyrics: null,
+  vocal_language: null,
+  model: null,
+  seed: null,
+  inference_steps: null,
+  parent_clip_ids: [],
+  generation_mode: null,
+  is_public: false,
+  created_at: "2026-01-01T00:00:00Z",
+} as Clip
+
+function renderForm(onGenerate = vi.fn(), c: Clip = clip) {
+  render(<VideoForm clip={c} onGenerate={onGenerate} />)
+  return onGenerate
+}
+
+beforeEach(() => {
+  tier = { tier: "free", isFreeTier: true, isLoading: false }
+  // Unique URL per call, like the real API — previews are keyed/removed by URL.
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn((f: File) => `blob:${f.name}`),
+    revokeObjectURL: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe("VideoForm", () => {
+  it("renders every configuration control", () => {
+    renderForm()
+    expect(screen.getByLabelText(/style prompt/i)).toBeInTheDocument()
+    expect(screen.getByRole("group", { name: /style preset/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/reference images/i)).toBeInTheDocument()
+    expect(screen.getByRole("switch", { name: /lyrics sync/i })).toBeInTheDocument()
+    expect(screen.getByRole("radiogroup", { name: /aspect ratio/i })).toBeInTheDocument()
+    expect(screen.getByRole("radiogroup", { name: /resolution/i })).toBeInTheDocument()
+    expect(screen.getByRole("radiogroup", { name: /frame rate/i })).toBeInTheDocument()
+    expect(screen.getByRole("radiogroup", { name: /transitions/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /generate video/i })).toBeInTheDocument()
+  })
+
+  it("keeps Generate disabled until a prompt or preset is chosen", () => {
+    const onGenerate = renderForm()
+    const generate = screen.getByRole("button", { name: /generate video/i })
+    expect(generate).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/style prompt/i), {
+      target: { value: "neon skyline" },
+    })
+    expect(generate).toBeEnabled()
+
+    fireEvent.click(generate)
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "neon skyline",
+        lyrics_sync: false,
+        aspect_ratio: "16:9",
+        resolution: "720p",
+        frame_rate: 30,
+        transitions: "auto",
+      })
+    )
+    // No hosted image URLs exist (no upload endpoint) — must not send any.
+    expect(onGenerate.mock.calls[0][0].reference_image_urls).toBeUndefined()
+  })
+
+  it("selecting a preset populates the prompt and enables Generate", () => {
+    const onGenerate = renderForm()
+    fireEvent.click(screen.getByRole("button", { name: /cinematic/i }))
+
+    const prompt = screen.getByLabelText(/style prompt/i) as HTMLTextAreaElement
+    expect(prompt.value).toMatch(/cinematic film scenes/i)
+
+    const generate = screen.getByRole("button", { name: /generate video/i })
+    expect(generate).toBeEnabled()
+    fireEvent.click(generate)
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ style_preset: "cinematic" })
+    )
+  })
+
+  it("shows a Pro badge and disables 1080p/4K for free users, with upgrade copy", () => {
+    renderForm()
+    const resolutions = screen.getByRole("radiogroup", { name: /resolution/i })
+    expect(within(resolutions).getByRole("radio", { name: /720p/i })).toBeEnabled()
+    expect(within(resolutions).getByRole("radio", { name: /1080p/i })).toBeDisabled()
+    expect(within(resolutions).getByRole("radio", { name: /4k/i })).toBeDisabled()
+    expect(within(resolutions).getAllByText("Pro")).toHaveLength(2)
+    expect(screen.getByText(/upgrade to pro/i)).toBeInTheDocument()
+  })
+
+  it("lets Pro users select every resolution and aspect ratio combination", () => {
+    tier = { tier: "pro", isFreeTier: false, isLoading: false }
+    const onGenerate = renderForm()
+    fireEvent.change(screen.getByLabelText(/style prompt/i), {
+      target: { value: "x" },
+    })
+    expect(screen.queryByText(/upgrade to pro/i)).not.toBeInTheDocument()
+
+    const aspects = screen.getByRole("radiogroup", { name: /aspect ratio/i })
+    const resolutions = screen.getByRole("radiogroup", { name: /resolution/i })
+    // Accessible names are the full labels ("16:9 Landscape", "1080p Pro", …).
+    const aspectName: Record<string, RegExp> = {
+      "16:9": /^16:9/,
+      "9:16": /^9:16/,
+      "1:1": /^1:1/,
+    }
+    for (const aspect of ["16:9", "9:16", "1:1"]) {
+      for (const res of ["720p", "1080p", "4K"]) {
+        fireEvent.click(
+          within(aspects).getByRole("radio", { name: aspectName[aspect] })
+        )
+        fireEvent.click(within(resolutions).getByRole("radio", { name: new RegExp(`^${res}`, "i") }))
+        fireEvent.click(screen.getByRole("button", { name: /generate video/i }))
+        expect(onGenerate).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            aspect_ratio: aspect,
+            resolution: res === "4K" ? "4k" : res,
+          })
+        )
+      }
+    }
+    expect(onGenerate).toHaveBeenCalledTimes(9)
+  })
+
+  it("shows the credit estimate and updates it with resolution and duration", () => {
+    tier = { tier: "pro", isFreeTier: false, isLoading: false }
+    renderForm()
+    expect(screen.getByText(/estimated cost/i)).toHaveTextContent("5 credits")
+
+    const resolutions = screen.getByRole("radiogroup", { name: /resolution/i })
+    fireEvent.click(within(resolutions).getByRole("radio", { name: /1080p/i }))
+    expect(screen.getByText(/estimated cost/i)).toHaveTextContent("7 credits")
+  })
+
+  it("adds the long-song surcharge to the estimate", () => {
+    renderForm(vi.fn(), { ...clip, duration: 200 })
+    expect(screen.getByText(/estimated cost/i)).toHaveTextContent("7 credits")
+  })
+
+  it("accepts up to five reference images with removable previews", () => {
+    renderForm()
+    const input = screen.getByLabelText(/reference images/i)
+    const img = (n: string) => new File(["x"], n, { type: "image/png" })
+
+    fireEvent.change(input, { target: { files: [img("a.png"), img("b.png")] } })
+    expect(screen.getAllByRole("img", { name: /reference/i })).toHaveLength(2)
+
+    fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0])
+    expect(screen.getAllByRole("img", { name: /reference/i })).toHaveLength(1)
+  })
+
+  it("rejects more than five reference images and non-image files", () => {
+    renderForm()
+    const input = screen.getByLabelText(/reference images/i)
+    const img = (n: string) => new File(["x"], n, { type: "image/png" })
+
+    fireEvent.change(input, {
+      target: {
+        files: [img("1"), img("2"), img("3"), img("4"), img("5"), img("6")],
+      },
+    })
+    expect(screen.getByText(/up to 5 reference images/i)).toBeInTheDocument()
+    expect(screen.queryAllByRole("img", { name: /reference/i })).toHaveLength(0)
+
+    // The input remounts (key bump) after every selection so the same files can
+    // be re-picked — re-query rather than reusing the detached node.
+    fireEvent.change(screen.getByLabelText(/reference images/i), {
+      target: { files: [new File(["x"], "doc.pdf", { type: "application/pdf" })] },
+    })
+    expect(screen.getByText(/image files only/i)).toBeInTheDocument()
+  })
+
+  it("caps the style prompt at the backend limit", () => {
+    renderForm()
+    const prompt = screen.getByLabelText(/style prompt/i)
+    expect(prompt).toHaveAttribute("maxlength", "2000")
+  })
+
+  it("disables the whole form while submitting", () => {
+    render(<VideoForm clip={clip} onGenerate={vi.fn()} disabled />)
+    expect(screen.getByRole("button", { name: /generate video/i })).toBeDisabled()
+    expect(screen.getByLabelText(/style prompt/i)).toBeDisabled()
+  })
+})

--- a/web/components/video/VideoForm.test.tsx
+++ b/web/components/video/VideoForm.test.tsx
@@ -195,6 +195,18 @@ describe("VideoForm", () => {
     expect(screen.getByText(/image files only/i)).toBeInTheDocument()
   })
 
+  it("revokes preview object URLs on unmount", () => {
+    const { unmount } = render(<VideoForm clip={clip} onGenerate={vi.fn()} />)
+    const input = screen.getByLabelText(/reference images/i)
+    fireEvent.change(input, {
+      target: { files: [new File(["x"], "a.png", { type: "image/png" })] },
+    })
+    expect(screen.getAllByRole("img", { name: /reference/i })).toHaveLength(1)
+
+    unmount()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:a.png")
+  })
+
   it("caps the style prompt at the backend limit", () => {
     renderForm()
     const prompt = screen.getByLabelText(/style prompt/i)

--- a/web/components/video/VideoForm.test.tsx
+++ b/web/components/video/VideoForm.test.tsx
@@ -213,9 +213,4 @@ describe("VideoForm", () => {
     expect(prompt).toHaveAttribute("maxlength", "2000")
   })
 
-  it("disables the whole form while submitting", () => {
-    render(<VideoForm clip={clip} onGenerate={vi.fn()} disabled />)
-    expect(screen.getByRole("button", { name: /generate video/i })).toBeDisabled()
-    expect(screen.getByLabelText(/style prompt/i)).toBeDisabled()
-  })
 })

--- a/web/components/video/VideoForm.tsx
+++ b/web/components/video/VideoForm.tsx
@@ -1,0 +1,337 @@
+"use client"
+
+import { useState } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Cancel01Icon, LockIcon } from "@hugeicons/core-free-icons"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { useSubscriptionTier } from "@/hooks/use-subscription-tier"
+import {
+  MAX_REFERENCE_IMAGES,
+  PROMPT_MAX_LENGTH,
+  VIDEO_ASPECT_RATIOS,
+  VIDEO_FRAME_RATES,
+  VIDEO_RESOLUTIONS,
+  VIDEO_STYLE_PRESETS,
+  VIDEO_TRANSITIONS,
+  estimateVideoCost,
+  type VideoAspectRatio,
+  type VideoConfig,
+  type VideoFrameRate,
+  type VideoResolution,
+  type VideoStylePreset,
+  type VideoTransitions,
+} from "@/lib/video"
+import type { Clip } from "@/lib/workspace-clips"
+
+/** One locally selected reference image and its preview object URL. */
+type ReferenceImage = { file: File; url: string }
+
+/**
+ * Video configuration form (US-22.2): style prompt + presets, reference images,
+ * lyrics sync, and the aspect/resolution/frame-rate/transitions pickers, with a
+ * live credit estimate. Generate stays disabled until a prompt or preset exists
+ * (the backend 422s otherwise). Pickers are inlined RadioGroups in fieldsets
+ * (mastering-config idiom — the codebase has no Select/ToggleGroup primitive).
+ *
+ * Pro gating: 1080p/4K are badge-locked and disabled for free users
+ * (SongActionsMenu idiom). Reference images are previewed locally but not sent —
+ * the backend accepts only hosted http(s) URLs and no image-hosting endpoint
+ * exists yet (documented limitation; wiring lands with a Stage 22 follow-up).
+ */
+export function VideoForm({
+  clip,
+  onGenerate,
+  disabled = false,
+}: {
+  clip: Clip
+  onGenerate: (config: VideoConfig) => void
+  /** Disable the whole form (e.g. while a job is submitting). */
+  disabled?: boolean
+}) {
+  const { isFreeTier } = useSubscriptionTier()
+
+  const [prompt, setPrompt] = useState("")
+  const [preset, setPreset] = useState<VideoStylePreset | null>(null)
+  const [images, setImages] = useState<ReferenceImage[]>([])
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [lyricsSync, setLyricsSync] = useState(false)
+  const [aspectRatio, setAspectRatio] = useState<VideoAspectRatio>("16:9")
+  const [resolution, setResolution] = useState<VideoResolution>("720p")
+  const [frameRate, setFrameRate] = useState<VideoFrameRate>(30)
+  const [transitions, setTransitions] = useState<VideoTransitions>("auto")
+  // Bumped to remount the file input so re-selecting the same files re-fires
+  // change (DistributionForm cover-art idiom).
+  const [imageInputKey, setImageInputKey] = useState(0)
+
+  const cost = estimateVideoCost(resolution, clip.duration)
+  const canGenerate = !disabled && (prompt.trim() !== "" || preset !== null)
+
+  /** Seed the prompt with the preset's text (US-22.2 acceptance criterion). */
+  function selectPreset(next: VideoStylePreset) {
+    setPreset(next)
+    const text = VIDEO_STYLE_PRESETS.find((p) => p.value === next)?.prompt
+    if (text) setPrompt(text)
+  }
+
+  function handleImages(files: FileList | null) {
+    setImageInputKey((k) => k + 1)
+    if (!files || files.length === 0) return
+    const added = Array.from(files)
+    if (added.some((f) => !f.type.startsWith("image/"))) {
+      setImageError("Image files only (JPG, PNG, …).")
+      return
+    }
+    if (images.length + added.length > MAX_REFERENCE_IMAGES) {
+      setImageError(`Add up to ${MAX_REFERENCE_IMAGES} reference images.`)
+      return
+    }
+    setImageError(null)
+    setImages((prev) => [
+      ...prev,
+      ...added.map((file) => ({ file, url: URL.createObjectURL(file) })),
+    ])
+  }
+
+  function removeImage(url: string) {
+    URL.revokeObjectURL(url)
+    setImages((prev) => prev.filter((img) => img.url !== url))
+    setImageError(null)
+  }
+
+  function handleGenerate() {
+    const config: VideoConfig = {
+      lyrics_sync: lyricsSync,
+      aspect_ratio: aspectRatio,
+      resolution,
+      frame_rate: frameRate,
+      transitions,
+    }
+    if (prompt.trim()) config.prompt = prompt.trim()
+    if (preset) config.style_preset = preset
+    onGenerate(config)
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Style presets — chips that seed the prompt below. */}
+      <div role="group" aria-label="Style preset" className="flex flex-col gap-2">
+        <span className="text-sm font-medium">Style preset</span>
+        <div className="flex flex-wrap gap-2">
+          {VIDEO_STYLE_PRESETS.map((p) => (
+            <Button
+              key={p.value}
+              type="button"
+              size="sm"
+              variant={preset === p.value ? "default" : "outline"}
+              disabled={disabled}
+              aria-pressed={preset === p.value}
+              onClick={() => selectPreset(p.value)}
+            >
+              {p.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* Free-form style prompt. */}
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="video-prompt">Style prompt</Label>
+        <Textarea
+          id="video-prompt"
+          value={prompt}
+          maxLength={PROMPT_MAX_LENGTH}
+          disabled={disabled}
+          placeholder="Describe the visual aesthetic for your video…"
+          onChange={(e) => setPrompt(e.target.value)}
+        />
+      </div>
+
+      {/* Reference images — local previews only (no hosting endpoint yet). */}
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="video-reference-images">
+          Reference images{" "}
+          <span className="font-normal text-muted-foreground">
+            (up to {MAX_REFERENCE_IMAGES}, optional)
+          </span>
+        </Label>
+        <input
+          key={imageInputKey}
+          id="video-reference-images"
+          type="file"
+          accept="image/*"
+          multiple
+          disabled={disabled}
+          className="text-sm"
+          aria-invalid={imageError !== null}
+          aria-describedby={imageError ? "video-reference-error" : undefined}
+          onChange={(e) => handleImages(e.target.files)}
+        />
+        {imageError && (
+          <p id="video-reference-error" className="text-sm text-destructive">
+            {imageError}
+          </p>
+        )}
+        {images.length > 0 && (
+          <ul className="flex flex-wrap gap-2">
+            {images.map((img) => (
+              <li key={img.url} className="relative">
+                {/* eslint-disable-next-line @next/next/no-img-element -- local
+                    object URL previews; next/image can't optimize blobs. */}
+                <img
+                  src={img.url}
+                  alt={`Reference ${img.file.name}`}
+                  className="size-16 rounded-md object-cover"
+                />
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="secondary"
+                  className="absolute -right-2 -top-2 size-5"
+                  aria-label={`Remove ${img.file.name}`}
+                  disabled={disabled}
+                  onClick={() => removeImage(img.url)}
+                >
+                  <HugeiconsIcon icon={Cancel01Icon} size={12} />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Lyrics sync. */}
+      <div className="flex items-center gap-3">
+        <Switch
+          id="video-lyrics-sync"
+          checked={lyricsSync}
+          disabled={disabled}
+          onCheckedChange={setLyricsSync}
+        />
+        <Label htmlFor="video-lyrics-sync">Lyrics sync</Label>
+        <span className="text-xs text-muted-foreground">
+          Animated lyric overlays synced to the audio
+        </span>
+      </div>
+
+      {/* Aspect ratio. */}
+      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+        <legend className="text-sm font-medium">Aspect ratio</legend>
+        <RadioGroup
+          value={aspectRatio}
+          onValueChange={(v) => setAspectRatio(v as VideoAspectRatio)}
+          aria-label="Aspect ratio"
+          className="flex flex-wrap gap-4"
+        >
+          {VIDEO_ASPECT_RATIOS.map((a) => (
+            <div key={a.value} className="flex items-center gap-2">
+              <RadioGroupItem value={a.value} id={`aspect-${a.value}`} />
+              <Label htmlFor={`aspect-${a.value}`} className="font-normal">
+                {a.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </fieldset>
+
+      {/* Resolution — 1080p/4K are Pro-gated. */}
+      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+        <legend className="text-sm font-medium">Resolution</legend>
+        <RadioGroup
+          value={resolution}
+          onValueChange={(v) => setResolution(v as VideoResolution)}
+          aria-label="Resolution"
+          className="flex flex-wrap gap-4"
+        >
+          {VIDEO_RESOLUTIONS.map((r) => {
+            const locked = r.proOnly && isFreeTier
+            return (
+              <div key={r.value} className="flex items-center gap-2">
+                <RadioGroupItem
+                  value={r.value}
+                  id={`resolution-${r.value}`}
+                  disabled={locked}
+                />
+                <Label
+                  htmlFor={`resolution-${r.value}`}
+                  className="flex items-center gap-1 font-normal"
+                >
+                  {r.label}
+                  {r.proOnly && (
+                    <Badge variant="outline" className="text-[10px]">
+                      {locked && (
+                        <HugeiconsIcon icon={LockIcon} data-icon="inline-start" />
+                      )}
+                      Pro
+                    </Badge>
+                  )}
+                </Label>
+              </div>
+            )
+          })}
+        </RadioGroup>
+        {isFreeTier && (
+          <p className="text-xs text-muted-foreground">
+            1080p and 4K rendering are Pro features. Upgrade to Pro to unlock
+            higher resolutions.
+          </p>
+        )}
+      </fieldset>
+
+      {/* Frame rate. */}
+      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+        <legend className="text-sm font-medium">Frame rate</legend>
+        <RadioGroup
+          value={String(frameRate)}
+          onValueChange={(v) => setFrameRate(Number(v) as VideoFrameRate)}
+          aria-label="Frame rate"
+          className="flex flex-wrap gap-4"
+        >
+          {VIDEO_FRAME_RATES.map((f) => (
+            <div key={f.value} className="flex items-center gap-2">
+              <RadioGroupItem value={String(f.value)} id={`fps-${f.value}`} />
+              <Label htmlFor={`fps-${f.value}`} className="font-normal">
+                {f.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </fieldset>
+
+      {/* Scene transitions. */}
+      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+        <legend className="text-sm font-medium">Scene transitions</legend>
+        <RadioGroup
+          value={transitions}
+          onValueChange={(v) => setTransitions(v as VideoTransitions)}
+          aria-label="Scene transitions"
+          className="flex flex-wrap gap-4"
+        >
+          {VIDEO_TRANSITIONS.map((t) => (
+            <div key={t.value} className="flex items-center gap-2">
+              <RadioGroupItem value={t.value} id={`transition-${t.value}`} />
+              <Label htmlFor={`transition-${t.value}`} className="font-normal">
+                {t.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </fieldset>
+
+      {/* Estimate + submit. */}
+      <div className="flex items-center gap-4">
+        <Button onClick={handleGenerate} disabled={!canGenerate}>
+          Generate Video
+        </Button>
+        <span className="text-sm text-muted-foreground tabular-nums">
+          Estimated cost: {cost} credits
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/web/components/video/VideoForm.tsx
+++ b/web/components/video/VideoForm.tsx
@@ -47,12 +47,9 @@ type ReferenceImage = { file: File; url: string }
 export function VideoForm({
   clip,
   onGenerate,
-  disabled = false,
 }: {
   clip: Clip
   onGenerate: (config: VideoConfig) => void
-  /** Disable the whole form (e.g. while a job is submitting). */
-  disabled?: boolean
 }) {
   const { isFreeTier } = useSubscriptionTier()
 
@@ -83,7 +80,7 @@ export function VideoForm({
   }, [])
 
   const cost = estimateVideoCost(resolution, clip.duration)
-  const canGenerate = !disabled && (prompt.trim() !== "" || preset !== null)
+  const canGenerate = prompt.trim() !== "" || preset !== null
 
   /** Seed the prompt with the preset's text (US-22.2 acceptance criterion). */
   function selectPreset(next: VideoStylePreset) {
@@ -142,7 +139,6 @@ export function VideoForm({
               type="button"
               size="sm"
               variant={preset === p.value ? "default" : "outline"}
-              disabled={disabled}
               aria-pressed={preset === p.value}
               onClick={() => selectPreset(p.value)}
             >
@@ -159,7 +155,6 @@ export function VideoForm({
           id="video-prompt"
           value={prompt}
           maxLength={PROMPT_MAX_LENGTH}
-          disabled={disabled}
           placeholder="Describe the visual aesthetic for your video…"
           onChange={(e) => setPrompt(e.target.value)}
         />
@@ -179,7 +174,6 @@ export function VideoForm({
           type="file"
           accept="image/*"
           multiple
-          disabled={disabled}
           className="text-sm"
           aria-invalid={imageError !== null}
           aria-describedby={imageError ? "video-reference-error" : undefined}
@@ -207,7 +201,6 @@ export function VideoForm({
                   variant="secondary"
                   className="absolute -right-2 -top-2 size-5"
                   aria-label={`Remove ${img.file.name}`}
-                  disabled={disabled}
                   onClick={() => removeImage(img.url)}
                 >
                   <HugeiconsIcon icon={Cancel01Icon} size={12} />
@@ -223,7 +216,6 @@ export function VideoForm({
         <Switch
           id="video-lyrics-sync"
           checked={lyricsSync}
-          disabled={disabled}
           onCheckedChange={setLyricsSync}
         />
         <Label htmlFor="video-lyrics-sync">Lyrics sync</Label>
@@ -233,7 +225,7 @@ export function VideoForm({
       </div>
 
       {/* Aspect ratio. */}
-      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+      <fieldset className="flex flex-col gap-3">
         <legend className="text-sm font-medium">Aspect ratio</legend>
         <RadioGroup
           value={aspectRatio}
@@ -253,7 +245,7 @@ export function VideoForm({
       </fieldset>
 
       {/* Resolution — 1080p/4K are Pro-gated. */}
-      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+      <fieldset className="flex flex-col gap-3">
         <legend className="text-sm font-medium">Resolution</legend>
         <RadioGroup
           value={resolution}
@@ -297,7 +289,7 @@ export function VideoForm({
       </fieldset>
 
       {/* Frame rate. */}
-      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+      <fieldset className="flex flex-col gap-3">
         <legend className="text-sm font-medium">Frame rate</legend>
         <RadioGroup
           value={String(frameRate)}
@@ -317,7 +309,7 @@ export function VideoForm({
       </fieldset>
 
       {/* Scene transitions. */}
-      <fieldset className="flex flex-col gap-3" disabled={disabled}>
+      <fieldset className="flex flex-col gap-3">
         <legend className="text-sm font-medium">Scene transitions</legend>
         <RadioGroup
           value={transitions}

--- a/web/components/video/VideoForm.tsx
+++ b/web/components/video/VideoForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { Cancel01Icon, LockIcon } from "@hugeicons/core-free-icons"
 
@@ -68,6 +68,19 @@ export function VideoForm({
   // Bumped to remount the file input so re-selecting the same files re-fires
   // change (DistributionForm cover-art idiom).
   const [imageInputKey, setImageInputKey] = useState(0)
+
+  // Revoke preview URLs on unmount (the form unmounts the moment a job is
+  // submitted). A ref — not [images] deps — so the cleanup only fires once, at
+  // unmount, and never revokes URLs still on screen.
+  const imagesRef = useRef(images)
+  useEffect(() => {
+    imagesRef.current = images
+  }, [images])
+  useEffect(() => {
+    return () => {
+      for (const img of imagesRef.current) URL.revokeObjectURL(img.url)
+    }
+  }, [])
 
   const cost = estimateVideoCost(resolution, clip.duration)
   const canGenerate = !disabled && (prompt.trim() !== "" || preset !== null)

--- a/web/components/video/VideoProgress.test.tsx
+++ b/web/components/video/VideoProgress.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { VideoProgress } from "@/components/video/VideoProgress"
+import type { VideoJobState } from "@/hooks/use-video-job"
+
+function renderState(state: VideoJobState) {
+  const onRetry = vi.fn()
+  const onReset = vi.fn()
+  render(<VideoProgress state={state} onRetry={onRetry} onReset={onReset} />)
+  return { onRetry, onReset }
+}
+
+describe("VideoProgress", () => {
+  it("shows a submitting spinner at 0%", () => {
+    renderState({ phase: "submitting" })
+    expect(screen.getByRole("status")).toHaveTextContent(/submitting/i)
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0")
+  })
+
+  it("shows the rendering state with progress and ETA", () => {
+    renderState({
+      phase: "polling",
+      detail: { job_id: "j1", status: "rendering", progress: 42, eta_seconds: 120 },
+    })
+    expect(screen.getByRole("status")).toHaveTextContent(/rendering scenes/i)
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "42")
+    expect(screen.getByText(/42%/)).toBeInTheDocument()
+    expect(screen.getByText(/~2 min remaining/)).toBeInTheDocument()
+  })
+
+  it("shows the encoding state", () => {
+    renderState({
+      phase: "polling",
+      detail: { job_id: "j1", status: "encoding", progress: 90 },
+    })
+    expect(screen.getByRole("status")).toHaveTextContent(/encoding video/i)
+  })
+
+  it("shows completion with a reset affordance", () => {
+    const { onReset } = renderState({
+      phase: "complete",
+      detail: { job_id: "j1", status: "complete", progress: 100, video_id: "v1" },
+    })
+    expect(screen.getByRole("status")).toHaveTextContent(/ready/i)
+    fireEvent.click(screen.getByRole("button", { name: /generate another/i }))
+    expect(onReset).toHaveBeenCalled()
+  })
+
+  it("shows errors with Retry and Back to settings", () => {
+    const { onRetry, onReset } = renderState({
+      phase: "error",
+      message: "render died",
+    })
+    expect(screen.getByRole("alert")).toHaveTextContent("render died")
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }))
+    expect(onRetry).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole("button", { name: /back to settings/i }))
+    expect(onReset).toHaveBeenCalled()
+  })
+})

--- a/web/components/video/VideoProgress.tsx
+++ b/web/components/video/VideoProgress.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+import { Button } from "@/components/ui/button"
+import type { VideoJobState } from "@/hooks/use-video-job"
+import type { VideoState } from "@/lib/video"
+
+// Human labels for the render vocabulary (US-22.1 status endpoint).
+const STATE_LABELS: Record<VideoState, string> = {
+  queued: "Queued",
+  rendering: "Rendering scenes",
+  encoding: "Encoding video",
+  complete: "Complete",
+  failed: "Failed",
+}
+
+/** Round an ETA to a compact human string ("~2 min", "~45s"). */
+function formatEta(seconds: number): string {
+  if (seconds >= 90) return `~${Math.round(seconds / 60)} min remaining`
+  return `~${Math.round(seconds)}s remaining`
+}
+
+/**
+ * Minimal post-submit progress view (US-22.2): state label, progress bar with
+ * percentage, ETA, and an error state with Retry. The richer progress/delivery
+ * experience (phase breakdown, completion notification, download) is US-22.3.
+ */
+export function VideoProgress({
+  state,
+  onRetry,
+  onReset,
+}: {
+  state: VideoJobState
+  onRetry: () => void
+  onReset: () => void
+}) {
+  if (state.phase === "error") {
+    return (
+      <div role="alert" className="flex flex-col gap-3">
+        <p className="text-sm text-destructive">{state.message}</p>
+        <div className="flex gap-2">
+          <Button size="sm" onClick={onRetry}>
+            Retry
+          </Button>
+          <Button size="sm" variant="outline" onClick={onReset}>
+            Back to settings
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (state.phase === "complete") {
+    return (
+      <div role="status" className="flex flex-col gap-3">
+        <p className="text-sm font-medium">Your music video is ready.</p>
+        <p className="text-sm text-muted-foreground">
+          Delivery and download arrive in the next story — find the render under
+          this song once they land.
+        </p>
+        <div>
+          <Button size="sm" variant="outline" onClick={onReset}>
+            Generate another
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  // submitting / polling.
+  const detail = state.phase === "polling" ? state.detail : undefined
+  const status: VideoState = detail?.status ?? "queued"
+  const progress = detail?.progress ?? 0
+
+  return (
+    <div role="status" className="flex flex-col gap-3">
+      <span className="flex items-center gap-2 text-sm text-muted-foreground">
+        <HugeiconsIcon
+          icon={Loading03Icon}
+          className="animate-spin"
+          data-icon="inline-start"
+        />
+        {state.phase === "submitting" ? "Submitting…" : STATE_LABELS[status]}
+      </span>
+      <div
+        role="progressbar"
+        aria-valuenow={progress}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className="h-2 w-full max-w-md overflow-hidden rounded-full bg-muted"
+      >
+        <div
+          className="h-full rounded-full bg-primary transition-all"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {progress}%
+        {detail?.eta_seconds != null && ` · ${formatEta(detail.eta_seconds)}`}
+      </span>
+    </div>
+  )
+}

--- a/web/hooks/use-song-actions.test.tsx
+++ b/web/hooks/use-song-actions.test.tsx
@@ -82,6 +82,13 @@ describe("useSongActions", () => {
     expect(result.current.activeModal).toBeNull()
   })
 
+  it("routes create-video to the video creation page (US-22.2)", () => {
+    const { result } = setup()
+    act(() => result.current.handleAction("create-video"))
+    expect(push).toHaveBeenCalledWith("/video/c1")
+    expect(result.current.activeModal).toBeNull()
+  })
+
   it("opens and closes the workflow modal for modal actions", () => {
     const { result } = setup()
     act(() => result.current.handleAction("cover"))

--- a/web/hooks/use-song-actions.ts
+++ b/web/hooks/use-song-actions.ts
@@ -72,9 +72,16 @@ export function useSongActions(clip: Clip, { onDeleted }: UseSongActionsOptions 
   function handleAction(action: SongActionId) {
     const workflow = findSongAction(action)?.workflow
     if (workflow === "navigation") {
-      // open-editor → the waveform editor (US-18.1); open-studio → the studio.
+      // open-editor → the waveform editor (US-18.1); create-video → the video
+      // page (US-22.2); open-studio → the studio.
       const id = encodeURIComponent(clip.id)
-      router.push(action === "open-editor" ? `/editor/${id}` : `/studio?song=${id}`)
+      const route =
+        action === "open-editor"
+          ? `/editor/${id}`
+          : action === "create-video"
+            ? `/video/${id}`
+            : `/studio?song=${id}`
+      router.push(route)
       return
     }
     if (workflow === "modal") {

--- a/web/hooks/use-video-job.test.tsx
+++ b/web/hooks/use-video-job.test.tsx
@@ -1,0 +1,164 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+
+import { AuthContext } from "@/contexts/auth-context"
+import { useVideoJob } from "@/hooks/use-video-job"
+import type { VideoConfig } from "@/lib/video"
+
+const push = vi.fn()
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }))
+
+const submitVideoJob = vi.fn()
+const fetchVideoStatus = vi.fn()
+vi.mock("@/lib/video", () => ({
+  submitVideoJob: (...a: unknown[]) => submitVideoJob(...a),
+  fetchVideoStatus: (...a: unknown[]) => fetchVideoStatus(...a),
+}))
+
+const authValue = {
+  user: { id: "u1", email: "a@b.co" },
+  accessToken: "tok",
+  isAuthenticated: true,
+  isLoading: false,
+  login: vi.fn(),
+  completeLogin: vi.fn(),
+  logout: vi.fn(),
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+}
+
+const config: VideoConfig = {
+  prompt: "neon city",
+  lyrics_sync: false,
+  aspect_ratio: "16:9",
+  resolution: "720p",
+  frame_rate: 30,
+  transitions: "auto",
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe("useVideoJob", () => {
+  it("submits, polls, and reaches complete", async () => {
+    const detail = { job_id: "j1", status: "complete", progress: 100, video_id: "v1" }
+    submitVideoJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchVideoStatus.mockResolvedValue({ kind: "complete", detail })
+    const { result } = renderHook(() => useVideoJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    await waitFor(() => expect(result.current.state.phase).toBe("complete"))
+    // Token comes from auth context, forwarded to the submit + poll.
+    expect(submitVideoJob).toHaveBeenCalledWith("c1", config, "tok")
+    expect(fetchVideoStatus).toHaveBeenCalledWith("j1", "tok")
+  })
+
+  it("stays in polling with the live detail while the job renders", async () => {
+    const detail = { job_id: "j1", status: "rendering", progress: 42, eta_seconds: 90 }
+    submitVideoJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchVideoStatus.mockResolvedValue({ kind: "pending", detail })
+    const { result } = renderHook(() => useVideoJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({ phase: "polling", detail })
+    )
+    act(() => result.current.reset())
+    expect(result.current.state).toEqual({ phase: "idle" })
+  })
+
+  it("surfaces a failed render as an error", async () => {
+    submitVideoJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchVideoStatus.mockResolvedValue({ kind: "failed", error: "render died" })
+    const { result } = renderHook(() => useVideoJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    await waitFor(() =>
+      expect(result.current.state).toEqual({ phase: "error", message: "render died" })
+    )
+  })
+
+  it("surfaces insufficient credits with a readable message", async () => {
+    submitVideoJob.mockResolvedValue({
+      status: "insufficient_credits",
+      balance: 2,
+      required: 5,
+    })
+    const { result } = renderHook(() => useVideoJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    expect(result.current.state.phase).toBe("error")
+    if (result.current.state.phase === "error") {
+      expect(result.current.state.message).toMatch(/5 required, 2 available/)
+    }
+  })
+
+  it("surfaces the 503 unavailable detail verbatim", async () => {
+    submitVideoJob.mockResolvedValue({
+      status: "unavailable",
+      detail: "Video generation is not configured on this deployment.",
+    })
+    const { result } = renderHook(() => useVideoJob(), { wrapper })
+
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+
+    expect(result.current.state).toEqual({
+      phase: "error",
+      message: "Video generation is not configured on this deployment.",
+    })
+  })
+
+  it("redirects to login when submission or a poll is unauthorized", async () => {
+    submitVideoJob.mockResolvedValue({ status: "unauthorized" })
+    const { result } = renderHook(() => useVideoJob(), { wrapper })
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+    expect(push).toHaveBeenCalledWith("/login")
+
+    push.mockClear()
+    submitVideoJob.mockResolvedValue({ status: "accepted", jobId: "j2" })
+    fetchVideoStatus.mockResolvedValue({ kind: "unauthorized" })
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/login"))
+  })
+
+  it("retry replays the last submission", async () => {
+    submitVideoJob.mockResolvedValue({ status: "error", detail: "boom" })
+    const { result } = renderHook(() => useVideoJob(), { wrapper })
+    await act(async () => {
+      await result.current.submit("c1", config)
+    })
+    expect(result.current.state).toEqual({ phase: "error", message: "boom" })
+
+    submitVideoJob.mockResolvedValue({ status: "accepted", jobId: "j1" })
+    fetchVideoStatus.mockResolvedValue({
+      kind: "pending",
+      detail: { job_id: "j1", status: "queued", progress: 0 },
+    })
+    await act(async () => {
+      result.current.retry()
+    })
+    await waitFor(() => expect(result.current.state.phase).toBe("polling"))
+    expect(submitVideoJob).toHaveBeenLastCalledWith("c1", config, "tok")
+    act(() => result.current.reset())
+  })
+})

--- a/web/hooks/use-video-job.ts
+++ b/web/hooks/use-video-job.ts
@@ -1,0 +1,187 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { useAuth } from "@/hooks/use-auth"
+import {
+  fetchVideoStatus,
+  submitVideoJob,
+  type VideoConfig,
+  type VideoStatusDetail,
+} from "@/lib/video"
+
+const POLL_INTERVAL_MS = 2500
+// Cap polling so a stuck/vanished job surfaces an error instead of spinning
+// forever. Renders run minutes to tens of minutes, so the cap is generous:
+// 720 × 2.5s = 30 min. ponytail: fixed cap; US-22.3's richer progress view can
+// revisit if real renders run longer.
+const MAX_POLLS = 720
+
+/** The video job state machine: idle → submitting → polling → complete|error. */
+export type VideoJobState =
+  | { phase: "idle" }
+  | { phase: "submitting" }
+  | { phase: "polling"; detail?: VideoStatusDetail }
+  | { phase: "complete"; detail: VideoStatusDetail }
+  | { phase: "error"; message: string }
+
+export type UseVideoJob = {
+  state: VideoJobState
+  /** Submit a video job for a clip and drive it to completion. */
+  submit: (clipId: string, config: VideoConfig) => Promise<void>
+  /** Re-run the last submit (for the error/failed state's Retry). No-op if none. */
+  retry: () => void
+  /** Clear back to idle (start a new render after completing/failing). */
+  reset: () => void
+}
+
+/**
+ * Owns one video render's lifecycle (US-22.2). After the 202 it polls the job
+ * through the BFF proxy until complete/failed, surfacing the live progress
+ * detail for the progress view. The access token is read from auth context and
+ * kept in a ref (it rotates mid-session, #285) so the poll loop always uses the
+ * latest without re-subscribing. Mirrors use-mastering-job.
+ */
+export function useVideoJob(): UseVideoJob {
+  const router = useRouter()
+  const { accessToken } = useAuth()
+  const [state, setState] = useState<VideoJobState>({ phase: "idle" })
+
+  const tokenRef = useRef(accessToken)
+  useEffect(() => {
+    tokenRef.current = accessToken
+  }, [accessToken])
+
+  // The active job. A ref (not state) so the poll loop reads the latest without
+  // re-subscribing; cleared the moment the job is superseded or terminal.
+  const jobRef = useRef<{ id: string; polls: number } | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The last submission's args, so Retry can replay it verbatim.
+  const lastArgsRef = useRef<{ clipId: string; config: VideoConfig } | null>(null)
+
+  // Holds the latest `poll` so the scheduled timeout can call it without `poll`
+  // referencing itself (hook-immutability lint forbids that).
+  const pollRef = useRef<() => void>(() => {})
+
+  // False once unmounted. Both the poll's and the submit's fetches resolve
+  // asynchronously; either can land after the component is gone, so every
+  // post-await branch checks this before it setState/arms a timer/kicks a poll.
+  const mountedRef = useRef(true)
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  // Clean up on unmount: mark unmounted, cancel any pending poll, drop the job.
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      clearTimer()
+      jobRef.current = null
+    }
+  }, [])
+
+  const poll = useCallback(async () => {
+    const job = jobRef.current
+    if (!job) return
+    const result = await fetchVideoStatus(job.id, tokenRef.current ?? "")
+    if (!mountedRef.current) return
+    // A reset/retry between the request and its response supersedes this job.
+    if (jobRef.current?.id !== job.id) return
+
+    switch (result.kind) {
+      case "complete":
+        jobRef.current = null
+        clearTimer()
+        setState({ phase: "complete", detail: result.detail })
+        return
+      case "failed":
+        jobRef.current = null
+        clearTimer()
+        setState({ phase: "error", message: result.error })
+        return
+      case "unauthorized":
+        jobRef.current = null
+        clearTimer()
+        router.push("/login")
+        return
+      case "pending":
+      case "transient":
+        job.polls += 1
+        if (job.polls >= MAX_POLLS) {
+          jobRef.current = null
+          clearTimer()
+          setState({
+            phase: "error",
+            message: "Video generation timed out. Please try again.",
+          })
+          return
+        }
+        if (result.kind === "pending") {
+          const { detail } = result
+          setState((s) => (s.phase === "polling" ? { ...s, detail } : s))
+        }
+        timerRef.current = setTimeout(() => pollRef.current(), POLL_INTERVAL_MS)
+        return
+    }
+  }, [router])
+
+  useEffect(() => {
+    pollRef.current = poll
+  }, [poll])
+
+  const submit = useCallback(
+    async (clipId: string, config: VideoConfig) => {
+      lastArgsRef.current = { clipId, config }
+      clearTimer()
+      jobRef.current = null
+      setState({ phase: "submitting" })
+
+      const result = await submitVideoJob(clipId, config, tokenRef.current ?? "")
+      // Bail if the page unmounted while the POST was in flight — otherwise the
+      // accepted branch would re-arm jobRef + a poll loop on a dead component.
+      if (!mountedRef.current) return
+      switch (result.status) {
+        case "accepted":
+          jobRef.current = { id: result.jobId, polls: 0 }
+          setState({ phase: "polling" })
+          // Poll immediately so a fast job doesn't sit idle for the first interval.
+          void poll()
+          return
+        case "unauthorized":
+          router.push("/login")
+          return
+        case "insufficient_credits":
+          setState({
+            phase: "error",
+            message: `Not enough credits — ${result.required} required, ${result.balance} available.`,
+          })
+          return
+        case "invalid":
+        case "unavailable":
+        case "error":
+          setState({ phase: "error", message: result.detail })
+          return
+      }
+    },
+    [poll, router]
+  )
+
+  const retry = useCallback(() => {
+    const args = lastArgsRef.current
+    if (args) void submit(args.clipId, args.config)
+  }, [submit])
+
+  const reset = useCallback(() => {
+    clearTimer()
+    jobRef.current = null
+    setState({ phase: "idle" })
+  }, [])
+
+  return { state, submit, retry, reset }
+}

--- a/web/lib/song-actions.test.ts
+++ b/web/lib/song-actions.test.ts
@@ -79,6 +79,8 @@ describe("SONG_ACTION_GROUPS", () => {
     expect(findSongAction("open-studio")?.workflow).toBe("navigation")
     // Open in Editor navigates to /editor/{id} (US-18.1).
     expect(findSongAction("open-editor")?.workflow).toBe("navigation")
+    // Create Music Video navigates to /video/{id} (US-22.2).
+    expect(findSongAction("create-video")?.workflow).toBe("navigation")
     // Remaster is one-click (US-17.3) — inline submit, no modal.
     expect(findSongAction("remaster")?.workflow).toBe("inline")
     expect(findSongAction("publish-toggle")?.workflow).toBe("inline")
@@ -100,7 +102,6 @@ describe("SONG_ACTION_GROUPS", () => {
       "adjust-speed",
       "send-mastering",
       "export-daw",
-      "create-video",
     ] as const) {
       expect(findSongAction(id)?.workflow).toBe("modal")
     }

--- a/web/lib/song-actions.ts
+++ b/web/lib/song-actions.ts
@@ -204,7 +204,8 @@ export const SONG_ACTION_GROUPS: SongActionGroup[] = [
         id: "create-video",
         label: "Create Music Video",
         icon: Video01Icon,
-        workflow: "modal",
+        // Navigates to the video creation page (US-22.2).
+        workflow: "navigation",
         proOnly: true,
       },
     ],

--- a/web/lib/video.test.ts
+++ b/web/lib/video.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  MAX_REFERENCE_IMAGES,
+  VIDEO_ASPECT_RATIOS,
+  VIDEO_FRAME_RATES,
+  VIDEO_RESOLUTIONS,
+  VIDEO_STYLE_PRESETS,
+  VIDEO_TRANSITIONS,
+  estimateVideoCost,
+  fetchVideoStatus,
+  presetLabel,
+  submitVideoJob,
+  type VideoConfig,
+} from "@/lib/video"
+
+const config: VideoConfig = {
+  prompt: "neon city",
+  style_preset: undefined,
+  lyrics_sync: false,
+  aspect_ratio: "16:9",
+  resolution: "720p",
+  frame_rate: 30,
+  transitions: "auto",
+}
+
+function mockFetch(status: number, body: unknown) {
+  return vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(new Response(JSON.stringify(body), { status }))
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("option tables", () => {
+  it("mirror the backend literals", () => {
+    expect(VIDEO_STYLE_PRESETS.map((p) => p.value)).toEqual([
+      "abstract",
+      "cinematic",
+      "animated",
+      "lyric_video",
+      "live_performance",
+      "nature",
+    ])
+    expect(VIDEO_ASPECT_RATIOS.map((a) => a.value)).toEqual(["16:9", "9:16", "1:1"])
+    expect(VIDEO_RESOLUTIONS.map((r) => r.value)).toEqual(["720p", "1080p", "4k"])
+    expect(VIDEO_FRAME_RATES.map((f) => f.value)).toEqual([24, 30, 60])
+    expect(VIDEO_TRANSITIONS.map((t) => t.value)).toEqual([
+      "auto",
+      "cut",
+      "fade",
+      "dissolve",
+    ])
+    expect(MAX_REFERENCE_IMAGES).toBe(5)
+  })
+
+  it("marks exactly 1080p and 4k as Pro-only", () => {
+    const proOnly = VIDEO_RESOLUTIONS.filter((r) => r.proOnly).map((r) => r.value)
+    expect(proOnly).toEqual(["1080p", "4k"])
+  })
+
+  it("every preset carries non-empty prompt seed text", () => {
+    for (const p of VIDEO_STYLE_PRESETS) {
+      expect(p.prompt.length).toBeGreaterThan(0)
+    }
+    expect(presetLabel("lyric_video")).toBe("Lyric Video")
+  })
+})
+
+describe("estimateVideoCost", () => {
+  // Mirrors src/acemusic/api/services/credits.py get_video_cost.
+  it("bills the base rate per resolution", () => {
+    expect(estimateVideoCost("720p", 60)).toBe(5)
+    expect(estimateVideoCost("1080p", 60)).toBe(7)
+    expect(estimateVideoCost("4k", 60)).toBe(8)
+  })
+
+  it("adds the long-duration surcharge past 180s, capped at 10", () => {
+    expect(estimateVideoCost("720p", 181)).toBe(7)
+    expect(estimateVideoCost("1080p", 300)).toBe(9)
+    expect(estimateVideoCost("4k", 300)).toBe(10) // 8 + 2 = 10, at the cap
+  })
+
+  it("bills the base rate when duration is unknown or at the boundary", () => {
+    expect(estimateVideoCost("720p", null)).toBe(5)
+    expect(estimateVideoCost("720p", 180)).toBe(5)
+  })
+})
+
+describe("submitVideoJob", () => {
+  it("posts the config with the clip id and classifies 202 as accepted", async () => {
+    const fetchSpy = mockFetch(202, { job_id: "j1", status: "queued" })
+    const result = await submitVideoJob("c1", config, "tok")
+    expect(result).toEqual({ status: "accepted", jobId: "j1" })
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe("/api/videos/generate")
+    expect(init?.headers).toMatchObject({ authorization: "Bearer tok" })
+    const body = JSON.parse(String(init?.body))
+    expect(body).toMatchObject({ clip_id: "c1", prompt: "neon city", resolution: "720p" })
+    // Optional fields that are unset must not be sent (extra="forbid" upstream
+    // is fine with them, but null would 422).
+    expect(body).not.toHaveProperty("style_preset")
+  })
+
+  it("classifies 401 as unauthorized", async () => {
+    mockFetch(401, { detail: "Not authenticated." })
+    expect(await submitVideoJob("c1", config, "tok")).toEqual({
+      status: "unauthorized",
+    })
+  })
+
+  it("classifies 402 with the balance payload", async () => {
+    mockFetch(402, {
+      detail: { error: "insufficient_credits", balance: 2, required: 5 },
+    })
+    expect(await submitVideoJob("c1", config, "tok")).toEqual({
+      status: "insufficient_credits",
+      balance: 2,
+      required: 5,
+    })
+  })
+
+  it("classifies 422 as invalid with the detail message", async () => {
+    mockFetch(422, { detail: [{ msg: "Provide a style prompt or a style_preset" }] })
+    expect(await submitVideoJob("c1", config, "tok")).toEqual({
+      status: "invalid",
+      detail: "Provide a style prompt or a style_preset",
+    })
+  })
+
+  it("classifies 503 as unavailable (video not configured)", async () => {
+    mockFetch(503, { detail: "Video generation is not configured on this deployment." })
+    expect(await submitVideoJob("c1", config, "tok")).toEqual({
+      status: "unavailable",
+      detail: "Video generation is not configured on this deployment.",
+    })
+  })
+
+  it("classifies a network failure as error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"))
+    const result = await submitVideoJob("c1", config, "tok")
+    expect(result.status).toBe("error")
+  })
+})
+
+describe("fetchVideoStatus", () => {
+  it("classifies queued/rendering/encoding as pending", async () => {
+    for (const status of ["queued", "rendering", "encoding"] as const) {
+      mockFetch(200, { job_id: "j1", status, progress: 40 })
+      const result = await fetchVideoStatus("j1", "tok")
+      expect(result).toMatchObject({ kind: "pending" })
+      vi.restoreAllMocks()
+    }
+  })
+
+  it("classifies complete with the detail (video id)", async () => {
+    mockFetch(200, { job_id: "j1", status: "complete", progress: 100, video_id: "v1" })
+    expect(await fetchVideoStatus("j1", "tok")).toEqual({
+      kind: "complete",
+      detail: { job_id: "j1", status: "complete", progress: 100, video_id: "v1" },
+    })
+  })
+
+  it("classifies failed with the error message", async () => {
+    mockFetch(200, { job_id: "j1", status: "failed", progress: 0, error: "render died" })
+    expect(await fetchVideoStatus("j1", "tok")).toEqual({
+      kind: "failed",
+      error: "render died",
+    })
+  })
+
+  it("classifies 401 as unauthorized and other 4xx as failed", async () => {
+    mockFetch(401, {})
+    expect(await fetchVideoStatus("j1", "tok")).toEqual({ kind: "unauthorized" })
+    vi.restoreAllMocks()
+    mockFetch(404, { detail: "Video job not found." })
+    expect((await fetchVideoStatus("j1", "tok")).kind).toBe("failed")
+  })
+
+  it("classifies 5xx and network errors as transient", async () => {
+    mockFetch(502, {})
+    expect(await fetchVideoStatus("j1", "tok")).toEqual({ kind: "transient" })
+    vi.restoreAllMocks()
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"))
+    expect(await fetchVideoStatus("j1", "tok")).toEqual({ kind: "transient" })
+  })
+})

--- a/web/lib/video.ts
+++ b/web/lib/video.ts
@@ -1,0 +1,299 @@
+// Client-side video generation workflow (US-22.2). The video page submits a
+// render job and polls its status — each call goes through a same-origin BFF
+// proxy under `/api/videos/*` that forwards the Bearer token and keeps the
+// backend URL server-side (mirrors lib/mastering). The backend endpoints
+// (US-22.1) already exist.
+
+/** The six style presets, mirroring the backend Literal. */
+export type VideoStylePreset =
+  | "abstract"
+  | "cinematic"
+  | "animated"
+  | "lyric_video"
+  | "live_performance"
+  | "nature"
+
+/** Output aspect ratios, mirroring the backend Literal. */
+export type VideoAspectRatio = "16:9" | "9:16" | "1:1"
+
+/** Output resolutions, mirroring the backend Literal. */
+export type VideoResolution = "720p" | "1080p" | "4k"
+
+/** Output frame rates, mirroring the backend Literal. */
+export type VideoFrameRate = 24 | 30 | 60
+
+/** Scene-transition modes, mirroring the backend Literal. */
+export type VideoTransitions = "auto" | "cut" | "fade" | "dissolve"
+
+/** The render lifecycle states the status endpoint reports. */
+export type VideoState = "queued" | "rendering" | "encoding" | "complete" | "failed"
+
+// Backend request bounds (src/acemusic/api/routers/videos.py).
+export const MAX_REFERENCE_IMAGES = 5
+export const PROMPT_MAX_LENGTH = 2000
+
+/** A preset's display metadata plus the prompt text it seeds the textarea with. */
+export type PresetOption = {
+  value: VideoStylePreset
+  label: string
+  prompt: string
+}
+
+// Selecting a preset populates the style prompt with its seed text (US-22.2
+// acceptance criterion) — the user can then edit it freely.
+export const VIDEO_STYLE_PRESETS: PresetOption[] = [
+  {
+    value: "abstract",
+    label: "Abstract",
+    prompt: "Abstract flowing shapes and colors that pulse with the music's energy.",
+  },
+  {
+    value: "cinematic",
+    label: "Cinematic",
+    prompt: "Cinematic film scenes with dramatic lighting and sweeping camera moves.",
+  },
+  {
+    value: "animated",
+    label: "Animated",
+    prompt: "Vibrant animated illustration style with smooth, expressive motion.",
+  },
+  {
+    value: "lyric_video",
+    label: "Lyric Video",
+    prompt: "Typography-driven lyric video with animated text as the visual focus.",
+  },
+  {
+    value: "live_performance",
+    label: "Live Performance",
+    prompt: "Live concert performance footage with stage lighting and crowd energy.",
+  },
+  {
+    value: "nature",
+    label: "Nature",
+    prompt: "Sweeping natural landscapes that mirror the mood of the song.",
+  },
+]
+
+export const VIDEO_ASPECT_RATIOS: { value: VideoAspectRatio; label: string }[] = [
+  { value: "16:9", label: "16:9 Landscape" },
+  { value: "9:16", label: "9:16 Vertical" },
+  { value: "1:1", label: "1:1 Square" },
+]
+
+/** A resolution's display metadata; Pro-only tiers are subscription-gated. */
+export type ResolutionOption = {
+  value: VideoResolution
+  label: string
+  proOnly: boolean
+}
+
+export const VIDEO_RESOLUTIONS: ResolutionOption[] = [
+  { value: "720p", label: "720p", proOnly: false },
+  { value: "1080p", label: "1080p", proOnly: true },
+  { value: "4k", label: "4K", proOnly: true },
+]
+
+export const VIDEO_FRAME_RATES: { value: VideoFrameRate; label: string }[] = [
+  { value: 24, label: "24 fps" },
+  { value: 30, label: "30 fps" },
+  { value: 60, label: "60 fps" },
+]
+
+export const VIDEO_TRANSITIONS: { value: VideoTransitions; label: string }[] = [
+  { value: "auto", label: "Auto (AI-driven)" },
+  { value: "cut", label: "Cut" },
+  { value: "fade", label: "Fade" },
+  { value: "dissolve", label: "Dissolve" },
+]
+
+/** Human label for a preset key, falling back to the raw value then a dash. */
+export function presetLabel(value?: string): string {
+  return VIDEO_STYLE_PRESETS.find((p) => p.value === value)?.label ?? value ?? "—"
+}
+
+// Client-side mirror of the server cost formula (src/acemusic/api/services/
+// credits.py get_video_cost) for the pre-submit estimate — the server remains
+// the billing authority. Same idiom as the MASTERING_SERVICES cost table.
+const VIDEO_COSTS: Record<VideoResolution, number> = {
+  "720p": 5,
+  "1080p": 7,
+  "4k": 8,
+}
+export const VIDEO_LONG_DURATION_S = 180
+const VIDEO_LONG_DURATION_SURCHARGE = 2
+const VIDEO_MAX_COST = 10
+
+/** Estimated credit cost of one render (base by resolution, +2 past 3 min, cap 10). */
+export function estimateVideoCost(
+  resolution: VideoResolution,
+  durationS: number | null
+): number {
+  let cost = VIDEO_COSTS[resolution]
+  if (durationS !== null && durationS > VIDEO_LONG_DURATION_S) {
+    cost += VIDEO_LONG_DURATION_SURCHARGE
+  }
+  return Math.min(cost, VIDEO_MAX_COST)
+}
+
+/** The render configuration a submission carries (clip id is passed separately). */
+export type VideoConfig = {
+  /** Free-form style description; required unless a preset is chosen. */
+  prompt?: string
+  style_preset?: VideoStylePreset
+  /** Public http(s) URLs only — the backend rejects anything else. */
+  reference_image_urls?: string[]
+  lyrics_sync: boolean
+  aspect_ratio: VideoAspectRatio
+  resolution: VideoResolution
+  frame_rate: VideoFrameRate
+  transitions: VideoTransitions
+}
+
+/** A video job's live status as the backend reports it. */
+export type VideoStatusDetail = {
+  job_id: string
+  status: VideoState
+  progress: number
+  eta_seconds?: number
+  video_id?: string
+  error?: string
+  created_at?: string
+  completed_at?: string
+}
+
+/** The outcome of submitting a video job, classified for the state machine. */
+export type SubmitVideoResult =
+  | { status: "accepted"; jobId: string }
+  | { status: "unauthorized" }
+  | { status: "insufficient_credits"; balance: number; required: number }
+  | { status: "invalid"; detail: string }
+  /** 503 — video generation isn't configured on this deployment. */
+  | { status: "unavailable"; detail: string }
+  | { status: "error"; detail: string }
+
+/** A single status poll's outcome, classified for the job state machine. */
+export type VideoPollResult =
+  | { kind: "pending"; detail: VideoStatusDetail }
+  | { kind: "complete"; detail: VideoStatusDetail }
+  | { kind: "failed"; error: string }
+  | { kind: "unauthorized" }
+  // Network blip / 5xx — not a real failure; the poller retries (up to its cap).
+  | { kind: "transient" }
+
+/** Pull a human-readable message out of a FastAPI error body (string or 422 list). */
+function extractDetail(body: unknown, fallback: string): string {
+  if (body && typeof body === "object" && "detail" in body) {
+    const detail = (body as { detail: unknown }).detail
+    if (typeof detail === "string") return detail
+    if (Array.isArray(detail) && detail.length > 0) {
+      const first = detail[0]
+      if (first && typeof first === "object" && "msg" in first) {
+        return String((first as { msg: unknown }).msg)
+      }
+    }
+  }
+  return fallback
+}
+
+/** Submit a video job through the BFF proxy and classify the response. */
+export async function submitVideoJob(
+  clipId: string,
+  config: VideoConfig,
+  accessToken: string
+): Promise<SubmitVideoResult> {
+  // Drop unset optional fields: the backend forbids unknown keys and treats
+  // null prompt/preset as "neither provided", so absence is the safe encoding.
+  const payload: Record<string, unknown> = { clip_id: clipId, ...config }
+  for (const key of ["prompt", "style_preset", "reference_image_urls"] as const) {
+    if (payload[key] === undefined) delete payload[key]
+  }
+
+  let res: Response
+  try {
+    res = await fetch("/api/videos/generate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(payload),
+    })
+  } catch {
+    return { status: "error", detail: "Video generation failed. Please try again." }
+  }
+
+  if (res.status === 202) {
+    const body = (await res.json().catch(() => ({}))) as { job_id?: string }
+    if (!body.job_id) {
+      return { status: "error", detail: "Server returned an unexpected response." }
+    }
+    return { status: "accepted", jobId: body.job_id }
+  }
+  if (res.status === 401) return { status: "unauthorized" }
+
+  const body = await res.json().catch(() => ({}))
+  if (res.status === 402) {
+    // The 402 detail is an object {error, balance, required}.
+    const detail = (body as { detail?: { balance?: number; required?: number } })
+      .detail
+    return {
+      status: "insufficient_credits",
+      balance: detail?.balance ?? 0,
+      required: detail?.required ?? 0,
+    }
+  }
+  if (res.status === 422) {
+    return { status: "invalid", detail: extractDetail(body, "Please check your input.") }
+  }
+  if (res.status === 503) {
+    return {
+      status: "unavailable",
+      detail: extractDetail(body, "Video generation is currently unavailable."),
+    }
+  }
+  return {
+    status: "error",
+    detail: extractDetail(body, "Video generation failed. Please try again."),
+  }
+}
+
+/** Poll one video job's status through the BFF proxy and classify it. */
+export async function fetchVideoStatus(
+  jobId: string,
+  accessToken: string
+): Promise<VideoPollResult> {
+  let res: Response
+  try {
+    res = await fetch(`/api/videos/${encodeURIComponent(jobId)}/status`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    })
+  } catch {
+    return { kind: "transient" }
+  }
+
+  if (res.status === 401) return { kind: "unauthorized" }
+  // A 4xx other than 401 is terminal (404 = unknown/not-owned job) — polling
+  // can never recover, so fail fast. 5xx/network stay transient (retried).
+  if (res.status >= 400 && res.status < 500) {
+    return { kind: "failed", error: "Video generation failed. Please try again." }
+  }
+  if (!res.ok) return { kind: "transient" }
+
+  const detail = (await res.json().catch(() => ({}))) as VideoStatusDetail
+  switch (detail.status) {
+    case "complete":
+      return { kind: "complete", detail }
+    case "failed":
+      return {
+        kind: "failed",
+        error: detail.error || "Video generation failed. Please try again.",
+      }
+    case "queued":
+    case "rendering":
+    case "encoding":
+      return { kind: "pending", detail }
+    default:
+      // Unknown/missing status — transient so one odd body doesn't abort a job.
+      return { kind: "transient" }
+  }
+}


### PR DESCRIPTION
Closes #312.

## Summary

Adds the US-22.2 video creation page: `/video/[songId]` presents the source
song, visual configuration, and a generation trigger over the US-22.1 backend
(`POST /api/v1/videos/generate`, `GET /api/v1/videos/{job_id}/status`).

- **`web/lib/video.ts`** — typed API client mirroring the backend Literals,
  option tables (presets with prompt seed text, aspect ratios, resolutions with
  Pro flags, frame rates, transitions), and `estimateVideoCost` (client-side
  mirror of `credits_service.get_video_cost`: 5/7/8 by resolution, +2 past
  180 s, cap 10). Submit/poll responses classified for the state machine
  (202/401/402/422/503, pending/complete/failed/transient).
- **BFF proxies** — `app/api/videos/generate` (POST) and
  `app/api/videos/[jobId]/status` (GET), mirroring the mastering proxies.
- **`web/hooks/use-video-job.ts`** — submit → poll state machine mirroring
  `use-mastering-job` (token rotation via ref, unmount safety, superseded-job
  guard, 30-min poll cap).
- **Components** (`web/components/video/`) — `VideoForm` (style prompt +
  preset chips that seed it, reference-image picker with previews, lyrics-sync
  switch, RadioGroup-fieldset pickers, live credit estimate, Pro gating on
  1080p/4K with lock badge + upgrade copy), `VideoProgress` (state label,
  progress bar, ETA, error + retry), `SourceSongCard` (title, duration, style
  tags, play/pause via the cookie-authed stream proxy), `VideoCreator`
  (composition + auth gate + not-found), and a thin `app/video/[songId]`
  page shim (editor idiom).
- **Entry point** — the existing Pro-gated "Create Music Video" song action
  flips from placeholder modal to navigation → `/video/{id}`.

## Acceptance criteria

- Page loads with song metadata and all configuration controls — `VideoForm`/
  `VideoCreator` tests; demo below.
- Style presets populate the style prompt — `VideoForm` test + demo.
- Pro-gated 1080p/4K show a Pro badge (+ upgrade copy) for free users —
  `VideoForm` test + demo.
- Generate submits to the backend and transitions to a progress view —
  `VideoCreator`/`use-video-job` tests + demo.
- All aspect-ratio × resolution combinations selectable — exhaustive 3×3
  `VideoForm` test.

## Testing

Web is **not in CI** — local results: vitest **1503/1503** (192 files, 48 new
tests), `tsc --noEmit` clean, eslint clean, production build green. Mutation
spot-checks (cost surcharge, Pro-gate) each caught by exactly one test.
Reviews: cross-family (GLM via opencode) + internal Claude reviewer — both
found the same single defect (object-URL leak on unmount), fixed with a
regression test in 6bb4e3d.

## Known limitations (by design)

- **Reference images are UI-local.** The backend accepts only hosted http(s)
  URLs (`reference_image_urls`) and no image-hosting endpoint exists yet, so
  the picker validates/previews up to 5 images but submissions omit them.
  Wiring lands with a Stage 22 follow-up. (Not covered by this story's
  acceptance criteria.)
- **Minimal progress view** — the rich progress/delivery UX (phase breakdown,
  completion notification, download/publish) is US-22.3.
- **Credit estimate is a client-side mirror** of the server formula; the
  server remains the billing authority (mastering-costs idiom).
- **Pro gating is UI-only** — the backend accepts any resolution regardless of
  tier, consistent with the platform-wide "Pro is display-only" convention
  (subscription enforcement is Stage 26).
