### PR TITLE
feat(video): US-22.4 Basic Video Editing (#314)

### DIFF
--- a/docs/demos/us-22.4-video-editing.md
+++ b/docs/demos/us-22.4-video-editing.md
@@ -1,0 +1,79 @@
+# US-22.4 — Basic Video Editing (demo)
+
+Non-destructive editing for a rendered music video: **trim**, **scene replacement**,
+**lyrics-overlay toggle**, and **transition timing**. Each edit forwards a spec to the
+video provider and produces a **new** `Video` version linked to its source
+(`parent_video_id`); the original is never mutated. Edit history is the owner's
+versions for that clip, newest first.
+
+No provider credentials exist in this environment (as with Dolby/ElevenLabs), so the
+evidence below is produced by `scripts/demo_us_22_4.py`, which drives the **real**
+service, HTTP endpoints and job handler against a local MongoDB with a fake provider —
+the same code paths the background worker runs. Run:
+
+```
+ACEMUSIC_TEST_MONGODB_URL=mongodb://127.0.0.1:27018 uv run python scripts/demo_us_22_4.py
+```
+
+## Original render (the starting point)
+```
+video_id=…bae63d  resolution=1080p  parent=None  edit=None
+created_at=2026-07-29T16:40:40.690000
+```
+
+## AC1 — Trimming (produces a new, shorter cut)
+`POST /api/v1/videos/{id}/edit` with a trim range → **202**, a new version whose parent
+is the original. The provider receives only the trim spec (+ inherited dimensions); it
+renders the shorter cut.
+```
+HTTP 202 -> job …bae63e
+new version_id=…bae640  parent_video_id=…bae63d  edit={'operation': 'trim', 'start_seconds': 5.0, 'end_seconds': 25.0}
+provider received spec: {'operation': 'trim', 'start_seconds': 5.0, 'end_seconds': 25.0, 'resolution': '1080p', 'aspect_ratio': '16:9'}
+```
+
+## AC2 — Scene replacement (regenerates only the selected range)
+The edit carries the time range **and** a new visual prompt; the surrounding video is
+preserved because the source video's bytes are the render input and only the selected
+range is re-described to the provider.
+```
+HTTP 202 -> job …bae641
+new version_id=…bae643  parent_video_id=…bae63d  edit={'operation': 'replace_scene', 'start_seconds': 10.0, 'end_seconds': 15.0, 'prompt': 'sunrise over the ocean'}
+provider received spec: {'operation': 'replace_scene', 'start_seconds': 10.0, 'end_seconds': 15.0, 'prompt': 'sunrise over the ocean', 'resolution': '1080p', 'aspect_ratio': '16:9'}
+```
+
+## AC3 — Lyrics overlay toggle (post-generation)
+```
+HTTP 202 -> job …bae644
+new version_id=…bae646  parent_video_id=…bae63d  edit={'operation': 'lyrics_overlay', 'lyrics_enabled': True}
+provider received spec: {'operation': 'lyrics_overlay', 'lyrics_enabled': True, 'resolution': '1080p', 'aspect_ratio': '16:9'}
+```
+(Transition timing works identically — `{'operation': 'transitions', 'transition_markers': [4, 8.5, 12]}`.)
+
+## AC4 — Original version accessible after edits (nothing mutated)
+```
+GET /videos/…bae63d -> HTTP 200
+original.parent_video_id=None  edit=None  (unchanged)
+original object still stored: True
+```
+
+## AC5 — Edit history shows all versions with timestamps
+`GET /api/v1/videos/{id}/versions` — the whole lineage, newest first:
+```
+HTTP 200 — 4 versions (newest first):
+  2026-07-29T16:40:40.811000  lyrics_overlay    id=…bae646  parent=…bae63d
+  2026-07-29T16:40:40.802000  replace_scene     id=…bae643  parent=…bae63d
+  2026-07-29T16:40:40.792000  trim              id=…bae640  parent=…bae63d
+  2026-07-29T16:40:40.690000  original render   id=…bae63d  parent=—
+```
+
+## Ownership guard (edit history is owner-only)
+```
+stranger GET /versions -> HTTP 404 (404, history is owner-only)
+```
+
+## Billing & safety (covered by tests, not shown above)
+- Each edit is credit-gated at the source's resolution (`test_charges_source_resolution_cost`),
+  refunds if job creation fails, and 402s with no charge when short of credits.
+- Edit ranges past the song length are 422'd before any charge; unknown/unowned source
+  videos 404; an unconfigured deployment 503s with no charge.
+- A failed edit rolls its uploaded object back (no orphaned storage), same as an original render.

--- a/scripts/demo_us_22_4.py
+++ b/scripts/demo_us_22_4.py
@@ -1,0 +1,179 @@
+"""US-22.4 demo driver — runs the real video-edit flow end to end.
+
+Drives the actual service, router (via the ASGI app) and job handler against a
+local MongoDB with a fake video provider (no credentials exist for the real
+one). Prints the outcome evidence the demo doc quotes: an original render, three
+non-destructive edits (each a new version linked to its source), the untouched
+original, and the version history.
+
+Run: ACEMUSIC_TEST_MONGODB_URL=mongodb://127.0.0.1:27018 uv run python scripts/demo_us_22_4.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import httpx
+
+from acemusic.api import database
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Clip, Job, JobStatus, Video, Workspace
+from acemusic.api.services import users as user_service
+from acemusic.api.services.video import VIDEO_JOB_TYPE
+from acemusic.api.settings import ApiSettings
+from acemusic.api.tasks import video as video_tasks
+from acemusic.storage import LocalStorage
+from acemusic.video_client import VideoJobUpdate
+
+FAKE_AUDIO = b"RIFF" + b"\x00" * 200
+RENDERED_MP4 = b"\x00\x00\x00\x18ftypmp42" + b"rendered" * 32
+
+
+class FakeProvider:
+    """Accepts a submit, reports complete, returns a rendered MP4."""
+
+    def __init__(self) -> None:
+        self.submissions: list[tuple[str, dict]] = []
+
+    def submit(self, media: bytes, filename: str, params: dict) -> str:
+        self.submissions.append((filename, dict(params)))
+        return f"pj-{len(self.submissions)}"
+
+    def get_status(self, provider_job_id: str) -> VideoJobUpdate:
+        return VideoJobUpdate(state="complete", progress=100)
+
+    def download(self, provider_job_id: str) -> bytes:
+        return RENDERED_MP4
+
+
+def hr(title: str) -> None:
+    print(f"\n{'=' * 4} {title} {'=' * 4}")
+
+
+async def run_job(job: Job, storage: LocalStorage, provider: FakeProvider) -> Video:
+    """Execute a queued video/edit job through the real handler; return its Video."""
+    result = await video_tasks.process_video_job(job, storage=storage, client=provider, poll_interval=0)
+    await job.set({Job.status: JobStatus.COMPLETED, Job.result: result})
+    return await Video.get(__import__("beanie").PydanticObjectId(result["video_ids"][0]))
+
+
+async def main() -> None:
+    url = os.environ.get("ACEMUSIC_TEST_MONGODB_URL", "mongodb://127.0.0.1:27018")
+    settings = ApiSettings(
+        _env_file=None,
+        mongodb_url=url,
+        mongodb_db_name=f"acemusic_demo_{uuid.uuid4().hex[:8]}",
+        jwt_secret_key="demo-secret-key-at-least-32-bytes-long-xx",
+        job_processor_enabled=False,
+        video_api_url="https://video.demo",
+        video_api_key="vk-demo",
+    )
+    client_db = await database.init_db(settings)
+    storage = LocalStorage(f"/tmp/us224-demo-{uuid.uuid4().hex[:8]}")
+    provider = FakeProvider()
+
+    try:
+        user = await user_service.get_or_create_user(
+            email="demo@example.com", provider="google", oauth_id="g-demo", name="Demo"
+        )
+        user.credits_balance = 100.0
+        await user.save()
+        ws = Workspace(name="Demo", user_id=user.id)
+        await ws.insert()
+        clip = Clip(
+            user_id=user.id,
+            workspace_id=ws.id,
+            file_path="song.wav",
+            title="Midnight Drive",
+            format="wav",
+            duration=30.0,
+        )
+        await clip.insert()
+        storage.upload(clip.file_path, FAKE_AUDIO)
+
+        token = create_access_token(
+            user_id=str(user.id), email=user.email, subscription_tier=user.subscription_tier, settings=settings
+        )
+        headers = {"Authorization": f"Bearer {token}"}
+        app = create_app(settings)
+
+        # 1) Original render — run a generate job through the handler.
+        gen_job = Job(
+            user_id=user.id,
+            workspace_id=ws.id,
+            job_type=VIDEO_JOB_TYPE,
+            input_params={
+                "clip_id": str(clip.id),
+                "prompt": "neon city",
+                "resolution": "1080p",
+                "aspect_ratio": "16:9",
+            },
+        )
+        await gen_job.insert()
+        original = await run_job(gen_job, storage, provider)
+        hr("Original render")
+        print(
+            f"video_id={original.id}  resolution={original.resolution}  parent={original.parent_video_id}  edit={original.edit}"
+        )
+        print(f"created_at={original.created_at.isoformat()}")
+
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://demo") as ac:
+            # 2) Trim, 3) Scene replacement, 4) Lyrics overlay — each via the real endpoint + handler.
+            edits = [
+                {"operation": "trim", "start_seconds": 5.0, "end_seconds": 25.0},
+                {
+                    "operation": "replace_scene",
+                    "start_seconds": 10.0,
+                    "end_seconds": 15.0,
+                    "prompt": "sunrise over the ocean",
+                },
+                {"operation": "lyrics_overlay", "lyrics_enabled": True},
+            ]
+            for spec in edits:
+                r = await ac.post(f"{API_V1_PREFIX}/videos/{original.id}/edit", json=spec, headers=headers)
+                assert r.status_code == 202, (r.status_code, r.text)
+                edit_job = await Job.get(__import__("beanie").PydanticObjectId(r.json()["job_id"]))
+                new = await run_job(edit_job, storage, provider)
+                hr(f"Edit: {spec['operation']}")
+                print(f"HTTP {r.status_code} -> job {edit_job.id}")
+                print(f"new version_id={new.id}  parent_video_id={new.parent_video_id}  edit={new.edit}")
+                print(f"provider received spec: {provider.submissions[-1][1]}")
+
+            # 5) Original preserved + accessible after all edits.
+            reread = await ac.get(f"{API_V1_PREFIX}/videos/{original.id}", headers=headers)
+            fresh_original = await Video.get(original.id)
+            hr("Original preserved & accessible")
+            print(f"GET /videos/{original.id} -> HTTP {reread.status_code}")
+            print(f"original.parent_video_id={fresh_original.parent_video_id}  edit={fresh_original.edit}  (unchanged)")
+            print(f"original object still stored: {storage.download(fresh_original.storage_path) == RENDERED_MP4}")
+
+            # 6) Edit history — all versions with timestamps, newest first.
+            versions = await ac.get(f"{API_V1_PREFIX}/videos/{original.id}/versions", headers=headers)
+            hr("Version history (GET /versions)")
+            print(f"HTTP {versions.status_code} — {len(versions.json())} versions (newest first):")
+            for v in versions.json():
+                op = (v.get("edit") or {}).get("operation", "original render")
+                print(f"  {v['created_at']}  {op:16s}  id={v['id']}  parent={v.get('parent_video_id', '—')}")
+
+            # A stranger cannot list another user's edit history.
+            other = await user_service.get_or_create_user(
+                email="stranger@example.com", provider="google", oauth_id="g-x", name="X"
+            )
+            other_token = create_access_token(
+                user_id=str(other.id), email=other.email, subscription_tier=other.subscription_tier, settings=settings
+            )
+            forbidden = await ac.get(
+                f"{API_V1_PREFIX}/videos/{original.id}/versions", headers={"Authorization": f"Bearer {other_token}"}
+            )
+            hr("Ownership guard")
+            print(f"stranger GET /versions -> HTTP {forbidden.status_code} (404, history is owner-only)")
+    finally:
+        await client_db.drop_database(settings.mongodb_db_name)
+        await database.close_db(client_db)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/acemusic/api/models/video.py
+++ b/src/acemusic/api/models/video.py
@@ -36,6 +36,12 @@ class Video(Document):
     # "start_seconds":5,"end_seconds":30}) so the version history can label it.
     parent_video_id: PydanticObjectId | None = None
     edit: dict | None = None
+    # The rendered length of THIS version (seconds): the source song's duration
+    # for an original render, ``end - start`` for a trim, otherwise the source
+    # version's duration. Lets an edit-of-an-edit validate its range against the
+    # actual video being edited rather than the full song. ``None`` for videos
+    # rendered before this field existed (validation then falls back to the clip).
+    duration: float | None = None
     created_at: datetime = Field(default_factory=utcnow)
 
     class Settings:

--- a/src/acemusic/api/models/video.py
+++ b/src/acemusic/api/models/video.py
@@ -30,6 +30,12 @@ class Video(Document):
     # US-22.3: a rendered video is private to its owner until published, at which
     # point it becomes visible on the (public) song detail page.
     published: bool = False
+    # US-22.4 basic editing: edits are non-destructive — each produces a new Video.
+    # ``parent_video_id`` links it back to the version it was derived from (None for
+    # an original render); ``edit`` records the operation (e.g. {"operation":"trim",
+    # "start_seconds":5,"end_seconds":30}) so the version history can label it.
+    parent_video_id: PydanticObjectId | None = None
+    edit: dict | None = None
     created_at: datetime = Field(default_factory=utcnow)
 
     class Settings:

--- a/src/acemusic/api/routers/videos.py
+++ b/src/acemusic/api/routers/videos.py
@@ -360,6 +360,198 @@ async def get_video(
     return VideoDetailResponse.from_video(video)
 
 
+# ---------------------------------------------------------------------------
+# US-22.4 basic editing: non-destructive edits (each produces a new version)
+# ---------------------------------------------------------------------------
+
+# The resolutions credit pricing recognises (mirrors VideoGenerationRequest).
+_KNOWN_RESOLUTIONS = ("720p", "1080p", "4k")
+
+
+class VideoEditRequest(BaseModel):
+    """One non-destructive edit of a rendered video (US-22.4).
+
+    A single tagged shape keyed on ``operation`` (rather than four endpoints):
+    ``trim`` and ``replace_scene`` need a time range, ``replace_scene`` also a
+    new visual ``prompt``, ``lyrics_overlay`` a boolean, ``transitions`` a list
+    of cut-point markers. ``extra="forbid"`` surfaces client typos as 422.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    operation: Literal["trim", "replace_scene", "lyrics_overlay", "transitions"]
+    start_seconds: float | None = Field(default=None, ge=0)
+    end_seconds: float | None = Field(default=None, ge=0)
+    prompt: str | None = Field(default=None, max_length=_PROMPT_MAX_LENGTH)
+    lyrics_enabled: bool | None = None
+    transition_markers: list[float] | None = Field(default=None, max_length=50)
+
+    @model_validator(mode="after")
+    def _check_operation(self) -> "VideoEditRequest":
+        if self.operation in ("trim", "replace_scene"):
+            if self.start_seconds is None or self.end_seconds is None:
+                raise ValueError(f"{self.operation} requires start_seconds and end_seconds")
+            if self.end_seconds <= self.start_seconds:
+                raise ValueError("end_seconds must be greater than start_seconds")
+        if self.operation == "replace_scene" and not self.prompt:
+            raise ValueError("replace_scene requires a prompt")
+        if self.operation == "lyrics_overlay" and self.lyrics_enabled is None:
+            raise ValueError("lyrics_overlay requires lyrics_enabled")
+        if self.operation == "transitions":
+            if not self.transition_markers:
+                raise ValueError("transitions requires at least one transition marker")
+            if any(m < 0 for m in self.transition_markers):
+                raise ValueError("transition markers must be non-negative")
+        return self
+
+    def to_spec(self) -> dict:
+        """The compact edit spec: ``operation`` plus only its relevant fields.
+
+        Stored on the new ``Video`` (drives the version-history label) and
+        forwarded to the provider — so a trim never carries a stray prompt.
+        """
+        spec: dict = {"operation": self.operation}
+        if self.operation in ("trim", "replace_scene"):
+            spec["start_seconds"] = self.start_seconds
+            spec["end_seconds"] = self.end_seconds
+        if self.operation == "replace_scene":
+            spec["prompt"] = self.prompt
+        if self.operation == "lyrics_overlay":
+            spec["lyrics_enabled"] = self.lyrics_enabled
+        if self.operation == "transitions":
+            spec["transition_markers"] = self.transition_markers
+        return spec
+
+    def bounded_times(self) -> list[float]:
+        """The times this edit references — validated against the clip duration."""
+        times = [t for t in (self.start_seconds, self.end_seconds) if t is not None]
+        times.extend(self.transition_markers or [])
+        return times
+
+
+class VideoVersionResponse(VideoDetailResponse):
+    """A rendered video plus its edit lineage, for the version-history list."""
+
+    parent_video_id: str | None = None
+    edit: dict | None = None
+
+    @classmethod
+    def from_video(cls, video: Video) -> "VideoVersionResponse":
+        return cls(
+            id=str(video.id),
+            clip_id=str(video.clip_id),
+            job_id=str(video.job_id),
+            resolution=video.resolution,
+            aspect_ratio=video.aspect_ratio,
+            published=video.published,
+            created_at=video.created_at,
+            parent_video_id=str(video.parent_video_id) if video.parent_video_id else None,
+            edit=video.edit,
+        )
+
+
+@router.post("/{video_id}/edit", response_model=VideoJobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def edit_video(
+    video_id: str,
+    request: VideoEditRequest,
+    current: CurrentUser = Depends(get_current_user),
+    settings: ApiSettings = Depends(_settings),
+) -> VideoJobResponse:
+    """Enqueue a non-destructive edit of the owner's rendered video (US-22.4).
+
+    The source video is never touched; the edit renders a new version linked to
+    it via ``parent_video_id``. Charges the render cost (each edit round-trips
+    the provider) with the same credit-gate flow as ``/generate``. Raises 503
+    (not configured), 404 (unknown/unowned video or its clip), 422 (edit range
+    past the song) and 402 (insufficient credits).
+    """
+    if not settings.video_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Video generation is not configured on this deployment.",
+        )
+
+    user = await user_service.get_user_by_id(current.user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+
+    source = await video_service.get_owned_video(video_id, current.user_id)
+    if source is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video not found.")
+
+    # The clip supplies the duration (for range validation) and the workspace the
+    # new version lands in; 404 if it is gone or no longer owned.
+    clip = await clip_service.get_owned_clip(str(source.clip_id), current.user_id)
+    if clip.duration is not None and any(t > clip.duration for t in request.bounded_times()):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Edit times must be within the {clip.duration:.1f}s song.",
+        )
+
+    # Bill at the source's resolution (the edit inherits it). Fall back to the base
+    # tier if the source predates resolution tracking, so pricing never raises.
+    resolution = source.resolution if source.resolution in _KNOWN_RESOLUTIONS else "720p"
+    cost = credits_service.get_video_cost(resolution, clip.duration)
+    balance_after = await credits_service.deduct_credits(user.id, cost)
+    if balance_after is None:
+        fresh = await user_service.get_user_by_id(user.id)
+        balance = fresh.credits_balance if fresh is not None else 0.0
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"error": "insufficient_credits", "balance": balance, "required": cost},
+        )
+
+    try:
+        params = {
+            "clip_id": str(source.clip_id),
+            "source_video_id": str(source.id),
+            "resolution": source.resolution,
+            "aspect_ratio": source.aspect_ratio,
+            "edit": request.to_spec(),
+        }
+        job = await video_service.create_video_job(
+            user_id=user.id,
+            workspace_id=clip.workspace_id,
+            params=params,
+        )
+    except BaseException:
+        await credits_service.refund_credits(user.id, cost)
+        raise
+    try:
+        await credits_service.record_transaction(
+            user_id=user.id,
+            amount=-cost,
+            action_type=video_service.VIDEO_JOB_TYPE,
+            job_id=str(job.id),
+            balance_after=balance_after,
+        )
+    except Exception:
+        logger.exception("Credit ledger write failed for edit job %s (user %s)", job.id, user.id)
+    return VideoJobResponse(job_id=str(job.id))
+
+
+@router.get(
+    "/{video_id}/versions",
+    response_model=list[VideoVersionResponse],
+    response_model_exclude_none=True,
+)
+async def list_video_versions(
+    video_id: str,
+    current: CurrentUser = Depends(get_current_user),
+) -> list[VideoVersionResponse]:
+    """List every version of the owner's video (edit history), newest first.
+
+    Owner-scoped: an unknown or unowned id is a 404. Returns all of the owner's
+    videos for the source's clip — the original plus each non-destructive edit —
+    each with its ``created_at`` and (for edits) its parent link and edit spec.
+    """
+    source = await video_service.get_owned_video(video_id, current.user_id)
+    if source is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video not found.")
+    videos = await video_service.list_clip_videos(str(source.clip_id), current.user_id)
+    return [VideoVersionResponse.from_video(v) for v in videos]
+
+
 @public_router.get("/{video_id}/stream", dependencies=[Depends(enforce_stream_rate_limit)])
 async def stream_video(
     video_id: str,

--- a/src/acemusic/api/routers/videos.py
+++ b/src/acemusic/api/routers/videos.py
@@ -434,6 +434,7 @@ class VideoVersionResponse(VideoDetailResponse):
 
     parent_video_id: str | None = None
     edit: dict | None = None
+    duration: float | None = None
 
     @classmethod
     def from_video(cls, video: Video) -> "VideoVersionResponse":
@@ -447,6 +448,7 @@ class VideoVersionResponse(VideoDetailResponse):
             created_at=video.created_at,
             parent_video_id=str(video.parent_video_id) if video.parent_video_id else None,
             edit=video.edit,
+            duration=video.duration,
         )
 
 
