### PR TITLE
feat(plugin): US-24.2 Selection-Aware Generation (#321)

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -12,6 +12,7 @@ Progress:
 | US-23.4 — Results panel and clip insertion | done |
 | US-23.5 — Local cache and file management | done |
 | US-24.1 — DAW tempo sync and tempo-matched insertion | done |
+| US-24.2 — Selection-aware generation | done |
 
 | Format | Windows | macOS | Linux |
 | --- | --- | --- | --- |
@@ -92,6 +93,9 @@ the VST3 in Reaper once and confirm the UI renders and audio passes through:
    indicator says `Sync: host 120 BPM`; change the project tempo and watch it
    follow. This is the one part of US-24.1 that no unit test can cover, because
    it needs a real host publishing a real tempo.
+5. Set the cycle locators over bars 5–13 and confirm the panel reads
+   `Selection: bars 5-13, 16.0s` with **Duration** at 16. Same reason: it needs a
+   real host publishing a real loop range.
 
 ## Connecting to ACE-Step
 
@@ -157,6 +161,36 @@ JUCE is [ARA](https://www.celemony.com/en/service1/about-celemony/technologies),
 a separately licensed SDK that a handful of hosts implement. There is no way to
 read the project key through VST3, AU or Standalone, so the **Key** field is
 always manual. The indicator deliberately never claims otherwise.
+
+### Selection
+
+The plugin follows the host's **loop / cycle range** and sizes generation to it. Set
+the cycle locators over bars 5–13 in a 120 BPM 4/4 project and the panel reads
+`Selection: bars 5-13, 16.0s`, with the **Duration** field set to 16.
+
+Duration follows the same rule as BPM: it tracks the host until you type your own
+value, and clearing the field hands it back.
+
+**It is the loop range, not an arbitrary time selection.** VST3 has no API for the
+latter — `AudioPlayHead::PositionInfo::getLoopPoints()` is what exists, and JUCE fills
+it from `Vst::ProcessContext::kCycleValid`. In Reaper the loop range is linked to the
+time selection by default (Options → Loop points linked to time selection); in Cubase
+and Logic these are the cycle markers. In a DAW where the two are not linked, moving
+the time selection alone will not move the plugin's.
+
+With no loop range set, the panel reads `Selection: none` and Duration keeps its
+default of 60 — the Stage-23 behaviour, unchanged.
+
+A loop range with no host tempo behind it shows the bars but no length, rather than
+claiming `0.0s`.
+
+### Where to drop it
+
+The results panel tags each clip with the bar a drop should line up with —
+`Clip 1  ->  120 BPM  @ bar 5`. The plugin cannot place the audio there itself: VST3
+gives it no way to write the host's arrangement. This is the same resolution agreed on
+[#318](https://github.com/frankbria/auto-music-studio/issues/318) for the playhead
+readout — the plugin reports the position, and the drop stays yours.
 
 ### Tempo-matched insertion
 

--- a/plugin/source/GenerationPanel.cpp
+++ b/plugin/source/GenerationPanel.cpp
@@ -111,6 +111,13 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
     bpmEditor.onTextChange = [this]
     {
         bpmSynced = bpmEditor.getText().trim().isEmpty();
+
+        // Applied right here, not left to the next timer tick: a user who clears the
+        // field and hits Generate straight away must get the host's tempo, not the
+        // "Auto" an empty field would otherwise submit.
+        if (bpmSynced)
+            applyHostTempo();
+
         refresh();
     };
     addAndMakeVisible (bpmEditor);
@@ -138,6 +145,12 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
         // types, and clearing hands it back. Auto-applied writes use
         // setText(..., false), which does not land here.
         durationSynced = durationEditor.getText().trim().isEmpty();
+
+        // Same reason as the BPM field: an empty duration means 60, so leaving the
+        // selection length until the next tick would submit the wrong length.
+        if (durationSynced)
+            applyHostSelection();
+
         refresh();
     };
     addAndMakeVisible (durationEditor);
@@ -263,15 +276,21 @@ void GenerationPanel::resized()
 
     area.removeFromBottom (8);
 
+    // The host readouts get a row to themselves. Sharing the language row left them a
+    // few pixels wide at the editor's minimum size, which made both unreadable — and a
+    // readout nobody can read is not a feature.
+    auto readoutRow = area.removeFromBottom (16);
+    syncLabel.setBounds (readoutRow.removeFromRight (readoutRow.getWidth() / 2));
+    selectionLabel.setBounds (readoutRow);
+
+    area.removeFromBottom (4);
+
     auto languageRow = area.removeFromBottom (24);
     languageLabel.setBounds (languageRow.removeFromLeft (70));
     languageSelector.setBounds (languageRow.removeFromLeft (180));
     languageRow.removeFromLeft (12);
     instrumentalToggle.setBounds (languageRow.removeFromLeft (120));
     lyricsToggle.setBounds (languageRow.removeFromLeft (90));
-    // Sync indicator right-aligned, selection readout taking what is left beside it.
-    syncLabel.setBounds (languageRow.removeFromRight (juce::jmin (170, languageRow.getWidth() / 2)));
-    selectionLabel.setBounds (languageRow);
 
     area.removeFromBottom (8);
 
@@ -298,6 +317,11 @@ void GenerationPanel::timerCallback()
     applyHostTempo();
     applyHostSelection();
     refresh();
+}
+
+HostSync::Snapshot GenerationPanel::getHostSnapshot() const
+{
+    return hostSync != nullptr ? hostSync->get() : HostSync::Snapshot{};
 }
 
 bool GenerationPanel::applyHostTempo()
@@ -358,9 +382,7 @@ bool GenerationPanel::applyHostSelection()
 
 juce::String GenerationPanel::getSelectionText() const
 {
-    const auto selection = hostSync != nullptr
-                             ? HostSync::describeSelection (hostSync->get())
-                             : HostSync::Selection{};
+    const auto selection = HostSync::describeSelection (getHostSnapshot());
 
     if (! selection.present)
         return "Selection: none";
@@ -394,7 +416,7 @@ juce::String GenerationPanel::getSyncStatusText() const
     if (! bpmSynced)
         return "Sync: off (manual BPM)";
 
-    const auto snapshot = hostSync != nullptr ? hostSync->get() : HostSync::Snapshot{};
+    const auto snapshot = getHostSnapshot();
 
     if (! snapshot.hasBpm())
         return "Sync: no host tempo";
@@ -417,14 +439,36 @@ GenerationRequest GenerationPanel::buildRequest() const
 
     request.instrumental = instrumentalToggle.getToggleState();
 
+    // An empty field means "follow the host" while sync is on, and only falls back to
+    // Auto when there is no host tempo to follow. Resolved here rather than relying on
+    // the display having already been updated: TextEditor delivers onTextChange
+    // asynchronously, so a Generate between clearing the field and that callback would
+    // otherwise submit Auto instead of the tempo the indicator is promising.
     const auto bpmText = bpmEditor.getText().trim();
-    request.bpm = bpmText.isEmpty() ? -1 : bpmText.getIntValue();
+
+    if (bpmText.isNotEmpty())
+        request.bpm = bpmText.getIntValue();
+    else if (const auto host = getHostSnapshot(); host.hasBpm())
+        request.bpm = juce::roundToInt (host.bpm);
+    else
+        request.bpm = -1;
 
     if (keySelector.getSelectedId() > 1)
         request.key = keySelector.getText();
 
+    // Same rule, and the same reason, for the duration and the host's loop range.
     const auto durationText = durationEditor.getText().trim();
-    request.durationSeconds = durationText.isEmpty() ? 60 : durationText.getIntValue();
+
+    if (durationText.isNotEmpty())
+    {
+        request.durationSeconds = durationText.getIntValue();
+    }
+    else
+    {
+        const auto selection = HostSync::describeSelection (getHostSnapshot());
+        const auto fromSelection = selection.hasLength ? juce::roundToInt (selection.lengthSeconds) : 0;
+        request.durationSeconds = fromSelection > 0 ? fromSelection : 60;
+    }
 
     const auto seedText = seedEditor.getText().trim();
     request.seed = seedText.isEmpty() ? -1 : seedText.getLargeIntValue();

--- a/plugin/source/GenerationPanel.cpp
+++ b/plugin/source/GenerationPanel.cpp
@@ -132,7 +132,14 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
     styleEditor (durationEditor, "60");
     durationEditor.setInputRestrictions (4, "0123456789");
     durationEditor.setText ("60", false);
-    durationEditor.onTextChange = [this] { refresh(); };
+    durationEditor.onTextChange = [this]
+    {
+        // Same rule as the BPM field (US-24.1): the host drives it until the user
+        // types, and clearing hands it back. Auto-applied writes use
+        // setText(..., false), which does not land here.
+        durationSynced = durationEditor.getText().trim().isEmpty();
+        refresh();
+    };
     addAndMakeVisible (durationEditor);
 
     styleCaption (seedLabel, "Seed");
@@ -180,6 +187,10 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
     syncLabel.setJustificationType (juce::Justification::centredRight);
     addAndMakeVisible (syncLabel);
 
+    selectionLabel.setFont (juce::FontOptions (12.0f));
+    selectionLabel.setColour (juce::Label::textColourId, genColours::textDim);
+    addAndMakeVisible (selectionLabel);
+
     generation.addChangeListener (this);
     connection.addChangeListener (this);
 
@@ -187,6 +198,7 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
     // that is already running shows the host tempo rather than a blank field that
     // fills in half a second later.
     applyHostTempo();
+    applyHostSelection();
     refresh();
 
     // Ticks the elapsed-time readout and follows the host tempo. Everything else the
@@ -257,7 +269,9 @@ void GenerationPanel::resized()
     languageRow.removeFromLeft (12);
     instrumentalToggle.setBounds (languageRow.removeFromLeft (120));
     lyricsToggle.setBounds (languageRow.removeFromLeft (90));
-    syncLabel.setBounds (languageRow);
+    // Sync indicator right-aligned, selection readout taking what is left beside it.
+    syncLabel.setBounds (languageRow.removeFromRight (juce::jmin (170, languageRow.getWidth() / 2)));
+    selectionLabel.setBounds (languageRow);
 
     area.removeFromBottom (8);
 
@@ -282,6 +296,7 @@ void GenerationPanel::timerCallback()
     // made in the DAW while the panel sits idle. refresh() is a handful of setters that
     // no-op when nothing moved, so 2Hz costs nothing.
     applyHostTempo();
+    applyHostSelection();
     refresh();
 }
 
@@ -309,6 +324,69 @@ bool GenerationPanel::applyHostTempo()
 
     bpmEditor.setText (wanted, false);
     return true;
+}
+
+bool GenerationPanel::applyHostSelection()
+{
+    if (hostSync == nullptr || ! durationSynced)
+        return false;
+
+    // Same reason as applyHostTempo: never rewrite a field being typed into.
+    if (durationEditor.hasKeyboardFocus (false))
+        return false;
+
+    const auto selection = HostSync::describeSelection (hostSync->get());
+
+    // No selection, or one whose length is unknowable, leaves the field exactly as
+    // Stage 23 left it. Nothing is invented from a range with no tempo behind it.
+    if (! selection.present || ! selection.hasLength)
+        return false;
+
+    const auto seconds = juce::roundToInt (selection.lengthSeconds);
+
+    if (seconds <= 0)
+        return false;
+
+    const auto wanted = juce::String (seconds);
+
+    if (durationEditor.getText() == wanted)
+        return false;
+
+    durationEditor.setText (wanted, false);
+    return true;
+}
+
+juce::String GenerationPanel::getSelectionText() const
+{
+    const auto selection = hostSync != nullptr
+                             ? HostSync::describeSelection (hostSync->get())
+                             : HostSync::Selection{};
+
+    if (! selection.present)
+        return "Selection: none";
+
+    juce::String text { "Selection: " };
+
+    if (selection.hasBars)
+    {
+        text << "bars " << HostSync::formatBar (selection.startBar)
+             << "-" << HostSync::formatBar (selection.endBar);
+    }
+
+    if (selection.hasLength)
+    {
+        if (selection.hasBars)
+            text << ", ";
+
+        text << juce::String (selection.lengthSeconds, 1) << "s";
+    }
+    else
+    {
+        // A range with no tempo behind it: say so rather than show "0.0s".
+        text << (selection.hasBars ? " (no host tempo)" : "set, but no host tempo");
+    }
+
+    return text;
 }
 
 juce::String GenerationPanel::getSyncStatusText() const
