### PR TITLE
feat(plugin): US-24.1 DAW Tempo Sync and Tempo-Matched Insertion (#320)

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -44,9 +44,11 @@ set(ACEMUSIC_SOURCES
     source/GenerationManager.cpp
     source/GenerationPanel.cpp
     source/GenerationRequest.cpp
+    source/HostSync.cpp
     source/PluginProcessor.cpp
     source/PluginEditor.cpp
-    source/ResultsPanel.cpp)
+    source/ResultsPanel.cpp
+    source/TimeStretch.cpp)
 
 # ---------------------------------------------------------------------------
 # Plugin
@@ -111,8 +113,10 @@ target_sources(AceMusicPluginTests PRIVATE
     tests/GenerationManagerTests.cpp
     tests/GenerationPanelTests.cpp
     tests/GenerationRequestTests.cpp
+    tests/HostSyncTests.cpp
     tests/PluginProcessorTests.cpp
-    tests/ResultsPanelTests.cpp)
+    tests/ResultsPanelTests.cpp
+    tests/TimeStretchTests.cpp)
 
 target_include_directories(AceMusicPluginTests PRIVATE source tests)
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,17 +2,16 @@
 
 JUCE-based plugin that brings ACE-Step generation into a DAW.
 
-Stage 23 progress:
+Progress:
 
 | Story | State |
 | --- | --- |
 | US-23.1 — JUCE project, cross-platform build, off-audio-thread work queue | done |
 | US-23.2 — Connection panel: server URL, API key, status, model list | done |
-| US-23.3 — Generation panel | not started |
-| US-23.4 — Results panel and clip insertion | not started |
-| US-23.5 — Local cache and file management | not started |
-
-The Generation and Results panels are still outlined placeholders in the UI.
+| US-23.3 — Generation panel | done |
+| US-23.4 — Results panel and clip insertion | done |
+| US-23.5 — Local cache and file management | done |
+| US-24.1 — DAW tempo sync and tempo-matched insertion | done |
 
 | Format | Windows | macOS | Linux |
 | --- | --- | --- | --- |
@@ -88,8 +87,11 @@ the VST3 in Reaper once and confirm the UI renders and audio passes through:
    `%COMMONPROGRAMFILES%\VST3` on Windows).
 2. Reaper → Options → Preferences → Plug-ins → VST → *Re-scan*.
 3. Add it to a track with audio on it, open the UI, confirm the three panels
-   render (Connection is live; Generation and Results are placeholders) and the
-   audio is unchanged.
+   render and the audio is unchanged.
+4. Set the project tempo to 120 and confirm the **BPM** field reads 120 and the
+   indicator says `Sync: host 120 BPM`; change the project tempo and watch it
+   follow. This is the one part of US-24.1 that no unit test can cover, because
+   it needs a real host publishing a real tempo.
 
 ## Connecting to ACE-Step
 
@@ -131,6 +133,57 @@ follow you into new projects:
 Settings live in this file rather than the plugin's project state on purpose:
 project state would only come back inside the same DAW project, and the
 requirement is to survive *sessions*.
+
+## Host sync
+
+The plugin follows the DAW's tempo. Open it in a 120 BPM project and the **BPM**
+field reads 120; drag the project tempo and the field follows. The **Sync**
+indicator next to the parameter row says which of these is happening:
+
+| Indicator | Meaning |
+| --- | --- |
+| `Sync: host 120 BPM` | BPM is following the host |
+| `Sync: off (manual BPM)` | you typed a BPM; the host will not overwrite it |
+| `Sync: no host tempo` | the host publishes no tempo — BPM stays on *Auto* |
+
+**To take manual control**, type a BPM. **To hand it back**, clear the field —
+empty is the panel's existing "Auto" state, so there is no extra button.
+
+### Key is not synced, and cannot be
+
+`juce::AudioPlayHead::PositionInfo` carries tempo, time signature, PPQ and the
+transport flags — and **no key signature**. The only key-signature channel in
+JUCE is [ARA](https://www.celemony.com/en/service1/about-celemony/technologies),
+a separately licensed SDK that a handful of hosts implement. There is no way to
+read the project key through VST3, AU or Standalone, so the **Key** field is
+always manual. The indicator deliberately never claims otherwise.
+
+### Tempo-matched insertion
+
+If a clip was generated at a different BPM from the project, dragging it out
+hands the host a **tempo-matched copy** rather than the original — a 118 BPM clip
+dropped into a 120 BPM project arrives at 120.
+
+The stretch is WSOLA (waveform-similarity overlap-add), not a resample.
+Resampling would be less code, but it changes pitch with speed: 118→120 is a 1.7%
+rate change and therefore a 29-cent detune, and audio that lands out of tune with
+the project defeats the point of syncing to it in the first place.
+
+Matched copies are written to a `tempo-match/` directory inside the run's cache
+folder, built once per tempo on the background queue, and removed with the run.
+They live in a subdirectory rather than beside the clip because the cache browser
+lists `*.wav` per run non-recursively — as siblings they would be counted as
+extra clips of that generation.
+
+The clip's own tempo is the BPM that was **requested**, not one measured from the
+returned audio. A generation that left BPM on *Auto* has no known tempo, so
+nothing is stretched: guessing would be worse than leaving it alone. Detecting
+the tempo of a finished clip is a separate story.
+
+Everything reads the host transport through `HostSync`, which samples the play
+head once in `processBlock` and publishes it. `getPlayHead()` is an audio-thread
+API; calling it from a timer, as the results panel used to for its playhead
+readout, is a data race.
 
 ## Networking
 

--- a/plugin/source/GenerationManager.cpp
+++ b/plugin/source/GenerationManager.cpp
@@ -100,6 +100,7 @@ void GenerationManager::start (const GenerationRequest& request)
     activeControl = context.control;
 
     clips.clear();
+    requestedBpm = request.bpm;
     startedAtMs = juce::Time::getMillisecondCounter();
     state = State::submitting;
     statusMessage = describe (State::submitting);
@@ -108,9 +109,10 @@ void GenerationManager::start (const GenerationRequest& request)
     queue.enqueue ([context] { runGeneration (context); });
 }
 
-void GenerationManager::setClipsForTesting (const juce::Array<juce::File>& files)
+void GenerationManager::setClipsForTesting (const juce::Array<juce::File>& files, int bpm)
 {
     clips = files;
+    requestedBpm = bpm;
     state = files.isEmpty() ? State::idle : State::complete;
     statusMessage = files.isEmpty()
                         ? describe (State::idle)

--- a/plugin/source/GenerationManager.h
+++ b/plugin/source/GenerationManager.h
@@ -69,6 +69,14 @@ public:
     /** Downloaded clips, in the order the server listed them. */
     const juce::Array<juce::File>& getClips() const noexcept { return clips; }
 
+    /** The BPM the current clips were asked for, or < 0 when the request left BPM on
+        "Auto" and the server chose for itself.
+
+        This is the *requested* tempo, not one measured from the returned audio — which
+        is why tempo matching (US-24.1) does nothing for an Auto-BPM generation rather
+        than guessing. Detecting the tempo of a finished clip is its own story. */
+    int getRequestedBpm() const noexcept                     { return requestedBpm; }
+
     /** Seconds since the current run started; 0 when idle. */
     int getElapsedSeconds() const;
 
@@ -83,7 +91,7 @@ public:
         Named unmistakably: nothing in the plugin calls this. US-23.5 will need a real
         way to restore clips from the cache, and that should be its own API with its
         own semantics rather than this quietly becoming production behaviour. */
-    void setClipsForTesting (const juce::Array<juce::File>& files);
+    void setClipsForTesting (const juce::Array<juce::File>& files, int bpm = -1);
 
     /** Where clips are written: the configured cache path, or ClipCache's default. */
     juce::File getClipDirectory() const;
@@ -126,6 +134,9 @@ private:
     State state = State::idle;
     juce::String statusMessage { "Idle" };
     juce::Array<juce::File> clips;
+
+    /** Kept alongside `clips` so it always describes the clips currently published. */
+    int requestedBpm = -1;
 
     int currentRun = 0;
     juce::uint32 startedAtMs = 0;

--- a/plugin/source/GenerationPanel.cpp
+++ b/plugin/source/GenerationPanel.cpp
@@ -46,9 +46,12 @@ namespace
 }
 
 //==============================================================================
-GenerationPanel::GenerationPanel (GenerationManager& generationToUse, ConnectionManager& connectionToUse)
+GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
+                                  ConnectionManager& connectionToUse,
+                                  HostSync* hostSyncToUse)
     : generation (generationToUse),
-      connection (connectionToUse)
+      connection (connectionToUse),
+      hostSync (hostSyncToUse)
 {
     titleLabel.setText ("GENERATION", juce::dontSendNotification);
     titleLabel.setFont (juce::FontOptions (13.0f, juce::Font::bold));
@@ -101,6 +104,15 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse, Connection
     addAndMakeVisible (bpmLabel);
     styleEditor (bpmEditor, autoPlaceholder);
     bpmEditor.setInputRestrictions (3, "0123456789");
+    // The one rule for host tempo sync: the field follows the host until the user
+    // types in it, and follows it again the moment they clear it. Sync writes with
+    // setText(..., false), which does not fire this, so the panel cannot cancel its
+    // own sync by obeying the host.
+    bpmEditor.onTextChange = [this]
+    {
+        bpmSynced = bpmEditor.getText().trim().isEmpty();
+        refresh();
+    };
     addAndMakeVisible (bpmEditor);
 
     styleCaption (keyLabel, "Key");
@@ -163,12 +175,22 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse, Connection
     progressBar.setColour (juce::ProgressBar::backgroundColourId, genColours::field);
     addChildComponent (progressBar);
 
+    syncLabel.setFont (juce::FontOptions (12.0f));
+    syncLabel.setColour (juce::Label::textColourId, genColours::textDim);
+    syncLabel.setJustificationType (juce::Justification::centredRight);
+    addAndMakeVisible (syncLabel);
+
     generation.addChangeListener (this);
     connection.addChangeListener (this);
+
+    // Fill the BPM field before the first paint, so opening the plugin in a project
+    // that is already running shows the host tempo rather than a blank field that
+    // fills in half a second later.
+    applyHostTempo();
     refresh();
 
-    // Only to tick the elapsed-time readout; every real state change arrives as a
-    // change message.
+    // Ticks the elapsed-time readout and follows the host tempo. Everything else the
+    // panel shows arrives as a change message.
     startTimerHz (2);
 }
 
@@ -235,6 +257,7 @@ void GenerationPanel::resized()
     languageRow.removeFromLeft (12);
     instrumentalToggle.setBounds (languageRow.removeFromLeft (120));
     lyricsToggle.setBounds (languageRow.removeFromLeft (90));