@@ -479,13 +481,16 @@ async def edit_video(
     if source is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video not found.")
 
-    # The clip supplies the duration (for range validation) and the workspace the
-    # new version lands in; 404 if it is gone or no longer owned.
+    # The clip supplies the workspace the new version lands in (404 if gone/unowned)
+    # and the duration fallback for videos rendered before per-version durations.
     clip = await clip_service.get_owned_clip(str(source.clip_id), current.user_id)
-    if clip.duration is not None and any(t > clip.duration for t in request.bounded_times()):
+    # Validate the edit range against the *video being edited*, not the whole song:
+    # editing an already-trimmed version must stay within that shorter version.
+    effective_duration = source.duration if source.duration is not None else clip.duration
+    if effective_duration is not None and any(t > effective_duration for t in request.bounded_times()):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Edit times must be within the {clip.duration:.1f}s song.",
+            detail=f"Edit times must be within the {effective_duration:.1f}s video.",
         )
 
     # Bill at the source's resolution (the edit inherits it). Fall back to the base

--- a/src/acemusic/api/services/video.py
+++ b/src/acemusic/api/services/video.py
@@ -96,6 +96,27 @@ async def publish_video(video_id: str, user_id: str) -> Video | None:
     return video
 
 
+async def list_clip_videos(clip_id: str, user_id: str) -> list[Video]:
+    """Return all of ``user_id``'s videos for a clip, newest first (US-22.4).
+
+    Backs the edit-history / version list: every non-destructive edit inserts a
+    new :class:`Video` for the same clip, so the owner's videos for that clip are
+    its versions. Served by the ``(clip_id, user_id)`` index. An unknown/malformed
+    clip id or a clip with no videos both yield an empty list.
+
+    ponytail: versions are listed by clip rather than walked as an explicit
+    parent/child tree — simpler and index-served; ``parent_video_id`` on each
+    document still records derivation for display.
+    """
+    oid = coerce_object_id(clip_id)
+    if oid is None:
+        return []
+    uid = coerce_object_id(user_id)
+    if uid is None:
+        return []
+    return await Video.find(Video.clip_id == oid, Video.user_id == uid).sort(-Video.created_at).to_list()
+
+
 async def get_published_video_for_clip(clip_id: str) -> Video | None:
     """Return the most recently created *published* video for a clip, if any.
 

--- a/src/acemusic/api/tasks/video.py
+++ b/src/acemusic/api/tasks/video.py
@@ -27,6 +27,7 @@ from acemusic.video_client import (
 
 from ..models import Job, Video
 from ..services import clips as clip_service
+from ..services.common import coerce_object_id
 from ..services.video import VIDEO_JOB_TYPE
 from .common import JobProcessingError, download_clip, load_source_clip
 
@@ -73,32 +74,33 @@ async def _set_progress(job: Job, state: str, progress: int | None, eta_seconds:
     await job.set({Job.progress_detail: detail})
 
 
-async def process_video_job(
-    job: Job,
-    *,
-    storage: StorageBackend,
-    client: VideoGenerationService,
-    poll_interval: float = POLL_INTERVAL_S,
-    poll_timeout: float = POLL_TIMEOUT_S,
-) -> dict[str, Any]:
-    """Render, store and associate the song's music video.
+async def _load_edit_source(job: Job, source_video_id: str) -> Video:
+    """Load the source ``Video`` for an edit job, owner-checked (US-22.4).
 
-    Returns ``{"video_ids": [<id>], "storage_path": <path>}``. Raises
-    :class:`JobProcessingError` on provider failure/timeout; the processor
-    records the message as the job's failure. Transient (5xx) provider errors
-    are already retried inside the client (shared ``_http`` policy, 3 retries).
+    The endpoint already validated ownership before enqueuing; re-checking here
+    (the job's owner must own the source) is defense in depth against a bad or
+    tampered ``source_video_id`` in params.
     """