@@ -383,6 +461,8 @@ void GenerationPanel::applyRequest (const GenerationRequest& request)
     const auto keyIndex = GenerationRequest::musicalKeys().indexOf (request.key);
     keySelector.setSelectedId (keyIndex >= 0 ? keyIndex + 1 : 1, juce::dontSendNotification);
 
+    // As with BPM: a recalled request carries its own duration, so it stops tracking.
+    durationSynced = false;
     durationEditor.setText (juce::String (request.durationSeconds), false);
     seedEditor.setText (request.seed >= 0 ? juce::String (request.seed) : juce::String(), false);
 
@@ -411,6 +491,11 @@ void GenerationPanel::refresh()
 
     if (syncLabel.getText() != syncText)
         syncLabel.setText (syncText, juce::dontSendNotification);
+
+    const auto selectionText = getSelectionText();
+
+    if (selectionLabel.getText() != selectionText)
+        selectionLabel.setText (selectionText, juce::dontSendNotification);
 
     for (auto* control : std::initializer_list<juce::Component*> {
              &promptEditor, &lyricsEditor, &lyricsToggle, &languageSelector, &instrumentalToggle,

--- a/plugin/source/GenerationPanel.h
+++ b/plugin/source/GenerationPanel.h
@@ -53,10 +53,14 @@ public:
     juce::TextButton&   getCancelButton() noexcept        { return cancelButton; }
     juce::Label&        getStatusLabel() noexcept         { return statusLabel; }
     juce::Label&        getSyncLabel() noexcept           { return syncLabel; }
+    juce::Label&        getSelectionLabel() noexcept      { return selectionLabel; }
+    juce::ProgressBar&  getProgressBar() noexcept         { return progressBar; }
 
     /** True while the BPM field is following the host rather than the user. */
     bool isBpmSynced() const noexcept                     { return bpmSynced; }
-    juce::ProgressBar&  getProgressBar() noexcept         { return progressBar; }
+
+    /** True while the duration field is following the host's loop range. */
+    bool isDurationSynced() const noexcept                { return durationSynced; }
 
 private:
     void changeListenerCallback (juce::ChangeBroadcaster*) override;
@@ -67,8 +71,15 @@ private:
         @returns true if the field changed. */
     bool applyHostTempo();
 
+    /** Copies the host's loop-range length into the duration field when that field is
+        still following it. @returns true if the field changed. */
+    bool applyHostSelection();
+
     /** What the sync indicator should read right now. */
     juce::String getSyncStatusText() const;
+
+    /** What the selection readout should read right now. */
+    juce::String getSelectionText() const;
 
     GenerationManager& generation;
     ConnectionManager& connection;
@@ -78,6 +89,10 @@ private:
         "Auto" placeholder sets it true again, which is how sync is resumed — the
         panel already treats an empty field as "let something else choose". */
     bool bpmSynced = true;
+
+    /** Same rule as bpmSynced, for the duration field and the host's loop range. False
+        once the user types their own duration; clearing the field resumes tracking. */
+    bool durationSynced = true;
 
     juce::Label      titleLabel;
 
@@ -108,6 +123,7 @@ private:
     juce::TextButton cancelButton { "Cancel" };
     juce::Label      statusLabel;
     juce::Label      syncLabel;
+    juce::Label      selectionLabel;
 
     /** The server reports no percentage, so this runs in indeterminate mode while a
         job is in flight. See the progress note in the README. */

--- a/plugin/source/GenerationPanel.h
+++ b/plugin/source/GenerationPanel.h
@@ -67,6 +67,9 @@ private:
     void timerCallback() override;
     void refresh();
 
+    /** The host's transport, or an empty snapshot when there is no host. */
+    HostSync::Snapshot getHostSnapshot() const;
+
     /** Copies the host tempo into the BPM field when the field is still following it.
         @returns true if the field changed. */
     bool applyHostTempo();

--- a/plugin/source/HostSync.cpp
+++ b/plugin/source/HostSync.cpp
@@ -6,9 +6,13 @@ namespace acemusic
 void HostSync::captureFrom (juce::AudioPlayHead* playHead) noexcept
 {
     // A host that stops reporting should clear the fields rather than leave the last
-    // value frozen on screen, so every path below writes both.
+    // values frozen on screen, so every field is written on every path below.
     double newBpm = 0.0;
     double newTime = -1.0;
+    double newLoopStart = 0.0;
+    double newLoopEnd = 0.0;
+    int newNumerator = 0;
+    int newDenominator = 0;
 
     if (playHead != nullptr)
     {
@@ -19,11 +23,68 @@ void HostSync::captureFrom (juce::AudioPlayHead* playHead) noexcept
 
             if (const auto seconds = position->getTimeInSeconds())
                 newTime = *seconds;
+
+            if (const auto loop = position->getLoopPoints())
+            {
+                newLoopStart = loop->ppqStart;
+                newLoopEnd = loop->ppqEnd;
+            }
+
+            if (const auto signature = position->getTimeSignature())
+            {
+                newNumerator = signature->numerator;
+                newDenominator = signature->denominator;
+            }
         }
     }
 
     bpm.store (newBpm, std::memory_order_relaxed);
     timeInSeconds.store (newTime, std::memory_order_relaxed);
+    loopStartPpq.store (newLoopStart, std::memory_order_relaxed);
+    loopEndPpq.store (newLoopEnd, std::memory_order_relaxed);
+    timeSigNumerator.store (newNumerator, std::memory_order_relaxed);
+    timeSigDenominator.store (newDenominator, std::memory_order_relaxed);
+}
+
+HostSync::Selection HostSync::describeSelection (const Snapshot& snapshot) noexcept
+{
+    Selection selection;
+
+    if (! snapshot.hasLoop())
+        return selection;
+
+    selection.present = true;
+
+    if (snapshot.hasBpm())
+    {
+        selection.hasLength = true;
+        // A quarter note is 60/bpm seconds, and the loop range is measured in them.
+        selection.lengthSeconds = (snapshot.loopEndPpq - snapshot.loopStartPpq) * 60.0 / snapshot.bpm;
+    }
+
+    if (snapshot.hasTimeSignature())
+    {
+        // 4/4 is 4 quarter notes to the bar, 6/8 is 3, 3/4 is 3.
+        const auto quarterNotesPerBar = (double) snapshot.timeSigNumerator * 4.0
+                                            / (double) snapshot.timeSigDenominator;
+
+        if (quarterNotesPerBar > 0.0)
+        {
+            selection.hasBars = true;
+            // +1 because DAWs number the first bar 1, not 0.
+            selection.startBar = snapshot.loopStartPpq / quarterNotesPerBar + 1.0;
+            selection.endBar   = snapshot.loopEndPpq / quarterNotesPerBar + 1.0;
+        }
+    }
+
+    return selection;
+}
+
+juce::String HostSync::formatBar (double bar)
+{
+    // Two decimals, then the trailing zeros and any bare point trimmed off, so a bar
+    // line reads "5" rather than "5.00" but an off-grid range still reads "5.25".
+    return juce::String (bar, 2).trimCharactersAtEnd ("0").trimCharactersAtEnd (".");
 }
 
 HostSync::Snapshot HostSync::get() const noexcept
@@ -31,6 +92,10 @@ HostSync::Snapshot HostSync::get() const noexcept
     Snapshot snapshot;
     snapshot.bpm = bpm.load (std::memory_order_relaxed);
     snapshot.timeInSeconds = timeInSeconds.load (std::memory_order_relaxed);
+    snapshot.loopStartPpq = loopStartPpq.load (std::memory_order_relaxed);
+    snapshot.loopEndPpq = loopEndPpq.load (std::memory_order_relaxed);
+    snapshot.timeSigNumerator = timeSigNumerator.load (std::memory_order_relaxed);
+    snapshot.timeSigDenominator = timeSigDenominator.load (std::memory_order_relaxed);
     return snapshot;
 }
 