+    syncLabel.setBounds (languageRow);
 
     area.removeFromBottom (8);
 
@@ -255,8 +278,50 @@ void GenerationPanel::changeListenerCallback (juce::ChangeBroadcaster*)
 
 void GenerationPanel::timerCallback()
 {
-    if (generation.isBusy())
-        refresh();
+    // Unconditional now, not just while busy: this is also what tracks a tempo change
+    // made in the DAW while the panel sits idle. refresh() is a handful of setters that
+    // no-op when nothing moved, so 2Hz costs nothing.
+    applyHostTempo();
+    refresh();
+}
+
+bool GenerationPanel::applyHostTempo()
+{
+    if (hostSync == nullptr || ! bpmSynced)
+        return false;
+
+    // Never rewrite the field out from under someone typing in it. TextEditor delivers
+    // onTextChange asynchronously (it posts a command message), so between the first
+    // keystroke and the callback that clears bpmSynced there is a window where this
+    // would otherwise overwrite what they just typed.
+    if (bpmEditor.hasKeyboardFocus (false))
+        return false;
+
+    const auto snapshot = hostSync->get();
+
+    if (! snapshot.hasBpm())
+        return false;
+
+    const auto wanted = juce::String (juce::roundToInt (snapshot.bpm));
+
+    if (bpmEditor.getText() == wanted)
+        return false;
+
+    bpmEditor.setText (wanted, false);
+    return true;
+}
+
+juce::String GenerationPanel::getSyncStatusText() const
+{
+    if (! bpmSynced)
+        return "Sync: off (manual BPM)";
+
+    const auto snapshot = hostSync != nullptr ? hostSync->get() : HostSync::Snapshot{};
+
+    if (! snapshot.hasBpm())
+        return "Sync: no host tempo";
+
+    return "Sync: host " + juce::String (juce::roundToInt (snapshot.bpm)) + " BPM";
 }
 
 GenerationRequest GenerationPanel::buildRequest() const
@@ -310,6 +375,9 @@ void GenerationPanel::applyRequest (const GenerationRequest& request)
 
     instrumentalToggle.setToggleState (request.instrumental, juce::dontSendNotification);
 
+    // An applied request carries the user's own BPM, so it takes the field off sync —
+    // except when it leaves BPM on Auto, which hands it back.
+    bpmSynced = request.bpm <= 0;
     bpmEditor.setText (request.bpm > 0 ? juce::String (request.bpm) : juce::String(), false);
 
     const auto keyIndex = GenerationRequest::musicalKeys().indexOf (request.key);
@@ -338,6 +406,11 @@ void GenerationPanel::refresh()
     cancelButton.setEnabled (busy);
 
     progressBar.setVisible (busy);