-    clip = await load_source_clip(job)
-    audio = await download_clip(storage, clip)
-    params = dict(job.input_params or {})
-    params.pop("clip_id", None)  # provider gets the audio itself, not our id
-    filename = f"{clip.id}.{clip_service.native_format(clip)}"
+    oid = coerce_object_id(source_video_id)
+    source = await Video.get(oid) if oid is not None else None
+    if source is None or source.user_id != job.user_id:
+        raise JobProcessingError(f"Edit source video {source_video_id!r} not found")
+    return source
 
-    try:
-        provider_job_id = await asyncio.to_thread(client.submit, audio, filename, params)
-    except VideoGenerationError as exc:
-        raise JobProcessingError(f"Video provider submission failed: {exc}") from exc
 
+async def _await_provider_render(
+    job: Job,
+    client: VideoGenerationService,
+    provider_job_id: str,
+    *,
+    poll_interval: float,
+    poll_timeout: float,
+) -> bytes:
+    """Poll the provider to completion, then download the rendered MP4 bytes.
+
+    Surfaces state/progress/ETA on ``job.progress_detail`` for the status
+    endpoint. Raises :class:`JobProcessingError` on failure/timeout.
+    """
     deadline = time.monotonic() + poll_timeout
     poll_failures = 0
     while True:
@@ -121,21 +123,83 @@ async def process_video_job(
         await asyncio.sleep(poll_interval)
 
     try:
-        data = await asyncio.to_thread(client.download, provider_job_id)
+        return await asyncio.to_thread(client.download, provider_job_id)
     except VideoGenerationError as exc:
         raise JobProcessingError(f"Video download failed: {exc}") from exc
 
-    # Namespace by job id so re-rendering the same song never overwrites an
-    # earlier video (and a failed job's rollback only deletes its own object).
-    path = f"{job.user_id}/{job.workspace_id}/videos/{clip.id}/{job.id}.mp4"
+
+async def process_video_job(
+    job: Job,
+    *,
+    storage: StorageBackend,
+    client: VideoGenerationService,
+    poll_interval: float = POLL_INTERVAL_S,
+    poll_timeout: float = POLL_TIMEOUT_S,
+) -> dict[str, Any]:
+    """Render (or edit) and store the song's music video.
+
+    An *original* render downloads the source song's audio and submits it. An
+    *edit* (US-22.4, params carry ``source_video_id``) downloads the source
+    rendered MP4 instead and submits it with the edit spec; the result is a new
+    ``Video`` linked to the source via ``parent_video_id`` (the source is never
+    mutated). Returns ``{"video_ids": [<id>], "storage_path": <path>}``. Raises
+    :class:`JobProcessingError` on provider failure/timeout.
+    """
+    params = dict(job.input_params or {})
+    source_video_id = params.get("source_video_id")
+
+    if source_video_id is not None:
+        # Edit: the media is the source video's bytes; the provider gets the edit
+        # spec (operation + fields), and the new render inherits its dimensions.
+        source = await _load_edit_source(job, str(source_video_id))
+        try:
+            media = await asyncio.to_thread(storage.download, source.storage_path)
+        except FileNotFoundError as exc:
+            raise JobProcessingError(f"Source video {source.id} object {source.storage_path!r} is missing") from exc
+        edit = params.get("edit") or {}
+        provider_params: dict[str, Any] = {
+            **edit,
+            "resolution": source.resolution,
+            "aspect_ratio": source.aspect_ratio,
+        }
+        filename = f"{source.id}.mp4"
+        clip_id, resolution, aspect_ratio = source.clip_id, source.resolution, source.aspect_ratio
+        parent_video_id: Any = source.id
+    else:
+        clip = await load_source_clip(job)
+        media = await download_clip(storage, clip)
+        provider_params = {k: v for k, v in params.items() if k != "clip_id"}  # provider gets the audio, not our id
+        filename = f"{clip.id}.{clip_service.native_format(clip)}"
+        clip_id, resolution, aspect_ratio = (
+            clip.id,
+            str(params.get("resolution", "")),
+            str(params.get("aspect_ratio", "")),
+        )
+        parent_video_id = None
+        edit = None
+
+    try:
+        provider_job_id = await asyncio.to_thread(client.submit, media, filename, provider_params)
+    except VideoGenerationError as exc:
+        raise JobProcessingError(f"Video provider submission failed: {exc}") from exc
+
+    data = await _await_provider_render(
+        job, client, provider_job_id, poll_interval=poll_interval, poll_timeout=poll_timeout
+    )
+
+    # Namespace by job id so re-rendering/editing the same song never overwrites
+    # an earlier video (and a failed job's rollback only deletes its own object).
+    path = f"{job.user_id}/{job.workspace_id}/videos/{clip_id}/{job.id}.mp4"
     await asyncio.to_thread(storage.upload, path, data)
     video = Video(
-        clip_id=clip.id,
+        clip_id=clip_id,
         user_id=job.user_id,
         job_id=job.id,
         storage_path=path,
-        resolution=str(params.get("resolution", "")),
-        aspect_ratio=str(params.get("aspect_ratio", "")),
+        resolution=resolution,
+        aspect_ratio=aspect_ratio,
+        parent_video_id=parent_video_id,
+        edit=edit or None,
     )
     try:
         await video.insert()

--- a/src/acemusic/api/tasks/video.py
+++ b/src/acemusic/api/tasks/video.py
@@ -165,6 +165,12 @@ async def process_video_job(
         filename = f"{source.id}.mp4"
         clip_id, resolution, aspect_ratio = source.clip_id, source.resolution, source.aspect_ratio
         parent_video_id: Any = source.id
+        # A trim resizes the video to its range; every other edit keeps the
+        # source's length. This is what a later edit-of-this-edit validates against.
+        if edit.get("operation") == "trim":
+            duration = float(edit["end_seconds"]) - float(edit["start_seconds"])
+        else:
+            duration = source.duration
     else:
         clip = await load_source_clip(job)
         media = await download_clip(storage, clip)
@@ -177,6 +183,7 @@ async def process_video_job(
         )
         parent_video_id = None
         edit = None
+        duration = clip.duration
 
     try:
         provider_job_id = await asyncio.to_thread(client.submit, media, filename, provider_params)
@@ -200,6 +207,7 @@ async def process_video_job(
         aspect_ratio=aspect_ratio,
         parent_video_id=parent_video_id,
         edit=edit or None,
+        duration=duration,
     )
     try:
         await video.insert()

--- a/tests/test_video_api.py
+++ b/tests/test_video_api.py
@@ -45,6 +45,14 @@ def _for_clip_url(clip_id: str) -> str:
     return f"{API_V1_PREFIX}/videos/for-clip/{clip_id}"
 
 
+def _edit_url(video_id: str) -> str:
+    return f"{API_V1_PREFIX}/videos/{video_id}/edit"
+
+
+def _versions_url(video_id: str) -> str:
+    return f"{API_V1_PREFIX}/videos/{video_id}/versions"
+
+
 # ---------------------------------------------------------------------------
 # Auth gate — runs in CI (no DB; plain TestClient does not run the lifespan)
 # ---------------------------------------------------------------------------
@@ -475,6 +483,8 @@ async def _insert_video(
     store: bool = True,
     data: bytes = _MP4_BYTES,
     resolution: str = "1080p",
+    parent_video_id: PydanticObjectId | None = None,
+    edit: dict | None = None,
 ) -> Video:
     video_id = PydanticObjectId()
     job_id = PydanticObjectId()
@@ -490,6 +500,8 @@ async def _insert_video(
         resolution=resolution,
         aspect_ratio="16:9",
         published=published,
+        parent_video_id=parent_video_id,
+        edit=edit,
     )
     await video.insert()
     return video
@@ -691,3 +703,223 @@ class TestForClip:
         await _insert_video(owner, clip, published=True)
         resp = await client.get(_for_clip_url(str(clip.id)), headers=_auth_headers(stranger, settings))
         assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# US-22.4 editing: POST /videos/{video_id}/edit + GET /videos/{video_id}/versions
+# ---------------------------------------------------------------------------
+
+
+class TestEditAuthGate:
+    def test_edit_without_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(_edit_url(str(PydanticObjectId())), json={"operation": "trim"})
+        assert resp.status_code == 401
+
+    def test_versions_without_auth_returns_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.get(_versions_url(str(PydanticObjectId())))
+        assert resp.status_code == 401
+
+
+@pytest.mark.integration
+class TestVideoEdit:
+    async def test_trim_returns_202_and_persists_edit_job(self, client, settings, local_storage) -> None:
+        user, ws, clip = await _user_with_clip("video-edit-trim@example.com", balance=100)
+        source = await _insert_video(user, clip, resolution="1080p")
+        body = {"operation": "trim", "start_seconds": 2.0, "end_seconds": 8.0}
+        resp = await client.post(_edit_url(str(source.id)), json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        job_id = resp.json()["job_id"]
+        job = await Job.get(PydanticObjectId(job_id))
+        assert job is not None
+        assert job.job_type == VIDEO_JOB_TYPE
+        assert job.status == JobStatus.QUEUED
+        assert job.workspace_id == ws.id
+        params = job.input_params
+        assert params["source_video_id"] == str(source.id)
+        assert params["clip_id"] == str(clip.id)
+        assert params["edit"] == {"operation": "trim", "start_seconds": 2.0, "end_seconds": 8.0}
+        # Source video is never mutated by enqueuing an edit.
+        assert (await Video.get(source.id)).parent_video_id is None
+
+    async def test_replace_scene_carries_prompt_only(self, client, settings, local_storage) -> None:
+        user, _ws, clip = await _user_with_clip("video-edit-scene@example.com", balance=100)
+        source = await _insert_video(user, clip)
+        body = {"operation": "replace_scene", "start_seconds": 1.0, "end_seconds": 4.0, "prompt": "sunset over waves"}
+        resp = await client.post(_edit_url(str(source.id)), json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 202
+        job = await Job.get(PydanticObjectId(resp.json()["job_id"]))
+        assert job.input_params["edit"] == {
+            "operation": "replace_scene",
+            "start_seconds": 1.0,
+            "end_seconds": 4.0,
+            "prompt": "sunset over waves",
+        }
+
+    async def test_lyrics_overlay_toggle(self, client, settings, local_storage) -> None:
+        user, _ws, clip = await _user_with_clip("video-edit-lyrics@example.com", balance=100)
+        source = await _insert_video(user, clip)
+        resp = await client.post(
+            _edit_url(str(source.id)),
+            json={"operation": "lyrics_overlay", "lyrics_enabled": True},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await Job.get(PydanticObjectId(resp.json()["job_id"]))
+        assert job.input_params["edit"] == {"operation": "lyrics_overlay", "lyrics_enabled": True}
+
+    async def test_transitions_markers(self, client, settings, local_storage) -> None:
+        user, _ws, clip = await _user_with_clip("video-edit-trans@example.com", balance=100)
+        source = await _insert_video(user, clip)
+        resp = await client.post(
+            _edit_url(str(source.id)),
+            json={"operation": "transitions", "transition_markers": [1.5, 3.0]},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        job = await Job.get(PydanticObjectId(resp.json()["job_id"]))
+        assert job.input_params["edit"] == {"operation": "transitions", "transition_markers": [1.5, 3.0]}
+
+    async def test_charges_source_resolution_cost(self, client, settings, local_storage) -> None:
+        user, _ws, clip = await _user_with_clip("video-edit-cost@example.com", balance=100, duration=10.0)
+        source = await _insert_video(user, clip, resolution="1080p")
+        resp = await client.post(
+            _edit_url(str(source.id)),
+            json={"operation": "trim", "start_seconds": 0.0, "end_seconds": 5.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 202
+        # 1080p base cost is 7 credits (short song, no surcharge).
+        assert (await _reload(user)).credits_balance == pytest.approx(93.0)
+        txns = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        assert any(t.amount == pytest.approx(-7.0) for t in txns)
+
+    async def test_edit_range_past_song_returns_422_no_charge(self, client, settings, local_storage) -> None:
+        user, _ws, clip = await _user_with_clip("video-edit-oob@example.com", balance=100, duration=10.0)
+        source = await _insert_video(user, clip)
+        resp = await client.post(
+            _edit_url(str(source.id)),
+            json={"operation": "trim", "start_seconds": 5.0, "end_seconds": 30.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 422
+        assert (await _reload(user)).credits_balance == 100
+
+    async def test_unknown_video_returns_404_no_charge(self, client, settings, local_storage) -> None:
+        user = await _make_user("video-edit-unknown@example.com", balance=100)
+        resp = await client.post(
+            _edit_url(str(PydanticObjectId())),
+            json={"operation": "trim", "start_seconds": 0.0, "end_seconds": 5.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 404
+        assert (await _reload(user)).credits_balance == 100
+
+    async def test_other_users_video_returns_404(self, client, settings, local_storage) -> None:
+        owner, _ws, clip = await _user_with_clip("video-edit-owner@example.com")
+        thief = await _make_user("video-edit-thief@example.com", balance=100)
+        source = await _insert_video(owner, clip)
+        resp = await client.post(
+            _edit_url(str(source.id)),
+            json={"operation": "trim", "start_seconds": 0.0, "end_seconds": 5.0},
+            headers=_auth_headers(thief, settings),
+        )
+        assert resp.status_code == 404
+
+    async def test_insufficient_credits_returns_402(self, client, settings, local_storage) -> None:
+        user, _ws, clip = await _user_with_clip("video-edit-broke@example.com", balance=1.0)
+        source = await _insert_video(user, clip, resolution="1080p")
+        resp = await client.post(
+            _edit_url(str(source.id)),
+            json={"operation": "trim", "start_seconds": 0.0, "end_seconds": 5.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert resp.status_code == 402
+        assert resp.json()["detail"]["error"] == "insufficient_credits"
+
+    async def test_not_configured_returns_503_no_charge(self, mongo_db, mongo_settings, local_storage) -> None:
+        cfg = mongo_settings.model_copy(
+            update={
+                "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+                "job_processor_enabled": False,
+                "video_api_url": None,
+                "video_api_key": None,
+            }
+        )
+        user, _ws, clip = await _user_with_clip("video-edit-503@example.com", balance=100)
+        source = await _insert_video(user, clip)
+        async with _async_client(create_app(cfg)) as ac:
+            resp = await ac.post(
+                _edit_url(str(source.id)),
+                json={"operation": "trim", "start_seconds": 0.0, "end_seconds": 5.0},
+                headers=_auth_headers(user, cfg),
+            )
+        assert resp.status_code == 503
+        assert (await _reload(user)).credits_balance == 100
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"operation": "trim", "start_seconds": 1.0},  # missing end
+            {"operation": "trim", "start_seconds": 5.0, "end_seconds": 2.0},  # end <= start
+            {"operation": "replace_scene", "start_seconds": 1.0, "end_seconds": 4.0},  # no prompt
+            {"operation": "lyrics_overlay"},  # no lyrics_enabled
+            {"operation": "transitions"},  # no markers
+            {"operation": "transitions", "transition_markers": [-1.0]},  # negative marker
+            {"operation": "bogus"},  # unknown operation
+            {"operation": "trim", "start_seconds": 0.0, "end_seconds": 5.0, "surprise": 1},  # extra field
+        ],
+    )
+    async def test_invalid_bodies_return_422(self, client, settings, local_storage, body) -> None:
+        user, _ws, clip = await _user_with_clip(
+            f"video-edit-invalid-{hash(str(body)) & 0xffff}@example.com", balance=100
+        )
+        source = await _insert_video(user, clip)
+        resp = await client.post(_edit_url(str(source.id)), json=body, headers=_auth_headers(user, settings))
+        assert resp.status_code == 422
+
+
+@pytest.mark.integration
+class TestVideoVersions:
+    async def test_lists_versions_newest_first_with_lineage(self, client, settings, local_storage) -> None:
+        user, _ws, clip = await _user_with_clip("video-ver-list@example.com")
+        original = await _insert_video(user, clip, resolution="1080p")
+        edited = await _insert_video(
+            user,
+            clip,
+            resolution="1080p",
+            parent_video_id=original.id,
+            edit={"operation": "trim", "start_seconds": 1.0, "end_seconds": 5.0},
+        )
+        resp = await client.get(_versions_url(str(original.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        items = resp.json()
+        assert [i["id"] for i in items] == [str(edited.id), str(original.id)]
+        # The edit carries its lineage; the original omits the null fields.
+        assert items[0]["parent_video_id"] == str(original.id)
+        assert items[0]["edit"]["operation"] == "trim"
+        assert "parent_video_id" not in items[1]
+        assert "edit" not in items[1]
+        assert all("created_at" in i for i in items)
+
+    async def test_from_edited_video_lists_the_same_lineage(self, client, settings, local_storage) -> None:
+        # Asking for versions of any member returns the whole clip's history.
+        user, _ws, clip = await _user_with_clip("video-ver-any@example.com")
+        original = await _insert_video(user, clip)
+        edited = await _insert_video(user, clip, parent_video_id=original.id, edit={"operation": "lyrics_overlay"})
+        resp = await client.get(_versions_url(str(edited.id)), headers=_auth_headers(user, settings))
+        assert resp.status_code == 200
+        assert {i["id"] for i in resp.json()} == {str(original.id), str(edited.id)}
+
+    async def test_unknown_video_returns_404(self, client, settings, local_storage) -> None:
+        user = await _make_user("video-ver-unknown@example.com")
+        resp = await client.get(_versions_url(str(PydanticObjectId())), headers=_auth_headers(user, settings))
+        assert resp.status_code == 404
+
+    async def test_other_users_video_returns_404(self, client, settings, local_storage) -> None:
+        owner, _ws, clip = await _user_with_clip("video-ver-owner@example.com")
+        stranger = await _make_user("video-ver-stranger@example.com")
+        source = await _insert_video(owner, clip)
+        resp = await client.get(_versions_url(str(source.id)), headers=_auth_headers(stranger, settings))
+        assert resp.status_code == 404

--- a/tests/test_video_api.py
+++ b/tests/test_video_api.py
@@ -485,6 +485,7 @@ async def _insert_video(
     resolution: str = "1080p",
     parent_video_id: PydanticObjectId | None = None,
     edit: dict | None = None,
+    duration: float | None = None,
 ) -> Video:
     video_id = PydanticObjectId()
     job_id = PydanticObjectId()
@@ -502,6 +503,7 @@ async def _insert_video(
         published=published,
         parent_video_id=parent_video_id,
         edit=edit,
+        duration=duration,
     )
     await video.insert()
     return video
@@ -805,6 +807,28 @@ class TestVideoEdit:
         )
         assert resp.status_code == 422
         assert (await _reload(user)).credits_balance == 100
+
+    async def test_chained_edit_validated_against_edited_length_not_song(self, client, settings, local_storage) -> None:
+        # An already-trimmed version is 8s even though the song is 30s: editing it
+        # with a range past 8s must 422 (validated against the video, not the song).
+        user, _ws, clip = await _user_with_clip("video-edit-chain@example.com", balance=100, duration=30.0)
+        trimmed = await _insert_video(
+            user, clip, edit={"operation": "trim", "start_seconds": 0.0, "end_seconds": 8.0}, duration=8.0
+        )
+        past = await client.post(
+            _edit_url(str(trimmed.id)),
+            json={"operation": "trim", "start_seconds": 5.0, "end_seconds": 20.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert past.status_code == 422
+        assert (await _reload(user)).credits_balance == 100
+        # A range inside the trimmed length is still accepted.
+        within = await client.post(
+            _edit_url(str(trimmed.id)),
+            json={"operation": "trim", "start_seconds": 2.0, "end_seconds": 6.0},
+            headers=_auth_headers(user, settings),
+        )
+        assert within.status_code == 202
 
     async def test_unknown_video_returns_404_no_charge(self, client, settings, local_storage) -> None:
         user = await _make_user("video-edit-unknown@example.com", balance=100)

--- a/tests/test_video_tasks.py
+++ b/tests/test_video_tasks.py
@@ -159,6 +159,7 @@ class TestProcessVideoJob:
         assert result == {"video_ids": [str(video.id)], "storage_path": video.storage_path}
         assert video.user_id == job.user_id and video.job_id == job.id
         assert video.resolution == "720p" and video.aspect_ratio == "16:9"
+        assert video.duration == clip.duration == 10.0  # original render inherits the song's length
         assert video.storage_path == f"{job.user_id}/{job.workspace_id}/videos/{clip.id}/{job.id}.mp4"
         # The stored object is the provider's rendered MP4, byte for byte.
         assert storage.download(video.storage_path) == FAKE_MP4
@@ -309,12 +310,27 @@ class TestProcessVideoEditJob:
         assert new.id != source.id  # a new version, original preserved
         assert new.parent_video_id == source.id
         assert new.edit == {"operation": "trim", "start_seconds": 2.0, "end_seconds": 8.0}
+        assert new.duration == 6.0  # a trim resizes the video to its range (8 - 2)
         assert new.clip_id == source.clip_id
         assert new.resolution == "1080p" and new.aspect_ratio == "9:16"
         assert new.storage_path == f"{job.user_id}/{job.workspace_id}/videos/{source.clip_id}/{job.id}.mp4"
         # The source document and its object are untouched.
         assert (await Video.get(source.id)).parent_video_id is None
         assert storage.download(source.storage_path) == FAKE_MP4
+
+    async def test_non_trim_edit_inherits_source_duration(self, storage) -> None:
+        # A lyrics-overlay edit keeps the source video's length (only trim resizes).
+        job, source = await _make_edit_job_and_source(storage)
+        source.duration = 8.0
+        await source.save()
+        job.input_params["edit"] = {"operation": "lyrics_overlay", "lyrics_enabled": True}
+        await job.save()
+        client = FakeVideoService(_updates_to_complete(), expect_media=FAKE_MP4)
+
+        result = await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+        new = await Video.get(PydanticObjectId(result["video_ids"][0]))
+        assert new.duration == 8.0
 
     async def test_edit_submits_source_media_and_spec(self, storage) -> None:
         job, source = await _make_edit_job_and_source(storage)

--- a/tests/test_video_tasks.py
+++ b/tests/test_video_tasks.py
@@ -11,6 +11,7 @@ tests need a local MongoDB (Beanie) and are ``integration``.
 from __future__ import annotations
 
 import pytest
+from beanie import PydanticObjectId
 
 from acemusic.api.models import Clip, Job, Video, Workspace
 from acemusic.api.services import users as user_service
@@ -28,16 +29,26 @@ FAKE_AUDIO = b"RIFF" + b"\x00" * 100
 class FakeVideoService:
     """Plays back a scripted sequence of status updates, then serves the MP4."""
 
-    def __init__(self, updates: list[VideoJobUpdate], *, submit_error: str | None = None) -> None:
+    def __init__(
+        self,
+        updates: list[VideoJobUpdate],
+        *,
+        submit_error: str | None = None,
+        expect_media: bytes | None = FAKE_AUDIO,
+    ) -> None:
         self.updates = list(updates)
         self.submit_error = submit_error
+        self.expect_media = expect_media
         self.submitted: list[tuple[str, dict]] = []
+        self.submitted_media: list[bytes] = []
         self.polls = 0
 
     def submit(self, audio_bytes: bytes, filename: str, params: dict) -> str:
         if self.submit_error:
             raise VideoGenerationError(self.submit_error)
-        assert audio_bytes == FAKE_AUDIO
+        if self.expect_media is not None:
+            assert audio_bytes == self.expect_media
+        self.submitted_media.append(audio_bytes)
         self.submitted.append((filename, params))
         return "pj-1"
 
@@ -249,4 +260,86 @@ class TestProcessVideoJob:
         client = FakeVideoService(_updates_to_complete())
 
         with pytest.raises(JobProcessingError, match="no longer exists"):
+            await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+
+# ---------------------------------------------------------------------------
+# Edit jobs (US-22.4) — integration
+# ---------------------------------------------------------------------------
+
+
+async def _make_edit_job_and_source(storage: LocalStorage) -> tuple[Job, Video]:
+    """A source Video (its MP4 stored) plus a queued edit job referencing it."""
+    user = await user_service.get_or_create_user(email="ve@e.com", provider="google", oauth_id="g-ve", name="VE")
+    workspace = Workspace(name="WS", user_id=user.id)
+    await workspace.insert()
+    clip = Clip(user_id=user.id, workspace_id=workspace.id, file_path="song.wav", title="Song", duration=10.0)
+    await clip.insert()
+    source = Video(
+        clip_id=clip.id,
+        user_id=user.id,
+        job_id=(await Job(user_id=user.id, workspace_id=workspace.id, job_type=VIDEO_JOB_TYPE).insert()).id,
+        storage_path=f"{user.id}/{workspace.id}/videos/{clip.id}/orig.mp4",
+        resolution="1080p",
+        aspect_ratio="9:16",
+    )
+    storage.upload(source.storage_path, FAKE_MP4)
+    await source.insert()
+    params = {
+        "clip_id": str(clip.id),
+        "source_video_id": str(source.id),
+        "resolution": source.resolution,
+        "aspect_ratio": source.aspect_ratio,
+        "edit": {"operation": "trim", "start_seconds": 2.0, "end_seconds": 8.0},
+    }
+    job = Job(user_id=user.id, workspace_id=workspace.id, job_type=VIDEO_JOB_TYPE, input_params=params)
+    await job.insert()
+    return job, source
+
+
+@pytest.mark.integration
+class TestProcessVideoEditJob:
+    async def test_edit_stores_new_version_linked_to_source(self, storage) -> None:
+        job, source = await _make_edit_job_and_source(storage)
+        client = FakeVideoService(_updates_to_complete(), expect_media=FAKE_MP4)
+
+        result = await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+        new = await Video.get(PydanticObjectId(result["video_ids"][0]))
+        assert new.id != source.id  # a new version, original preserved
+        assert new.parent_video_id == source.id
+        assert new.edit == {"operation": "trim", "start_seconds": 2.0, "end_seconds": 8.0}
+        assert new.clip_id == source.clip_id
+        assert new.resolution == "1080p" and new.aspect_ratio == "9:16"
+        assert new.storage_path == f"{job.user_id}/{job.workspace_id}/videos/{source.clip_id}/{job.id}.mp4"
+        # The source document and its object are untouched.
+        assert (await Video.get(source.id)).parent_video_id is None
+        assert storage.download(source.storage_path) == FAKE_MP4
+
+    async def test_edit_submits_source_media_and_spec(self, storage) -> None:
+        job, source = await _make_edit_job_and_source(storage)
+        client = FakeVideoService(_updates_to_complete(), expect_media=FAKE_MP4)
+
+        await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+        (filename, params), *_ = client.submitted
+        assert filename == f"{source.id}.mp4"
+        assert params["operation"] == "trim"
+        assert params["start_seconds"] == 2.0
+        assert "source_video_id" not in params  # provider gets the media + spec, not our ids
+
+    async def test_missing_source_object_fails_job(self, storage) -> None:
+        job, source = await _make_edit_job_and_source(storage)
+        storage.delete(source.storage_path)
+        client = FakeVideoService(_updates_to_complete(), expect_media=None)
+
+        with pytest.raises(JobProcessingError, match="is missing"):
+            await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)
+
+    async def test_deleted_source_document_fails_job(self, storage) -> None:
+        job, source = await _make_edit_job_and_source(storage)
+        await source.delete()
+        client = FakeVideoService(_updates_to_complete(), expect_media=None)
+
+        with pytest.raises(JobProcessingError, match="not found"):
             await tasks.process_video_job(job, storage=storage, client=client, poll_interval=0)

--- a/web/app/api/videos/[jobId]/edit/route.ts
+++ b/web/app/api/videos/[jobId]/edit/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for POST /api/v1/videos/{video_id}/edit (US-22.4).
+// Owner-only, so the Bearer token is required; status/body pass through verbatim
+// (202 with the job id, 401/402/404/422/503). The dynamic segment is named
+// `jobId` for Next routing but carries a *video* id here.
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ jobId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { jobId: videoId } = await ctx.params
+  const body = await request.text()
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/videos/${encodeURIComponent(videoId)}/edit`,
+      {
+        method: "POST",
+        headers: {
+          authorization: auth,
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body,
+      }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Video service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const payload = await res.json().catch(() => ({}))
+  return NextResponse.json(payload, { status: res.status })
+}

--- a/web/app/api/videos/[jobId]/versions/route.ts
+++ b/web/app/api/videos/[jobId]/versions/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/videos/{video_id}/versions (US-22.4).
+// Owner-only (edit history), so the Bearer token is required; status/body pass
+// through verbatim (200 with the version list, 401/404). The dynamic segment is
+// named `jobId` for Next routing but carries a *video* id here.
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ jobId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { jobId: videoId } = await ctx.params
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/videos/${encodeURIComponent(videoId)}/versions`,
+      {
+        headers: { authorization: auth, accept: "application/json" },
+      }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Video service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/components/video/VideoDelivery.tsx
+++ b/web/components/video/VideoDelivery.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
+import { VideoEditor } from "@/components/video/VideoEditor"
 import { useAuth } from "@/hooks/use-auth"
 import { publishVideo, videoStreamUrl } from "@/lib/video"
 
@@ -32,6 +33,7 @@ export function VideoDelivery({
 }) {
   const { accessToken } = useAuth()
   const [publish, setPublish] = useState<PublishState>({ status: "idle" })
+  const [editing, setEditing] = useState(false)
 
   async function handlePublish() {
     setPublish({ status: "publishing" })
@@ -41,10 +43,16 @@ export function VideoDelivery({
         setPublish({ status: "published" })
         return
       case "unauthorized":
-        setPublish({ status: "error", message: "Please sign in again to publish." })
+        setPublish({
+          status: "error",
+          message: "Please sign in again to publish.",
+        })
         return
       case "not_found":
-        setPublish({ status: "error", message: "This video is no longer available." })
+        setPublish({
+          status: "error",
+          message: "This video is no longer available.",
+        })
         return
       case "error":
         setPublish({ status: "error", message: result.detail })
@@ -79,13 +87,28 @@ export function VideoDelivery({
             onClick={handlePublish}
             disabled={publish.status === "publishing"}
           >
-            {publish.status === "publishing" ? "Publishing…" : "Publish to song page"}
+            {publish.status === "publishing"
+              ? "Publishing…"
+              : "Publish to song page"}
           </Button>
         )}
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => setEditing((e) => !e)}
+          aria-expanded={editing}
+        >
+          {editing ? "Close editor" : "Edit video"}
+        </Button>
         <Button size="sm" variant="ghost" onClick={onReset}>
           Generate another
         </Button>
       </div>
+      {editing && (
+        <div className="mt-2 rounded-lg border p-4">
+          <VideoEditor videoId={videoId} />
+        </div>
+      )}
       {publish.status === "published" && (
         <p className="text-sm text-muted-foreground">
           Published — it now appears on the song page.

--- a/web/components/video/VideoEditor.test.tsx
+++ b/web/components/video/VideoEditor.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { VideoEditor } from "@/components/video/VideoEditor"
+import { fetchVideoVersions, submitVideoEdit } from "@/lib/video"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok" }),
+}))
+
+// Keep the pure helpers (editOperationLabel, videoStreamUrl); stub the network.
+vi.mock("@/lib/video", async (orig) => ({
+  ...(await orig<typeof import("@/lib/video")>()),
+  submitVideoEdit: vi.fn(),
+  fetchVideoVersions: vi.fn(),
+}))
+
+const submitMock = vi.mocked(submitVideoEdit)
+const versionsMock = vi.mocked(fetchVideoVersions)
+
+afterEach(() => vi.clearAllMocks())
+
+const VERSIONS = [
+  {
+    id: "v2",
+    clip_id: "c",
+    job_id: "j",
+    resolution: "1080p",
+    aspect_ratio: "16:9",
+    published: false,
+    created_at: "2026-07-29T00:00:00Z",
+    parent_video_id: "v1",
+    edit: { operation: "trim" as const },
+  },
+  {
+    id: "v1",
+    clip_id: "c",
+    job_id: "j",
+    resolution: "1080p",
+    aspect_ratio: "16:9",
+    published: false,
+    created_at: "2026-07-28T00:00:00Z",
+  },
+]
+
+describe("VideoEditor", () => {
+  it("lists the version history with edit labels and view/download links", async () => {
+    versionsMock.mockResolvedValue(VERSIONS)
+    render(<VideoEditor videoId="v1" />)
+
+    const list = await screen.findByTestId("version-list")
+    expect(list).toHaveTextContent("Trim")
+    expect(list).toHaveTextContent("Original render")
+    // The original stays reachable via its stream URL.
+    const views = screen.getAllByRole("link", { name: /view/i })
+    expect(
+      views.some((a) => a.getAttribute("href") === "/api/videos/v1/stream")
+    ).toBe(true)
+    expect(versionsMock).toHaveBeenCalledWith("v1", "tok")
+  })
+
+  it("submits a trim edit with the typed payload and shows it queued", async () => {
+    versionsMock.mockResolvedValue([])
+    submitMock.mockResolvedValue({ status: "accepted", jobId: "job-1" })
+    render(<VideoEditor videoId="v1" />)
+
+    fireEvent.change(screen.getByLabelText(/start/i), {
+      target: { value: "2" },
+    })
+    fireEvent.change(screen.getByLabelText(/end/i), { target: { value: "8" } })
+    fireEvent.click(screen.getByRole("button", { name: /apply edit/i }))
+
+    await waitFor(() =>
+      expect(submitMock).toHaveBeenCalledWith(
+        "v1",
+        { operation: "trim", start_seconds: 2, end_seconds: 8 },
+        "tok"
+      )
+    )
+    expect(await screen.findByRole("status")).toHaveTextContent(/queued/i)
+  })
+
+  it("blocks an invalid trim range client-side without submitting", async () => {
+    versionsMock.mockResolvedValue([])
+    render(<VideoEditor videoId="v1" />)
+
+    fireEvent.change(screen.getByLabelText(/start/i), {
+      target: { value: "9" },
+    })
+    fireEvent.change(screen.getByLabelText(/end/i), { target: { value: "3" } })
+    fireEvent.click(screen.getByRole("button", { name: /apply edit/i }))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/after start/i)
+    expect(submitMock).not.toHaveBeenCalled()
+  })
+
+  it("submits a lyrics_overlay toggle", async () => {
+    versionsMock.mockResolvedValue([])
+    submitMock.mockResolvedValue({ status: "accepted", jobId: "job-2" })
+    render(<VideoEditor videoId="v1" />)
+
+    fireEvent.change(screen.getByLabelText(/^edit$/i), {
+      target: { value: "lyrics_overlay" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /apply edit/i }))
+
+    await waitFor(() =>
+      expect(submitMock).toHaveBeenCalledWith(
+        "v1",
+        { operation: "lyrics_overlay", lyrics_enabled: true },
+        "tok"
+      )
+    )
+  })
+
+  it("parses transition markers from the comma-separated field", async () => {
+    versionsMock.mockResolvedValue([])
+    submitMock.mockResolvedValue({ status: "accepted", jobId: "job-3" })
+    render(<VideoEditor videoId="v1" />)
+
+    fireEvent.change(screen.getByLabelText(/^edit$/i), {
+      target: { value: "transitions" },
+    })
+    fireEvent.change(screen.getByLabelText(/cut points/i), {
+      target: { value: "4, 8.5, 12" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /apply edit/i }))
+
+    await waitFor(() =>
+      expect(submitMock).toHaveBeenCalledWith(
+        "v1",
+        { operation: "transitions", transition_markers: [4, 8.5, 12] },
+        "tok"
+      )
+    )
+  })
+
+  it("surfaces an insufficient-credits error", async () => {
+    versionsMock.mockResolvedValue([])
+    submitMock.mockResolvedValue({
+      status: "insufficient_credits",
+      balance: 3,
+      required: 7,
+    })
+    render(<VideoEditor videoId="v1" />)
+
+    fireEvent.change(screen.getByLabelText(/start/i), {
+      target: { value: "0" },
+    })
+    fireEvent.change(screen.getByLabelText(/end/i), { target: { value: "5" } })
+    fireEvent.click(screen.getByRole("button", { name: /apply edit/i }))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /not enough credits/i
+    )
+  })
+})

--- a/web/components/video/VideoEditor.tsx
+++ b/web/components/video/VideoEditor.tsx
@@ -1,0 +1,300 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useAuth } from "@/hooks/use-auth"
+import {
+  editOperationLabel,
+  fetchVideoVersions,
+  submitVideoEdit,
+  videoStreamUrl,
+  type VideoEditOperation,
+  type VideoEditPayload,
+  type VideoVersion,
+} from "@/lib/video"
+
+type SubmitState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "queued" }
+  | { status: "error"; message: string }
+
+const OPERATIONS: { value: VideoEditOperation; label: string }[] = [
+  { value: "trim", label: "Trim" },
+  { value: "replace_scene", label: "Replace a scene" },
+  { value: "lyrics_overlay", label: "Lyrics overlay" },
+  { value: "transitions", label: "Transition timing" },
+]
+
+/** Parse a positive-number field, returning null when blank/invalid. */
+function num(value: string): number | null {
+  if (value.trim() === "") return null
+  const n = Number(value)
+  return Number.isFinite(n) && n >= 0 ? n : null
+}
+
+/**
+ * Non-destructive video editing (US-22.4): pick an edit operation, submit it
+ * (each produces a new version — the source is never touched), and see the full
+ * edit history. Rendering runs on the provider, so a submitted edit shows as
+ * "queued" and joins the version list once it finishes (Refresh re-fetches).
+ */
+export function VideoEditor({ videoId }: { videoId: string }) {
+  const { accessToken } = useAuth()
+  const [operation, setOperation] = useState<VideoEditOperation>("trim")
+  const [start, setStart] = useState("")
+  const [end, setEnd] = useState("")
+  const [prompt, setPrompt] = useState("")
+  const [lyricsEnabled, setLyricsEnabled] = useState(true)
+  const [markers, setMarkers] = useState("")
+  const [submit, setSubmit] = useState<SubmitState>({ status: "idle" })
+  const [versions, setVersions] = useState<VideoVersion[]>([])
+
+  // Handler-side refresh (the button, and after a submit) — setState here is a
+  // user/async callback, clear of the set-state-in-effect lint.
+  const refreshVersions = useCallback(async () => {
+    setVersions(await fetchVideoVersions(videoId, accessToken ?? ""))
+  }, [videoId, accessToken])
+
+  // Initial load: the fetch is inlined so the effect body never calls setState
+  // synchronously (mirrors useClip); the `active` guard drops a stale response.
+  useEffect(() => {
+    let active = true
+    fetchVideoVersions(videoId, accessToken ?? "").then((list) => {
+      if (active) setVersions(list)
+    })
+    return () => {
+      active = false
+    }
+  }, [videoId, accessToken])
+
+  /** Build the typed payload for the chosen operation, or an error string. */
+  function buildPayload(): VideoEditPayload | string {
+    if (operation === "trim" || operation === "replace_scene") {
+      const s = num(start)
+      const e = num(end)
+      if (s === null || e === null) return "Enter start and end times."
+      if (e <= s) return "End must be after start."
+      if (operation === "trim")
+        return { operation, start_seconds: s, end_seconds: e }
+      if (!prompt.trim()) return "Describe the replacement scene."
+      return {
+        operation,
+        start_seconds: s,
+        end_seconds: e,
+        prompt: prompt.trim(),
+      }
+    }
+    if (operation === "lyrics_overlay") {
+      return { operation, lyrics_enabled: lyricsEnabled }
+    }
+    const parsed = markers
+      .split(",")
+      .map((m) => m.trim())
+      .filter((m) => m !== "")
+      .map(Number)
+    if (
+      parsed.length === 0 ||
+      parsed.some((m) => !Number.isFinite(m) || m < 0)
+    ) {
+      return "Enter one or more non-negative marker times (comma-separated)."
+    }
+    return { operation, transition_markers: parsed }
+  }
+
+  async function handleSubmit() {
+    const payload = buildPayload()
+    if (typeof payload === "string") {
+      setSubmit({ status: "error", message: payload })
+      return
+    }
+    setSubmit({ status: "submitting" })
+    const result = await submitVideoEdit(videoId, payload, accessToken ?? "")
+    switch (result.status) {
+      case "accepted":
+        setSubmit({ status: "queued" })
+        void refreshVersions()
+        return
+      case "unauthorized":
+        setSubmit({ status: "error", message: "Please sign in again to edit." })
+        return
+      case "insufficient_credits":
+        setSubmit({
+          status: "error",
+          message: `Not enough credits — ${result.required} required, ${result.balance} available.`,
+        })
+        return
+      case "invalid":
+      case "unavailable":
+      case "error":
+        setSubmit({ status: "error", message: result.detail })
+        return
+    }
+  }
+
+  const rangeOp = operation === "trim" || operation === "replace_scene"
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="flex flex-col gap-3" aria-label="Edit video">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="edit-operation">Edit</Label>
+          <select
+            id="edit-operation"
+            className="h-9 rounded-md border bg-transparent px-3 text-sm"
+            value={operation}
+            onChange={(e) => {
+              setOperation(e.target.value as VideoEditOperation)
+              setSubmit({ status: "idle" })
+            }}
+          >
+            {OPERATIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {rangeOp && (
+          <div className="flex flex-wrap gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-start">Start (s)</Label>
+              <Input
+                id="edit-start"
+                type="number"
+                min={0}
+                step="0.1"
+                value={start}
+                onChange={(e) => setStart(e.target.value)}
+                className="w-28"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-end">End (s)</Label>
+              <Input
+                id="edit-end"
+                type="number"
+                min={0}
+                step="0.1"
+                value={end}
+                onChange={(e) => setEnd(e.target.value)}
+                className="w-28"
+              />
+            </div>
+          </div>
+        )}
+
+        {operation === "replace_scene" && (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-prompt">New scene prompt</Label>
+            <Input
+              id="edit-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="A slow zoom over city lights at night"
+            />
+          </div>
+        )}
+
+        {operation === "lyrics_overlay" && (
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={lyricsEnabled}
+              onChange={(e) => setLyricsEnabled(e.target.checked)}
+            />
+            Show lyrics overlay (synced to the audio)
+          </label>
+        )}
+
+        {operation === "transitions" && (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-markers">
+              Cut points (seconds, comma-separated)
+            </Label>
+            <Input
+              id="edit-markers"
+              value={markers}
+              onChange={(e) => setMarkers(e.target.value)}
+              placeholder="4, 8.5, 12"
+            />
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={submit.status === "submitting"}
+          >
+            {submit.status === "submitting" ? "Submitting…" : "Apply edit"}
+          </Button>
+          {submit.status === "queued" && (
+            <p role="status" className="text-sm text-muted-foreground">
+              Edit queued — it will appear below once rendered.
+            </p>
+          )}
+          {submit.status === "error" && (
+            <p role="alert" className="text-sm text-destructive">
+              {submit.message}
+            </p>
+          )}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2" aria-label="Version history">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium">Version history</h3>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => void refreshVersions()}
+          >
+            Refresh
+          </Button>
+        </div>
+        {versions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No versions yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2" data-testid="version-list">
+            {versions.map((v) => (
+              <li
+                key={v.id}
+                className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+              >
+                <span className="flex flex-col">
+                  <span className="font-medium">
+                    {editOperationLabel(v.edit?.operation)}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(v.created_at).toLocaleString()}
+                  </span>
+                </span>
+                <span className="flex gap-2">
+                  <Button asChild size="sm" variant="outline">
+                    <a
+                      href={videoStreamUrl(v.id)}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      View
+                    </a>
+                  </Button>
+                  <Button asChild size="sm" variant="ghost">
+                    <a href={videoStreamUrl(v.id, { download: true })} download>
+                      Download
+                    </a>
+                  </Button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/web/lib/video.test.ts
+++ b/web/lib/video.test.ts
@@ -7,12 +7,15 @@ import {
   VIDEO_RESOLUTIONS,
   VIDEO_STYLE_PRESETS,
   VIDEO_TRANSITIONS,
+  editOperationLabel,
   estimateVideoCost,
   fetchPublishedVideoForClip,
   fetchVideoDetail,
   fetchVideoStatus,
+  fetchVideoVersions,
   presetLabel,
   publishVideo,
+  submitVideoEdit,
   submitVideoJob,
   videoStreamUrl,
   type VideoConfig,
@@ -49,8 +52,16 @@ describe("option tables", () => {
       "live_performance",
       "nature",
     ])
-    expect(VIDEO_ASPECT_RATIOS.map((a) => a.value)).toEqual(["16:9", "9:16", "1:1"])
-    expect(VIDEO_RESOLUTIONS.map((r) => r.value)).toEqual(["720p", "1080p", "4k"])
+    expect(VIDEO_ASPECT_RATIOS.map((a) => a.value)).toEqual([
+      "16:9",
+      "9:16",
+      "1:1",
+    ])
+    expect(VIDEO_RESOLUTIONS.map((r) => r.value)).toEqual([
+      "720p",
+      "1080p",
+      "4k",
+    ])
     expect(VIDEO_FRAME_RATES.map((f) => f.value)).toEqual([24, 30, 60])
     expect(VIDEO_TRANSITIONS.map((t) => t.value)).toEqual([
       "auto",
@@ -62,7 +73,9 @@ describe("option tables", () => {
   })
 
   it("marks exactly 1080p and 4k as Pro-only", () => {
-    const proOnly = VIDEO_RESOLUTIONS.filter((r) => r.proOnly).map((r) => r.value)
+    const proOnly = VIDEO_RESOLUTIONS.filter((r) => r.proOnly).map(
+      (r) => r.value
+    )
     expect(proOnly).toEqual(["1080p", "4k"])
   })
 
@@ -103,7 +116,11 @@ describe("submitVideoJob", () => {
     expect(url).toBe("/api/videos/generate")
     expect(init?.headers).toMatchObject({ authorization: "Bearer tok" })
     const body = JSON.parse(String(init?.body))
-    expect(body).toMatchObject({ clip_id: "c1", prompt: "neon city", resolution: "720p" })
+    expect(body).toMatchObject({
+      clip_id: "c1",
+      prompt: "neon city",
+      resolution: "720p",
+    })
     // Optional fields that are unset must not be sent (extra="forbid" upstream
     // is fine with them, but null would 422).
     expect(body).not.toHaveProperty("style_preset")
@@ -128,7 +145,9 @@ describe("submitVideoJob", () => {
   })
 
   it("classifies 422 as invalid with the detail message", async () => {
-    mockFetch(422, { detail: [{ msg: "Provide a style prompt or a style_preset" }] })
+    mockFetch(422, {
+      detail: [{ msg: "Provide a style prompt or a style_preset" }],
+    })
     expect(await submitVideoJob("c1", config, "tok")).toEqual({
       status: "invalid",
       detail: "Provide a style prompt or a style_preset",
@@ -136,7 +155,9 @@ describe("submitVideoJob", () => {
   })
 
   it("classifies 503 as unavailable (video not configured)", async () => {
-    mockFetch(503, { detail: "Video generation is not configured on this deployment." })
+    mockFetch(503, {
+      detail: "Video generation is not configured on this deployment.",
+    })
     expect(await submitVideoJob("c1", config, "tok")).toEqual({
       status: "unavailable",
       detail: "Video generation is not configured on this deployment.",
@@ -161,15 +182,30 @@ describe("fetchVideoStatus", () => {
   })
 
   it("classifies complete with the detail (video id)", async () => {
-    mockFetch(200, { job_id: "j1", status: "complete", progress: 100, video_id: "v1" })
+    mockFetch(200, {
+      job_id: "j1",
+      status: "complete",
+      progress: 100,
+      video_id: "v1",
+    })
     expect(await fetchVideoStatus("j1", "tok")).toEqual({
       kind: "complete",
-      detail: { job_id: "j1", status: "complete", progress: 100, video_id: "v1" },
+      detail: {
+        job_id: "j1",
+        status: "complete",
+        progress: 100,
+        video_id: "v1",
+      },
     })
   })
 
   it("classifies failed with the error message", async () => {
-    mockFetch(200, { job_id: "j1", status: "failed", progress: 0, error: "render died" })
+    mockFetch(200, {
+      job_id: "j1",
+      status: "failed",
+      progress: 0,
+      error: "render died",
+    })
     expect(await fetchVideoStatus("j1", "tok")).toEqual({
       kind: "failed",
       error: "render died",
@@ -178,7 +214,9 @@ describe("fetchVideoStatus", () => {
 
   it("classifies 401 as unauthorized and other 4xx as failed", async () => {
     mockFetch(401, {})
-    expect(await fetchVideoStatus("j1", "tok")).toEqual({ kind: "unauthorized" })
+    expect(await fetchVideoStatus("j1", "tok")).toEqual({
+      kind: "unauthorized",
+    })
     vi.restoreAllMocks()
     mockFetch(404, { detail: "Video job not found." })
     expect((await fetchVideoStatus("j1", "tok")).kind).toBe("failed")
@@ -209,7 +247,9 @@ describe("videoStreamUrl", () => {
   })
 
   it("adds the download flag and encodes the id", () => {
-    expect(videoStreamUrl("v 1", { download: true })).toBe("/api/videos/v%201/stream?download=1")
+    expect(videoStreamUrl("v 1", { download: true })).toBe(
+      "/api/videos/v%201/stream?download=1"
+    )
   })
 })
 
@@ -217,7 +257,10 @@ describe("publishVideo", () => {
   it("returns the published video on 200", async () => {
     mockFetch(200, { ...videoDetail, published: true })
     const result = await publishVideo("v1", "tok")
-    expect(result).toEqual({ status: "published", video: { ...videoDetail, published: true } })
+    expect(result).toEqual({
+      status: "published",
+      video: { ...videoDetail, published: true },
+    })
   })
 
   it("sends the Bearer token to the publish proxy", async () => {
@@ -225,7 +268,10 @@ describe("publishVideo", () => {
     await publishVideo("v1", "tok")
     expect(fetchSpy).toHaveBeenCalledWith(
       "/api/videos/v1/publish",
-      expect.objectContaining({ method: "POST", headers: { authorization: "Bearer tok" } })
+      expect.objectContaining({
+        method: "POST",
+        headers: { authorization: "Bearer tok" },
+      })
     )
   })
 
@@ -266,11 +312,157 @@ describe("fetchVideoDetail / fetchPublishedVideoForClip", () => {
     vi.restoreAllMocks()
     const anon = mockFetch(200, videoDetail)
     await fetchPublishedVideoForClip("c1")
-    expect(anon).toHaveBeenCalledWith("/api/videos/for-clip/c1", { headers: {} })
+    expect(anon).toHaveBeenCalledWith("/api/videos/for-clip/c1", {
+      headers: {},
+    })
   })
 
   it("returns null on a network error", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"))
     expect(await fetchVideoDetail("v1")).toBeNull()
+  })
+})
+
+describe("editOperationLabel", () => {
+  it("labels each operation and falls back to Original render", () => {
+    expect(editOperationLabel("trim")).toBe("Trim")
+    expect(editOperationLabel("replace_scene")).toBe("Scene replacement")
+    expect(editOperationLabel("lyrics_overlay")).toBe("Lyrics overlay")
+    expect(editOperationLabel("transitions")).toBe("Transition timing")
+    expect(editOperationLabel(undefined)).toBe("Original render")
+    expect(editOperationLabel("bogus")).toBe("Original render")
+  })
+})
+
+describe("submitVideoEdit", () => {
+  it("posts the payload and returns the accepted job id", async () => {
+    const spy = mockFetch(202, { job_id: "job-9" })
+    const result = await submitVideoEdit(
+      "v1",
+      { operation: "trim", start_seconds: 2, end_seconds: 8 },
+      "tok"
+    )
+    expect(result).toEqual({ status: "accepted", jobId: "job-9" })
+    expect(spy).toHaveBeenCalledWith("/api/videos/v1/edit", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer tok",
+      },
+      body: JSON.stringify({
+        operation: "trim",
+        start_seconds: 2,
+        end_seconds: 8,
+      }),
+    })
+  })
+
+  it("maps 402 to insufficient_credits with the balance payload", async () => {
+    mockFetch(402, {
+      detail: { error: "insufficient_credits", balance: 3, required: 7 },
+    })
+    const result = await submitVideoEdit(
+      "v1",
+      { operation: "lyrics_overlay", lyrics_enabled: true },
+      "tok"
+    )
+    expect(result).toEqual({
+      status: "insufficient_credits",
+      balance: 3,
+      required: 7,
+    })
+  })
+
+  it("maps 422 to invalid with the message", async () => {
+    mockFetch(422, { detail: "end_seconds must be greater than start_seconds" })
+    const result = await submitVideoEdit(
+      "v1",
+      { operation: "trim", start_seconds: 5, end_seconds: 2 },
+      "tok"
+    )
+    expect(result).toEqual({
+      status: "invalid",
+      detail: "end_seconds must be greater than start_seconds",
+    })
+  })
+
+  it("maps 401 to unauthorized and 503 to unavailable", async () => {
+    mockFetch(401, {})
+    expect(
+      await submitVideoEdit(
+        "v1",
+        { operation: "lyrics_overlay", lyrics_enabled: false },
+        "t"
+      )
+    ).toEqual({
+      status: "unauthorized",
+    })
+    vi.restoreAllMocks()
+    mockFetch(503, { detail: "off" })
+    expect(
+      await submitVideoEdit(
+        "v1",
+        { operation: "lyrics_overlay", lyrics_enabled: false },
+        "t"
+      )
+    ).toEqual({
+      status: "unavailable",
+      detail: "off",
+    })
+  })
+
+  it("returns error on a network failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"))
+    const result = await submitVideoEdit(
+      "v1",
+      { operation: "trim", start_seconds: 0, end_seconds: 1 },
+      "t"
+    )
+    expect(result.status).toBe("error")
+  })
+})
+
+describe("fetchVideoVersions", () => {
+  it("returns the version array on 200", async () => {
+    const versions = [
+      {
+        id: "v2",
+        clip_id: "c",
+        job_id: "j",
+        resolution: "1080p",
+        aspect_ratio: "16:9",
+        published: false,
+        created_at: "2026-07-29T00:00:00Z",
+        parent_video_id: "v1",
+        edit: { operation: "trim" },
+      },
+      {
+        id: "v1",
+        clip_id: "c",
+        job_id: "j",
+        resolution: "1080p",
+        aspect_ratio: "16:9",
+        published: false,
+        created_at: "2026-07-28T00:00:00Z",
+      },
+    ]
+    const spy = mockFetch(200, versions)
+    expect(await fetchVideoVersions("v1", "tok")).toEqual(versions)
+    expect(spy).toHaveBeenCalledWith("/api/videos/v1/versions", {
+      headers: { authorization: "Bearer tok" },
+    })
+  })
+
+  it("returns [] on error status or a non-array body", async () => {
+    mockFetch(404, { detail: "nope" })
+    expect(await fetchVideoVersions("v1", "tok")).toEqual([])
+    vi.restoreAllMocks()
+    mockFetch(200, { not: "an array" })
+    expect(await fetchVideoVersions("v1", "tok")).toEqual([])
+  })
+
+  it("returns [] on a network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"))
+    expect(await fetchVideoVersions("v1", "tok")).toEqual([])
   })
 })

--- a/web/lib/video.ts
+++ b/web/lib/video.ts
@@ -26,7 +26,12 @@ export type VideoFrameRate = 24 | 30 | 60
 export type VideoTransitions = "auto" | "cut" | "fade" | "dissolve"
 
 /** The render lifecycle states the status endpoint reports. */
-export type VideoState = "queued" | "rendering" | "encoding" | "complete" | "failed"
+export type VideoState =
+  | "queued"
+  | "rendering"
+  | "encoding"
+  | "complete"
+  | "failed"
 
 // Backend request bounds (src/acemusic/api/routers/videos.py).
 export const MAX_REFERENCE_IMAGES = 5
@@ -45,27 +50,32 @@ export const VIDEO_STYLE_PRESETS: PresetOption[] = [
   {
     value: "abstract",
     label: "Abstract",
-    prompt: "Abstract flowing shapes and colors that pulse with the music's energy.",
+    prompt:
+      "Abstract flowing shapes and colors that pulse with the music's energy.",
   },
   {
     value: "cinematic",
     label: "Cinematic",
-    prompt: "Cinematic film scenes with dramatic lighting and sweeping camera moves.",
+    prompt:
+      "Cinematic film scenes with dramatic lighting and sweeping camera moves.",
   },
   {
     value: "animated",
     label: "Animated",
-    prompt: "Vibrant animated illustration style with smooth, expressive motion.",
+    prompt:
+      "Vibrant animated illustration style with smooth, expressive motion.",
   },
   {
     value: "lyric_video",
     label: "Lyric Video",
-    prompt: "Typography-driven lyric video with animated text as the visual focus.",
+    prompt:
+      "Typography-driven lyric video with animated text as the visual focus.",
   },
   {
     value: "live_performance",
     label: "Live Performance",
-    prompt: "Live concert performance footage with stage lighting and crowd energy.",
+    prompt:
+      "Live concert performance footage with stage lighting and crowd energy.",
   },
   {
     value: "nature",
@@ -74,11 +84,12 @@ export const VIDEO_STYLE_PRESETS: PresetOption[] = [
   },
 ]
 
-export const VIDEO_ASPECT_RATIOS: { value: VideoAspectRatio; label: string }[] = [
-  { value: "16:9", label: "16:9 Landscape" },
-  { value: "9:16", label: "9:16 Vertical" },
-  { value: "1:1", label: "1:1 Square" },
-]
+export const VIDEO_ASPECT_RATIOS: { value: VideoAspectRatio; label: string }[] =
+  [
+    { value: "16:9", label: "16:9 Landscape" },
+    { value: "9:16", label: "9:16 Vertical" },
+    { value: "1:1", label: "1:1 Square" },
+  ]
 
 /** A resolution's display metadata; Pro-only tiers are subscription-gated. */
 export type ResolutionOption = {
@@ -108,7 +119,9 @@ export const VIDEO_TRANSITIONS: { value: VideoTransitions; label: string }[] = [
 
 /** Human label for a preset key, falling back to the raw value then a dash. */
 export function presetLabel(value?: string): string {
-  return VIDEO_STYLE_PRESETS.find((p) => p.value === value)?.label ?? value ?? "—"
+  return (
+    VIDEO_STYLE_PRESETS.find((p) => p.value === value)?.label ?? value ?? "—"
+  )
 }
 
 // Client-side mirror of the server cost formula (src/acemusic/api/services/
@@ -222,7 +235,11 @@ export async function submitVideoJob(
   // Drop unset optional fields: the backend forbids unknown keys and treats
   // null prompt/preset as "neither provided", so absence is the safe encoding.
   const payload: Record<string, unknown> = { clip_id: clipId, ...config }
-  for (const key of ["prompt", "style_preset", "reference_image_urls"] as const) {
+  for (const key of [
+    "prompt",
+    "style_preset",
+    "reference_image_urls",
+  ] as const) {
     if (payload[key] === undefined) delete payload[key]
   }
 
@@ -237,13 +254,19 @@ export async function submitVideoJob(
       body: JSON.stringify(payload),
     })
   } catch {
-    return { status: "error", detail: "Video generation failed. Please try again." }
+    return {
+      status: "error",
+      detail: "Video generation failed. Please try again.",
+    }
   }
 
   if (res.status === 202) {
     const body = (await res.json().catch(() => ({}))) as { job_id?: string }
     if (!body.job_id) {
-      return { status: "error", detail: "Server returned an unexpected response." }
+      return {
+        status: "error",
+        detail: "Server returned an unexpected response.",
+      }
     }
     return { status: "accepted", jobId: body.job_id }
   }
@@ -252,8 +275,9 @@ export async function submitVideoJob(
   const body = await res.json().catch(() => ({}))
   if (res.status === 402) {
     // The 402 detail is an object {error, balance, required}.
-    const detail = (body as { detail?: { balance?: number; required?: number } })
-      .detail
+    const detail = (
+      body as { detail?: { balance?: number; required?: number } }
+    ).detail
     return {
       status: "insufficient_credits",
       balance: detail?.balance ?? 0,
@@ -261,7 +285,10 @@ export async function submitVideoJob(
     }
   }
   if (res.status === 422) {
-    return { status: "invalid", detail: extractDetail(body, "Please check your input.") }
+    return {
+      status: "invalid",
+      detail: extractDetail(body, "Please check your input."),
+    }
   }
   if (res.status === 503) {
     return {
@@ -282,7 +309,10 @@ export async function submitVideoJob(
  * unpublished) video — the same trick the clip stream proxy uses (issue #282).
  * `download` forces a save-to-disk response (Content-Disposition: attachment).
  */
-export function videoStreamUrl(videoId: string, opts?: { download?: boolean }): string {
+export function videoStreamUrl(
+  videoId: string,
+  opts?: { download?: boolean }
+): string {
   const base = `/api/videos/${encodeURIComponent(videoId)}/stream`
   return opts?.download ? `${base}?download=1` : base
 }
@@ -306,11 +336,141 @@ export async function publishVideo(
   if (res.status === 404) return { status: "not_found" }
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    return { status: "error", detail: extractDetail(body, "Publishing failed. Please try again.") }
+    return {
+      status: "error",
+      detail: extractDetail(body, "Publishing failed. Please try again."),
+    }
   }
   const video = (await res.json().catch(() => null)) as VideoDetail | null
-  if (!video) return { status: "error", detail: "Server returned an unexpected response." }
+  if (!video)
+    return {
+      status: "error",
+      detail: "Server returned an unexpected response.",
+    }
   return { status: "published", video }
+}
+
+// --- US-22.4 basic editing -------------------------------------------------
+
+/** The non-destructive edit operations (mirrors the backend VideoEditRequest). */
+export type VideoEditOperation =
+  | "trim"
+  | "replace_scene"
+  | "lyrics_overlay"
+  | "transitions"
+
+/** A single edit request payload (only the fields the operation needs). */
+export type VideoEditPayload =
+  | { operation: "trim"; start_seconds: number; end_seconds: number }
+  | {
+      operation: "replace_scene"
+      start_seconds: number
+      end_seconds: number
+      prompt: string
+    }
+  | { operation: "lyrics_overlay"; lyrics_enabled: boolean }
+  | { operation: "transitions"; transition_markers: number[] }
+
+/** A rendered video plus its edit lineage (mirrors the backend VideoVersionResponse). */
+export type VideoVersion = VideoDetail & {
+  parent_video_id?: string
+  edit?: { operation: VideoEditOperation; [key: string]: unknown }
+}
+
+/** Human label for an edit operation (for the version-history list). */
+export function editOperationLabel(op?: string): string {
+  switch (op) {
+    case "trim":
+      return "Trim"
+    case "replace_scene":
+      return "Scene replacement"
+    case "lyrics_overlay":
+      return "Lyrics overlay"
+    case "transitions":
+      return "Transition timing"
+    default:
+      return "Original render"
+  }
+}
+
+/** Submit a non-destructive edit through the BFF proxy; classified like a render. */
+export async function submitVideoEdit(
+  videoId: string,
+  payload: VideoEditPayload,
+  accessToken: string
+): Promise<SubmitVideoResult> {
+  let res: Response
+  try {
+    res = await fetch(`/api/videos/${encodeURIComponent(videoId)}/edit`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(payload),
+    })
+  } catch {
+    return { status: "error", detail: "Video edit failed. Please try again." }
+  }
+
+  if (res.status === 202) {
+    const body = (await res.json().catch(() => ({}))) as { job_id?: string }
+    if (!body.job_id)
+      return {
+        status: "error",
+        detail: "Server returned an unexpected response.",
+      }
+    return { status: "accepted", jobId: body.job_id }
+  }
+  if (res.status === 401) return { status: "unauthorized" }
+
+  const body = await res.json().catch(() => ({}))
+  if (res.status === 402) {
+    const detail = (
+      body as { detail?: { balance?: number; required?: number } }
+    ).detail
+    return {
+      status: "insufficient_credits",
+      balance: detail?.balance ?? 0,
+      required: detail?.required ?? 0,
+    }
+  }
+  if (res.status === 422) {
+    return {
+      status: "invalid",
+      detail: extractDetail(body, "Please check your edit."),
+    }
+  }
+  if (res.status === 503) {
+    return {
+      status: "unavailable",
+      detail: extractDetail(body, "Video editing is currently unavailable."),
+    }
+  }
+  return {
+    status: "error",
+    detail: extractDetail(body, "Video edit failed. Please try again."),
+  }
+}
+
+/** Fetch a video's version history (newest first) through the BFF proxy; `[]` on error. */
+export async function fetchVideoVersions(
+  videoId: string,
+  accessToken: string
+): Promise<VideoVersion[]> {
+  try {
+    const res = await fetch(
+      `/api/videos/${encodeURIComponent(videoId)}/versions`,
+      {
+        headers: { authorization: `Bearer ${accessToken}` },
+      }
+    )
+    if (!res.ok) return []
+    const body = await res.json().catch(() => null)
+    return Array.isArray(body) ? (body as VideoVersion[]) : []
+  } catch {
+    return []
+  }
 }
 
 /** Fetch one rendered video's metadata through the BFF proxy; `null` if absent. */
@@ -318,7 +478,10 @@ export async function fetchVideoDetail(
   videoId: string,
   accessToken?: string
 ): Promise<VideoDetail | null> {
-  return fetchVideoDetailAt(`/api/videos/${encodeURIComponent(videoId)}`, accessToken)
+  return fetchVideoDetailAt(
+    `/api/videos/${encodeURIComponent(videoId)}`,
+    accessToken
+  )
 }
 
 /** Fetch the published video for a clip (the song page's "Music video"); `null` if none. */
@@ -326,11 +489,17 @@ export async function fetchPublishedVideoForClip(
   clipId: string,
   accessToken?: string
 ): Promise<VideoDetail | null> {
-  return fetchVideoDetailAt(`/api/videos/for-clip/${encodeURIComponent(clipId)}`, accessToken)
+  return fetchVideoDetailAt(
+    `/api/videos/for-clip/${encodeURIComponent(clipId)}`,
+    accessToken
+  )
 }
 
 /** Shared GET-and-parse for the two VideoDetail endpoints — 404/error both mean "no video". */
-async function fetchVideoDetailAt(url: string, accessToken?: string): Promise<VideoDetail | null> {
+async function fetchVideoDetailAt(
+  url: string,
+  accessToken?: string
+): Promise<VideoDetail | null> {
   try {
     const res = await fetch(url, {
       headers: accessToken ? { authorization: `Bearer ${accessToken}` } : {},
@@ -360,7 +529,10 @@ export async function fetchVideoStatus(
   // A 4xx other than 401 is terminal (404 = unknown/not-owned job) — polling
   // can never recover, so fail fast. 5xx/network stay transient (retried).
   if (res.status >= 400 && res.status < 500) {
-    return { kind: "failed", error: "Video generation failed. Please try again." }
+    return {
+      kind: "failed",
+      error: "Video generation failed. Please try again.",
+    }
   }
   if (!res.ok) return { kind: "transient" }
 


### PR DESCRIPTION
Closes #314 — **US-22.4: Basic Video Editing**.

## What

Non-destructive editing for a rendered music video. Each edit forwards a spec to the
video provider and produces a **new** `Video` version linked to its source
(`parent_video_id`); the original is never mutated. Edit history is the owner's versions
for that clip, newest first.

Four operations: **trim** (start/end), **scene replacement** (range + new prompt),
**lyrics-overlay toggle**, **transition timing** (cut-point markers).

## How

Reuses the existing `video` job type and `/{job_id}/status` polling — no new job type or
processor wiring.

**Backend**
- `Video` gains `parent_video_id` + `edit` lineage fields (nullable).
- `POST /videos/{id}/edit` — owned source video, edit range validated against the clip
  duration, credit-gated at the source's resolution (refund on job-creation failure),
  enqueues a `video` job carrying `source_video_id` + the compact edit spec.
- `GET /videos/{id}/versions` — the clip's version history, newest first, with each
  version's parent link + edit spec + `created_at`. Owner-only.
- `process_video_job` branches on `source_video_id`: downloads the **source MP4** (not
  the clip audio), submits the edit spec, stores the linked new version. Same
  rollback-on-failure guarantee (no orphaned storage).

**Web**
- `lib/video`: `submitVideoEdit`, `fetchVideoVersions`, edit types + `editOperationLabel`.
- `VideoEditor`: the four edit controls + version history, wired into `VideoDelivery`
  behind an "Edit video" toggle.
- BFF proxies for `/edit` and `/versions`.

## Testing

- Backend: 82 integration + 11 unit video tests pass (edit validation, credit-gate,
  ownership 404s, range-vs-duration 422, handler edit branch, versions listing).
- Web: full suite green (1561 tests); typecheck, lint, prettier, `next build` clean.
- Cross-family review (opencode/GLM) run pre-PR; findings triaged in the thread.
- **Demo** (`docs/demos/us-22.4-video-editing.md`, driven by `scripts/demo_us_22_4.py`)
  maps every acceptance criterion to outcome evidence against the real endpoints + handler.

## Acceptance criteria

- [x] Trimming produces a new shorter cut (provider renders it from the trim spec)
- [x] Scene replacement carries the range + new prompt; surrounding video preserved (source MP4 is the render input)
- [x] Lyrics overlay toggled post-generation (spec forwarded to the provider)
- [x] Original version accessible after edits — nothing is mutated; each edit is a new document
- [x] Edit history shows all versions with timestamps

## Known limitations

- Actual trim/scene/lyrics/transition rendering is the provider's job — no provider
  credentials exist here, so the render itself is verified with a fake provider (like
  Dolby/ElevenLabs stories). The platform contract (spec forwarding, versioning, billing,
  history, ownership) is fully covered.
- Every edit is billed a flat render cost (all round-trip the provider). Per-operation
  pricing (a trim is cheaper than a scene re-render) is a future refinement.
- Version history is listed by clip (index-served), not walked as an explicit tree;
  `parent_video_id` records derivation for display.
- The editor shows a submitted edit as "queued" and it joins the version list on Refresh;
  live edit-job progress polling in the editor is deferred (the app-level watcher already
  notifies on job completion).