--- a/plugin/source/HostSync.h
+++ b/plugin/source/HostSync.h
@@ -40,9 +40,56 @@ public:
         /** Transport position, or < 0 when the host reports none. */
         double timeInSeconds = -1.0;
 
+        /** The host's loop / cycle range in quarter notes. `loopEndPpq > loopStartPpq`
+            is what makes it a range; equal values mean the host reports none.
+
+            This is the **cycle locators**, not an arbitrary time selection — VST3 has no
+            API for the latter. In Reaper the loop range is linked to the time selection
+            by default; in Cubase and Logic these are the cycle markers. */
+        double loopStartPpq = 0.0;
+        double loopEndPpq = 0.0;
+
+        /** Time signature, or 0/0 when the host reports none. Needed to turn a position
+            in quarter notes into a bar number. */
+        int timeSigNumerator = 0;
+        int timeSigDenominator = 0;
+
         bool hasBpm() const noexcept                          { return bpm > 0.0; }
         bool hasTime() const noexcept                         { return timeInSeconds >= 0.0; }
+        bool hasLoop() const noexcept                         { return loopEndPpq > loopStartPpq; }
+        bool hasTimeSignature() const noexcept                { return timeSigNumerator > 0 && timeSigDenominator > 0; }
     };
+
+    /** The host's loop range, in the terms the generation panel shows it.
+
+        Derived rather than stored, because it needs two other things the host reports
+        separately: the length in seconds needs the tempo, and the bar numbers need the
+        time signature. Either being absent is a real state the UI has to render — a
+        selection whose length is unknown must not read as "0.0s". */
+    struct Selection
+    {
+        /** True when the host reports a loop range at all. */
+        bool present = false;
+
+        /** True when the length in seconds is known, i.e. the host also reports a tempo. */
+        bool hasLength = false;
+
+        /** True when the bar numbers are known, i.e. the host also reports a time signature. */
+        bool hasBars = false;
+
+        double lengthSeconds = 0.0;
+
+        /** 1-based, the way every DAW displays bars. */
+        double startBar = 1.0;
+        double endBar = 1.0;
+    };
+
+    /** Interprets `snapshot`'s loop range. Pure — exposed so it can be tested without a host. */
+    static Selection describeSelection (const Snapshot& snapshot) noexcept;
+
+    /** A bar number as a DAW would show it: "5", or "5.5" when the range does not start
+        on a bar line. Shared so the generation and results panels cannot disagree. */
+    static juce::String formatBar (double bar);
 
     /** Publishes `playHead`'s position. Audio thread: allocates nothing, takes no
         locks, and tolerates a null play head (the host gave us none). */