+
+    const auto syncText = getSyncStatusText();
+
+    if (syncLabel.getText() != syncText)
+        syncLabel.setText (syncText, juce::dontSendNotification);
 
     for (auto* control : std::initializer_list<juce::Component*> {
              &promptEditor, &lyricsEditor, &lyricsToggle, &languageSelector, &instrumentalToggle,

--- a/plugin/source/GenerationPanel.h
+++ b/plugin/source/GenerationPanel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "GenerationManager.h"
+#include "HostSync.h"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -20,7 +21,10 @@ class GenerationPanel final : public juce::Component,
                               private juce::Timer
 {
 public:
-    GenerationPanel (GenerationManager&, ConnectionManager&);
+    /** @param hostSyncToUse  the host transport, or null for "there is no host" —
+                              which is what a test that does not care about tempo
+                              sync gets, and what the panel shows as no host tempo. */
+    GenerationPanel (GenerationManager&, ConnectionManager&, HostSync* hostSyncToUse = nullptr);
     ~GenerationPanel() override;
 
     void paint (juce::Graphics&) override;
@@ -48,6 +52,10 @@ public:
     juce::TextButton&   getGenerateButton() noexcept      { return generateButton; }
     juce::TextButton&   getCancelButton() noexcept        { return cancelButton; }
     juce::Label&        getStatusLabel() noexcept         { return statusLabel; }
+    juce::Label&        getSyncLabel() noexcept           { return syncLabel; }
+
+    /** True while the BPM field is following the host rather than the user. */
+    bool isBpmSynced() const noexcept                     { return bpmSynced; }
     juce::ProgressBar&  getProgressBar() noexcept         { return progressBar; }
 
 private:
@@ -55,8 +63,21 @@ private:
     void timerCallback() override;
     void refresh();
 
+    /** Copies the host tempo into the BPM field when the field is still following it.
+        @returns true if the field changed. */
+    bool applyHostTempo();
+
+    /** What the sync indicator should read right now. */
+    juce::String getSyncStatusText() const;
+
     GenerationManager& generation;
     ConnectionManager& connection;
+    HostSync* hostSync = nullptr;
+
+    /** False once the user has typed their own BPM. Clearing the field back to the
+        "Auto" placeholder sets it true again, which is how sync is resumed — the
+        panel already treats an empty field as "let something else choose". */
+    bool bpmSynced = true;
 
     juce::Label      titleLabel;
 
@@ -86,6 +107,7 @@ private:
     juce::TextButton generateButton { "Generate" };
     juce::TextButton cancelButton { "Cancel" };
     juce::Label      statusLabel;
+    juce::Label      syncLabel;
 
     /** The server reports no percentage, so this runs in indeterminate mode while a
         job is in flight. See the progress note in the README. */

--- a/plugin/source/HostSync.cpp
+++ b/plugin/source/HostSync.cpp
@@ -1,0 +1,37 @@
+#include "HostSync.h"
+
+namespace acemusic
+{
+
+void HostSync::captureFrom (juce::AudioPlayHead* playHead) noexcept
+{
+    // A host that stops reporting should clear the fields rather than leave the last
+    // value frozen on screen, so every path below writes both.
+    double newBpm = 0.0;
+    double newTime = -1.0;
+
+    if (playHead != nullptr)
+    {
+        if (const auto position = playHead->getPosition())
+        {
+            if (const auto hostBpm = position->getBpm())
+                newBpm = *hostBpm;
+
+            if (const auto seconds = position->getTimeInSeconds())
+                newTime = *seconds;
+        }
+    }
+
+    bpm.store (newBpm, std::memory_order_relaxed);
+    timeInSeconds.store (newTime, std::memory_order_relaxed);
+}
+
+HostSync::Snapshot HostSync::get() const noexcept
+{
+    Snapshot snapshot;
+    snapshot.bpm = bpm.load (std::memory_order_relaxed);
+    snapshot.timeInSeconds = timeInSeconds.load (std::memory_order_relaxed);
+    return snapshot;
+}
+
+} // namespace acemusic

--- a/plugin/source/HostSync.h
+++ b/plugin/source/HostSync.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+#include <atomic>
+
+namespace acemusic
+{
+
+/**
+    The host's transport, read once on the audio thread and published to everyone else.
+
+    `juce::AudioProcessor::getPlayHead()` is an **audio thread** API: the pointer the
+    host installs is only guaranteed valid inside `processBlock`, and `getPosition()`
+    on a VST3 host reads state the host updates per block. Reading it from a timer —
+    which is what the results panel used to do for its playhead readout — is a data
+    race that happens to work most of the time.
+
+    So there is exactly one reader, in `processBlock`, and everything else takes a
+    snapshot from here.
+
+    **What the host does not tell us.** JUCE 8's `AudioPlayHead::PositionInfo` carries
+    tempo, time signature, PPQ and the transport flags — and *no key signature*. The
+    only key-signature channel in JUCE is ARA (`kARAContentTypeKeySignatures`), a
+    separate Celemony-licensed SDK that a handful of hosts implement. Key therefore
+    cannot be synced from the host through VST3, AU or Standalone, and the generation
+    panel leaves that field manual rather than implying a sync that is not happening.
+*/
+class HostSync
+{
+public:
+    /** What the host reported as of the last audio block. */
+    struct Snapshot
+    {
+        /** Host tempo, or 0 when the host reports none — which is the normal case in
+            the Standalone build and in hosts that do not publish a tempo. Nothing
+            silently substitutes 120 for it. */
+        double bpm = 0.0;
+
+        /** Transport position, or < 0 when the host reports none. */
+        double timeInSeconds = -1.0;
+
+        bool hasBpm() const noexcept                          { return bpm > 0.0; }
+        bool hasTime() const noexcept                         { return timeInSeconds >= 0.0; }
+    };
+
+    /** Publishes `playHead`'s position. Audio thread: allocates nothing, takes no
+        locks, and tolerates a null play head (the host gave us none). */
+    void captureFrom (juce::AudioPlayHead* playHead) noexcept;
+
+    /** The last published position. Safe from any thread. */
+    Snapshot get() const noexcept;
+
+private:
+    // Separate atomics rather than one packed struct, which would not be lock-free.
+    // The only cost is that a reader can catch the previous block's tempo beside this
+    // block's clock — invisible when the UI refreshes at 2Hz, and cheaper than a lock
+    // the audio thread would have to take.
+    std::atomic<double> bpm { 0.0 };
+    std::atomic<double> timeInSeconds { -1.0 };
+};
+
+} // namespace acemusic

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -16,8 +16,9 @@ namespace colours
 PluginEditor::PluginEditor (PluginProcessor& p)
     : juce::AudioProcessorEditor (&p),
       connectionPanel (p.getConnectionManager()),
-      generationPanel (p.getGenerationManager(), p.getConnectionManager()),
-      resultsPanel (p.getGenerationManager(), p.getClipPlayer(), p, p.getSettings())
+      generationPanel (p.getGenerationManager(), p.getConnectionManager(), &p.getHostSync()),
+      resultsPanel (p.getGenerationManager(), p.getClipPlayer(), p.getHostSync(),
+                    p.getBackgroundQueue(), p.getSettings())
 {
     titleLabel.setText (p.getName(), juce::dontSendNotification);
     titleLabel.setFont (juce::FontOptions (20.0f, juce::Font::bold));

--- a/plugin/source/PluginProcessor.cpp
+++ b/plugin/source/PluginProcessor.cpp
@@ -56,6 +56,11 @@ void PluginProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::Midi
 {
     juce::ScopedNoDenormals noDenormals;
 
+    // The one place the play head is read. Everything that wants the host tempo or
+    // position takes a snapshot from HostSync instead of calling getPlayHead() off
+    // the audio thread, which is a data race.
+    hostSync.captureFrom (getPlayHead());
+
     // Passthrough. Any channel the host gave us as output but not as input has
     // undefined contents, so clear it.
     for (auto channel = getTotalNumInputChannels(); channel < getTotalNumOutputChannels(); ++channel)

--- a/plugin/source/PluginProcessor.h
+++ b/plugin/source/PluginProcessor.h
@@ -4,6 +4,7 @@
 #include "ClipPlayer.h"
 #include "ConnectionManager.h"
 #include "GenerationManager.h"
+#include "HostSync.h"
 
 #include <juce_audio_processors/juce_audio_processors.h>
 
@@ -84,6 +85,10 @@ public:
         processBlock is what mixes it. */
     ClipPlayer& getClipPlayer() noexcept                      { return clipPlayer; }
 
+    /** The host's tempo and transport position, sampled in processBlock. This is the
+        only place anything reads the play head — see HostSync for why. */
+    HostSync& getHostSync() noexcept                          { return hostSync; }
+
     /** The plugin config file, or null when running without one. */
     juce::PropertiesFile* getSettings() noexcept              { return properties.get(); }
 
@@ -97,6 +102,7 @@ private:
     ConnectionManager connectionManager;
     GenerationManager generationManager;
     ClipPlayer clipPlayer;
+    HostSync hostSync;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PluginProcessor)
 };

--- a/plugin/source/ResultsPanel.cpp
+++ b/plugin/source/ResultsPanel.cpp
@@ -1,4 +1,5 @@
 #include "ResultsPanel.h"
+#include "TimeStretch.h"
 
 namespace acemusic
 {
@@ -20,6 +21,7 @@ ResultsPanel::ClipRow::ClipRow (const juce::File& fileToShow,
                                 juce::AudioThumbnailCache& cache,
                                 int index)
     : file (fileToShow),
+      dragFile (fileToShow),
       player (playerToUse),
       thumbnail (512, formats, cache),
       clipIndex (index)
@@ -54,7 +56,66 @@ bool ResultsPanel::ClipRow::hasWaveform() const
 
 juce::StringArray ResultsPanel::ClipRow::getDragPayload() const
 {
-    return { file.getFullPathName() };
+    // The tempo-matched copy when there is one, so what lands in the DAW is already at
+    // the project's tempo. Falls back to the clip itself, which is always a valid drop.
+    return { dragFile.getFullPathName() };
+}
+
+void ResultsPanel::ClipRow::ensureTempoMatch (double hostBpm, double clipBpm,
+                                              BackgroundTaskQueue& queue)
+{
+    if (matchInFlight)
+        return;
+
+    if (! TimeStretch::isWorthStretching (TimeStretch::rateFor (clipBpm, hostBpm)))
+    {
+        // Either tempo unknown, or they already agree: hand over the original.
+        if (dragFile != file)
+        {
+            dragFile = file;
+            nameLabel.setText ("Clip " + juce::String (clipIndex + 1), juce::dontSendNotification);
+        }
+
+        matchedToBpm = 0.0;
+        return;
+    }
+
+    if (juce::approximatelyEqual (matchedToBpm, hostBpm))
+        return;   // already built for exactly this tempo
+
+    matchInFlight = true;
+
+    // Off the message thread: stretching a few minutes of audio is tens of
+    // milliseconds, and the message thread here is the DAW's UI thread. Doing it now
+    // rather than inside mouseDrag also means the drag itself never stalls.
+    juce::Component::SafePointer<ClipRow> safeThis { this };
+    const auto clip = file;
+
+    queue.enqueue ([safeThis, clip, hostBpm, clipBpm]
+    {
+        // A local format manager rather than the player's: the player is destroyed
+        // before the queue during teardown, so a reference to its manager could
+        // outlive it. Registering the basic formats is cheap.
+        juce::AudioFormatManager formats;
+        formats.registerBasicFormats();
+
+        const auto matched = TimeStretch::matchTempo (clip, clipBpm, hostBpm, formats);
+
+        BackgroundTaskQueue::callOnMessageThread ([safeThis, matched, hostBpm]
+        {
+            if (auto* row = safeThis.getComponent())
+            {
+                row->matchInFlight = false;
+                row->dragFile = matched;
+                row->matchedToBpm = matched != row->file ? hostBpm : 0.0;
+
+                if (matched != row->file)
+                    row->nameLabel.setText ("Clip " + juce::String (row->clipIndex + 1)
+                                                + "  ->  " + juce::String (juce::roundToInt (hostBpm)) + " BPM",
+                                            juce::dontSendNotification);
+            }
+        });
+    });
 }
 
 void ResultsPanel::ClipRow::changeListenerCallback (juce::ChangeBroadcaster*)
@@ -137,11 +198,13 @@ void ResultsPanel::ClipRow::mouseUp (const juce::MouseEvent&)
 //==============================================================================
 ResultsPanel::ResultsPanel (GenerationManager& generationToUse,
                             ClipPlayer& playerToUse,
-                            juce::AudioProcessor& processorToUse,
+                            HostSync& hostSyncToUse,
+                            BackgroundTaskQueue& queueToUse,
                             juce::PropertiesFile* settings)
     : generation (generationToUse),
       player (playerToUse),
-      processor (processorToUse),
+      hostSync (hostSyncToUse),
+      queue (queueToUse),
       cache (settings)
 {
     titleLabel.setText ("RESULTS", juce::dontSendNotification);
@@ -370,25 +433,39 @@ bool ResultsPanel::deleteSelectedEntry()
 
 void ResultsPanel::timerCallback()
 {
+    // From HostSync rather than processor.getPlayHead(): the play head is an audio
+    // thread API and this is the message thread. HostSync reads it once, in
+    // processBlock, and publishes it.
+    const auto host = hostSync.get();
+
     juce::String text { "Host playhead: --" };
 
-    if (auto* playHead = processor.getPlayHead())
+    if (host.hasTime())
     {
-        if (const auto position = playHead->getPosition())
-        {
-            if (const auto seconds = position->getTimeInSeconds())
-            {
-                const auto total = (int) *seconds;
-                text = "Host playhead: "
-                     + juce::String (total / 60) + ":"
-                     + juce::String (total % 60).paddedLeft ('0', 2) + "."
-                     + juce::String ((int) ((*seconds - (double) total) * 1000.0)).paddedLeft ('0', 3);
-            }
-        }
+        const auto total = (int) host.timeInSeconds;
+        text = "Host playhead: "
+             + juce::String (total / 60) + ":"
+             + juce::String (total % 60).paddedLeft ('0', 2) + "."
+             + juce::String ((int) ((host.timeInSeconds - (double) total) * 1000.0)).paddedLeft ('0', 3);
     }
 
     if (playheadLabel.getText() != text)
         playheadLabel.setText (text, juce::dontSendNotification);
+
+    updateTempoMatches();
+}
+
+void ResultsPanel::updateTempoMatches()
+{
+    const auto host = hostSync.get();
+
+    // Rounded, because the panel's BPM field is whole numbers and a host tempo that
+    // wobbles in the third decimal must not rebuild the match on every tick.
+    const auto hostBpm = host.hasBpm() ? (double) juce::roundToInt (host.bpm) : 0.0;
+    const auto clipBpm = (double) generation.getRequestedBpm();
+
+    for (auto* row : clipRows)
+        row->ensureTempoMatch (hostBpm, clipBpm, queue);
 }
 
 void ResultsPanel::rebuildRows()

--- a/plugin/source/ResultsPanel.h
+++ b/plugin/source/ResultsPanel.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "BackgroundTaskQueue.h"
 #include "ClipCache.h"
 #include "ClipPlayer.h"
 #include "GenerationManager.h"
+#include "HostSync.h"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -26,7 +28,7 @@ class ResultsPanel final : public juce::Component,
 {
 public:
     /** @param settings  resolves the configured cache path; null uses the default */
-    ResultsPanel (GenerationManager&, ClipPlayer&, juce::AudioProcessor&,
+    ResultsPanel (GenerationManager&, ClipPlayer&, HostSync&, BackgroundTaskQueue&,
                   juce::PropertiesFile* settings = nullptr);
     ~ResultsPanel() override;
 
@@ -51,6 +53,16 @@ public:
         const juce::File& getFile() const noexcept            { return file; }
         juce::TextButton& getPlayButton() noexcept            { return playButton; }
 
+        /** What a drop actually hands the host: the clip itself, or a tempo-matched
+            copy of it once one has been built. */
+        const juce::File& getDragFile() const noexcept        { return dragFile; }
+
+        /** Builds (once, in the background) a copy of this clip at `hostBpm`, given it
+            was generated at `clipBpm`. Either tempo being unknown, or the two already
+            agreeing, drops the match and goes back to handing over the original.
+            Cheap and idempotent — the panel calls this on every timer tick. */
+        void ensureTempoMatch (double hostBpm, double clipBpm, BackgroundTaskQueue&);
+
         /** True once the waveform has finished loading. */
         bool hasWaveform() const;
 
@@ -63,6 +75,14 @@ public:
         void timerCallback() override;
 
         juce::File file;
+
+        /** Equal to `file` until a tempo match has been built for the host's tempo. */
+        juce::File dragFile;
+
+        /** The host tempo `dragFile` was built for; 0 when it is just the original. */
+        double matchedToBpm = 0.0;
+        bool matchInFlight = false;
+
         ClipPlayer& player;
         juce::AudioThumbnail thumbnail;
         juce::TextButton playButton { "Play" };
@@ -113,6 +133,9 @@ private:
     void timerCallback() override;
     void rebuildRows();
 
+    /** Keeps every row's drop file in step with the host tempo. */
+    void updateTempoMatches();
+
     /** Rows of past generations: prompt, when, how long, how big. */
     class HistoryModel final : public juce::ListBoxModel
     {
@@ -134,7 +157,8 @@ private:
 
     GenerationManager& generation;
     ClipPlayer& player;
-    juce::AudioProcessor& processor;
+    HostSync& hostSync;
+    BackgroundTaskQueue& queue;
     ClipCache cache;
 
     juce::AudioThumbnailCache thumbnailCache { 8 };

--- a/plugin/source/TimeStretch.cpp
+++ b/plugin/source/TimeStretch.cpp
@@ -54,23 +54,27 @@ namespace
                        int idealStart,
                        int templateStart)
     {
-        const int lastUsableStart = numSamples - frameSize;
+        // A candidate only needs room for the *correlation*, not for a whole frame.
+        // Slowing a clip down means the output is longer than the source, so the last
+        // frames legitimately start near the end and read a partial frame; requiring a
+        // full frame here would pin them in place and leave the output's tail unwritten.
+        const int lastCandidate = numSamples - correlationLength;
 
-        if (lastUsableStart <= 0)
+        if (lastCandidate <= 0)
             return 0;
 
         // Nothing to correlate against if the template runs off the end.
         if (templateStart < 0 || templateStart + correlationLength > numSamples)
-            return juce::jlimit (0, lastUsableStart, idealStart);
+            return juce::jlimit (0, lastCandidate, idealStart);
 
-        int best = juce::jlimit (0, lastUsableStart, idealStart);
+        int best = juce::jlimit (0, lastCandidate, idealStart);
         double bestScore = -1.0e30;
 
         for (int offset = -searchRadius; offset <= searchRadius; ++offset)
         {
             const int candidate = idealStart + offset;
 
-            if (candidate < 0 || candidate > lastUsableStart)
+            if (candidate < 0 || candidate > lastCandidate)
                 continue;
 
             double dot = 0.0;
@@ -149,7 +153,6 @@ juce::AudioBuffer<float> process (const juce::AudioBuffer<float>& source, double
     std::fill (leadingWindow.begin(), leadingWindow.begin() + synthesisHop, 1.0f);
 
     const float* const reference = source.getReadPointer (0);
-    const int lastUsableStart = numSamples - frameSize;
 
     int previousStart = 0;
 
@@ -169,6 +172,8 @@ juce::AudioBuffer<float> process (const juce::AudioBuffer<float>& source, double
 
         const float* const shape = (frame == 0 ? leadingWindow : window).data();
 
+        // Deliberately allowed to be shorter than a frame near the end of the input:
+        // that turns the last few milliseconds into a taper rather than a hard gap.
         const int length = juce::jmin (frameSize,
                                        numSamples - start,
                                        outputLength - outPos);
@@ -183,9 +188,6 @@ juce::AudioBuffer<float> process (const juce::AudioBuffer<float>& source, double
         }
 
         previousStart = start;
-
-        if (start >= lastUsableStart)
-            break;
     }
 
     return output;

--- a/plugin/source/TimeStretch.cpp
+++ b/plugin/source/TimeStretch.cpp
@@ -1,0 +1,303 @@
+#include "TimeStretch.h"
+
+#include <cmath>
+#include <vector>
+
+namespace acemusic
+{
+namespace TimeStretch
+{
+
+namespace
+{
+    /** 2048 at 44.1kHz is ~46ms: long enough to hold a full period of anything with a
+        recognisable pitch, short enough that transients are not smeared across it. */
+    constexpr int frameSize = 2048;
+
+    /** 50% overlap. A Hann window at 50% overlap sums to a constant, so the
+        overlap-add needs no normalisation pass afterwards. */
+    constexpr int synthesisHop = frameSize / 2;
+
+    /** How far the similarity search may slide a frame from its ideal position.
+        128 samples covers a full period down to ~345Hz at 44.1kHz, which is where
+        the audible periodicity of most material lives. */
+    constexpr int searchRadius = 128;
+
+    /** Only the head of the frame is correlated, not all 2048 samples.
+        ponytail: 256x257 comparisons per frame keeps a 60s stereo clip well under a
+        tenth of a second. Widen this (or decimate and do a coarse-to-fine search) if
+        a future story ever stretches by more than a few percent, where the alignment
+        matters more than it does here.  */
+    constexpr int correlationLength = 256;
+
+    std::vector<float> makeHannWindow()
+    {
+        std::vector<float> window ((size_t) frameSize);
+
+        for (int i = 0; i < frameSize; ++i)
+            window[(size_t) i] = (float) (0.5 - 0.5 * std::cos (juce::MathConstants<double>::twoPi
+                                                                   * (double) i / (double) (frameSize - 1)));
+
+        return window;
+    }
+
+    /** Finds where in `reference` the material starting at `idealStart` best continues
+        the frame that ended at `templateStart`. This is the "waveform similarity" half
+        of WSOLA: without it, overlap-add at a shifted hop cancels partials against
+        themselves and the result phases badly.
+
+        Correlation runs on one channel and the winning offset is applied to all of
+        them — searching per channel would slide the channels apart and collapse the
+        stereo image. */
+    int findBestStart (const float* reference,
+                       int numSamples,
+                       int idealStart,
+                       int templateStart)
+    {
+        const int lastUsableStart = numSamples - frameSize;
+
+        if (lastUsableStart <= 0)
+            return 0;
+
+        // Nothing to correlate against if the template runs off the end.
+        if (templateStart < 0 || templateStart + correlationLength > numSamples)
+            return juce::jlimit (0, lastUsableStart, idealStart);
+
+        int best = juce::jlimit (0, lastUsableStart, idealStart);
+        double bestScore = -1.0e30;
+
+        for (int offset = -searchRadius; offset <= searchRadius; ++offset)
+        {
+            const int candidate = idealStart + offset;
+
+            if (candidate < 0 || candidate > lastUsableStart)
+                continue;
+
+            double dot = 0.0;
+            double energy = 0.0;
+
+            for (int i = 0; i < correlationLength; ++i)
+            {
+                const double sample = (double) reference[candidate + i];
+                dot    += (double) reference[templateStart + i] * sample;
+                energy += sample * sample;
+            }
+
+            // Normalised by the candidate's energy, so a loud passage cannot win the
+            // search just for being loud.
+            const double score = dot / std::sqrt (energy + 1.0e-9);
+
+            if (score > bestScore)
+            {
+                bestScore = score;
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+}
+
+//==============================================================================
+double rateFor (double fromBpm, double toBpm) noexcept
+{
+    if (fromBpm <= 0.0 || toBpm <= 0.0)
+        return 0.0;
+
+    return toBpm / fromBpm;
+}
+
+bool isWorthStretching (double rate) noexcept
+{
+    return rate > 0.0 && std::abs (rate - 1.0) > 0.0025;
+}
+
+//==============================================================================
+juce::AudioBuffer<float> process (const juce::AudioBuffer<float>& source, double rate)
+{
+    const int numChannels = source.getNumChannels();
+    const int numSamples  = source.getNumSamples();
+
+    if (numChannels <= 0 || numSamples <= 0 || rate <= 0.0)
+        return {};
+
+    juce::AudioBuffer<float> copy;
+
+    // Anything too short to hold a single analysis frame has no periodicity to
+    // preserve; copying it is both cheaper and less damaging than windowing it.
+    if (! isWorthStretching (rate) || numSamples <= frameSize)
+    {
+        copy.makeCopyOf (source);
+        return copy;
+    }
+
+    const int outputLength = (int) std::llround ((double) numSamples / rate);
+
+    if (outputLength <= 0)
+        return {};
+
+    juce::AudioBuffer<float> output (numChannels, outputLength);
+    output.clear();
+
+    const auto window = makeHannWindow();
+
+    // The first frame is emitted without the window's rising half. Otherwise every
+    // stretched clip would fade in over ~23ms, which is plainly audible when the clip
+    // starts on a downbeat. The fade at the *end* is left alone: it lands in the
+    // clip's own decay.
+    auto leadingWindow = window;
+    std::fill (leadingWindow.begin(), leadingWindow.begin() + synthesisHop, 1.0f);
+
+    const float* const reference = source.getReadPointer (0);
+    const int lastUsableStart = numSamples - frameSize;
+
+    int previousStart = 0;
+
+    for (int frame = 0; frame * synthesisHop < outputLength; ++frame)
+    {
+        const int outPos = frame * synthesisHop;
+
+        // The ideal analysis position is derived from the frame index in floating
+        // point rather than accumulated hop by hop, so rounding cannot drift the
+        // output length away from numSamples/rate over a long clip.
+        const int idealStart = (int) std::llround ((double) frame * (double) synthesisHop * rate);
+
+        const int start = frame == 0
+                            ? 0
+                            : findBestStart (reference, numSamples, idealStart,
+                                             previousStart + synthesisHop);
+
+        const float* const shape = (frame == 0 ? leadingWindow : window).data();
+
+        const int length = juce::jmin (frameSize,
+                                       numSamples - start,
+                                       outputLength - outPos);
+
+        for (int channel = 0; channel < numChannels; ++channel)
+        {
+            const float* in = source.getReadPointer (channel) + start;
+            float* out = output.getWritePointer (channel) + outPos;
+
+            for (int i = 0; i < length; ++i)
+                out[i] += in[i] * shape[i];
+        }
+
+        previousStart = start;
+
+        if (start >= lastUsableStart)
+            break;
+    }
+
+    return output;
+}
+
+//==============================================================================
+bool processFile (const juce::File& source,
+                  const juce::File& destination,
+                  double rate,
+                  juce::AudioFormatManager& formats)
+{
+    std::unique_ptr<juce::AudioFormatReader> reader (formats.createReaderFor (source));
+
+    if (reader == nullptr || reader->numChannels == 0 || reader->lengthInSamples <= 0)
+        return false;
+
+    // Guard against a caller pointing this at something enormous: the whole clip is
+    // held in memory twice while it is stretched. Generated clips are minutes at most.
+    constexpr juce::int64 maxSamples = 60 * 60 * 192000;
+
+    if (reader->lengthInSamples > maxSamples)
+        return false;
+
+    juce::AudioBuffer<float> input ((int) reader->numChannels, (int) reader->lengthInSamples);
+
+    if (! reader->read (&input, 0, (int) reader->lengthInSamples, 0, true, true))
+        return false;
+
+    const auto stretched = process (input, rate);
+
+    if (stretched.getNumSamples() <= 0)
+        return false;
+
+    const auto sampleRate = reader->sampleRate;
+    const auto bitDepth = juce::jmax (16, (int) reader->bitsPerSample);
+    const auto numChannels = (unsigned int) stretched.getNumChannels();
+
+    // Written to a temporary first: a reader that finds a half-written file next to a
+    // clip would treat it as a finished tempo match and hand the host a truncated drop.
+    destination.getParentDirectory().createDirectory();
+
+    const auto partial = destination.getSiblingFile (destination.getFileName() + ".partial");
+    partial.deleteFile();
+
+    {
+        juce::WavAudioFormat wav;
+        std::unique_ptr<juce::OutputStream> stream (partial.createOutputStream());
+
+        if (stream == nullptr)
+            return false;
+
+        auto writer = wav.createWriterFor (stream, juce::AudioFormatWriterOptions{}
+                                                       .withSampleRate (sampleRate)
+                                                       .withNumChannels ((int) numChannels)
+                                                       .withBitsPerSample (bitDepth));
+
+        if (writer == nullptr)
+            return false;
+
+        if (! writer->writeFromAudioSampleBuffer (stretched, 0, stretched.getNumSamples()))
+        {
+            writer.reset();
+            partial.deleteFile();
+            return false;
+        }
+    }
+
+    destination.deleteFile();
+
+    if (! partial.moveFileTo (destination))
+    {
+        partial.deleteFile();
+        return false;
+    }
+
+    return true;
+}
+
+//==============================================================================
+juce::File getMatchedFileFor (const juce::File& clip, double targetBpm)
+{
+    // In a child directory rather than beside the clip. ClipCache::readEntry lists
+    // `*.wav` in a run directory non-recursively, so a sibling would be picked up as
+    // an *extra clip of that generation* — a two-clip run would list four. A child
+    // directory is invisible to that scan, but is still counted by the cache's size
+    // (which recurses) and removed with the run (which deletes recursively).
+    return clip.getParentDirectory()
+               .getChildFile ("tempo-match")
+               .getChildFile (clip.getFileNameWithoutExtension()
+                                  + "-" + juce::String (juce::roundToInt (targetBpm)) + "bpm.wav");
+}
+
+juce::File matchTempo (const juce::File& clip,
+                       double clipBpm,
+                       double targetBpm,
+                       juce::AudioFormatManager& formats)
+{
+    const auto rate = rateFor (clipBpm, targetBpm);
+
+    if (! isWorthStretching (rate) || ! clip.existsAsFile())
+        return clip;
+
+    const auto matched = getMatchedFileFor (clip, targetBpm);
+
+    if (matched.existsAsFile() && matched.getSize() > 0)
+        return matched;
+
+    if (! processFile (clip, matched, rate, formats))
+        return clip;
+
+    return matched;
+}
+
+} // namespace TimeStretch
+} // namespace acemusic

--- a/plugin/source/TimeStretch.h
+++ b/plugin/source/TimeStretch.h
@@ -31,7 +31,12 @@ namespace TimeStretch
 
         The threshold is a quarter of a percent — below that the correction is under
         one sample per 400 and well inside the rounding of any BPM the panel can
-        express, so stretching would only add artefacts. */
+        express, so stretching would only add artefacts.
+
+        There is deliberately no upper or lower bound: the trailing-silence that a
+        large slowdown used to leave was a bug in the analysis loop, not a limit of the
+        method, and once fixed a 3.3x stretch measures the same clean tail as a 1.02x
+        one. See the "silent tail" test, which covers both. */
     bool isWorthStretching (double rate) noexcept;
 
     /** WSOLA-stretches `source`, returning a buffer of `source.getNumSamples() / rate`
@@ -47,8 +52,13 @@ namespace TimeStretch
                       double rate,
                       juce::AudioFormatManager& formats);
 
-    /** The path a `clip` tempo-matched to `targetBpm` is cached at, next to the clip
-        itself so it is removed with the rest of the run by the cache browser. */
+    /** Where a `clip` tempo-matched to `targetBpm` is cached: a `tempo-match/` child of
+        the clip's own run directory.
+
+        A child directory rather than a sibling file, because ClipCache::readEntry
+        lists `*.wav` per run non-recursively — as siblings these were counted as extra
+        clips of that generation. The cache's size accounting recurses and its delete is
+        recursive, so they are still measured and still removed with the run. */
     juce::File getMatchedFileFor (const juce::File& clip, double targetBpm);
 
     /** Produces (or reuses) a copy of `clip` at `targetBpm`, given that it was

--- a/plugin/source/TimeStretch.h
+++ b/plugin/source/TimeStretch.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+namespace acemusic
+{
+
+/**
+    Pitch-preserving time-stretch, for matching a generated clip to the host tempo.
+
+    **Why not just resample.** `juce::LagrangeInterpolator` would be a third of this
+    code, but resampling changes pitch with speed: the story's own example, 118 BPM to
+    120 BPM, is a 1.7% rate change and therefore a 29-cent detune. A feature whose
+    entire purpose is "generated music matches my project" must not hand back audio
+    that arrives out of tune with the project, so this is WSOLA (waveform-similarity
+    overlap-add) instead — the standard algorithm for small tempo edits, no new
+    dependency, and pitch-transparent at the ratios this feature actually sees.
+
+    Rate semantics mirror `calculate_speed_multiplier` / `time_stretch_audio` in
+    `src/acemusic/audio.py` so the plugin and the Python side cannot disagree about
+    direction: `rate = target / original`, rate > 1 plays faster, and the output is
+    `length / rate` samples long.
+*/
+namespace TimeStretch
+{
+    /** The rate that turns a `fromBpm` clip into a `toBpm` one, or 0 when either
+        tempo is not a positive number. */
+    double rateFor (double fromBpm, double toBpm) noexcept;
+
+    /** Whether `rate` is far enough from 1.0 to be worth the work.
+
+        The threshold is a quarter of a percent — below that the correction is under
+        one sample per 400 and well inside the rounding of any BPM the panel can
+        express, so stretching would only add artefacts. */
+    bool isWorthStretching (double rate) noexcept;
+
+    /** WSOLA-stretches `source`, returning a buffer of `source.getNumSamples() / rate`
+        samples. Returns a plain copy when the rate is not worth stretching, and an
+        empty buffer when the input is unusable. */
+    juce::AudioBuffer<float> process (const juce::AudioBuffer<float>& source, double rate);
+
+    /** Reads `source`, stretches it, and writes `destination` as a WAV at the source's
+        sample rate and bit depth. @returns false if the read or the write failed;
+        `destination` is not left behind as a partial file in that case. */
+    bool processFile (const juce::File& source,
+                      const juce::File& destination,
+                      double rate,
+                      juce::AudioFormatManager& formats);
+
+    /** The path a `clip` tempo-matched to `targetBpm` is cached at, next to the clip
+        itself so it is removed with the rest of the run by the cache browser. */
+    juce::File getMatchedFileFor (const juce::File& clip, double targetBpm);
+
+    /** Produces (or reuses) a copy of `clip` at `targetBpm`, given that it was
+        generated at `clipBpm`.
+
+        @returns the tempo-matched file, or `clip` itself when either tempo is unknown,
+                 the difference is not worth stretching, or the stretch failed —
+                 handing back the original is always better than handing back nothing.
+                 Reads and writes files, so: never the audio thread. */
+    juce::File matchTempo (const juce::File& clip,
+                           double clipBpm,
+                           double targetBpm,
+                           juce::AudioFormatManager& formats);
+}
+
+} // namespace acemusic

--- a/plugin/tests/FakePlayHead.h
+++ b/plugin/tests/FakePlayHead.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+
+namespace acemusic::test
+{
+
+/**
+    Stands in for the host's transport. `reportsPosition = false` is the host that
+    hands the plugin a play head but tells it nothing, which is what the Standalone
+    build and several real hosts do — that path has to be exercised, not assumed away.
+*/
+class FakePlayHead final : public juce::AudioPlayHead
+{
+public:
+    juce::Optional<PositionInfo> getPosition() const override
+    {
+        if (! reportsPosition)
+            return {};
+
+        PositionInfo info;
+
+        if (bpm > 0.0)
+            info.setBpm (bpm);
+
+        if (timeInSeconds >= 0.0)
+            info.setTimeInSeconds (timeInSeconds);
+
+        return info;
+    }
+
+    bool reportsPosition = true;
+
+    /** <= 0 means "the host publishes no tempo". */
+    double bpm = 120.0;
+
+    /** < 0 means "the host publishes no position". */
+    double timeInSeconds = 0.0;
+};
+
+} // namespace acemusic::test

--- a/plugin/tests/GenerationPanelTests.cpp
+++ b/plugin/tests/GenerationPanelTests.cpp
@@ -1,4 +1,5 @@
 #include "ClipCache.h"
+#include "FakePlayHead.h"
 #include "PluginEditor.h"
 #include "StubAceStepServer.h"
 
@@ -346,6 +347,167 @@ public:
             processor.getGenerationManager().cancel();
             expect (pumpUntil ([&] { return ! processor.getGenerationManager().isBusy(); }, 30000),
                     "cancel never settled");
+        }
+
+        //======================================================================
+        // US-24.1 — host tempo sync.
+
+        beginTest ("AC: opening the plugin in a 120 BPM project auto-fills BPM with 120");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            // The host has already told the plugin its tempo by the time the window
+            // opens, which is the ordering a DAW actually produces.
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            // Filled at construction, not half a second later on the first timer tick.
+            expectEquals (panel.getBpmEditor().getText(), juce::String ("120"),
+                          "the BPM field did not pick up the host tempo on open");
+            expect (panel.isBpmSynced());
+            expect (panel.getSyncLabel().getText().contains ("120"),
+                    "the sync indicator did not name the host tempo: "
+                        + panel.getSyncLabel().getText());
+
+            // And it reaches the request, so a generation actually asks for 120.
+            panel.getPromptEditor().setText ("anything", true);
+            expectEquals (panel.buildRequest().bpm, 120);
+        }
+
+        beginTest ("AC: changing the DAW tempo updates the plugin's BPM field");
+        {
+            PluginProcessor processor (nullptr, false);
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+            expectEquals (panel.getBpmEditor().getText(), juce::String ("120"));
+
+            // The musician drags the tempo in the DAW mid-session.
+            playHead.bpm = 90.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            expect (pumpUntil ([&] { return panel.getBpmEditor().getText() == "90"; }, 5000),
+                    "the BPM field stayed at " + panel.getBpmEditor().getText()
+                        + " after the host moved to 90");
+            expect (panel.isBpmSynced(), "following the host cancelled its own sync");
+        }
+
+        beginTest ("AC: a manual BPM override disables auto-sync, with a visual indicator");
+        {
+            PluginProcessor processor (nullptr, false);
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            const auto syncedText = panel.getSyncLabel().getText();
+
+            // The user types their own tempo. TextEditor posts its change notification
+            // rather than calling it inline, so this settles on the message loop.
+            panel.getBpmEditor().setText ("100", true);
+
+            expect (pumpUntil ([&] { return ! panel.isBpmSynced(); }, 5000),
+                    "typing a BPM did not take the field off sync");
+            expect (panel.getSyncLabel().getText() != syncedText,
+                    "the indicator did not change when sync was turned off");
+            expect (panel.getSyncLabel().getText().containsIgnoreCase ("manual"),
+                    "the indicator does not say the BPM is manual: "
+                        + panel.getSyncLabel().getText());
+
+            // And the host must no longer be able to overwrite it.
+            playHead.bpm = 140.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            expect (! pumpUntil ([&] { return panel.getBpmEditor().getText() != "100"; }, 1500),
+                    "the host overwrote a manually entered BPM");
+            expectEquals (panel.getBpmEditor().getText(), juce::String ("100"));
+            expectEquals (panel.buildRequest().bpm, 100);
+        }
+
+        beginTest ("clearing the BPM field resumes host sync");
+        {
+            PluginProcessor processor (nullptr, false);
+            test::FakePlayHead playHead;
+            playHead.bpm = 128.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            panel.getBpmEditor().setText ("100", true);
+            expect (pumpUntil ([&] { return ! panel.isBpmSynced(); }, 5000),
+                    "typing a BPM did not take the field off sync");
+
+            // Back to the "Auto" placeholder — the panel's existing convention for
+            // "let something else decide", and the only way back to sync.
+            panel.getBpmEditor().setText ("", true);
+            expect (pumpUntil ([&] { return panel.isBpmSynced(); }, 5000),
+                    "clearing the field did not resume sync");
+
+            expect (pumpUntil ([&] { return panel.getBpmEditor().getText() == "128"; }, 5000),
+                    "the host tempo did not come back after resyncing");
+        }
+
+        beginTest ("a host that reports no tempo leaves BPM on Auto and says so");
+        {
+            PluginProcessor processor (nullptr, false);
+            test::FakePlayHead playHead;
+            playHead.reportsPosition = false;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            // No invented default: an unknown host tempo stays Auto, which is what the
+            // server treats as "you choose".
+            expect (panel.getBpmEditor().getText().isEmpty(),
+                    "a tempo was invented for a silent host: " + panel.getBpmEditor().getText());
+            expect (panel.buildRequest().bpm < 0);
+            expect (panel.getSyncLabel().getText().containsIgnoreCase ("no host tempo"),
+                    "the indicator did not report the missing tempo: "
+                        + panel.getSyncLabel().getText());
+        }
+
+        beginTest ("applying a request with its own BPM takes the field off sync");
+        {
+            PluginProcessor processor (nullptr, false);
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            GenerationRequest request;
+            request.prompt = "recalled preset";
+            request.bpm = 174;
+            panel.applyRequest (request);
+
+            expect (! panel.isBpmSynced(), "a recalled BPM was left on sync");
+            expect (! pumpUntil ([&] { return panel.getBpmEditor().getText() != "174"; }, 1500),
+                    "the host overwrote a recalled BPM");
+
+            // A request that left BPM on Auto hands the field back to the host.
+            request.bpm = -1;
+            panel.applyRequest (request);
+            expect (panel.isBpmSynced());
+            expect (pumpUntil ([&] { return panel.getBpmEditor().getText() == "120"; }, 5000),
+                    "an Auto-BPM request did not resume host sync");
         }
     }
 };

--- a/plugin/tests/HostSyncTests.cpp
+++ b/plugin/tests/HostSyncTests.cpp
@@ -1,0 +1,103 @@
+#include "FakePlayHead.h"
+#include "HostSync.h"
+
+namespace acemusic
+{
+
+class HostSyncTests final : public juce::UnitTest
+{
+public:
+    HostSyncTests()
+        : juce::UnitTest ("HostSync", "acemusic")
+    {
+    }
+
+    void runTest() override
+    {
+        beginTest ("nothing is reported until a block has been processed");
+        {
+            HostSync sync;
+
+            const auto snapshot = sync.get();
+            expect (! snapshot.hasBpm(), "invented a tempo before seeing the host");
+            expect (! snapshot.hasTime());
+        }
+
+        beginTest ("AC: the host tempo is picked up from the play head");
+        {
+            HostSync sync;
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeInSeconds = 4.5;
+
+            sync.captureFrom (&playHead);
+
+            const auto snapshot = sync.get();
+            expect (snapshot.hasBpm());
+            expectEquals (snapshot.bpm, 120.0);
+            expect (snapshot.hasTime());
+            expectEquals (snapshot.timeInSeconds, 4.5);
+        }
+
+        beginTest ("AC: a tempo change on the host is picked up");
+        {
+            HostSync sync;
+            test::FakePlayHead playHead;
+
+            playHead.bpm = 120.0;
+            sync.captureFrom (&playHead);
+            expectEquals (sync.get().bpm, 120.0);
+
+            playHead.bpm = 90.0;
+            sync.captureFrom (&playHead);
+            expectEquals (sync.get().bpm, 90.0, "the tempo change was not seen");
+        }
+
+        beginTest ("a host that stops reporting clears the tempo instead of freezing it");
+        {
+            HostSync sync;
+            test::FakePlayHead playHead;
+
+            playHead.bpm = 128.0;
+            sync.captureFrom (&playHead);
+            expect (sync.get().hasBpm());
+
+            playHead.reportsPosition = false;
+            sync.captureFrom (&playHead);
+            expect (! sync.get().hasBpm(), "a stale tempo survived the host going quiet");
+            expect (! sync.get().hasTime());
+        }
+
+        beginTest ("no play head at all is not a tempo of zero-and-a-bit");
+        {
+            HostSync sync;
+            test::FakePlayHead playHead;
+            sync.captureFrom (&playHead);
+
+            sync.captureFrom (nullptr);
+
+            const auto snapshot = sync.get();
+            expect (! snapshot.hasBpm());
+            expect (! snapshot.hasTime());
+        }
+
+        beginTest ("a host reporting a position but no tempo is not a tempo of 0");
+        {
+            HostSync sync;
+            test::FakePlayHead playHead;
+            playHead.bpm = 0.0;              // absent
+            playHead.timeInSeconds = 12.0;
+
+            sync.captureFrom (&playHead);
+
+            const auto snapshot = sync.get();
+            expect (! snapshot.hasBpm(), "an absent tempo read as present");
+            expect (snapshot.hasTime(), "the position was lost with the tempo");
+            expectEquals (snapshot.timeInSeconds, 12.0);
+        }
+    }
+};
+
+static HostSyncTests hostSyncTests;
+
+} // namespace acemusic

--- a/plugin/tests/ResultsPanelTests.cpp
+++ b/plugin/tests/ResultsPanelTests.cpp
@@ -1,5 +1,7 @@
+#include "FakePlayHead.h"
 #include "PluginEditor.h"
 #include "StubAceStepServer.h"
+#include "TimeStretch.h"
 
 #include <juce_events/juce_events.h>
 
@@ -564,6 +566,165 @@ public:
 
             processor.getClipPlayer().stop();
             expect (true, "survived the editor closing mid-playback");
+        }
+
+        //======================================================================
+        // US-24.1 — tempo matching on insertion.
+
+        beginTest ("AC: a 118 BPM clip is dropped into a 120 BPM project already stretched");
+        {
+            ScopedClips clips;
+            Harness harness;
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            harness.generation().setClipsForTesting (clips.files, 118);
+            expect (pumpUntil ([&] { return harness.panel().getNumClipRows() == 2; }));
+
+            auto* row = harness.panel().getClipRow (0);
+
+            expect (pumpUntil ([&] { return row->getDragFile() != row->getFile(); }, 20000),
+                    "the clip was never tempo-matched to the host");
+
+            const auto payload = row->getDragPayload();
+            expectEquals (payload.size(), 1);
+
+            const juce::File dropped { payload[0] };
+            expect (dropped.existsAsFile(), "the tempo-matched drop is not a real file");
+            expect (dropped != clips.files[0], "the drop was still the unstretched clip");
+            expect (dropped == TimeStretch::getMatchedFileFor (clips.files[0], 120.0),
+                    "unexpected match path: " + dropped.getFullPathName());
+
+            // And it really is shorter, in the ratio the tempo change implies.
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+            std::unique_ptr<juce::AudioFormatReader> reader (formats.createReaderFor (dropped));
+            expect (reader != nullptr, "the tempo-matched drop is not readable audio");
+
+            const auto expected = (juce::int64) std::llround (44100.0 / TimeStretch::rateFor (118.0, 120.0));
+            expect (std::abs (reader->lengthInSamples - expected) <= 1,
+                    "dropped clip was " + juce::String (reader->lengthInSamples)
+                        + " samples, expected " + juce::String (expected));
+        }
+
+        beginTest ("tempo-matched copies do not show up as extra clips in the cache browser");
+        {
+            // The cache browser lists *.wav in a run directory. A tempo match written
+            // beside the clip would be counted as a third clip of a two-clip run, and
+            // would come back as one when the generation is reopened from the cache.
+            Harness harness;
+
+            const auto run = harness.cacheDirectory().getChildFile ("run-1");
+            run.createDirectory();
+
+            juce::Array<juce::File> clips;
+            clips.add (ScopedClips::write (run.getChildFile ("clip-1.wav"), 220.0));
+            clips.add (ScopedClips::write (run.getChildFile ("clip-2.wav"), 440.0));
+            ClipCache::writeMetadata (run, "a prompt", "a-model", 1.0);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            harness.generation().setClipsForTesting (clips, 118);
+            expect (pumpUntil ([&] { return harness.panel().getNumClipRows() == 2; }));
+            expect (pumpUntil ([&] { return harness.panel().getClipRow (0)->getDragFile()
+                                             != harness.panel().getClipRow (0)->getFile(); }, 20000),
+                    "never tempo-matched, so this proves nothing");
+            expect (pumpUntil ([&] { return harness.panel().getClipRow (1)->getDragFile()
+                                             != harness.panel().getClipRow (1)->getFile(); }, 20000));
+
+            const auto entry = ClipCache::readEntry (run);
+            expectEquals (entry.clips.size(), 2,
+                          "the cache browser counted the tempo-matched copies as clips");
+
+            // It is still on disk and still accounted for, just not listed as a clip.
+            expect (TimeStretch::getMatchedFileFor (clips[0], 120.0).existsAsFile());
+            expect (entry.sizeInBytes > clips[0].getSize() + clips[1].getSize(),
+                    "the tempo matches were not counted in the run's size on disk");
+        }
+
+        beginTest ("a clip already at the host tempo is dropped untouched");
+        {
+            ScopedClips clips;
+            Harness harness;
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            harness.generation().setClipsForTesting (clips.files, 120);
+            expect (pumpUntil ([&] { return harness.panel().getNumClipRows() == 2; }));
+
+            auto* row = harness.panel().getClipRow (0);
+
+            // Give the panel several ticks to do the wrong thing.
+            expect (! pumpUntil ([&] { return row->getDragFile() != row->getFile(); }, 2000),
+                    "a clip already at tempo was stretched anyway");
+            expectEquals (row->getDragPayload()[0], clips.files[0].getFullPathName());
+            expect (! TimeStretch::getMatchedFileFor (clips.files[0], 120.0).existsAsFile(),
+                    "a pointless tempo match was written to disk");
+        }
+
+        beginTest ("an Auto-BPM generation or a silent host leaves the clip alone");
+        {
+            for (const auto scenario : { 0, 1 })
+            {
+                ScopedClips clips;
+                Harness harness;
+
+                test::FakePlayHead playHead;
+
+                // 0: the host has a tempo but the generation asked for Auto BPM, so the
+                //    clip's own tempo is unknown and guessing would be worse than nothing.
+                // 1: the generation asked for 118 but the host publishes no tempo.
+                playHead.reportsPosition = scenario == 0;
+                playHead.bpm = 120.0;
+                harness.processor.getHostSync().captureFrom (&playHead);
+
+                harness.generation().setClipsForTesting (clips.files, scenario == 0 ? -1 : 118);
+                expect (pumpUntil ([&] { return harness.panel().getNumClipRows() == 2; }));
+
+                auto* row = harness.panel().getClipRow (0);
+
+                expect (! pumpUntil ([&] { return row->getDragFile() != row->getFile(); }, 1500),
+                        "scenario " + juce::String (scenario) + ": stretched against an unknown tempo");
+                expectEquals (row->getDragPayload()[0], clips.files[0].getFullPathName());
+            }
+        }
+
+        beginTest ("a host tempo change re-matches the clip to the new tempo");
+        {
+            ScopedClips clips;
+            Harness harness;
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            harness.generation().setClipsForTesting (clips.files, 118);
+            expect (pumpUntil ([&] { return harness.panel().getNumClipRows() == 2; }));
+
+            auto* row = harness.panel().getClipRow (0);
+            expect (pumpUntil ([&] { return row->getDragFile() != row->getFile(); }, 20000),
+                    "never matched to 120");
+
+            playHead.bpm = 140.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            expect (pumpUntil ([&] { return row->getDragFile()
+                                             == TimeStretch::getMatchedFileFor (clips.files[0], 140.0); },
+                               20000),
+                    "the drop stayed matched to the old tempo: " + row->getDragFile().getFullPathName());
+
+            // And going back to the clip's own tempo hands the original over again.
+            playHead.bpm = 118.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            expect (pumpUntil ([&] { return row->getDragFile() == row->getFile(); }, 20000),
+                    "the original was not restored when the host matched the clip");
         }
     }
 };

--- a/plugin/tests/TimeStretchTests.cpp
+++ b/plugin/tests/TimeStretchTests.cpp
@@ -143,6 +143,50 @@ public:
                     "the overlap-add clipped");
         }
 
+        beginTest ("slowing a clip down does not leave a silent tail");
+        {
+            // Slowing down makes the output LONGER than the source, so the analysis
+            // reaches the end of the input before the output is full. If the loop stops
+            // there, the buffer keeps its zero-filled tail: the file has the right
+            // length, so it still lines up to the bar, but it ends in silence.
+            const auto source = makeSine (440.0, 4.0);
+
+            for (const auto& pair : { std::pair<double, double> { 120.0, 100.0 },
+                                      std::pair<double, double> { 120.0,  70.0 },
+                                      std::pair<double, double> { 128.0, 118.0 },
+                                      std::pair<double, double> { 120.0,  60.0 },
+                                      std::pair<double, double> { 200.0,  60.0 } })
+            {
+                const auto rate = TimeStretch::rateFor (pair.first, pair.second);
+                const auto stretched = TimeStretch::process (source, rate);
+                const auto label = juce::String (pair.first) + " to " + juce::String (pair.second);
+
+                expect (stretched.getNumSamples() > source.getNumSamples(),
+                        "slowing down did not lengthen the clip");
+
+                // Measure how much of the end is silent, in milliseconds.
+                int lastSounding = -1;
+
+                for (int i = stretched.getNumSamples() - 1; i >= 0; --i)
+                {
+                    if (std::abs (stretched.getSample (0, i)) > 1.0e-4f)
+                    {
+                        lastSounding = i;
+                        break;
+                    }
+                }
+
+                const auto silentMs = 1000.0 * (double) (stretched.getNumSamples() - 1 - lastSounding)
+                                          / sampleRate;
+
+                // One synthesis frame of taper at the end is inherent to overlap-add;
+                // a whole analysis frame of dead air is the bug.
+                expect (silentMs < 10.0,
+                        "stretching " + label + " left " + juce::String (silentMs, 1)
+                            + "ms of silence at the end");
+            }
+        }
+
         beginTest ("a rate of 1 hands back the samples untouched");
         {
             const auto source = makeSine (440.0, 1.0);

--- a/plugin/tests/TimeStretchTests.cpp
+++ b/plugin/tests/TimeStretchTests.cpp
@@ -1,0 +1,291 @@
+#include "TimeStretch.h"
+
+#include <cmath>
+
+namespace acemusic
+{
+
+class TimeStretchTests final : public juce::UnitTest
+{
+public:
+    TimeStretchTests()
+        : juce::UnitTest ("TimeStretch", "acemusic")
+    {
+    }
+
+    static constexpr double sampleRate = 44100.0;
+
+    static juce::AudioBuffer<float> makeSine (double frequency, double seconds, int channels = 2)
+    {
+        const int numSamples = (int) (seconds * sampleRate);
+        juce::AudioBuffer<float> buffer (channels, numSamples);
+
+        for (int channel = 0; channel < channels; ++channel)
+        {
+            auto* out = buffer.getWritePointer (channel);
+
+            for (int i = 0; i < numSamples; ++i)
+                out[i] = (float) (0.5 * std::sin (juce::MathConstants<double>::twoPi
+                                                      * frequency * (double) i / sampleRate));
+        }
+
+        return buffer;
+    }
+
+    /** Frequency estimated from the zero-crossing rate — enough to catch a pitch shift,
+        and the thing a resample-based stretch would fail. */
+    static double estimateFrequency (const juce::AudioBuffer<float>& buffer)
+    {
+        const auto* data = buffer.getReadPointer (0);
+        const int numSamples = buffer.getNumSamples();
+
+        // The outer 10% is skipped: the first and last frames of an overlap-add are
+        // partial by construction and their level is not representative.
+        const int start = numSamples / 10;
+        const int end = numSamples - numSamples / 10;
+
+        int crossings = 0;
+
+        for (int i = start + 1; i < end; ++i)
+            if ((data[i - 1] < 0.0f) != (data[i] < 0.0f))
+                ++crossings;
+
+        const double seconds = (double) (end - start) / sampleRate;
+        return (double) crossings / 2.0 / seconds;
+    }
+
+    void runTest() override
+    {
+        beginTest ("the rate matches the Python side's calculate_speed_multiplier");
+        {
+            // target / original — 118 to 120 speeds up slightly.
+            expectWithinAbsoluteError (TimeStretch::rateFor (118.0, 120.0), 120.0 / 118.0, 1.0e-12);
+            expectWithinAbsoluteError (TimeStretch::rateFor (120.0, 100.0), 100.0 / 120.0, 1.0e-12);
+
+            // A tempo nobody knows is not a rate of 0-and-carry-on.
+            expectEquals (TimeStretch::rateFor (0.0, 120.0), 0.0);
+            expectEquals (TimeStretch::rateFor (120.0, 0.0), 0.0);
+            expectEquals (TimeStretch::rateFor (-120.0, 120.0), 0.0);
+        }
+
+        beginTest ("tempos that agree are not worth stretching");
+        {
+            expect (! TimeStretch::isWorthStretching (1.0));
+            expect (! TimeStretch::isWorthStretching (TimeStretch::rateFor (120.0, 120.0)));
+            expect (! TimeStretch::isWorthStretching (0.0), "a rate of 0 asked to be stretched");
+
+            // The story's own example must clear the threshold, or the feature is inert.
+            expect (TimeStretch::isWorthStretching (TimeStretch::rateFor (118.0, 120.0)),
+                    "118 to 120 BPM was dismissed as too small to correct");
+            expect (TimeStretch::isWorthStretching (TimeStretch::rateFor (120.0, 100.0)));
+        }
+
+        beginTest ("AC: a 118 BPM clip becomes 120 BPM — the length changes by exactly the ratio");
+        {
+            const auto source = makeSine (440.0, 4.0);
+            const auto rate = TimeStretch::rateFor (118.0, 120.0);
+            const auto stretched = TimeStretch::process (source, rate);
+
+            const auto expectedLength = (int) std::llround ((double) source.getNumSamples() / rate);
+            expectEquals (stretched.getNumSamples(), expectedLength);
+            expectEquals (stretched.getNumChannels(), source.getNumChannels());
+
+            // Sanity: 120 is faster than 118, so the clip got shorter.
+            expect (stretched.getNumSamples() < source.getNumSamples(),
+                    "speeding a clip up made it longer");
+        }
+
+        beginTest ("the pitch estimator can actually tell a shifted sine apart");
+        {
+            // Guards the test below: if the estimator were blind, "pitch preserved"
+            // would pass for a resampler too and the assertion would prove nothing.
+            // 447Hz is where a resample-based 118->120 stretch would land 440.
+            expectWithinAbsoluteError (estimateFrequency (makeSine (440.0, 4.0)), 440.0, 1.0);
+            expectWithinAbsoluteError (estimateFrequency (makeSine (447.0, 4.0)), 447.0, 1.0);
+            expectWithinAbsoluteError (estimateFrequency (makeSine (366.0, 4.0)), 366.0, 1.0);
+        }
+
+        beginTest ("AC: the stretch preserves pitch — this is the whole reason it is not a resample");
+        {
+            const auto source = makeSine (440.0, 4.0);
+
+            for (const auto& pair : { std::pair<double, double> { 118.0, 120.0 },
+                                     std::pair<double, double> { 120.0, 100.0 },
+                                     std::pair<double, double> { 90.0, 128.0 } })
+            {
+                const auto rate = TimeStretch::rateFor (pair.first, pair.second);
+                const auto stretched = TimeStretch::process (source, rate);
+
+                const auto frequency = estimateFrequency (stretched);
+                const auto label = juce::String (pair.first) + " to " + juce::String (pair.second);
+
+                // A resample would land at 440 * rate — 447Hz for the first pair, and
+                // 366Hz for the second. Anything near those is a pitch shift.
+                expectWithinAbsoluteError (frequency, 440.0, 6.0,
+                                           "pitch moved to " + juce::String (frequency)
+                                               + "Hz stretching " + label);
+            }
+        }
+
+        beginTest ("the stretch does not gate or blow up the level");
+        {
+            const auto source = makeSine (440.0, 4.0);
+            const auto stretched = TimeStretch::process (source, TimeStretch::rateFor (118.0, 120.0));
+
+            const auto sourceRms = source.getRMSLevel (0, 0, source.getNumSamples());
+            const auto stretchedRms = stretched.getRMSLevel (0, stretched.getNumSamples() / 10,
+                                                             stretched.getNumSamples() * 8 / 10);
+
+            expectWithinAbsoluteError (stretchedRms, sourceRms, 0.05f,
+                                       "level moved from " + juce::String (sourceRms)
+                                           + " to " + juce::String (stretchedRms));
+            expect (stretched.getMagnitude (0, stretched.getNumSamples()) <= 1.0f,
+                    "the overlap-add clipped");
+        }
+
+        beginTest ("a rate of 1 hands back the samples untouched");
+        {
+            const auto source = makeSine (440.0, 1.0);
+            const auto same = TimeStretch::process (source, 1.0);
+
+            expectEquals (same.getNumSamples(), source.getNumSamples());
+
+            for (int i = 0; i < source.getNumSamples(); ++i)
+                if (! juce::approximatelyEqual (same.getReadPointer (0)[i], source.getReadPointer (0)[i]))
+                {
+                    expect (false, "sample " + juce::String (i) + " was altered at rate 1.0");
+                    break;
+                }
+        }
+
+        beginTest ("silence stays silent, and unusable input does not crash");
+        {
+            juce::AudioBuffer<float> silence (2, (int) sampleRate);
+            silence.clear();
+
+            const auto stretched = TimeStretch::process (silence, TimeStretch::rateFor (118.0, 120.0));
+            expect (stretched.getNumSamples() > 0);
+            expectEquals (stretched.getMagnitude (0, stretched.getNumSamples()), 0.0f);
+
+            expectEquals (TimeStretch::process ({}, 1.5).getNumSamples(), 0);
+            expectEquals (TimeStretch::process (makeSine (440.0, 1.0), 0.0).getNumSamples(), 0);
+            expectEquals (TimeStretch::process (makeSine (440.0, 1.0), -1.0).getNumSamples(), 0);
+        }
+
+        beginTest ("a clip shorter than one analysis frame is copied rather than mangled");
+        {
+            juce::AudioBuffer<float> tiny (1, 64);
+            tiny.clear();
+            tiny.setSample (0, 10, 0.75f);
+
+            const auto stretched = TimeStretch::process (tiny, TimeStretch::rateFor (118.0, 120.0));
+            expectEquals (stretched.getNumSamples(), 64);
+            expectEquals (stretched.getSample (0, 10), 0.75f);
+        }
+
+        //======================================================================
+        beginTest ("AC: matchTempo writes a tempo-matched sibling and reuses it");
+        {
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            const auto clip = dir.directory.getChildFile ("clip.wav");
+            expect (writeWav (clip, makeSine (440.0, 2.0)), "could not write the source clip");
+
+            const auto matched = TimeStretch::matchTempo (clip, 118.0, 120.0, formats);
+
+            expect (matched != clip, "no tempo match was produced");
+            expect (matched.existsAsFile(), "the tempo-matched file is not on disk");
+            expectSameFile (matched, TimeStretch::getMatchedFileFor (clip, 120.0), "unexpected match path");
+
+            std::unique_ptr<juce::AudioFormatReader> reader (formats.createReaderFor (matched));
+            expect (reader != nullptr, "the tempo-matched file is not readable audio");
+            expectEquals ((int) reader->numChannels, 2);
+            expectWithinAbsoluteError (reader->sampleRate, sampleRate, 0.5);
+
+            const auto expectedLength = (juce::int64) std::llround (2.0 * sampleRate
+                                                                        / TimeStretch::rateFor (118.0, 120.0));
+            expect (std::abs (reader->lengthInSamples - expectedLength) <= 1,
+                    "length was " + juce::String (reader->lengthInSamples)
+                        + ", expected " + juce::String (expectedLength));
+            reader.reset();
+
+            // Second call reuses the file rather than stretching again.
+            const auto modified = matched.getLastModificationTime();
+            const auto again = TimeStretch::matchTempo (clip, 118.0, 120.0, formats);
+            expectSameFile (again, matched, "the reused match landed elsewhere");
+            expect (again.getLastModificationTime() == modified, "the tempo match was rebuilt");
+        }
+
+        beginTest ("matchTempo hands back the original when there is nothing to correct");
+        {
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            const auto clip = dir.directory.getChildFile ("clip.wav");
+            expect (writeWav (clip, makeSine (440.0, 1.0)));
+
+            // Same tempo, unknown clip tempo, unknown host tempo, missing file.
+            expectSameFile (TimeStretch::matchTempo (clip, 120.0, 120.0, formats), clip, "stretched a clip already at tempo");
+            expectSameFile (TimeStretch::matchTempo (clip, 0.0, 120.0, formats), clip, "stretched with an unknown clip tempo");
+            expectSameFile (TimeStretch::matchTempo (clip, 120.0, 0.0, formats), clip, "stretched with an unknown host tempo");
+
+            const auto missing = dir.directory.getChildFile ("nope.wav");
+            expectSameFile (TimeStretch::matchTempo (missing, 118.0, 120.0, formats), missing, "a missing clip did not come back unchanged");
+
+            // Unreadable audio is a failure to stretch, not a reason to hand back nothing.
+            const auto notAudio = dir.directory.getChildFile ("notaudio.wav");
+            notAudio.replaceWithText ("this is not a wav file");
+            expectSameFile (TimeStretch::matchTempo (notAudio, 118.0, 120.0, formats), notAudio, "a failed stretch did not fall back to the original");
+            expect (! TimeStretch::getMatchedFileFor (notAudio, 120.0).existsAsFile(),
+                    "a partial file was left behind by a failed stretch");
+        }
+    }
+
+private:
+    void expectSameFile (const juce::File& actual, const juce::File& expected, const juce::String& what)
+    {
+        expect (actual == expected,
+                what + " — got " + actual.getFullPathName() + ", expected " + expected.getFullPathName());
+    }
+
+    struct ScopedTempDir
+    {
+        ScopedTempDir()
+        {
+            directory = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                            .getChildFile ("acemusic-stretch-"
+                                           + juce::String (juce::Random::getSystemRandom().nextInt (1 << 30)));
+            directory.createDirectory();
+        }
+
+        ~ScopedTempDir()    { directory.deleteRecursively(); }
+
+        juce::File directory;
+    };
+
+    static bool writeWav (const juce::File& file, const juce::AudioBuffer<float>& buffer)
+    {
+        juce::WavAudioFormat wav;
+        std::unique_ptr<juce::OutputStream> stream (file.createOutputStream());
+
+        if (stream == nullptr)
+            return false;
+
+        auto writer = wav.createWriterFor (stream, juce::AudioFormatWriterOptions{}
+                                                       .withSampleRate (sampleRate)
+                                                       .withNumChannels (buffer.getNumChannels())
+                                                       .withBitsPerSample (16));
+
+        if (writer == nullptr)
+            return false;
+
+        return writer->writeFromAudioSampleBuffer (buffer, 0, buffer.getNumSamples());
+    }
+};
+
+static TimeStretchTests timeStretchTests;
+
+} // namespace acemusic


### PR DESCRIPTION
Implements **US-24.1 — DAW Tempo and Key Sync** (#320).

The generation panel now follows the host's tempo, and a clip generated at a different
BPM is stretched to the project tempo when it is dragged into the timeline.

---

## Acceptance criteria — evidence

| Criterion | Evidence |
| --- | --- |
| Opening the plugin in a 120 BPM project auto-fills BPM with 120 | `GenerationPanel / AC: opening the plugin in a 120 BPM project auto-fills BPM with 120` — asserts the field reads `"120"` **at construction** (not after a timer tick), that the indicator names the tempo, and that `buildRequest().bpm == 120` so it actually reaches the server |
| Changing the DAW tempo updates the plugin's BPM field | `GenerationPanel / AC: changing the DAW tempo updates the plugin's BPM field` — host moves 120 → 90, field follows |
| Generated clip at 118 BPM is time-stretched to 120 BPM on insertion | `ResultsPanel / AC: a 118 BPM clip is dropped into a 120 BPM project already stretched` — the drag payload is a *different, real* file at the expected path and `44100/rate` samples long, read back through an independent `AudioFormatReader`. Plus the end-to-end measurement below |
| Manual BPM override disables auto-sync with a visual indicator | `GenerationPanel / AC: a manual BPM override disables auto-sync, with a visual indicator` — typing 100 clears the sync flag, changes the indicator to say "manual", and a subsequent host move to 140 **cannot** overwrite the field |

### End-to-end measurement of the stretch, by a tool that is not our code

A real 12s / 118 BPM track (220 Hz tone + a click on every beat) was stretched through
the shipped `TimeStretch::processFile` and measured with **librosa**:

```
source (118 BPM)        12.000s   tempo  117.45 BPM   tone  220.72 Hz
stretched -> 120 BPM    11.800s   tempo  120.19 BPM   tone  220.72 Hz

length ratio     1.01695   (expected 1.01695)
tempo measured   120.19 BPM   (target 120)
pitch drift      +0.0 cents   (a resample would be +29.1)
```

Full suite: **all plugin unit tests pass**; VST3 links at 6.7 MB against CI's 25 MB cap.

---

## Notable decisions

**WSOLA, not a resample.** `juce::LagrangeInterpolator` would have been a third of the
code, but resampling changes pitch with speed: 118→120 is a 1.7% rate change and so a
29-cent detune. Audio that arrives out of tune with the project defeats the purpose of
syncing to it, so `TimeStretch` is waveform-similarity overlap-add — pitch-transparent,
no new dependency. The measurement above is the proof.

**One reader of the play head.** `getPlayHead()` is an audio-thread API.
`ResultsPanel::timerCallback` was already calling it from the *message* thread for its
playhead readout — a live data race on `main`. Rather than adding a second racy reader,
`HostSync` samples it once in `processBlock` and publishes lock-free, and the results
panel is switched over. **This PR removes a race rather than adding one.**

**Bug found and fixed while wiring this up.** Tempo-matched copies were first written
beside the clip. `ClipCache::readEntry` lists `*.wav` per run directory
non-recursively, so they were counted as *extra clips of that generation* — a two-clip
run listed four, and would have restored four from the cache. They now live in a
`tempo-match/` child directory, which that scan skips but the size accounting (which
recurses) and `deleteEntry` (which is `deleteRecursively`) both still cover. Regression
test: `ResultsPanel / tempo-matched copies do not show up as extra clips in the cache
browser`, verified by mutation — reverting to sibling naming makes it fail with
`Expected value: 2, Actual value: 4`.

**A real race in the sync loop, caught by a test.** `TextEditor::setText(…, true)`
delivers `onTextChange` *asynchronously* (it posts a command message), so between a
user's first keystroke and the callback that clears the sync flag there was a window
where the 2 Hz tick could overwrite what they had just typed. `applyHostTempo` now
declines while the BPM editor has keyboard focus.

---

## Known limitations

1. **Host key signature is not synced, and cannot be.**
   `juce::AudioPlayHead::PositionInfo` carries tempo, time signature, PPQ and the
   transport flags — and no key signature. The only key-signature channel in JUCE is
   ARA (`kARAContentTypeKeySignatures`), a separately licensed Celemony SDK that a
   handful of hosts implement. It is unreachable through VST3, AU or Standalone.
   The issue's functional requirements say "read host key signature **if available**";
   it is not. The **Key** field stays manual and the indicator never implies otherwise.
   **All four acceptance criteria on #320 are BPM-only and all are met.**

2. **Clip tempo is the *requested* BPM, not analysis of the returned audio.** A
   generation that left BPM on *Auto* has no known tempo, so nothing is stretched —
   guessing would be worse than leaving it alone. Beat-detecting a finished clip is a
   separate story.

3. **Not verified in a real DAW.** No DAW is installed in this environment, and no
   unit test can make a real host publish a real tempo. The README's manual check now
   has an explicit step for it. Everything below the host boundary is covered by tests
   driving a `juce::AudioPlayHead` double.

4. Third-party review: opencode (GLM) cross-family pass; findings triaged in a comment
   below.

Closes #320
