### PR TITLE
fix(ci): skip Docker Publish when Docker Hub secrets are absent

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,9 @@
 # Required repository secrets (Settings → Secrets and variables → Actions):
 #   - DOCKERHUB_USERNAME  Docker Hub account name (e.g. frankbria)
 #   - DOCKERHUB_TOKEN     Docker Hub access token with read/write scope
+#
+# When those secrets are absent the job logs a warning and skips rather than failing, so
+# unrelated pushes to docker/ do not report a red build on main.
 name: Docker Publish
 
 on:
@@ -25,13 +28,27 @@ jobs:
     # Only ever publish from main — a manual workflow_dispatch on a feature branch must
     # not overwrite the public `latest` tag.
     if: github.ref == 'refs/heads/main'
+    env:
+      # ponytail: exposed as job env so the steps below can test for it — the `secrets`
+      # context is not available in `if:` conditions, but `env` is.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
+      # Without credentials the publish cannot work, and every push touching docker/ or
+      # this file (e.g. a Dependabot action bump) turns main red. Warn and skip instead.
+      - name: Warn when Docker Hub credentials are missing
+        if: env.DOCKERHUB_USERNAME == ''
+        run: |
+          echo "::warning title=Docker publish skipped::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not set. Add them under Settings → Secrets and variables → Actions to publish frankbria/ace-step."
+
       - uses: actions/checkout@v7
+        if: env.DOCKERHUB_USERNAME != ''
 
       - name: Set up Docker Buildx
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,6 +57,7 @@ jobs:
       # Derive tags: `latest` for main plus the git SHA for traceability.
       - name: Derive image tags
         id: meta
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/metadata-action@v6
         with:
           images: frankbria/ace-step
@@ -48,6 +66,7 @@ jobs:
             type=sha,format=long
 
       - name: Build and push
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/build-push-action@v7.3.0
         with:
           context: docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,26 +29,27 @@ jobs:
     # not overwrite the public `latest` tag.
     if: github.ref == 'refs/heads/main'
     env:
-      # ponytail: exposed as job env so the steps below can test for it — the `secrets`
-      # context is not available in `if:` conditions, but `env` is.
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      # ponytail: collapsed to one flag in job env because the `secrets` context is not
+      # available in `if:` conditions, but `env` is. Both halves must be present — a
+      # username without a token fails login just as hard as neither being set.
+      HAS_DOCKERHUB_CREDS: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       # Without credentials the publish cannot work, and every push touching docker/ or
       # this file (e.g. a Dependabot action bump) turns main red. Warn and skip instead.
       - name: Warn when Docker Hub credentials are missing
-        if: env.DOCKERHUB_USERNAME == ''
+        if: env.HAS_DOCKERHUB_CREDS != 'true'
         run: |
           echo "::warning title=Docker publish skipped::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not set. Add them under Settings → Secrets and variables → Actions to publish frankbria/ace-step."
 
       - uses: actions/checkout@v7
-        if: env.DOCKERHUB_USERNAME != ''
+        if: env.HAS_DOCKERHUB_CREDS == 'true'
 
       - name: Set up Docker Buildx
-        if: env.DOCKERHUB_USERNAME != ''
+        if: env.HAS_DOCKERHUB_CREDS == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        if: env.DOCKERHUB_USERNAME != ''
+        if: env.HAS_DOCKERHUB_CREDS == 'true'
         uses: docker/login-action@v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -57,7 +58,7 @@ jobs:
       # Derive tags: `latest` for main plus the git SHA for traceability.
       - name: Derive image tags
         id: meta
-        if: env.DOCKERHUB_USERNAME != ''
+        if: env.HAS_DOCKERHUB_CREDS == 'true'
         uses: docker/metadata-action@v6
         with:
           images: frankbria/ace-step
@@ -66,7 +67,7 @@ jobs:
             type=sha,format=long
 
       - name: Build and push
-        if: env.DOCKERHUB_USERNAME != ''
+        if: env.HAS_DOCKERHUB_CREDS == 'true'
         uses: docker/build-push-action@v7.3.0
         with:
           context: docker


### PR DESCRIPTION
## Why Docker Publish fails on main

Every `Docker Publish` run on `main` — going back at least to 2026-07-19 — fails in the same place:

```
X Log in to Docker Hub
ANNOTATIONS
X Username and password required
```

The workflow is correct; the credentials simply do not exist. `gh secret list` on this repo returns only `CLAUDE_CODE_OAUTH_TOKEN` and `ZHIPU_API_KEY` — **`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` have never been configured.** `docker/login-action` fails hard on empty inputs, so the job dies ~15s in and the build/push steps never run.

The reason it looks like a recurring regression is the path filter: the workflow triggers on changes to `.github/workflows/docker-publish.yml` itself, so each Dependabot action bump that merges to `main` (#286, #288, #289, #294, #356) immediately re-triggers a run that fails for the same missing-secret reason.

Failed runs, all identical: [30416412958](https://github.com/frankbria/auto-music-studio/actions/runs/30416412958), [29673446436](https://github.com/frankbria/auto-music-studio/actions/runs/29673446436), [29673444348](https://github.com/frankbria/auto-music-studio/actions/runs/29673444348), [29673442038](https://github.com/frankbria/auto-music-studio/actions/runs/29673442038), [29673437897](https://github.com/frankbria/auto-music-studio/actions/runs/29673437897).

## What this PR changes

Guards the credential-dependent steps on both secrets being present, and emits a warning annotation when they are not — so the job **skips** instead of failing.

- A single `HAS_DOCKERHUB_CREDS` flag is computed in job-level `env`, because the `secrets` context is not available in `if:` conditions but `env` is.
- Gated on *both* secrets: a username set without a token fails `docker/login-action` just as hard as neither being set (caught in pre-PR review).
- Validated with `actionlint` (clean).

## What this PR does *not* do

It does not make publishing work — I can't create the Docker Hub token. **To actually publish `frankbria/ace-step` again:** add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` under Settings → Secrets and variables → Actions, then run the workflow from the Actions tab. The guard is a no-op once they exist.

Note that the build/push steps have never successfully executed on CI, so `docker/Dockerfile` is unverified in this pipeline — the first run with real credentials may surface build issues.