@@ -58,6 +105,10 @@ private:
     // the audio thread would have to take.
     std::atomic<double> bpm { 0.0 };
     std::atomic<double> timeInSeconds { -1.0 };
+    std::atomic<double> loopStartPpq { 0.0 };
+    std::atomic<double> loopEndPpq { 0.0 };
+    std::atomic<int> timeSigNumerator { 0 };
+    std::atomic<int> timeSigDenominator { 0 };
 };
 
 } // namespace acemusic

--- a/plugin/source/ResultsPanel.cpp
+++ b/plugin/source/ResultsPanel.cpp
@@ -73,7 +73,7 @@ void ResultsPanel::ClipRow::ensureTempoMatch (double hostBpm, double clipBpm,
         if (dragFile != file)
         {
             dragFile = file;
-            nameLabel.setText ("Clip " + juce::String (clipIndex + 1), juce::dontSendNotification);
+            updateNameLabel();
         }
 
         matchedToBpm = 0.0;
@@ -108,14 +108,34 @@ void ResultsPanel::ClipRow::ensureTempoMatch (double hostBpm, double clipBpm,
                 row->matchInFlight = false;
                 row->dragFile = matched;
                 row->matchedToBpm = matched != row->file ? hostBpm : 0.0;
-
-                if (matched != row->file)
-                    row->nameLabel.setText ("Clip " + juce::String (row->clipIndex + 1)
-                                                + "  ->  " + juce::String (juce::roundToInt (hostBpm)) + " BPM",
-                                            juce::dontSendNotification);
+                row->updateNameLabel();
             }
         });
     });
+}
+
+void ResultsPanel::ClipRow::setTargetBar (double bar, bool present)
+{
+    if (present == hasTargetBar && (! present || juce::approximatelyEqual (bar, targetBar)))
+        return;
+
+    hasTargetBar = present;
+    targetBar = bar;
+    updateNameLabel();
+}
+
+void ResultsPanel::ClipRow::updateNameLabel()
+{
+    juce::String text { "Clip " + juce::String (clipIndex + 1) };
+
+    if (dragFile != file)
+        text << "  ->  " << juce::String (juce::roundToInt (matchedToBpm)) << " BPM";
+
+    if (hasTargetBar)
+        text << "  @ bar " << HostSync::formatBar (targetBar);
+
+    if (nameLabel.getText() != text)
+        nameLabel.setText (text, juce::dontSendNotification);
 }
 
 void ResultsPanel::ClipRow::changeListenerCallback (juce::ChangeBroadcaster*)
