### PR TITLE
perf(storage): streaming/partial-read media delivery (#365)

### DIFF
--- a/src/acemusic/api/routers/clips.py
+++ b/src/acemusic/api/routers/clips.py
@@ -22,14 +22,13 @@ Access and filter rules live in :mod:`acemusic.api.services.clips`.
 import asyncio
 import logging
 import math
-import secrets
 from datetime import datetime
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from acemusic.storage import get_storage_backend
+from acemusic.storage import StorageBackend, get_storage_backend
 
 from ..auth.dependencies import CurrentUser, get_current_user, get_current_user_optional, require_existing_user
 from ..models import Clip, VisibilityState
@@ -37,14 +36,34 @@ from ..services import clips as clip_service
 from ..services.audio_conversion import convert_audio_format
 from ..services.clips import get_clip_for_audio_access, get_clip_for_streaming
 from ..utils.media_types import get_audio_content_type
-from ..utils.range_requests import (
-    build_multipart_ranges_response,
-    parse_range_header,
-    parse_range_header_multi,
-)
+from ..utils.range_requests import stream_stored_object
 from ..utils.rate_limit import enforce_stream_rate_limit
 
 logger = logging.getLogger(__name__)
+
+
+async def _download_clip_audio(storage: StorageBackend, clip: Clip) -> bytes:
+    """Download a clip's stored audio, mapping a missing object to a 404.
+
+    The document exists but its object is gone — a data-integrity problem worth
+    logging, surfaced to the client as a plain 404. Storage I/O is synchronous,
+    so keep it off the event loop.
+    """
+    try:
+        return await asyncio.to_thread(storage.download, clip.file_path)
+    except FileNotFoundError:
+        logger.warning("Clip %s exists but its audio object %r is missing", clip.id, clip.file_path)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio file not found.")
+
+
+async def _clip_audio_size(storage: StorageBackend, clip: Clip) -> int:
+    """Return a clip audio object's byte length, mapping a missing object to 404."""
+    try:
+        return await asyncio.to_thread(storage.size, clip.file_path)
+    except FileNotFoundError:
+        logger.warning("Clip %s exists but its audio object %r is missing", clip.id, clip.file_path)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio file not found.")
+
 
 # Titles are stored verbatim and re-served on every list; cap them so one PATCH
 # cannot bloat the document (mirrors the users router's field caps).
@@ -407,20 +426,12 @@ async def get_clip_audio(
     clip = await get_clip_for_audio_access(clip_id, current.user_id)
 
     storage = get_storage_backend()
-    try:
-        # download() does file/network I/O via the sync backend; keep it off
-        # the event loop.
-        audio = await asyncio.to_thread(storage.download, clip.file_path)
-    except FileNotFoundError:
-        # The clip document exists but its object is gone — a data integrity
-        # problem worth logging, surfaced to the client as a plain 404.
-        logger.warning("Clip %s exists but its audio object %r is missing", clip.id, clip.file_path)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio file not found.")
-
     native_format = clip_service.native_format(clip)
-    serve_format = native_format
-    converted = False
+
+    # Conversion needs the whole object (a re-encode has a different byte layout),
+    # so Range doesn't apply — download, convert, and serve buffered.
     if format is not None and format != native_format:
+        audio = await _download_clip_audio(storage, clip)
         try:
             audio = await asyncio.to_thread(convert_audio_format, audio, native_format, format)
         except Exception as exc:
@@ -429,29 +440,19 @@ async def get_clip_audio(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Could not convert audio to {format}.",
             ) from exc
-        serve_format = format
-        converted = True
+        return Response(content=audio, media_type=get_audio_content_type(format))
 
-    # Byte ranges address the stored representation; conversion produces a
-    # different byte layout, so Range (and the Accept-Ranges advertisement)
-    # only applies to unconverted responses.
-    headers = {} if converted else {"Accept-Ranges": "bytes"}
-    media_type = get_audio_content_type(serve_format)
-
-    range_header = request.headers.get("range")
-    if range_header is not None and not converted:
-        byte_range = parse_range_header(range_header, len(audio))
-        if byte_range is not None:
-            start, end = byte_range
-            headers["Content-Range"] = f"bytes {start}-{end}/{len(audio)}"
-            return Response(
-                content=audio[start : end + 1],
-                status_code=status.HTTP_206_PARTIAL_CONTENT,
-                media_type=media_type,
-                headers=headers,
-            )
-
-    return Response(content=audio, media_type=media_type, headers=headers)
+    # Unconverted: stream the stored representation with Range support so a large
+    # object is never buffered whole.
+    total = await _clip_audio_size(storage, clip)
+    return await stream_stored_object(
+        storage,
+        clip.file_path,
+        total,
+        get_audio_content_type(native_format),
+        {"Accept-Ranges": "bytes"},
+        request.headers.get("range"),
+    )
 
 
 @stream_router.get(
@@ -498,16 +499,16 @@ async def stream_clip_audio(
     clip = await get_clip_for_streaming(clip_id, current.user_id if current else None)
 
     storage = get_storage_backend()
-    try:
-        audio = await asyncio.to_thread(storage.download, clip.file_path)
-    except FileNotFoundError:
-        logger.warning("Clip %s exists but its audio object %r is missing", clip.id, clip.file_path)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio file not found.")
-
     native_format = clip_service.native_format(clip)
-    serve_format = native_format
-    converted = False
+    # Access-controlled: a shorter max-age bounds how long a shared cache keeps
+    # serving a clip after it is made private again (the origin check can't reach
+    # cached copies). Private clips stay client-only and uncached.
+    cache_control = "public, max-age=300" if clip.is_public else "private, no-store"
+
+    # Conversion needs the whole object and produces a different byte layout, so
+    # Range (and Accept-Ranges) doesn't apply — download, convert, serve buffered.
     if format is not None and format != native_format:
+        audio = await _download_clip_audio(storage, clip)
         try:
             audio = await asyncio.to_thread(convert_audio_format, audio, native_format, format)
         except Exception as exc:
@@ -516,41 +517,17 @@ async def stream_clip_audio(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Could not convert audio to {format}.",
             ) from exc
-        serve_format = format
-        converted = True
+        return Response(
+            content=audio, media_type=get_audio_content_type(format), headers={"Cache-Control": cache_control}
+        )
 
-    media_type = get_audio_content_type(serve_format)
-    # Public clips are immutable once shared, so shared caches may hold them;
-    # private clips stay client-only and uncached.
-    cache_control = "public, max-age=3600" if clip.is_public else "private, no-store"
-
-    # Conversion changes the byte layout, so Range (and Accept-Ranges) only
-    # applies to the unconverted stored representation — mirrors /audio.
-    if converted:
-        return Response(content=audio, media_type=media_type, headers={"Cache-Control": cache_control})
-
-    headers = {"Accept-Ranges": "bytes", "Cache-Control": cache_control}
-    range_header = request.headers.get("range")
-    if range_header is not None:
-        ranges = parse_range_header_multi(range_header, len(audio))  # raises 416 if all unsatisfiable
-        if ranges is not None and len(ranges) == 1:
-            start, end = ranges[0]
-            headers["Content-Range"] = f"bytes {start}-{end}/{len(audio)}"
-            return Response(
-                content=audio[start : end + 1],
-                status_code=status.HTTP_206_PARTIAL_CONTENT,
-                media_type=media_type,
-                headers=headers,
-            )
-        if ranges is not None:
-            # secrets.token_hex gives a boundary that won't appear in the audio.
-            boundary = secrets.token_hex(16)
-            body, multipart_type = build_multipart_ranges_response(audio, ranges, media_type, boundary)
-            return Response(
-                content=body,
-                status_code=status.HTTP_206_PARTIAL_CONTENT,
-                media_type=multipart_type,
-                headers=headers,
-            )
-
-    return Response(content=audio, media_type=media_type, headers=headers)
+    # Unconverted: stream the stored representation with Range support.
+    total = await _clip_audio_size(storage, clip)
+    return await stream_stored_object(
+        storage,
+        clip.file_path,
+        total,
+        get_audio_content_type(native_format),
+        {"Accept-Ranges": "bytes", "Cache-Control": cache_control},
+        request.headers.get("range"),
+    )

--- a/src/acemusic/api/routers/videos.py
+++ b/src/acemusic/api/routers/videos.py
@@ -14,7 +14,6 @@ refunds, and the ledger write is best-effort.
 
 import asyncio
 import logging
-import secrets
 from datetime import datetime
 from typing import Literal
 
@@ -33,7 +32,7 @@ from ..services import (
 )
 from ..services.clips import get_clip_for_streaming
 from ..settings import ApiSettings
-from ..utils.range_requests import build_multipart_ranges_response, parse_range_header_multi
+from ..utils.range_requests import stream_stored_object
 from ..utils.rate_limit import enforce_stream_rate_limit
 
 logger = logging.getLogger(__name__)
@@ -378,38 +377,20 @@ async def stream_video(
 
     storage = get_storage_backend()
     try:
-        data = await asyncio.to_thread(storage.download, video.storage_path)
+        total = await asyncio.to_thread(storage.size, video.storage_path)
     except FileNotFoundError:
         # The document exists but its object is gone — a data-integrity problem
         # worth logging, surfaced to the client as a plain 404.
         logger.warning("Video %s exists but its object %r is missing", video.id, video.storage_path)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video file not found.")
 
-    cache_control = "public, max-age=3600" if video.published else "private, no-store"
+    # Access-controlled: a shorter max-age bounds how long a shared cache can keep
+    # serving a video after it is un-published (the origin check can't reach it).
+    cache_control = "public, max-age=300" if video.published else "private, no-store"
     headers = {"Accept-Ranges": "bytes", "Cache-Control": cache_control}
     if download:
         headers["Content-Disposition"] = f'attachment; filename="video-{video.id}.mp4"'
 
-    range_header = request.headers.get("range")
-    if range_header is not None:
-        ranges = parse_range_header_multi(range_header, len(data))  # raises 416 if all unsatisfiable
-        if ranges is not None and len(ranges) == 1:
-            start, end = ranges[0]
-            headers["Content-Range"] = f"bytes {start}-{end}/{len(data)}"
-            return Response(
-                content=data[start : end + 1],
-                status_code=status.HTTP_206_PARTIAL_CONTENT,
-                media_type=_VIDEO_MEDIA_TYPE,
-                headers=headers,
-            )
-        if ranges is not None:
-            boundary = secrets.token_hex(16)
-            body, multipart_type = build_multipart_ranges_response(data, ranges, _VIDEO_MEDIA_TYPE, boundary)
-            return Response(
-                content=body,
-                status_code=status.HTTP_206_PARTIAL_CONTENT,
-                media_type=multipart_type,
-                headers=headers,
-            )
-
-    return Response(content=data, media_type=_VIDEO_MEDIA_TYPE, headers=headers)
+    return await stream_stored_object(
+        storage, video.storage_path, total, _VIDEO_MEDIA_TYPE, headers, request.headers.get("range")
+    )

--- a/src/acemusic/api/utils/range_requests.py
+++ b/src/acemusic/api/utils/range_requests.py
@@ -9,9 +9,16 @@ US-14.2 adds :func:`parse_range_header_multi` (comma-separated ranges) and
 the streaming endpoint, leaving the proven single-range path above untouched.
 """
 
+import asyncio
 import re
+import secrets
+from typing import TYPE_CHECKING
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException, Response, status
+from fastapi.responses import StreamingResponse
+
+if TYPE_CHECKING:
+    from acemusic.storage import StorageBackend
 
 # One range-spec in the bytes unit: "bytes=<start?>-<end?>".
 _RANGE_RE = re.compile(r"bytes=(\d*)-(\d*)$")
@@ -168,3 +175,57 @@ def build_multipart_ranges_response(
         parts.append(content[start : end + 1])
     parts.append(f"\r\n--{boundary}--\r\n".encode("ascii"))
     return b"".join(parts), f"multipart/byteranges; boundary={boundary}"
+
+
+async def stream_stored_object(
+    storage: "StorageBackend",
+    path: str,
+    total: int,
+    media_type: str,
+    headers: dict[str, str],
+    range_header: str | None,
+) -> Response:
+    """Serve a stored object with Range support, streaming from ``storage``.
+
+    Single-range (206) and full-body (200) responses stream a chunk at a time via
+    :meth:`StorageBackend.open_range`, so a large object never buffers whole.
+    Multi-range (``multipart/byteranges``) is rare and size-bounded
+    (:data:`MAX_MULTIRANGE_SPECS` + a total-bytes cap), so it still buffers via
+    :meth:`StorageBackend.download`.
+
+    ``total`` is the object's byte length (from :meth:`StorageBackend.size`); the
+    caller resolves it first so existence is checked — and a 404 returned —
+    before any streaming headers are sent. ``headers`` are applied to every
+    branch; this adds ``Content-Length`` (and ``Content-Range`` for 206).
+    """
+    if range_header is not None:
+        ranges = parse_range_header_multi(range_header, total)  # may raise 416
+        if ranges is not None and len(ranges) == 1:
+            start, end = ranges[0]
+            part_headers = {
+                **headers,
+                "Content-Range": f"bytes {start}-{end}/{total}",
+                "Content-Length": str(end - start + 1),
+            }
+            return StreamingResponse(
+                storage.open_range(path, start, end),
+                status_code=status.HTTP_206_PARTIAL_CONTENT,
+                media_type=media_type,
+                headers=part_headers,
+            )
+        if ranges is not None:
+            # Multipart needs the whole object assembled; keep it off the loop.
+            data = await asyncio.to_thread(storage.download, path)
+            boundary = secrets.token_hex(16)
+            body, multipart_type = build_multipart_ranges_response(data, ranges, media_type, boundary)
+            return Response(
+                content=body,
+                status_code=status.HTTP_206_PARTIAL_CONTENT,
+                media_type=multipart_type,
+                headers=headers,
+            )
+
+    # No (usable) Range: stream the full body rather than buffering it.
+    full_headers = {**headers, "Content-Length": str(total)}
+    body_iter = storage.open_range(path, 0, total - 1) if total > 0 else iter(())
+    return StreamingResponse(body_iter, media_type=media_type, headers=full_headers)

--- a/src/acemusic/storage.py
+++ b/src/acemusic/storage.py
@@ -15,9 +15,15 @@ from __future__ import annotations
 
 import mimetypes
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from pathlib import Path
 
 from .config import load_config
+
+# Chunk size for range streaming (:meth:`StorageBackend.open_range`). 1 MiB keeps
+# a large media transfer off a single whole-object buffer without a syscall per
+# byte. Module-level so tests can shrink it to exercise multi-chunk streaming.
+_STREAM_CHUNK_SIZE = 1 << 20
 
 # S3 error codes that mean "this object does not exist"; normalised to
 # FileNotFoundError so callers handle a miss identically across backends.
@@ -72,6 +78,27 @@ class StorageBackend(ABC):
     def download(self, path: str) -> bytes:
         """Return the bytes stored at ``path``; raise if it does not exist."""
 
+    def size(self, path: str) -> int:
+        """Return the byte length of ``path``; raise ``FileNotFoundError`` if missing.
+
+        Lets a caller serve a Range request (Content-Range, 416 checks) without
+        first downloading the whole object. Concrete (not abstract) so existing
+        subclasses keep working: the default buffers via :meth:`download`;
+        backends that can stat cheaply (local, S3) override it.
+        """
+        return len(self.download(path))
+
+    def open_range(self, path: str, start: int, end: int) -> Iterator[bytes]:
+        """Yield the inclusive byte range ``[start, end]`` of ``path`` in chunks.
+
+        Overriding backends stream a chunk at a time so a large object is never
+        buffered whole; this default slices a full :meth:`download` (fine for
+        small objects and test fakes). ``start``/``end`` must be valid
+        (``0 <= start <= end < size``); callers resolve them against
+        :meth:`size` first. Raises ``FileNotFoundError`` if the object is missing.
+        """
+        yield self.download(path)[start : end + 1]
+
     @abstractmethod
     def delete(self, path: str) -> None:
         """Remove ``path``. Missing objects are not an error (idempotent)."""
@@ -107,6 +134,22 @@ class LocalStorage(StorageBackend):
 
     def download(self, path: str) -> bytes:
         return self._full_path(path).read_bytes()
+
+    def size(self, path: str) -> int:
+        # stat() raises FileNotFoundError for a missing file — exactly our contract.
+        return self._full_path(path).stat().st_size
+
+    def open_range(self, path: str, start: int, end: int) -> Iterator[bytes]:
+        target = self._full_path(path)
+        with target.open("rb") as fh:  # raises FileNotFoundError if missing
+            fh.seek(start)
+            remaining = end - start + 1
+            while remaining > 0:
+                chunk = fh.read(min(_STREAM_CHUNK_SIZE, remaining))
+                if not chunk:  # object shorter than requested end — stop cleanly
+                    break
+                remaining -= len(chunk)
+                yield chunk
 
     def delete(self, path: str) -> None:
         self._full_path(path).unlink(missing_ok=True)
@@ -162,6 +205,29 @@ class S3Storage(StorageBackend):
                 raise FileNotFoundError(path) from exc
             raise
         return response["Body"].read()
+
+    def size(self, path: str) -> int:
+        try:
+            response = self.client.head_object(Bucket=self.bucket, Key=self._key(path))
+        except Exception as exc:  # noqa: BLE001 - inspected and re-raised below
+            # HeadObject returns no body, so a miss surfaces as a bare "404".
+            if _s3_error_code(exc) in _S3_NOT_FOUND_CODES:
+                raise FileNotFoundError(path) from exc
+            raise
+        return response["ContentLength"]
+
+    def open_range(self, path: str, start: int, end: int) -> Iterator[bytes]:
+        try:
+            response = self.client.get_object(Bucket=self.bucket, Key=self._key(path), Range=f"bytes={start}-{end}")
+        except Exception as exc:  # noqa: BLE001 - inspected and re-raised below
+            if _s3_error_code(exc) in _S3_NOT_FOUND_CODES:
+                raise FileNotFoundError(path) from exc
+            raise
+        body = response["Body"]
+        try:
+            yield from body.iter_chunks(chunk_size=_STREAM_CHUNK_SIZE)
+        finally:
+            body.close()
 
     def delete(self, path: str) -> None:
         # The S3 DeleteObject API is already idempotent for missing keys.

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -107,6 +107,44 @@ class TestLocalStorage:
         # Stored under the exact convention path.
         assert (tmp_path / "user123" / "ws456" / "clips" / "clip789.mp3").exists()
 
+    def test_size_returns_byte_length(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+        backend.upload(SAMPLE_KEY, b"twelve bytes")
+        assert backend.size(SAMPLE_KEY) == 12
+
+    def test_size_missing_raises(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            backend.size("does/not/exist.mp3")
+
+    def test_open_range_yields_inclusive_slice(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+        backend.upload(SAMPLE_KEY, b"0123456789")
+        assert b"".join(backend.open_range(SAMPLE_KEY, 2, 5)) == b"2345"
+
+    def test_open_range_full_object(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+        backend.upload(SAMPLE_KEY, b"0123456789")
+        assert b"".join(backend.open_range(SAMPLE_KEY, 0, 9)) == b"0123456789"
+
+    def test_open_range_chunks_large_object(self, tmp_path: Path, monkeypatch):
+        from acemusic import storage
+
+        monkeypatch.setattr(storage, "_STREAM_CHUNK_SIZE", 1024)
+        backend = self._backend(tmp_path)
+        blob = bytes(range(256)) * 40  # 10 KiB, larger than the shrunk chunk
+        backend.upload(SAMPLE_KEY, blob)
+        chunks = list(backend.open_range(SAMPLE_KEY, 0, len(blob) - 1))
+        assert b"".join(chunks) == blob
+        # Streams a chunk at a time rather than the whole object in one buffer.
+        assert all(len(c) <= 1024 for c in chunks)
+        assert len(chunks) > 1
+
+    def test_open_range_missing_raises(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            list(backend.open_range("does/not/exist.mp3", 0, 3))
+
 
 # ---------------------------------------------------------------------------
 # S3Storage (boto3 mocked)
@@ -187,6 +225,46 @@ class TestS3Storage:
         with pytest.raises(RuntimeError, match="network down"):
             backend.download(SAMPLE_KEY)
 
+    def test_size_returns_content_length(self):
+        backend, client, _ = self._backend_and_client()
+        client.head_object.return_value = {"ContentLength": 4096}
+        assert backend.size(SAMPLE_KEY) == 4096
+        client.head_object.assert_called_once_with(Bucket="my-bucket", Key=SAMPLE_KEY)
+
+    def test_size_missing_key_raises_file_not_found(self):
+        backend, client, _ = self._backend_and_client()
+        err = Exception("not found")
+        # HeadObject signals a miss with a bare 404 code (no NoSuchKey body).
+        err.response = {"Error": {"Code": "404"}}  # type: ignore[attr-defined]
+        client.head_object.side_effect = err
+        with pytest.raises(FileNotFoundError):
+            backend.size(SAMPLE_KEY)
+
+    def test_size_other_error_propagates(self):
+        backend, client, _ = self._backend_and_client()
+        err = Exception("access denied")
+        err.response = {"Error": {"Code": "AccessDenied"}}  # type: ignore[attr-defined]
+        client.head_object.side_effect = err
+        with pytest.raises(Exception, match="access denied"):
+            backend.size(SAMPLE_KEY)
+
+    def test_open_range_requests_byte_range_and_streams_chunks(self):
+        backend, client, _ = self._backend_and_client()
+        body = MagicMock()
+        body.iter_chunks.return_value = iter([b"23", b"45"])
+        client.get_object.return_value = {"Body": body}
+        assert b"".join(backend.open_range(SAMPLE_KEY, 2, 5)) == b"2345"
+        client.get_object.assert_called_once_with(Bucket="my-bucket", Key=SAMPLE_KEY, Range="bytes=2-5")
+        body.close.assert_called_once()
+
+    def test_open_range_missing_key_raises_file_not_found(self):
+        backend, client, _ = self._backend_and_client()
+        err = Exception("not found")
+        err.response = {"Error": {"Code": "NoSuchKey"}}  # type: ignore[attr-defined]
+        client.get_object.side_effect = err
+        with pytest.raises(FileNotFoundError):
+            list(backend.open_range(SAMPLE_KEY, 0, 3))
+
     def test_delete_calls_delete_object(self):
         backend, client, _ = self._backend_and_client()
         backend.delete(SAMPLE_KEY)
@@ -226,6 +304,52 @@ class TestS3Storage:
         with patch.object(storage, "boto3", None):
             with pytest.raises(storage.StorageError, match="boto3"):
                 storage.S3Storage(bucket="my-bucket")
+
+
+# ---------------------------------------------------------------------------
+# StorageBackend base-class defaults (subclasses overriding only the originals)
+# ---------------------------------------------------------------------------
+
+
+class TestStorageBackendDefaults:
+    """size()/open_range() are concrete on the base so existing subclasses that
+    implement only upload/download/delete/get_url keep instantiating and get a
+    correct (buffered) fallback — regression guard for the streaming addition."""
+
+    def _minimal_backend(self):
+        from acemusic.storage import StorageBackend
+
+        class Minimal(StorageBackend):
+            def __init__(self) -> None:
+                self._store: dict[str, bytes] = {}
+
+            def upload(self, path: str, data: bytes) -> None:
+                self._store[path] = data
+
+            def download(self, path: str) -> bytes:
+                if path not in self._store:
+                    raise FileNotFoundError(path)
+                return self._store[path]
+
+            def delete(self, path: str) -> None:
+                self._store.pop(path, None)
+
+            def get_url(self, path: str) -> str:
+                return path
+
+        return Minimal()
+
+    def test_subclass_without_size_or_open_range_instantiates(self):
+        # Would raise TypeError if the methods were still abstract.
+        backend = self._minimal_backend()
+        backend.upload(SAMPLE_KEY, b"0123456789")
+        assert backend.size(SAMPLE_KEY) == 10
+        assert b"".join(backend.open_range(SAMPLE_KEY, 2, 5)) == b"2345"
+
+    def test_default_size_missing_raises(self):
+        backend = self._minimal_backend()
+        with pytest.raises(FileNotFoundError):
+            backend.size("missing")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Closes #365 (P2.9). `GET /videos/{id}/stream`, `/clips/{id}/stream`, and `/clips/{id}/audio` all called `storage.download() -> bytes`, buffering the **entire** object into memory before slicing a Range. Fine for audio, an OOM/latency risk for large (1080p/4K) video renders where a few concurrent viewers could stall the event loop.

## Changes

- **`StorageBackend` gains two methods** (`src/acemusic/storage.py`):
  - `size(path) -> int` — object byte length without downloading it (Local: `stat()`; S3: `head_object` ContentLength; missing → `FileNotFoundError`).
  - `open_range(path, start, end) -> Iterator[bytes]` — yields the inclusive byte range a chunk at a time (Local: `seek` + chunked read; S3: `get_object(Range=)` → `iter_chunks`, body closed in `finally`).
  - Both are **concrete base-class defaults** (buffered via `download()`), so any existing subclass that implements only the original four methods keeps working; `LocalStorage`/`S3Storage` override for the efficient streaming path.
- **Shared async helper** `stream_stored_object(...)` (`api/utils/range_requests.py`): single-range (206) and full-body (200) responses stream via `StreamingResponse` (sync generator → Starlette threadpool, so the event loop isn't blocked), with correct `Content-Range` / `Content-Length`. Multi-range `multipart/byteranges` stays buffered — it's rare and already size-bounded by `MAX_MULTIRANGE_SPECS` + a total-bytes cap.
- **Endpoints rewired**: `stream_video`, `stream_clip_audio`, `get_clip_audio` resolve `size()` first (existence check → 404 before any streaming headers), then delegate to the helper. Conversion paths still download the whole object (a re-encode has a different byte layout, so Range doesn't apply).
- **Cache staleness (issue comment)**: lowered `Cache-Control: max-age` from `3600` → `300` on access-controlled media, bounding how long a shared cache can keep serving a resource after a visibility flip (publish → later make-private). No ETag/revalidation infra added — shorter max-age is the minimal fix.

## Tests / evidence

- New `tests/test_storage.py` cases for `size` + `open_range` on Local and S3 (mocked), missing → `FileNotFoundError`, chunked streaming of a large object, and a base-class-default regression guard (a subclass overriding only `download` still instantiates and works).
- Existing endpoint suites (`test_video_api`, `test_clips_api`, `test_clips`) stay green — 206/multipart/416/404/full-body all preserved.
- Manual check: a 5 MiB object serves `size()` via stat, `open_range` in multiple chunks with exact bytes, a 206 single-range with correct `Content-Range`/`Content-Length`, and a full-body 200 streamed in 20 chunks.

## Known limitations

- **Multi-range** (`multipart/byteranges`) still buffers the whole object via `download()`. It's rare (browsers seek with a single range) and bounded by the existing multi-range caps, so it wasn't worth a streaming multipart assembler.
- **Truncation race**: `size()` is read before streaming; if the object is truncated/deleted between `size()` and iteration, the stream ends short (or errors mid-transfer) rather than returning a clean 404. Narrow window, matches the prior data-integrity assumptions.

## Review

Cross-family pre-PR review via `codex review` flagged one P1 — new abstract methods would break existing `StorageBackend` subclasses (e.g. test `FailingStorage`) and the integration CI job. Fixed by making `size`/`open_range` concrete defaults; verified `FailingStorage` instantiates and the integration tests collect. (opencode/GLM hit a transient server error this run.)