@@ -464,8 +484,15 @@ void ResultsPanel::updateTempoMatches()
     const auto hostBpm = host.hasBpm() ? (double) juce::roundToInt (host.bpm) : 0.0;
     const auto clipBpm = (double) generation.getRequestedBpm();
 
+    // Where a drop should land: the start of the host's loop range. The plugin cannot
+    // put it there itself (VST3 has no arrangement write), so it says where.
+    const auto selection = HostSync::describeSelection (host);
+
     for (auto* row : clipRows)
+    {
         row->ensureTempoMatch (hostBpm, clipBpm, queue);
+        row->setTargetBar (selection.startBar, selection.present && selection.hasBars);
+    }
 }
 
 void ResultsPanel::rebuildRows()

--- a/plugin/source/ResultsPanel.cpp
+++ b/plugin/source/ResultsPanel.cpp
@@ -129,10 +129,10 @@ void ResultsPanel::ClipRow::updateNameLabel()
     juce::String text { "Clip " + juce::String (clipIndex + 1) };
 
     if (dragFile != file)
-        text << "  ->  " << juce::String (juce::roundToInt (matchedToBpm)) << " BPM";
+        text << " | " << juce::String (juce::roundToInt (matchedToBpm)) << " BPM";
 
     if (hasTargetBar)
-        text << "  @ bar " << HostSync::formatBar (targetBar);
+        text << " | bar " << HostSync::formatBar (targetBar);
 
     if (nameLabel.getText() != text)
         nameLabel.setText (text, juce::dontSendNotification);
@@ -189,7 +189,12 @@ void ResultsPanel::ClipRow::paint (juce::Graphics& g)
 void ResultsPanel::ClipRow::resized()
 {
     auto bounds = getLocalBounds();
-    nameLabel.setBounds (bounds.removeFromLeft (52).reduced (2));
+
+    // 52px fitted "Clip 1" and nothing else. The caption now also carries the tempo
+    // match (US-24.1) and the drop-target bar (US-24.2), so it scales with the row and
+    // the waveform gets what is left.
+    const auto nameWidth = juce::jlimit (52, 200, bounds.getWidth() * 2 / 5);
+    nameLabel.setBounds (bounds.removeFromLeft (nameWidth).reduced (2));
     playButton.setBounds (bounds.removeFromLeft (70).reduced (2));
 }
 

--- a/plugin/source/ResultsPanel.h
+++ b/plugin/source/ResultsPanel.h
@@ -52,6 +52,7 @@ public:
 
         const juce::File& getFile() const noexcept            { return file; }
         juce::TextButton& getPlayButton() noexcept            { return playButton; }
+        juce::Label& getNameLabel() noexcept                  { return nameLabel; }
 
         /** What a drop actually hands the host: the clip itself, or a tempo-matched
             copy of it once one has been built. */
@@ -62,6 +63,14 @@ public:
             agreeing, drops the match and goes back to handing over the original.
             Cheap and idempotent — the panel calls this on every timer tick. */
         void ensureTempoMatch (double hostBpm, double clipBpm, BackgroundTaskQueue&);
+
+        /** Tags the row with the bar a drop should be aligned to — the start of the
+            host's loop range. `present` false clears it.
+
+            VST3 cannot place audio on the host timeline (see the class note), so
+            reporting where it *should* go is the closest reachable thing, and the same
+            resolution #318 settled on for the playhead. */
+        void setTargetBar (double bar, bool present);
 
         /** True once the waveform has finished loading. */
         bool hasWaveform() const;
@@ -74,6 +83,10 @@ public:
         void changeListenerCallback (juce::ChangeBroadcaster*) override;
         void timerCallback() override;
 
+        /** Rebuilds the row caption from the tempo match and target bar. One writer, so
+            the two cannot overwrite each other's half of the text. */
+        void updateNameLabel();
+
         juce::File file;
 
         /** Equal to `file` until a tempo match has been built for the host's tempo. */
@@ -82,6 +95,10 @@ public:
         /** The host tempo `dragFile` was built for; 0 when it is just the original. */
         double matchedToBpm = 0.0;
         bool matchInFlight = false;
+
+        /** The bar a drop should line up with, when the host reports a loop range. */
+        double targetBar = 0.0;
+        bool hasTargetBar = false;
 
         ClipPlayer& player;
         juce::AudioThumbnail thumbnail;

--- a/plugin/tests/FakePlayHead.h
+++ b/plugin/tests/FakePlayHead.h
@@ -26,6 +26,12 @@ public:
         if (timeInSeconds >= 0.0)
             info.setTimeInSeconds (timeInSeconds);
 
+        if (loopEndPpq > loopStartPpq)
+            info.setLoopPoints (LoopPoints { loopStartPpq, loopEndPpq });
+
+        if (timeSigNumerator > 0 && timeSigDenominator > 0)
+            info.setTimeSignature (TimeSignature { timeSigNumerator, timeSigDenominator });
+
         return info;
     }
 
@@ -36,6 +42,15 @@ public:
 
     /** < 0 means "the host publishes no position". */
     double timeInSeconds = 0.0;
+
+    /** The loop / cycle range in quarter notes. Equal values mean "no loop range",
+        which is what a host with no cycle locators set reports. */
+    double loopStartPpq = 0.0;
+    double loopEndPpq = 0.0;
+
+    /** 0/0 means "the host publishes no time signature". */
+    int timeSigNumerator = 0;
+    int timeSigDenominator = 0;
 };
 
 } // namespace acemusic::test

--- a/plugin/tests/GenerationPanelTests.cpp
+++ b/plugin/tests/GenerationPanelTests.cpp
@@ -482,6 +482,166 @@ public:
                         + panel.getSyncLabel().getText());
         }
 
+        //======================================================================
+        // US-24.2 — selection-aware generation.
+
+        beginTest ("AC: selecting bars 5-13 auto-sets the duration to 16 seconds");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;   // bar 5
+            playHead.loopEndPpq = 48.0;     // bar 13
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            expectEquals (panel.getDurationEditor().getText(), juce::String ("16"),
+                          "the duration did not follow the selection");
+            expect (panel.isDurationSynced());
+
+            // And it reaches the request, so the generation is actually that long.
+            panel.getPromptEditor().setText ("fits the gap", true);
+            expectEquals (panel.buildRequest().durationSeconds, 16);
+        }
+
+        beginTest ("AC: the selection is displayed in the generation panel");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+
+            const auto text = editor.getGenerationPanel().getSelectionLabel().getText();
+
+            expect (text.contains ("5"), "no start bar in: " + text);
+            expect (text.contains ("13"), "no end bar in: " + text);
+            expect (text.contains ("16.0s"), "no length in: " + text);
+        }
+
+        beginTest ("a moved selection re-drives the duration");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+            expectEquals (panel.getDurationEditor().getText(), juce::String ("16"));
+
+            // The musician drags the loop range out to 16 bars.
+            playHead.loopEndPpq = 80.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            expect (pumpUntil ([&] { return panel.getDurationEditor().getText() == "32"; }, 5000),
+                    "duration stayed at " + panel.getDurationEditor().getText());
+        }
+
+        beginTest ("AC: a manual duration override survives the host, and clearing resumes");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            panel.getDurationEditor().setText ("45", true);
+            expect (pumpUntil ([&] { return ! panel.isDurationSynced(); }, 5000),
+                    "typing a duration did not stop the tracking");
+
+            playHead.loopEndPpq = 80.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            expect (! pumpUntil ([&] { return panel.getDurationEditor().getText() != "45"; }, 1500),
+                    "the host overwrote a manually entered duration");
+
+            // Clearing hands it back, exactly as the BPM field does.
+            panel.getDurationEditor().setText ("", true);
+            expect (pumpUntil ([&] { return panel.getDurationEditor().getText() == "32"; }, 5000),
+                    "clearing did not resume selection tracking");
+        }
+
+        beginTest ("AC: with no selection the panel behaves exactly as it did in Stage 23");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            // No cycle locators set: loopStartPpq == loopEndPpq == 0.
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            // The Stage-23 default, untouched.
+            expectEquals (panel.getDurationEditor().getText(), juce::String ("60"));
+            panel.getPromptEditor().setText ("no selection here", true);
+            expectEquals (panel.buildRequest().durationSeconds, 60);
+
+            expect (panel.getSelectionLabel().getText().containsIgnoreCase ("none"),
+                    "did not report the absent selection: "
+                        + panel.getSelectionLabel().getText());
+
+            // And it stays 60 across several ticks rather than drifting to 0.
+            expect (! pumpUntil ([&] { return panel.getDurationEditor().getText() != "60"; }, 1500),
+                    "the duration moved with no selection to move it");
+        }
+
+        beginTest ("a selection with no host tempo sets no duration and says why");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 0.0;              // host publishes no tempo
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+
+            // Without a tempo the length in seconds is unknowable — 0 would be a lie.
+            expectEquals (panel.getDurationEditor().getText(), juce::String ("60"));
+
+            const auto text = panel.getSelectionLabel().getText();
+            expect (! text.contains ("0.0s"), "reported a fabricated length: " + text);
+            expect (text.containsIgnoreCase ("no host tempo"), "did not explain: " + text);
+        }
+
         beginTest ("applying a request with its own BPM takes the field off sync");
         {
             PluginProcessor processor (nullptr, false);

--- a/plugin/tests/GenerationPanelTests.cpp
+++ b/plugin/tests/GenerationPanelTests.cpp
@@ -642,6 +642,75 @@ public:
             expect (text.containsIgnoreCase ("no host tempo"), "did not explain: " + text);
         }
 
+        beginTest ("clearing a field and hitting Generate immediately uses the host value");
+        {
+            // The 2Hz timer is not the only path that has to be right: a user who clears
+            // the duration to resume sync and clicks Generate straight away must get the
+            // selection's length, not the 60 second fallback an empty field means.
+            PluginProcessor processor (nullptr, false);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;     // 16 seconds
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 640);
+            auto& panel = editor.getGenerationPanel();
+            panel.getPromptEditor().setText ("something", true);
+
+            panel.getDurationEditor().setText ("45", true);
+            expect (pumpUntil ([&] { return ! panel.isDurationSynced(); }, 5000));
+
+            // Clear it, then read the request with no timer tick in between.
+            panel.getDurationEditor().setText ("", juce::sendNotificationSync);
+
+            expectEquals (panel.buildRequest().durationSeconds, 16,
+                          "an immediate Generate after clearing fell back to the default");
+
+            // Same for BPM: clearing must restore the host tempo, not leave it on Auto.
+            panel.getBpmEditor().setText ("100", true);
+            expect (pumpUntil ([&] { return ! panel.isBpmSynced(); }, 5000));
+            panel.getBpmEditor().setText ("", juce::sendNotificationSync);
+
+            expectEquals (panel.buildRequest().bpm, 120,
+                          "an immediate Generate after clearing BPM fell back to Auto");
+        }
+
+        beginTest ("the sync and selection readouts fit the space they are given");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;
+            processor.getHostSync().captureFrom (&playHead);
+
+            PluginEditor editor (processor);
+            // The minimum the editor allows, so this is the worst case a user can make.
+            editor.setSize (560, 700);
+            auto& panel = editor.getGenerationPanel();
+
+            const auto fits = [this] (juce::Label& label, const char* what)
+            {
+                const auto needed = juce::GlyphArrangement::getStringWidth (label.getFont(),
+                                                                           label.getText());
+                expect ((float) label.getWidth() >= needed,
+                        juce::String (what) + " is clipped: \"" + label.getText() + "\" needs "
+                            + juce::String (needed, 0) + "px, has "
+                            + juce::String (label.getWidth()) + "px");
+            };
+
+            fits (panel.getSyncLabel(), "the sync indicator");
+            fits (panel.getSelectionLabel(), "the selection readout");
+        }
+
         beginTest ("applying a request with its own BPM takes the field off sync");
         {
             PluginProcessor processor (nullptr, false);

--- a/plugin/tests/HostSyncTests.cpp
+++ b/plugin/tests/HostSyncTests.cpp
@@ -81,6 +81,133 @@ public:
             expect (! snapshot.hasTime());
         }
 
+        //======================================================================
+        // US-24.2 — the host's loop / cycle range as a selection.
+
+        beginTest ("AC: bars 5-13 at 120 BPM 4/4 is a 16 second selection");
+        {
+            HostSync sync;
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+
+            // Bar 5 starts after 4 bars = 16 quarter notes; bar 13 after 48.
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;
+
+            sync.captureFrom (&playHead);
+
+            const auto selection = HostSync::describeSelection (sync.get());
+
+            expect (selection.present, "the loop range was not seen");
+            expect (selection.hasLength);
+            expect (selection.hasBars);
+
+            // 32 quarter notes at 120 BPM = 32 * 0.5s = 16s. This is the story's example.
+            expectWithinAbsoluteError (selection.lengthSeconds, 16.0, 1.0e-9);
+            expectWithinAbsoluteError (selection.startBar, 5.0, 1.0e-9);
+            expectWithinAbsoluteError (selection.endBar, 13.0, 1.0e-9);
+        }
+
+        beginTest ("bar arithmetic follows the time signature, not a hardcoded 4/4");
+        {
+            const auto barsFor = [] (int numerator, int denominator, double ppq)
+            {
+                HostSync::Snapshot snapshot;
+                snapshot.bpm = 120.0;
+                snapshot.timeSigNumerator = numerator;
+                snapshot.timeSigDenominator = denominator;
+                snapshot.loopStartPpq = ppq;
+                snapshot.loopEndPpq = ppq + 4.0;
+                return HostSync::describeSelection (snapshot).startBar;
+            };
+
+            // 3/4: 3 quarter notes to the bar, so bar 3 starts at 6 quarter notes.
+            expectWithinAbsoluteError (barsFor (3, 4, 6.0), 3.0, 1.0e-9);
+
+            // 6/8: 6 eighths = 3 quarter notes to the bar. Same maths, different route.
+            expectWithinAbsoluteError (barsFor (6, 8, 6.0), 3.0, 1.0e-9);
+
+            // 7/8: 3.5 quarter notes to the bar.
+            expectWithinAbsoluteError (barsFor (7, 8, 7.0), 3.0, 1.0e-9);
+
+            // 4/4 sanity: bar 1 is at 0, not bar 0.
+            expectWithinAbsoluteError (barsFor (4, 4, 0.0), 1.0, 1.0e-9);
+        }
+
+        beginTest ("a selection with no tempo has no length, rather than a length of zero");
+        {
+            HostSync::Snapshot snapshot;
+            snapshot.bpm = 0.0;                 // host publishes no tempo
+            snapshot.loopStartPpq = 16.0;
+            snapshot.loopEndPpq = 48.0;
+            snapshot.timeSigNumerator = 4;
+            snapshot.timeSigDenominator = 4;
+
+            const auto selection = HostSync::describeSelection (snapshot);
+
+            expect (selection.present, "the range itself is still known");
+            expect (! selection.hasLength, "an unknowable length was reported as known");
+            expectEquals (selection.lengthSeconds, 0.0);
+
+            // The bars do not depend on tempo, so they are still available.
+            expect (selection.hasBars);
+            expectWithinAbsoluteError (selection.startBar, 5.0, 1.0e-9);
+        }
+
+        beginTest ("a selection with no time signature still has a length");
+        {
+            HostSync::Snapshot snapshot;
+            snapshot.bpm = 120.0;
+            snapshot.loopStartPpq = 16.0;
+            snapshot.loopEndPpq = 48.0;
+            // no time signature reported
+
+            const auto selection = HostSync::describeSelection (snapshot);
+
+            expect (selection.present);
+            expect (selection.hasLength);
+            expectWithinAbsoluteError (selection.lengthSeconds, 16.0, 1.0e-9);
+            expect (! selection.hasBars, "bars were invented without a time signature");
+        }
+
+        beginTest ("AC: no selection is reported when the host has no loop range");
+        {
+            HostSync sync;
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            // loopStartPpq == loopEndPpq == 0: no cycle locators set
+
+            sync.captureFrom (&playHead);
+
+            const auto selection = HostSync::describeSelection (sync.get());
+            expect (! selection.present, "a selection was invented from an empty loop range");
+            expect (! selection.hasLength);
+            expect (! selection.hasBars);
+        }
+
+        beginTest ("clearing the loop range in the host clears the selection");
+        {
+            HostSync sync;
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;
+
+            sync.captureFrom (&playHead);
+            expect (HostSync::describeSelection (sync.get()).present);
+
+            playHead.loopStartPpq = 0.0;
+            playHead.loopEndPpq = 0.0;
+            sync.captureFrom (&playHead);
+
+            expect (! HostSync::describeSelection (sync.get()).present,
+                    "a stale selection survived the host clearing its loop range");
+        }
+
         beginTest ("a host reporting a position but no tempo is not a tempo of 0");
         {
             HostSync sync;

--- a/plugin/tests/ResultsPanelTests.cpp
+++ b/plugin/tests/ResultsPanelTests.cpp
@@ -609,6 +609,64 @@ public:
                         + " samples, expected " + juce::String (expected));
         }
 
+        beginTest ("AC (amended, see #318): each clip is tagged with the bar to drop it at");
+        {
+            // VST3 cannot place audio on the host timeline, so the reachable form of
+            // "insert at the selection start" is reporting where the selection starts.
+            ScopedClips clips;
+            Harness harness;
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;   // bar 5
+            playHead.loopEndPpq = 48.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            harness.generation().setClipsForTesting (clips.files, 120);
+            expect (pumpUntil ([&] { return harness.panel().getNumClipRows() == 2; }));
+
+            auto* row = harness.panel().getClipRow (0);
+
+            expect (pumpUntil ([&] { return row->getNameLabel().getText().contains ("bar 5"); }, 5000),
+                    "the row does not say where to drop it: " + row->getNameLabel().getText());
+
+            // Moving the selection moves the tag.
+            playHead.loopStartPpq = 32.0;   // bar 9
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            expect (pumpUntil ([&] { return row->getNameLabel().getText().contains ("bar 9"); }, 5000),
+                    "the tag stayed at the old bar: " + row->getNameLabel().getText());
+
+            // And clearing the loop range clears the tag rather than stranding it.
+            playHead.loopStartPpq = 0.0;
+            playHead.loopEndPpq = 0.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            expect (pumpUntil ([&] { return ! row->getNameLabel().getText().contains ("bar"); }, 5000),
+                    "a stale drop target survived the selection going away: "
+                        + row->getNameLabel().getText());
+        }
+
+        beginTest ("with no selection the clip row is captioned exactly as in Stage 23");
+        {
+            ScopedClips clips;
+            Harness harness;
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            harness.generation().setClipsForTesting (clips.files, 120);
+            expect (pumpUntil ([&] { return harness.panel().getNumClipRows() == 2; }));
+
+            auto* row = harness.panel().getClipRow (0);
+            expect (! pumpUntil ([&] { return row->getNameLabel().getText() != "Clip 1"; }, 1500),
+                    "the caption gained something with no selection and no tempo match: "
+                        + row->getNameLabel().getText());
+        }
+
         beginTest ("tempo-matched copies do not show up as extra clips in the cache browser");
         {
             // The cache browser lists *.wav in a run directory. A tempo match written

--- a/plugin/tests/ResultsPanelTests.cpp
+++ b/plugin/tests/ResultsPanelTests.cpp
@@ -649,6 +649,39 @@ public:
                         + row->getNameLabel().getText());
         }
 
+        beginTest ("the clip caption fits the space it is given");
+        {
+            // The caption carries a tempo tag (US-24.1) and a drop-target bar (US-24.2).
+            // Both are pointless if the label is too narrow to show them.
+            ScopedClips clips;
+            Harness harness;
+
+            test::FakePlayHead playHead;
+            playHead.bpm = 120.0;
+            playHead.timeSigNumerator = 4;
+            playHead.timeSigDenominator = 4;
+            playHead.loopStartPpq = 16.0;
+            playHead.loopEndPpq = 48.0;
+            harness.processor.getHostSync().captureFrom (&playHead);
+
+            harness.generation().setClipsForTesting (clips.files, 118);
+            expect (pumpUntil ([&] { return harness.panel().getNumClipRows() == 2; }));
+
+            auto* row = harness.panel().getClipRow (0);
+
+            // Wait for the fullest caption: tempo match AND drop target.
+            expect (pumpUntil ([&] { return row->getNameLabel().getText().contains ("BPM")
+                                             && row->getNameLabel().getText().contains ("bar"); }, 20000),
+                    "never reached the full caption: " + row->getNameLabel().getText());
+
+            auto& label = row->getNameLabel();
+            const auto needed = juce::GlyphArrangement::getStringWidth (label.getFont(), label.getText());
+
+            expect ((float) label.getWidth() >= needed,
+                    "the clip caption is clipped: \"" + label.getText() + "\" needs "
+                        + juce::String (needed, 0) + "px, has " + juce::String (label.getWidth()) + "px");
+        }
+
         beginTest ("with no selection the clip row is captioned exactly as in Stage 23");
         {
             ScopedClips clips;


### PR DESCRIPTION
Implements **US-24.2 — Selection-Aware Generation** (#321).

The plugin follows the host's loop/cycle range: the generation panel displays it and the
**Duration** field is sized to it, so a generation fits the gap it was meant for.

---

## Acceptance criteria — evidence

| Criterion | Evidence |
| --- | --- |
| Selecting bars 5–13 auto-sets duration to the correct seconds | `GenerationPanel / AC: selecting bars 5-13 auto-sets the duration to 16 seconds` — the story's own example. Field reads `"16"` at construction and `buildRequest().durationSeconds == 16` |
| ~~"Generate & Insert" places audio starting at bar 5~~ | **Amended** per #318 → each clip row is tagged with the bar to drop it at (`Clip 1 -> 120 BPM @ bar 5`). See below |
| With no selection, behaves as in Stage 23 | `GenerationPanel / AC: with no selection the panel behaves exactly as it did in Stage 23` — duration stays at the 60 default and provably does not drift across ticks |
| Selection info displayed correctly | `GenerationPanel / AC: the selection is displayed in the generation panel` — asserts bars **and** length in the label |

`HostSync` bar arithmetic is covered for **4/4, 3/4, 6/8 and 7/8**, not just four-four.

## AC 2 — applying the decision already taken on #318

VST3 gives a plugin no way to write the host's arrangement. This is the identical
constraint raised on **#318** and resolved there: *"Insert to Track" became
drag-to-timeline, and the playhead-position criterion became "the plugin reports the
position so the user can align the drop."* I applied that settled decision rather than
re-asking.

**I did not add a "Generate & Insert" button.** With duration driven by the selection, the
existing Generate button already produces a correctly sized clip; a second button that
cannot actually place anything would promise a capability that does not exist. One honest
button beats two, one of which lies.

## What is actually being read

The **loop / cycle locators** — `AudioPlayHead::getLoopPoints()`, which JUCE fills from
`Vst::ProcessContext::kCycleValid` (`juce_audio_plugin_client_VST3.cpp:3120`). There is no
VST3 API for an arbitrary time selection. Reaper links the two by default; Cubase and Logic
use cycle markers. The README says this plainly rather than implying more.

## Design notes

**Duration reuses the BPM rule from US-24.1 exactly** — the host drives the field until the
user types, and clearing it hands control back. One mechanism to understand, not two.

**Absent host data is a rendered state, not a default.** A loop range with no tempo behind
it has no knowable length, so the panel shows the bars and says `no host tempo` rather than
claiming `0.0s`. Pinned by its own test.

**One writer for the clip caption.** The tempo tag (US-24.1) and the new bar tag both live
in `ClipRow::updateNameLabel()`, so they cannot overwrite each other's half.

`HostSync::formatBar` was extracted at its third call site, not before.

---

## Known limitations

1. Placement at the selection start is not possible (above). The clip is *sized* to the
   selection and the start bar is *reported*.
2. It follows the loop/cycle range. In a DAW where the time selection is not linked to it,
   moving the time selection alone will not update the plugin.
3. Bar numbers assume the reported time signature and a bar-1 origin. A host reporting no
   time signature shows the length only.
4. **Not verified in a real DAW** — none is installed here, and no unit test can make a
   real host publish a real loop range. `plugin/README.md` carries an explicit manual-check
   step. Everything below the host boundary is covered by tests driving a
   `juce::AudioPlayHead` double.

Closes #321
