### PR TITLE
feat(plugin): US-24.3 MIDI Input and Sidechain Audio (#322)

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -37,6 +37,7 @@ set(ACEMUSIC_SOURCES
     source/AceStepClient.cpp
     source/BackgroundTaskQueue.cpp
     source/ClipCache.cpp
+    source/AudioIo.cpp
     source/ClipPlayer.cpp
     source/ConnectionManager.cpp
     source/ConnectionPanel.cpp
@@ -45,9 +46,11 @@ set(ACEMUSIC_SOURCES
     source/GenerationPanel.cpp
     source/GenerationRequest.cpp
     source/HostSync.cpp
+    source/MidiCapture.cpp
     source/PluginProcessor.cpp
     source/PluginEditor.cpp
     source/ResultsPanel.cpp
+    source/SidechainCapture.cpp
     source/TimeStretch.cpp)
 
 # ---------------------------------------------------------------------------
@@ -64,7 +67,7 @@ juce_add_plugin(AceMusicPlugin
     PLUGIN_MANUFACTURER_CODE    Amst
     PLUGIN_CODE                 Aces
     IS_SYNTH                    FALSE
-    NEEDS_MIDI_INPUT            FALSE
+    NEEDS_MIDI_INPUT            TRUE
     NEEDS_MIDI_OUTPUT           FALSE
     IS_MIDI_EFFECT              FALSE
     EDITOR_WANTS_KEYBOARD_FOCUS TRUE
@@ -104,6 +107,7 @@ target_sources(AceMusicPluginTests PRIVATE
     tests/TestMain.cpp
     tests/AceStepClientTests.cpp
     tests/BackgroundTaskQueueTests.cpp
+    tests/CaptureTests.cpp
     tests/ClipCacheTests.cpp
     tests/ClipPlayerTests.cpp
     tests/ConnectionManagerTests.cpp

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -13,6 +13,7 @@ Progress:
 | US-23.5 — Local cache and file management | done |
 | US-24.1 — DAW tempo sync and tempo-matched insertion | done |
 | US-24.2 — Selection-aware generation | done |
+| US-24.3 — MIDI input and sidechain audio | done |
 
 | Format | Windows | macOS | Linux |
 | --- | --- | --- | --- |
@@ -218,6 +219,59 @@ Everything reads the host transport through `HostSync`, which samples the play
 head once in `processBlock` and publishes it. `getPlayHead()` is an audio-thread
 API; calling it from a timer, as the results panel used to for its playhead
 readout, is a data race.
+
+## MIDI and sidechain input
+
+Two more ways to seed a generation, beyond typing a prompt.
+
+| Mode | Needs | Server task type |
+| --- | --- | --- |
+| Text to Music | nothing | *(server default)* |
+| Cover | a sidechain capture | `cover` |
+| Complete | a MIDI capture | `complete` |
+| Repaint | a sidechain capture (+ the loop range) | `repaint` |
+
+A mode is greyed out until its input has actually been captured, so the selector never
+offers something that cannot be submitted.
+
+### MIDI reaches the model as audio, not as MIDI
+
+**ACE-Step has no MIDI input.** Its task types are `text2music`, `cover`, `repaint`,
+`extract`, `lego`, `complete` and `mashup`, and `complete` — the one this feeds — takes
+`src_audio_path`. There is not a single reference to MIDI anywhere in the ACE-Step
+source.
+
+So *Record MIDI* captures what you play, and the plugin **renders it to a plain tone**
+which is submitted as the melodic reference. The rendering is a description of the
+performance — pitch and rhythm — not an attempt to sound good. What conditions the model
+is that audio, not your note data.
+
+Nothing is synthesised on the audio thread: `processBlock` only pushes note events into
+a lock-free FIFO, and the rendering happens on the message thread when you disarm.
+
+If a take overruns the event buffer, the indicator says how many events were dropped
+rather than reporting the take as clean.
+
+### Sidechain
+
+*Capture sidechain* records the plugin's sidechain input, for Cover and Repaint. The
+sidechain bus is **disabled by default**, so a host with no sidechain send is unaffected
+and existing sessions do not change shape; the toggle is unavailable until you route
+something to it.
+
+The capture buffer is allocated once, in `prepareToPlay`, and holds up to
+`SidechainCapture::maxSeconds`. When it fills, recording stops and the indicator says so
+— it does not wrap, because overwriting the start of a take would quietly hand the model
+the wrong reference.
+
+**Repaint's time range** comes from the host loop range (US-24.2), expressed as an
+offset into the take rather than into the project. The transport position when the take
+started is recorded for exactly this. If the loop range does not overlap the capture,
+the range is omitted and the server decides.
+
+Captures are written under `<cache>/captures/` and referenced by `src_audio_path`. That
+is a **server-side** path, which works because the plugin targets a local ACE-Step;
+a remote server would need an upload endpoint.
 
 ## Networking
 

--- a/plugin/source/AudioIo.cpp
+++ b/plugin/source/AudioIo.cpp
@@ -1,0 +1,56 @@
+#include "AudioIo.h"
+
+namespace acemusic
+{
+namespace AudioIo
+{
+
+bool writeWav (const juce::File& destination,
+               const juce::AudioBuffer<float>& buffer,
+               double sampleRate,
+               int bitsPerSample)
+{
+    if (buffer.getNumSamples() <= 0 || buffer.getNumChannels() <= 0 || sampleRate <= 0.0)
+        return false;
+
+    destination.getParentDirectory().createDirectory();
+
+    const auto partial = destination.getSiblingFile (destination.getFileName() + ".partial");
+    partial.deleteFile();
+
+    {
+        juce::WavAudioFormat wav;
+        std::unique_ptr<juce::OutputStream> stream (partial.createOutputStream());
+
+        if (stream == nullptr)
+            return false;
+
+        auto writer = wav.createWriterFor (stream, juce::AudioFormatWriterOptions{}
+                                                       .withSampleRate (sampleRate)
+                                                       .withNumChannels (buffer.getNumChannels())
+                                                       .withBitsPerSample (bitsPerSample));
+
+        if (writer == nullptr)
+            return false;
+
+        if (! writer->writeFromAudioSampleBuffer (buffer, 0, buffer.getNumSamples()))
+        {
+            writer.reset();
+            partial.deleteFile();
+            return false;
+        }
+    }
+
+    destination.deleteFile();
+
+    if (! partial.moveFileTo (destination))
+    {
+        partial.deleteFile();
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace AudioIo
+} // namespace acemusic

--- a/plugin/source/AudioIo.h
+++ b/plugin/source/AudioIo.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+namespace acemusic
+{
+
+/**
+    The one place a buffer becomes a file on disk.
+
+    Extracted at its third caller (TimeStretch, MidiCapture, SidechainCapture) rather
+    than up front. All three want the same thing and the same care: write to a temporary
+    and move it into place, so nothing can ever read a half-written WAV and treat it as
+    a finished one.
+*/
+namespace AudioIo
+{
+    /** Writes `buffer` to `destination` as a 16-bit WAV, creating the parent directory.
+
+        The write goes to a `.partial` sibling first and is moved into place only once
+        complete; on any failure the partial is removed and `destination` is left as it
+        was. Touches the disk, so: never the audio thread.
+
+        @returns false if the buffer is empty, or the write or the move failed. */
+    bool writeWav (const juce::File& destination,
+                   const juce::AudioBuffer<float>& buffer,
+                   double sampleRate,
+                   int bitsPerSample = 16);
+}
+
+} // namespace acemusic

--- a/plugin/source/GenerationPanel.cpp
+++ b/plugin/source/GenerationPanel.cpp
@@ -477,14 +477,7 @@ juce::String GenerationPanel::getSelectionText() const
 
 bool GenerationPanel::isModeAvailable (GenerationRequest::Mode mode) const
 {
-    if (! GenerationRequest::needsSourceAudio (mode))
-        return true;
-
-    if (mode == GenerationRequest::Mode::complete)
-        return midiCapture != nullptr && midiCapture->hasCapture();
-
-    // Cover and Repaint both want the sidechain.
-    return hostOffersSidechain && sidechainCapture != nullptr && sidechainCapture->hasCapture();
+    return ! GenerationRequest::needsSourceAudio (mode) || hasCaptureFor (mode);
 }
 
 void GenerationPanel::refreshModeAvailability()
@@ -526,33 +519,36 @@ juce::String GenerationPanel::getCaptureText() const
     return parts.isEmpty() ? juce::String ("No input captured") : parts.joinIntoString ("  |  ");
 }
 
-bool GenerationPanel::attachSourceAudio (GenerationRequest& request) const
+juce::File GenerationPanel::getCaptureFileFor (GenerationRequest::Mode mode) const
 {
     const auto directory = generation.getClipDirectory().getChildFile ("captures");
 
-    if (request.mode == GenerationRequest::Mode::complete)
-    {
-        if (midiCapture == nullptr || ! midiCapture->hasCapture())
-            return false;
+    return mode == GenerationRequest::Mode::complete
+             ? directory.getChildFile ("midi-sketch.wav")
+             : directory.getChildFile ("sidechain.wav");
+}
 
-        const auto file = directory.getChildFile ("midi-sketch.wav");
+bool GenerationPanel::hasCaptureFor (GenerationRequest::Mode mode) const
+{
+    if (mode == GenerationRequest::Mode::complete)
+        return midiCapture != nullptr && midiCapture->hasCapture();
 
-        if (! midiCapture->writeTo (file))
-            return false;
+    return hostOffersSidechain && sidechainCapture != nullptr && sidechainCapture->hasCapture();
+}
 
-        request.sourceAudioPath = file.getFullPathName();
-        return true;
-    }
-
-    if (sidechainCapture == nullptr || ! sidechainCapture->hasCapture())
+bool GenerationPanel::attachSourceAudio (GenerationRequest& request) const
+{
+    if (! hasCaptureFor (request.mode))
         return false;
 
-    const auto file = directory.getChildFile ("sidechain.wav");
+    const auto file = getCaptureFileFor (request.mode);
+    request.sourceAudioPath = file.getFullPathName();
+
+    if (request.mode == GenerationRequest::Mode::complete)
+        return midiCapture->writeTo (file);
 
     if (! sidechainCapture->writeTo (file))
         return false;
-
-    request.sourceAudioPath = file.getFullPathName();
 
     if (request.mode == GenerationRequest::Mode::repaint)
     {
@@ -647,8 +643,18 @@ GenerationRequest GenerationPanel::buildRequest() const
     const auto qualityIndex = juce::jlimit (0, qualities.size() - 1, qualitySelector.getSelectedId() - 1);
     request.quality = qualities[qualityIndex];
 
-    request.mode = modeSelector.getSelectedId() == 2 ? GenerationRequest::Mode::cover
-                                                     : GenerationRequest::Mode::textToMusic;
+    // Indexed off the same list the selector was built from. The previous
+    // "id == 2 ? cover : textToMusic" silently submitted Complete and Repaint as
+    // text-to-music once the list grew past two entries.
+    const auto modes = GenerationRequest::allModes();
+    const auto modeIndex = juce::jlimit (0, modes.size() - 1, modeSelector.getSelectedId() - 1);
+    request.mode = modes[modeIndex];
+
+    // The capture is written at Generate time, but the path is known now — and has to
+    // be, or findProblem() would report "needs a source audio file" and keep Generate
+    // disabled forever for exactly the modes this story added.
+    if (GenerationRequest::needsSourceAudio (request.mode) && hasCaptureFor (request.mode))
+        request.sourceAudioPath = getCaptureFileFor (request.mode).getFullPathName();
 
     return request;
 }

--- a/plugin/source/GenerationPanel.cpp
+++ b/plugin/source/GenerationPanel.cpp
@@ -48,10 +48,16 @@ namespace
 //==============================================================================
 GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
                                   ConnectionManager& connectionToUse,
-                                  HostSync* hostSyncToUse)
+                                  HostSync* hostSyncToUse,
+                                  MidiCapture* midiCaptureToUse,
+                                  SidechainCapture* sidechainCaptureToUse,
+                                  bool hostOffersSidechainToUse)
     : generation (generationToUse),
       connection (connectionToUse),
-      hostSync (hostSyncToUse)
+      hostSync (hostSyncToUse),
+      midiCapture (midiCaptureToUse),
+      sidechainCapture (sidechainCaptureToUse),
+      hostOffersSidechain (hostOffersSidechainToUse)
 {
     titleLabel.setText ("GENERATION", juce::dontSendNotification);
     titleLabel.setFont (juce::FontOptions (13.0f, juce::Font::bold));
@@ -176,13 +182,63 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
     styleCaption (modeLabel, "Mode");
     addAndMakeVisible (modeLabel);
     styleCombo (modeSelector);
-    modeSelector.addItem (GenerationRequest::toString (GenerationRequest::Mode::textToMusic), 1);
-    modeSelector.addItem (GenerationRequest::toString (GenerationRequest::Mode::cover), 2);
+    {
+        const auto modes = GenerationRequest::allModes();
+
+        for (int i = 0; i < modes.size(); ++i)
+            modeSelector.addItem (GenerationRequest::toString (modes[i]), i + 1);
+    }
     modeSelector.setSelectedId (1, juce::dontSendNotification);
     modeSelector.onChange = [this] { refresh(); };
     addAndMakeVisible (modeSelector);
 
-    generateButton.onClick = [this] { generation.start (buildRequest()); };
+    // Capture arming. Both are no-ops without the corresponding capture, which is what
+    // a test that does not care about them gets.
+    midiRecordToggle.setColour (juce::ToggleButton::textColourId, genColours::textDim);
+    midiRecordToggle.onClick = [this]
+    {
+        if (midiCapture != nullptr)
+            midiCapture->setRecording (midiRecordToggle.getToggleState());
+
+        refresh();
+    };
+    addAndMakeVisible (midiRecordToggle);
+
+    sidechainRecordToggle.setColour (juce::ToggleButton::textColourId, genColours::textDim);
+    sidechainRecordToggle.onClick = [this]
+    {
+        if (sidechainCapture != nullptr)
+        {
+            // The transport position is handed over so Repaint can express the host's
+            // loop range as an offset into this take rather than into the project.
+            const auto host = getHostSnapshot();
+            sidechainCapture->setRecording (sidechainRecordToggle.getToggleState(),
+                                            host.hasTime() ? host.timeInSeconds : -1.0);
+        }
+
+        refresh();
+    };
+    sidechainRecordToggle.setEnabled (hostOffersSidechain);
+    addAndMakeVisible (sidechainRecordToggle);
+
+    captureLabel.setFont (juce::FontOptions (12.0f));
+    captureLabel.setColour (juce::Label::textColourId, genColours::textDim);
+    addAndMakeVisible (captureLabel);
+
+    generateButton.onClick = [this]
+    {
+        auto request = buildRequest();
+
+        // Writing the capture is deferred to the click rather than done on every edit:
+        // it touches the disk, and most edits never lead to a generation.
+        if (GenerationRequest::needsSourceAudio (request.mode) && ! attachSourceAudio (request))
+        {
+            refresh();
+            return;
+        }
+
+        generation.start (request);
+    };
     addAndMakeVisible (generateButton);
 
     cancelButton.onClick = [this] { generation.cancel(); };
@@ -279,6 +335,14 @@ void GenerationPanel::resized()
     // The host readouts get a row to themselves. Sharing the language row left them a
     // few pixels wide at the editor's minimum size, which made both unreadable — and a
     // readout nobody can read is not a feature.
+    auto captureRow = area.removeFromBottom (22);
+    midiRecordToggle.setBounds (captureRow.removeFromLeft (110));
+    sidechainRecordToggle.setBounds (captureRow.removeFromLeft (150));
+    captureRow.removeFromLeft (8);
+    captureLabel.setBounds (captureRow);
+
+    area.removeFromBottom (4);
+
     auto readoutRow = area.removeFromBottom (16);
     syncLabel.setBounds (readoutRow.removeFromRight (readoutRow.getWidth() / 2));
     selectionLabel.setBounds (readoutRow);
@@ -411,6 +475,112 @@ juce::String GenerationPanel::getSelectionText() const
     return text;
 }
 
+bool GenerationPanel::isModeAvailable (GenerationRequest::Mode mode) const
+{
+    if (! GenerationRequest::needsSourceAudio (mode))
+        return true;
+
+    if (mode == GenerationRequest::Mode::complete)
+        return midiCapture != nullptr && midiCapture->hasCapture();
+
+    // Cover and Repaint both want the sidechain.
+    return hostOffersSidechain && sidechainCapture != nullptr && sidechainCapture->hasCapture();
+}
+
+void GenerationPanel::refreshModeAvailability()
+{
+    const auto modes = GenerationRequest::allModes();
+
+    for (int i = 0; i < modes.size(); ++i)
+        modeSelector.setItemEnabled (i + 1, isModeAvailable (modes[i]));
+}
+
+juce::String GenerationPanel::getCaptureText() const
+{
+    juce::StringArray parts;
+
+    if (midiCapture != nullptr)
+    {
+        if (midiCapture->isRecording())
+            parts.add ("MIDI: recording");
+        else if (midiCapture->hasCapture())
+            parts.add ("MIDI: " + juce::String ((int) midiCapture->getNotes().size()) + " notes");
+
+        if (midiCapture->getDroppedCount() > 0)
+            parts.add (juce::String (midiCapture->getDroppedCount()) + " MIDI events dropped");
+    }
+
+    if (! hostOffersSidechain)
+    {
+        parts.add ("no sidechain routed");
+    }
+    else if (sidechainCapture != nullptr)
+    {
+        if (sidechainCapture->isRecording())
+            parts.add ("Sidechain: recording");
+        else if (sidechainCapture->hasCapture())
+            parts.add ("Sidechain: " + juce::String (sidechainCapture->getLengthSeconds(), 1) + "s"
+                           + (sidechainCapture->isFull() ? " (buffer full)" : ""));
+    }
+
+    return parts.isEmpty() ? juce::String ("No input captured") : parts.joinIntoString ("  |  ");
+}
+
+bool GenerationPanel::attachSourceAudio (GenerationRequest& request) const
+{
+    const auto directory = generation.getClipDirectory().getChildFile ("captures");
+
+    if (request.mode == GenerationRequest::Mode::complete)
+    {
+        if (midiCapture == nullptr || ! midiCapture->hasCapture())
+            return false;
+
+        const auto file = directory.getChildFile ("midi-sketch.wav");
+
+        if (! midiCapture->writeTo (file))
+            return false;
+
+        request.sourceAudioPath = file.getFullPathName();
+        return true;
+    }
+
+    if (sidechainCapture == nullptr || ! sidechainCapture->hasCapture())
+        return false;
+
+    const auto file = directory.getChildFile ("sidechain.wav");
+
+    if (! sidechainCapture->writeTo (file))
+        return false;
+
+    request.sourceAudioPath = file.getFullPathName();
+
+    if (request.mode == GenerationRequest::Mode::repaint)
+    {
+        // The host's loop range, expressed as an offset into this take. Omitted unless
+        // it actually overlaps what was captured — a range outside the reference would
+        // be worse than letting the server choose.
+        const auto host = getHostSnapshot();
+        const auto selection = HostSync::describeSelection (host);
+        const auto takeStart = sidechainCapture->getTransportStartSeconds();
+
+        if (selection.hasLength && takeStart >= 0.0 && host.hasBpm())
+        {
+            const auto loopStartSeconds = host.loopStartPpq * 60.0 / host.bpm;
+            const auto start = loopStartSeconds - takeStart;
+            const auto end = start + selection.lengthSeconds;
+            const auto length = sidechainCapture->getLengthSeconds();
+
+            if (end > 0.0 && start < length)
+            {
+                request.repaintStartSeconds = juce::jmax (0.0, start);
+                request.repaintEndSeconds = juce::jmin (length, end);
+            }
+        }
+    }
+
+    return true;
+}
+
 juce::String GenerationPanel::getSyncStatusText() const
 {
     if (! bpmSynced)
@@ -540,6 +710,16 @@ void GenerationPanel::refresh()
 
     if (selectionLabel.getText() != selectionText)
         selectionLabel.setText (selectionText, juce::dontSendNotification);
+
+    refreshModeAvailability();
+
+    const auto captureText = getCaptureText();
+
+    if (captureLabel.getText() != captureText)
+        captureLabel.setText (captureText, juce::dontSendNotification);
+
+    midiRecordToggle.setEnabled (! busy && midiCapture != nullptr);
+    sidechainRecordToggle.setEnabled (! busy && hostOffersSidechain && sidechainCapture != nullptr);
 
     for (auto* control : std::initializer_list<juce::Component*> {
              &promptEditor, &lyricsEditor, &lyricsToggle, &languageSelector, &instrumentalToggle,

--- a/plugin/source/GenerationPanel.h
+++ b/plugin/source/GenerationPanel.h
@@ -103,6 +103,13 @@ private:
     /** Greys out the modes whose input has not been captured. */
     void refreshModeAvailability();
 
+    /** Where the capture backing `mode` is written. Known before the write happens, so
+        buildRequest can name it and validation can pass. */
+    juce::File getCaptureFileFor (GenerationRequest::Mode) const;
+
+    /** Whether `mode`'s input has actually been captured. */
+    bool hasCaptureFor (GenerationRequest::Mode) const;
+
     /** Writes the capture a non-text mode needs and points `request` at it.
         @returns false when the mode's input is missing or could not be written. */
     bool attachSourceAudio (GenerationRequest&) const;

--- a/plugin/source/GenerationPanel.h
+++ b/plugin/source/GenerationPanel.h
@@ -2,6 +2,8 @@
 
 #include "GenerationManager.h"
 #include "HostSync.h"
+#include "MidiCapture.h"
+#include "SidechainCapture.h"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -24,7 +26,12 @@ public:
     /** @param hostSyncToUse  the host transport, or null for "there is no host" —
                               which is what a test that does not care about tempo
                               sync gets, and what the panel shows as no host tempo. */
-    GenerationPanel (GenerationManager&, ConnectionManager&, HostSync* hostSyncToUse = nullptr);
+    GenerationPanel (GenerationManager&,
+                     ConnectionManager&,
+                     HostSync* hostSyncToUse = nullptr,
+                     MidiCapture* midiCaptureToUse = nullptr,
+                     SidechainCapture* sidechainCaptureToUse = nullptr,
+                     bool hostOffersSidechain = false);
     ~GenerationPanel() override;
 
     void paint (juce::Graphics&) override;
@@ -54,6 +61,12 @@ public:
     juce::Label&        getStatusLabel() noexcept         { return statusLabel; }
     juce::Label&        getSyncLabel() noexcept           { return syncLabel; }
     juce::Label&        getSelectionLabel() noexcept      { return selectionLabel; }
+    juce::ToggleButton& getMidiRecordToggle() noexcept     { return midiRecordToggle; }
+    juce::ToggleButton& getSidechainRecordToggle() noexcept { return sidechainRecordToggle; }
+    juce::Label&        getCaptureLabel() noexcept         { return captureLabel; }
+
+    /** True when `mode` has the input it needs and can be chosen. */
+    bool isModeAvailable (GenerationRequest::Mode) const;
     juce::ProgressBar&  getProgressBar() noexcept         { return progressBar; }
 
     /** True while the BPM field is following the host rather than the user. */
@@ -84,9 +97,25 @@ private:
     /** What the selection readout should read right now. */
     juce::String getSelectionText() const;
 
+    /** What the capture indicator should read right now. */
+    juce::String getCaptureText() const;
+
+    /** Greys out the modes whose input has not been captured. */
+    void refreshModeAvailability();
+
+    /** Writes the capture a non-text mode needs and points `request` at it.
+        @returns false when the mode's input is missing or could not be written. */
+    bool attachSourceAudio (GenerationRequest&) const;
+
     GenerationManager& generation;
     ConnectionManager& connection;
     HostSync* hostSync = nullptr;
+    MidiCapture* midiCapture = nullptr;
+    SidechainCapture* sidechainCapture = nullptr;
+
+    /** Whether the host actually gave the plugin a sidechain bus. Without one, Cover and
+        Repaint can never be satisfied and say so rather than sitting there enabled. */
+    bool hostOffersSidechain = false;
 
     /** False once the user has typed their own BPM. Clearing the field back to the
         "Auto" placeholder sets it true again, which is how sync is resumed — the
@@ -127,6 +156,10 @@ private:
     juce::Label      statusLabel;
     juce::Label      syncLabel;
     juce::Label      selectionLabel;
+
+    juce::ToggleButton midiRecordToggle { "Record MIDI" };
+    juce::ToggleButton sidechainRecordToggle { "Capture sidechain" };
+    juce::Label        captureLabel;
 
     /** The server reports no percentage, so this runs in indeterminate mode while a
         job is in flight. See the progress note in the README. */

--- a/plugin/source/GenerationRequest.cpp
+++ b/plugin/source/GenerationRequest.cpp
@@ -35,6 +35,8 @@ juce::String GenerationRequest::toString (Mode mode) noexcept
     {
         case Mode::textToMusic:  return "Text to Music";
         case Mode::cover:        return "Cover";
+        case Mode::complete:     return "Complete";
+        case Mode::repaint:      return "Repaint";
     }
 
     return "Text to Music";
@@ -62,6 +64,36 @@ juce::StringArray GenerationRequest::vocalLanguages()
              "Urdu", "Vietnamese", "Welsh", "Yoruba", "Zulu" };
 }
 
+bool GenerationRequest::needsSourceAudio (Mode mode) noexcept
+{
+    return mode != Mode::textToMusic;
+}
+
+juce::String GenerationRequest::taskTypeFor (Mode mode) noexcept
+{
+    switch (mode)
+    {
+        case Mode::cover:    return "cover";
+        case Mode::complete: return "complete";
+        case Mode::repaint:  return "repaint";
+        // text2music is the server's default; the Python client omits it for exactly
+        // this reason, so sending it would be a behaviour change rather than a no-op.
+        case Mode::textToMusic: break;
+    }
+
+    return {};
+}
+
+juce::Array<GenerationRequest::Mode> GenerationRequest::allModes()
+{
+    return { Mode::textToMusic, Mode::cover, Mode::complete, Mode::repaint };
+}
+
+bool GenerationRequest::hasRepaintRange() const
+{
+    return repaintStartSeconds >= 0.0 && repaintEndSeconds > repaintStartSeconds;
+}
+
 juce::StringArray GenerationRequest::musicalKeys()
 {
     juce::StringArray keys { "Any" };
@@ -84,8 +116,8 @@ juce::String GenerationRequest::findProblem() const
     if (durationSeconds <= 0)
         return "Duration must be greater than zero";
 
-    if (mode == Mode::cover && sourceAudioPath.trim().isEmpty())
-        return "Cover mode needs a source audio file";
+    if (needsSourceAudio (mode) && sourceAudioPath.trim().isEmpty())
+        return toString (mode) + " mode needs a source audio file";
 
     return {};
 }
@@ -123,12 +155,18 @@ juce::var GenerationRequest::toPayload() const
     if (model.isNotEmpty())
         payload->setProperty ("model", model);
 
-    // text2music is the server's default; the Python client omits it for exactly
-    // this reason, so sending it would be a behaviour change rather than a no-op.
-    if (mode == Mode::cover)
+    if (const auto taskType = taskTypeFor (mode); taskType.isNotEmpty())
     {
-        payload->setProperty ("task_type", "cover");
+        payload->setProperty ("task_type", taskType);
         payload->setProperty ("src_audio_path", sourceAudioPath.trim());
+
+        // Repaint regenerates a range of the source rather than all of it. Omitted
+        // unless both ends are set, matching the Python client's optional handling.
+        if (mode == Mode::repaint && hasRepaintRange())
+        {
+            payload->setProperty ("repainting_start", repaintStartSeconds);
+            payload->setProperty ("repainting_end", repaintEndSeconds);
+        }
     }
 
     return juce::var (payload);

--- a/plugin/source/GenerationRequest.h
+++ b/plugin/source/GenerationRequest.h
@@ -15,12 +15,25 @@ namespace acemusic
 */
 struct GenerationRequest
 {
-    /** Text-to-Music or Cover. Cover needs a source reference. */
+    /** How the generation is seeded.
+
+        Every mode but textToMusic needs a source audio file. That is a property of the
+        server, not a choice: ACE-Step's cover / complete / repaint task types all take
+        `src_audio_path`, and it has no MIDI input at all — a MIDI sketch reaches
+        `complete` as audio rendered by MidiCapture. */
     enum class Mode
     {
         textToMusic,
-        cover
+        cover,      ///< restyle a reference: the sidechain capture
+        complete,   ///< flesh out a sketch: the MIDI capture, rendered
+        repaint     ///< regenerate a time range of a reference
     };
+
+    /** True when `mode` cannot be submitted without sourceAudioPath. */
+    static bool needsSourceAudio (Mode) noexcept;
+
+    /** The server's `task_type` for `mode`, or empty for the server default. */
+    static juce::String taskTypeFor (Mode) noexcept;
 
     /** Maps to `inference_steps`. The values come from the documented ranges in
         `src/acemusic/client.py` ("Turbo: 8, Standard: 32–64"), not from guesswork. */
@@ -50,8 +63,15 @@ struct GenerationRequest
     Quality quality = Quality::standard;
     Mode mode = Mode::textToMusic;
 
-    /** Server-side path to the source audio, for Cover mode. */
+    /** Server-side path to the source audio, for every mode but Text to Music. */
     juce::String sourceAudioPath;
+
+    /** Repaint only: the range of the source to regenerate, in seconds. A negative
+        start means "not set", and the range is omitted so the server decides. */
+    double repaintStartSeconds = -1.0;
+    double repaintEndSeconds = -1.0;
+
+    bool hasRepaintRange() const;
 
     /** Model name from the connection panel; empty = let the server decide. */
     juce::String model;
@@ -66,6 +86,9 @@ struct GenerationRequest
 
     /** Every quality preset, in menu order. */
     static juce::Array<Quality> allQualities();
+
+    /** Every mode, in menu order. */
+    static juce::Array<Mode> allModes();
 
     /** Vocal languages offered by the panel. */
     static juce::StringArray vocalLanguages();

--- a/plugin/source/MidiCapture.cpp
+++ b/plugin/source/MidiCapture.cpp
@@ -1,0 +1,209 @@
+#include "MidiCapture.h"
+#include "AudioIo.h"
+
+#include <cmath>
+
+namespace acemusic
+{
+
+namespace
+{
+    /** Short attack and release on every rendered note. Without them each note starts
+        and ends on a discontinuity, and a reference full of clicks describes the clicks
+        as much as the melody. */
+    constexpr double envelopeSeconds = 0.005;
+
+    /** Notes still held when recording stops are given this much tail rather than being
+        thrown away — a held final chord is usually the point of the take. */
+    constexpr double unfinishedNoteSeconds = 0.5;
+}
+
+void MidiCapture::prepare (double sampleRate)
+{
+    if (sampleRate > 0.0)
+        preparedSampleRate = sampleRate;
+}
+
+void MidiCapture::processBlock (const juce::MidiBuffer& midi, int numSamples) noexcept
+{
+    if (! recording.load (std::memory_order_relaxed))
+        return;
+
+    const auto blockStart = position.load (std::memory_order_relaxed);
+
+    for (const auto metadata : midi)
+    {
+        const auto message = metadata.getMessage();
+
+        if (! message.isNoteOnOrOff())
+            continue;
+
+        int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
+        fifo.prepareToWrite (1, start1, size1, start2, size2);
+
+        if (size1 + size2 < 1)
+        {
+            // Full. Dropping is the only option that does not allocate here; the count
+            // is surfaced so the take is not silently reported as complete.
+            dropped.fetch_add (1, std::memory_order_relaxed);
+            continue;
+        }
+
+        auto& event = events[(size_t) (size1 > 0 ? start1 : start2)];
+        event.sample = blockStart + metadata.samplePosition;
+        event.noteNumber = message.getNoteNumber();
+        event.velocity = message.getFloatVelocity();
+        // A note-on at velocity 0 is a note-off; juce::MidiMessage already knows this.
+        event.isNoteOn = message.isNoteOn();
+
+        fifo.finishedWrite (1);
+    }
+
+    position.store (blockStart + numSamples, std::memory_order_relaxed);
+}
+
+void MidiCapture::setRecording (bool shouldRecord)
+{
+    if (shouldRecord == recording.load())
+        return;
+
+    if (shouldRecord)
+    {
+        // A new take replaces the old one rather than appending to it.
+        clear();
+        recording.store (true);
+    }
+    else
+    {
+        recording.store (false);
+        drain();
+    }
+}
+
+void MidiCapture::drain()
+{
+    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
+    fifo.prepareToRead (fifo.getNumReady(), start1, size1, start2, size2);
+
+    const auto consume = [this] (int start, int size)
+    {
+        for (int i = 0; i < size; ++i)
+        {
+            const auto& event = events[(size_t) (start + i)];
+
+            if (event.isNoteOn)
+            {
+                notes.push_back ({ event.noteNumber, event.velocity, event.sample, -1 });
+                continue;
+            }
+
+            // Close the most recent open note of the same pitch. Searching backwards
+            // matters for repeated notes: the newest one is the one being released.
+            for (auto note = notes.rbegin(); note != notes.rend(); ++note)
+            {
+                if (note->noteNumber == event.noteNumber && note->endSample < 0)
+                {
+                    note->endSample = event.sample;
+                    break;
+                }
+            }
+        }
+    };
+
+    consume (start1, size1);
+    consume (start2, size2);
+
+    fifo.finishedRead (size1 + size2);
+}
+
+double MidiCapture::getLengthSeconds() const
+{
+    juce::int64 last = 0;
+
+    for (const auto& note : notes)
+    {
+        last = juce::jmax (last, note.isFinished()
+                                     ? note.endSample
+                                     : note.startSample + (juce::int64) (unfinishedNoteSeconds * preparedSampleRate));
+    }
+
+    return (double) last / preparedSampleRate;
+}
+
+void MidiCapture::clear()
+{
+    notes.clear();
+    position.store (0);
+    dropped.store (0);
+
+    int start1 = 0, size1 = 0, start2 = 0, size2 = 0;
+    fifo.prepareToRead (fifo.getNumReady(), start1, size1, start2, size2);
+    fifo.finishedRead (size1 + size2);
+}
+
+juce::AudioBuffer<float> MidiCapture::render() const
+{
+    const auto lengthSeconds = getLengthSeconds();
+
+    if (notes.empty() || lengthSeconds <= 0.0)
+        return {};
+
+    const auto numSamples = (int) std::ceil (lengthSeconds * preparedSampleRate);
+    juce::AudioBuffer<float> buffer (1, numSamples);
+    buffer.clear();
+
+    auto* out = buffer.getWritePointer (0);
+    const auto envelopeSamples = juce::jmax (1, (int) (envelopeSeconds * preparedSampleRate));
+
+    for (const auto& note : notes)
+    {
+        const auto start = (int) note.startSample;
+        const auto end = (int) (note.isFinished()
+                                    ? note.endSample
+                                    : note.startSample + (juce::int64) (unfinishedNoteSeconds * preparedSampleRate));
+
+        if (start >= numSamples || end <= start)
+            continue;
+
+        const auto last = juce::jmin (end, numSamples);
+        const auto frequency = juce::MidiMessage::getMidiNoteInHertz (note.noteNumber);
+        const auto increment = juce::MathConstants<double>::twoPi * frequency / preparedSampleRate;
+
+        // Velocity-scaled, and headroom for the overlap of a chord: several notes
+        // sounding at once must not sum past full scale.
+        const auto gain = 0.2f * juce::jlimit (0.05f, 1.0f, note.velocity);
+
+        for (int i = start; i < last; ++i)
+        {
+            const auto into = i - start;
+            const auto remaining = last - i;
+
+            const auto envelope = juce::jmin (1.0f,
+                                              (float) into / (float) envelopeSamples,
+                                              (float) remaining / (float) envelopeSamples);
+
+            out[i] += gain * envelope * (float) std::sin (increment * (double) into);
+        }
+    }
+
+    // A dense chord can still stack past 1.0; scale the whole take rather than clipping
+    // individual notes, which would change their relative levels.
+    const auto peak = buffer.getMagnitude (0, numSamples);
+
+    if (peak > 1.0f)
+        buffer.applyGain (1.0f / peak);
+
+    return buffer;
+}
+
+bool MidiCapture::writeTo (const juce::File& destination) const
+{
+    const auto rendered = render();
+
+    if (rendered.getNumSamples() <= 0)
+        return false;
+
+    return AudioIo::writeWav (destination, rendered, preparedSampleRate);
+}
+
+} // namespace acemusic

--- a/plugin/source/MidiCapture.h
+++ b/plugin/source/MidiCapture.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <array>
+#include <atomic>
+#include <vector>
+
+namespace acemusic
+{
+
+/**
+    Records MIDI played into the plugin, and renders it to audio for submission.
+
+    **Why it renders to audio at all.** ACE-Step has no MIDI input — its task types are
+    text2music / cover / repaint / extract / lego / complete / mashup, and `complete`,
+    the mode this feeds, takes `src_audio_path`. There is not one reference to MIDI in
+    the whole ACE-Step source. So a MIDI sketch can only reach the model as *audio*, and
+    this is what turns one into the other. The rendered tone is a description of the
+    performance — pitch and rhythm — not an attempt to sound good.
+
+    **Nothing is synthesised on the audio thread.** `processBlock` only pushes note
+    events into a lock-free FIFO. Draining, rendering and writing all happen on the
+    message thread, when the user stops recording. That is far less machinery than a
+    live juce::Synthesiser, and the audio callback keeps allocating nothing.
+*/
+class MidiCapture
+{
+public:
+    MidiCapture() = default;
+
+    /** One note, as captured. Times are in samples from the start of the recording. */
+    struct Note
+    {
+        int noteNumber = 0;
+        float velocity = 0.0f;
+        juce::int64 startSample = 0;
+
+        /** < 0 while the note is still held — i.e. no note-off has arrived yet. */
+        juce::int64 endSample = -1;
+
+        bool isFinished() const noexcept                      { return endSample > startSample; }
+    };
+
+    //==============================================================================
+    /** From prepareToPlay. Message thread. */
+    void prepare (double sampleRate);
+
+    /** Audio thread. Pushes any note events in `midi` into the FIFO when recording, and
+        advances the recording clock. Allocates nothing and never blocks; events beyond
+        the FIFO's capacity are dropped rather than growing it (see getDroppedCount). */
+    void processBlock (const juce::MidiBuffer& midi, int numSamples) noexcept;
+
+    //==============================================================================
+    /** Starts or stops recording. Starting clears whatever was captured before, so a
+        second take replaces the first rather than appending to it. Message thread. */
+    void setRecording (bool shouldRecord);
+
+    bool isRecording() const noexcept                         { return recording.load(); }
+
+    /** Moves everything the audio thread has pushed into the note list. Message thread;
+        cheap, and safe to call on a timer. */
+    void drain();
+
+    /** Notes captured, oldest first. Call drain() first. */
+    const std::vector<Note>& getNotes() const noexcept        { return notes; }
+
+    /** True when there is something worth submitting. */
+    bool hasCapture() const noexcept                          { return ! notes.empty(); }
+
+    /** How long the capture runs, in seconds. */
+    double getLengthSeconds() const;
+
+    /** Events the FIFO could not hold. Non-zero means the capture is incomplete, and
+        the UI says so rather than pretending the take was clean. */
+    int getDroppedCount() const noexcept                      { return dropped.load(); }
+
+    void clear();
+
+    //==============================================================================
+    /** Renders the captured notes to audio. Message thread — allocates. */
+    juce::AudioBuffer<float> render() const;
+
+    /** Renders and writes a mono WAV. @returns false if nothing was captured or the
+        file could not be written. */
+    bool writeTo (const juce::File& destination) const;
+
+private:
+    /** What crosses the thread boundary. Kept trivially copyable and small. */
+    struct Event
+    {
+        juce::int64 sample = 0;
+        int noteNumber = 0;
+        float velocity = 0.0f;
+        bool isNoteOn = false;
+    };
+
+    // 4096 events is minutes of ordinary playing. A fixed capacity is the point: the
+    // audio thread cannot allocate, so the choice is a bound or a leak.
+    static constexpr int fifoCapacity = 4096;
+
+    juce::AbstractFifo fifo { fifoCapacity };
+    std::array<Event, (size_t) fifoCapacity> events {};
+
+    std::atomic<bool> recording { false };
+    std::atomic<int> dropped { 0 };
+
+    /** Samples since recording started. Audio thread writes, message thread reads. */
+    std::atomic<juce::int64> position { 0 };
+
+    double preparedSampleRate = 44100.0;
+    std::vector<Note> notes;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MidiCapture)
+};
+
+} // namespace acemusic

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -16,7 +16,8 @@ namespace colours
 PluginEditor::PluginEditor (PluginProcessor& p)
     : juce::AudioProcessorEditor (&p),
       connectionPanel (p.getConnectionManager()),
-      generationPanel (p.getGenerationManager(), p.getConnectionManager(), &p.getHostSync()),
+      generationPanel (p.getGenerationManager(), p.getConnectionManager(), &p.getHostSync(),
+                       &p.getMidiCapture(), &p.getSidechainCapture(), p.hasSidechainInput()),
       resultsPanel (p.getGenerationManager(), p.getClipPlayer(), p.getHostSync(),
                     p.getBackgroundQueue(), p.getSettings())
 {
@@ -42,8 +43,10 @@ PluginEditor::PluginEditor (PluginProcessor& p)
     // Results now carries clip rows AND the cache browser, so it needs roughly twice
     // the height it did in US-23.4. Raised again rather than letting either half be
     // a sliver.
-    setResizeLimits (560, 700, 1600, 1600);
-    setSize (780, 860);
+    // Raised again for US-24.3: Generation gained a capture row and two host readouts,
+    // and below this the Results panel had no room left for a clip row at all.
+    setResizeLimits (560, 800, 1600, 1600);
+    setSize (780, 920);
 }
 
 PluginEditor::~PluginEditor() = default;
@@ -69,7 +72,9 @@ void PluginEditor::resized()
 
     // Both panels have real content now, so split the remaining space rather than
     // starving Results.
-    generationPanel.setBounds (area.removeFromTop (juce::jmax (230, area.getHeight() * 55 / 100)));
+    // Raised from 230: the capture row and the two host readouts are new since US-23.3,
+    // and below this the prompt box collapses to nothing.
+    generationPanel.setBounds (area.removeFromTop (juce::jmax (280, area.getHeight() * 55 / 100)));
     area.removeFromTop (12);
     resultsPanel.setBounds (area);
 }

--- a/plugin/source/PluginProcessor.cpp
+++ b/plugin/source/PluginProcessor.cpp
@@ -12,7 +12,11 @@ PluginProcessor::PluginProcessor()
 PluginProcessor::PluginProcessor (std::unique_ptr<juce::PropertiesFile> propertiesToUse, bool probeOnLoad)
     : juce::AudioProcessor (BusesProperties()
                                 .withInput  ("Input",  juce::AudioChannelSet::stereo(), true)
-                                .withOutput ("Output", juce::AudioChannelSet::stereo(), true)),
+                                .withOutput ("Output", juce::AudioChannelSet::stereo(), true)
+                                // Off by default: a host with no sidechain send must load
+                                // the plugin exactly as it did before US-24.3, and existing
+                                // sessions must not change shape underneath the user.
+                                .withInput  ("Sidechain", juce::AudioChannelSet::stereo(), false)),
       properties (std::move (propertiesToUse)),
       connectionManager (backgroundQueue, properties.get()),
       generationManager (backgroundQueue, connectionManager, properties.get())
@@ -32,6 +36,10 @@ void PluginProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
     // The clip preview is the only thing in this plugin that produces audio, and it
     // allocates everything it needs here rather than in the callback.
     clipPlayer.prepare (sampleRate, samplesPerBlock);
+
+    // Both captures take all the memory they will ever use here, for the same reason.
+    midiCapture.prepare (sampleRate);
+    sidechainCapture.prepare (sampleRate, juce::jmax (1, getChannelCountOfBus (true, 1)));
 }
 
 void PluginProcessor::releaseResources()
@@ -49,10 +57,33 @@ bool PluginProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
     // Input may be disabled entirely (AU allows this); otherwise it must match.
     const auto& in = layouts.getMainInputChannelSet();
 
-    return in == out || in == juce::AudioChannelSet::disabled();
+    if (in != out && in != juce::AudioChannelSet::disabled())
+        return false;
+
+    // The sidechain is optional and independent of the main pair: absent, mono or
+    // stereo. pluginval fuzzes every combination of these, so all three are accepted
+    // rather than only the one the UI happens to use.
+    if (layouts.inputBuses.size() > 1)
+    {
+        const auto& sidechain = layouts.getChannelSet (true, 1);
+
+        if (sidechain != juce::AudioChannelSet::disabled()
+            && sidechain != juce::AudioChannelSet::mono()
+            && sidechain != juce::AudioChannelSet::stereo())
+        {
+            return false;
+        }
+    }
+
+    return true;
 }
 
-void PluginProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer&)
+bool PluginProcessor::hasSidechainInput() const
+{
+    return getChannelCountOfBus (true, 1) > 0;
+}
+
+void PluginProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midi)
 {
     juce::ScopedNoDenormals noDenormals;
 
@@ -60,6 +91,16 @@ void PluginProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::Midi
     // position takes a snapshot from HostSync instead of calling getPlayHead() off
     // the audio thread, which is a data race.
     hostSync.captureFrom (getPlayHead());
+
+    // Both of these only record when armed, and neither allocates or blocks. The MIDI
+    // side pushes note events into a lock-free FIFO — nothing is synthesised here.
+    midiCapture.processBlock (midi, buffer.getNumSamples());
+
+    if (auto* sidechain = getBus (true, 1); sidechain != nullptr && sidechain->isEnabled())
+    {
+        const auto sidechainBuffer = sidechain->getBusBuffer (buffer);
+        sidechainCapture.processBlock (sidechainBuffer);
+    }
 
     // Passthrough. Any channel the host gave us as output but not as input has
     // undefined contents, so clear it.

--- a/plugin/source/PluginProcessor.h
+++ b/plugin/source/PluginProcessor.h
@@ -5,6 +5,8 @@
 #include "ConnectionManager.h"
 #include "GenerationManager.h"
 #include "HostSync.h"
+#include "MidiCapture.h"
+#include "SidechainCapture.h"
 
 #include <juce_audio_processors/juce_audio_processors.h>
 
@@ -55,7 +57,9 @@ public:
     const juce::String getName() const override               { return "AceMusic Studio"; }
     static juce::String getPluginVersion()                    { return ACEMUSIC_PLUGIN_VERSION; }
 
-    bool acceptsMidi() const override                         { return false; }
+    // US-24.3: MIDI is captured as a melodic sketch for Complete mode. The plugin still
+    // produces no MIDI and is not a MIDI effect.
+    bool acceptsMidi() const override                         { return true; }
     bool producesMidi() const override                        { return false; }
     bool isMidiEffect() const override                        { return false; }
     double getTailLengthSeconds() const override              { return 0.0; }
@@ -89,6 +93,16 @@ public:
         only place anything reads the play head — see HostSync for why. */
     HostSync& getHostSync() noexcept                          { return hostSync; }
 
+    /** MIDI played into the plugin, for Complete mode. */
+    MidiCapture& getMidiCapture() noexcept                    { return midiCapture; }
+
+    /** The sidechain input, for Cover and Repaint. */
+    SidechainCapture& getSidechainCapture() noexcept          { return sidechainCapture; }
+
+    /** True when the host actually gave us a sidechain bus with channels on it — a
+        Cover or Repaint offered without one would be a dead end. */
+    bool hasSidechainInput() const;
+
     /** The plugin config file, or null when running without one. */
     juce::PropertiesFile* getSettings() noexcept              { return properties.get(); }
 
@@ -103,6 +117,8 @@ private:
     GenerationManager generationManager;
     ClipPlayer clipPlayer;
     HostSync hostSync;
+    MidiCapture midiCapture;
+    SidechainCapture sidechainCapture;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PluginProcessor)
 };

--- a/plugin/source/SidechainCapture.cpp
+++ b/plugin/source/SidechainCapture.cpp
@@ -1,0 +1,111 @@
+#include "SidechainCapture.h"
+#include "AudioIo.h"
+
+namespace acemusic
+{
+
+void SidechainCapture::prepare (double sampleRate, int numChannels)
+{
+    if (sampleRate <= 0.0 || numChannels <= 0)
+        return;
+
+    preparedSampleRate = sampleRate;
+
+    // Allocated here, on the message thread, and never again.
+    buffer.setSize (numChannels, (int) (sampleRate * (double) maxSeconds), false, true, false);
+    clear();
+}
+
+void SidechainCapture::processBlock (const juce::AudioBuffer<float>& source) noexcept
+{
+    if (! recording.load (std::memory_order_relaxed))
+        return;
+
+    const auto capacity = buffer.getNumSamples();
+    const auto offset = (int) written.load (std::memory_order_relaxed);
+    const auto available = capacity - offset;
+
+    if (available <= 0)
+    {
+        // Stop rather than wrap: overwriting the start of the take would quietly hand
+        // the model the wrong reference.
+        recording.store (false, std::memory_order_relaxed);
+        full.store (true, std::memory_order_relaxed);
+        return;
+    }
+
+    const auto toCopy = juce::jmin (available, source.getNumSamples());
+    const auto channels = juce::jmin (buffer.getNumChannels(), source.getNumChannels());
+
+    for (int channel = 0; channel < channels; ++channel)
+        buffer.copyFrom (channel, offset, source, channel, 0, toCopy);
+
+    // A mono sidechain into a stereo buffer would otherwise leave the right channel as
+    // whatever the last take put there.
+    for (int channel = channels; channel < buffer.getNumChannels(); ++channel)
+        buffer.copyFrom (channel, offset, source, 0, 0, toCopy);
+
+    written.store ((juce::int64) (offset + toCopy), std::memory_order_relaxed);
+
+    if (toCopy < source.getNumSamples())
+    {
+        recording.store (false, std::memory_order_relaxed);
+        full.store (true, std::memory_order_relaxed);
+    }
+}
+
+void SidechainCapture::setRecording (bool shouldRecord, double transportSecondsAtStart)
+{
+    if (shouldRecord == recording.load())
+        return;
+
+    if (shouldRecord)
+    {
+        clear();
+        transportStart = transportSecondsAtStart;
+        recording.store (true);
+    }
+    else
+    {
+        recording.store (false);
+    }
+}
+
+double SidechainCapture::getLengthSeconds() const
+{
+    return (double) written.load() / preparedSampleRate;
+}
+
+void SidechainCapture::clear()
+{
+    written.store (0);
+    full.store (false);
+    buffer.clear();
+}
+
+juce::AudioBuffer<float> SidechainCapture::getCapturedAudio() const
+{
+    const auto length = (int) written.load();
+
+    if (length <= 0 || buffer.getNumChannels() <= 0)
+        return {};
+
+    juce::AudioBuffer<float> captured (buffer.getNumChannels(), length);
+
+    for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
+        captured.copyFrom (channel, 0, buffer, channel, 0, length);
+
+    return captured;
+}
+
+bool SidechainCapture::writeTo (const juce::File& destination) const
+{
+    const auto captured = getCapturedAudio();
+
+    if (captured.getNumSamples() <= 0)
+        return false;
+
+    return AudioIo::writeWav (destination, captured, preparedSampleRate);
+}
+
+} // namespace acemusic

--- a/plugin/source/SidechainCapture.h
+++ b/plugin/source/SidechainCapture.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+
+#include <atomic>
+
+namespace acemusic
+{
+
+/**
+    Records the plugin's sidechain input, so an existing DAW track can be used as the
+    reference for Cover and Repaint generation.
+
+    The buffer is allocated once in prepare() and never grows. That is not a
+    simplification to revisit: the audio thread cannot allocate, so a recording either
+    has a bound or it is a hazard. Recording stops of its own accord when the buffer is
+    full, and `isFull()` says so, rather than silently overwriting the take.
+*/
+class SidechainCapture
+{
+public:
+    SidechainCapture() = default;
+
+    /** How much audio a take can hold. Generated clips are up to a few minutes and a
+        reference only needs to describe the material, so this is generous. */
+    static constexpr int maxSeconds = 120;
+
+    /** From prepareToPlay. Message thread — this is where the memory comes from. */
+    void prepare (double sampleRate, int numChannels);
+
+    /** Audio thread. Appends `source` while recording. Allocates nothing, never blocks,
+        and stops recording rather than wrapping when the buffer fills. */
+    void processBlock (const juce::AudioBuffer<float>& source) noexcept;
+
+    //==============================================================================
+    /** Starts or stops. Starting discards the previous take. Message thread.
+
+        @param transportSecondsAtStart  where the host transport was when recording
+               began, or < 0 if unknown. Repaint needs it to express the host's loop
+               range as an offset into *this take* rather than into the project. */
+    void setRecording (bool shouldRecord, double transportSecondsAtStart = -1.0);
+
+    /** Host transport position when this take started, or < 0 if it was not recorded. */
+    double getTransportStartSeconds() const noexcept          { return transportStart; }
+
+    bool isRecording() const noexcept                         { return recording.load(); }
+
+    /** True once the take hit the buffer bound and recording stopped itself. */
+    bool isFull() const noexcept                              { return full.load(); }
+
+    /** True when there is something worth submitting. */
+    bool hasCapture() const noexcept                          { return getRecordedSamples() > 0; }
+
+    juce::int64 getRecordedSamples() const noexcept           { return written.load(); }
+    double getLengthSeconds() const;
+
+    void clear();
+
+    //==============================================================================
+    /** Writes the take as a WAV. @returns false if nothing was captured or the write
+        failed. Message thread. */
+    bool writeTo (const juce::File& destination) const;
+
+    /** The captured audio. Message thread; for tests and rendering. */
+    juce::AudioBuffer<float> getCapturedAudio() const;
+
+private:
+    juce::AudioBuffer<float> buffer;
+
+    std::atomic<bool> recording { false };
+    std::atomic<bool> full { false };
+
+    /** Samples written so far. Audio thread writes, message thread reads. */
+    std::atomic<juce::int64> written { 0 };
+
+    double preparedSampleRate = 44100.0;
+    double transportStart = -1.0;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SidechainCapture)
+};
+
+} // namespace acemusic

--- a/plugin/source/TimeStretch.cpp
+++ b/plugin/source/TimeStretch.cpp
@@ -1,4 +1,5 @@
 #include "TimeStretch.h"
+#include "AudioIo.h"
 
 #include <cmath>
 #include <vector>
@@ -223,47 +224,8 @@ bool processFile (const juce::File& source,
 
     const auto sampleRate = reader->sampleRate;
     const auto bitDepth = juce::jmax (16, (int) reader->bitsPerSample);
-    const auto numChannels = (unsigned int) stretched.getNumChannels();
 
-    // Written to a temporary first: a reader that finds a half-written file next to a
-    // clip would treat it as a finished tempo match and hand the host a truncated drop.
-    destination.getParentDirectory().createDirectory();
-
-    const auto partial = destination.getSiblingFile (destination.getFileName() + ".partial");
-    partial.deleteFile();
-
-    {
-        juce::WavAudioFormat wav;
-        std::unique_ptr<juce::OutputStream> stream (partial.createOutputStream());
-
-        if (stream == nullptr)
-            return false;
-
-        auto writer = wav.createWriterFor (stream, juce::AudioFormatWriterOptions{}
-                                                       .withSampleRate (sampleRate)
-                                                       .withNumChannels ((int) numChannels)
-                                                       .withBitsPerSample (bitDepth));
-
-        if (writer == nullptr)
-            return false;
-
-        if (! writer->writeFromAudioSampleBuffer (stretched, 0, stretched.getNumSamples()))
-        {
-            writer.reset();
-            partial.deleteFile();
-            return false;
-        }
-    }
-
-    destination.deleteFile();
-
-    if (! partial.moveFileTo (destination))
-    {
-        partial.deleteFile();
-        return false;
-    }
-
-    return true;
+    return AudioIo::writeWav (destination, stretched, sampleRate, bitDepth);
 }
 
 //==============================================================================

--- a/plugin/tests/CaptureTests.cpp
+++ b/plugin/tests/CaptureTests.cpp
@@ -1,0 +1,404 @@
+#include "MidiCapture.h"
+#include "SidechainCapture.h"
+
+#include <cmath>
+
+namespace acemusic
+{
+
+/** MidiCapture and SidechainCapture: the two things US-24.3 feeds the server with. */
+class CaptureTests final : public juce::UnitTest
+{
+public:
+    CaptureTests()
+        : juce::UnitTest ("Capture", "acemusic")
+    {
+    }
+
+    static constexpr double sampleRate = 44100.0;
+
+    /** A note-on and its note-off, `lengthSamples` apart, delivered across blocks. */
+    static void playNote (MidiCapture& capture, int noteNumber, int startSample,
+                          int lengthSamples, int blockSize = 512, float velocity = 0.8f)
+    {
+        const auto endSample = startSample + lengthSamples;
+
+        for (int block = 0; block * blockSize < endSample + blockSize; ++block)
+        {
+            const auto blockStart = block * blockSize;
+            juce::MidiBuffer midi;
+
+            if (startSample >= blockStart && startSample < blockStart + blockSize)
+                midi.addEvent (juce::MidiMessage::noteOn (1, noteNumber, velocity),
+                               startSample - blockStart);
+
+            if (endSample >= blockStart && endSample < blockStart + blockSize)
+                midi.addEvent (juce::MidiMessage::noteOff (1, noteNumber),
+                               endSample - blockStart);
+
+            capture.processBlock (midi, blockSize);
+        }
+    }
+
+    static double estimateFrequency (const juce::AudioBuffer<float>& buffer, int from, int to)
+    {
+        const auto* data = buffer.getReadPointer (0);
+        int crossings = 0;
+
+        for (int i = from + 1; i < to; ++i)
+            if ((data[i - 1] < 0.0f) != (data[i] < 0.0f))
+                ++crossings;
+
+        return (double) crossings / 2.0 / ((double) (to - from) / sampleRate);
+    }
+
+    void runTest() override
+    {
+        //======================================================================
+        beginTest ("nothing is captured until recording is armed");
+        {
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+
+            playNote (capture, 69, 0, 4410);
+            capture.drain();
+
+            expect (! capture.hasCapture(), "captured MIDI without being armed");
+            expect (capture.getNotes().empty());
+        }
+
+        beginTest ("AC: playing MIDI into the plugin captures it");
+        {
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+            capture.setRecording (true);
+
+            playNote (capture, 69, 1000, 22050);      // A4, half a second
+            capture.setRecording (false);              // stopping drains
+
+            expect (capture.hasCapture(), "nothing was captured");
+            expectEquals ((int) capture.getNotes().size(), 1);
+
+            const auto& note = capture.getNotes().front();
+            expectEquals (note.noteNumber, 69);
+            expect (note.isFinished(), "the note-off never landed");
+            expectEquals ((int) note.startSample, 1000);
+            expectEquals ((int) note.endSample, 1000 + 22050);
+            expectWithinAbsoluteError (note.velocity, 0.8f, 0.02f);
+        }
+
+        beginTest ("a chord captures every note, and repeats close the right one");
+        {
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+            capture.setRecording (true);
+
+            // C major triad held together.
+            juce::MidiBuffer on;
+            on.addEvent (juce::MidiMessage::noteOn (1, 60, 0.7f), 0);
+            on.addEvent (juce::MidiMessage::noteOn (1, 64, 0.7f), 0);
+            on.addEvent (juce::MidiMessage::noteOn (1, 67, 0.7f), 0);
+            capture.processBlock (on, 512);
+
+            for (int i = 0; i < 10; ++i)
+                capture.processBlock ({}, 512);
+
+            juce::MidiBuffer off;
+            off.addEvent (juce::MidiMessage::noteOff (1, 60), 0);
+            off.addEvent (juce::MidiMessage::noteOff (1, 64), 0);
+            off.addEvent (juce::MidiMessage::noteOff (1, 67), 0);
+            capture.processBlock (off, 512);
+
+            capture.setRecording (false);
+
+            expectEquals ((int) capture.getNotes().size(), 3);
+
+            for (const auto& note : capture.getNotes())
+                expect (note.isFinished(), "note " + juce::String (note.noteNumber) + " never closed");
+        }
+
+        beginTest ("a note-on at velocity 0 is treated as a note-off");
+        {
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+            capture.setRecording (true);
+
+            juce::MidiBuffer midi;
+            midi.addEvent (juce::MidiMessage::noteOn (1, 60, 0.8f), 0);
+            capture.processBlock (midi, 512);
+
+            juce::MidiBuffer running;
+            // Running-status note-off: note-on with velocity 0. Sequencers emit these.
+            running.addEvent (juce::MidiMessage::noteOn (1, 60, (juce::uint8) 0), 0);
+            capture.processBlock (running, 512);
+
+            capture.setRecording (false);
+
+            expectEquals ((int) capture.getNotes().size(), 1);
+            expect (capture.getNotes().front().isFinished(),
+                    "a velocity-0 note-on did not close the note");
+        }
+
+        beginTest ("re-arming replaces the previous take rather than appending to it");
+        {
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+
+            capture.setRecording (true);
+            playNote (capture, 60, 0, 4410);
+            capture.setRecording (false);
+            expectEquals ((int) capture.getNotes().size(), 1);
+
+            capture.setRecording (true);
+            playNote (capture, 72, 0, 4410);
+            capture.setRecording (false);
+
+            expectEquals ((int) capture.getNotes().size(), 1);
+            expectEquals (capture.getNotes().front().noteNumber, 72,
+                          "the second take was appended to the first");
+        }
+
+        beginTest ("AC: the render carries the pitch and the rhythm of the performance");
+        {
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+            capture.setRecording (true);
+
+            // A4 (440Hz) for half a second, starting a quarter second in.
+            playNote (capture, 69, 11025, 22050);
+            capture.setRecording (false);
+
+            const auto rendered = capture.render();
+            expect (rendered.getNumSamples() > 0, "nothing was rendered");
+
+            // Silence before the note...
+            const auto before = rendered.getMagnitude (0, 0, 11000);
+            expectWithinAbsoluteError (before, 0.0f, 1.0e-4f,
+                                       "sound where the performance was silent");
+
+            // ...sound during it...
+            const auto during = rendered.getMagnitude (0, 12000, 20000);
+            expect (during > 0.01f, "the note did not sound: magnitude " + juce::String (during));
+
+            // ...and the pitch is A440, not some other note.
+            const auto frequency = estimateFrequency (rendered, 12000, 32000);
+            expectWithinAbsoluteError (frequency, 440.0, 5.0,
+                                       "rendered at " + juce::String (frequency) + "Hz, expected 440");
+        }
+
+        beginTest ("a chord renders without clipping");
+        {
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+            capture.setRecording (true);
+
+            juce::MidiBuffer on;
+            for (auto note : { 60, 64, 67, 72, 76 })
+                on.addEvent (juce::MidiMessage::noteOn (1, note, 1.0f), 0);
+
+            capture.processBlock (on, 512);
+
+            for (int i = 0; i < 40; ++i)
+                capture.processBlock ({}, 512);
+
+            juce::MidiBuffer off;
+            for (auto note : { 60, 64, 67, 72, 76 })
+                off.addEvent (juce::MidiMessage::noteOff (1, note), 0);
+
+            capture.processBlock (off, 512);
+            capture.setRecording (false);
+
+            const auto rendered = capture.render();
+            expect (rendered.getNumSamples() > 0);
+            expect (rendered.getMagnitude (0, rendered.getNumSamples()) <= 1.0f,
+                    "five notes at full velocity clipped");
+        }
+
+        beginTest ("a note still held when recording stops is not thrown away");
+        {
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+            capture.setRecording (true);
+
+            juce::MidiBuffer on;
+            on.addEvent (juce::MidiMessage::noteOn (1, 60, 0.9f), 0);
+            capture.processBlock (on, 512);
+            capture.setRecording (false);   // never released
+
+            expectEquals ((int) capture.getNotes().size(), 1);
+            expect (! capture.getNotes().front().isFinished());
+            expect (capture.getLengthSeconds() > 0.0, "a held note gave the take no length");
+            expect (capture.render().getNumSamples() > 0, "a held note rendered nothing");
+        }
+
+        beginTest ("writing produces a readable WAV");
+        {
+            ScopedTempDir dir;
+
+            MidiCapture capture;
+            capture.prepare (sampleRate);
+            capture.setRecording (true);
+            playNote (capture, 69, 0, 22050);
+            capture.setRecording (false);
+
+            const auto file = dir.directory.getChildFile ("nested").getChildFile ("sketch.wav");
+            expect (capture.writeTo (file), "the write failed");
+            expect (file.existsAsFile(), "no file was created");
+
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+            std::unique_ptr<juce::AudioFormatReader> reader (formats.createReaderFor (file));
+
+            expect (reader != nullptr, "what was written is not readable audio");
+            expectWithinAbsoluteError (reader->sampleRate, sampleRate, 0.5);
+            expect (reader->lengthInSamples > 0);
+
+            // An empty capture writes nothing rather than an empty file.
+            MidiCapture empty;
+            empty.prepare (sampleRate);
+            expect (! empty.writeTo (dir.directory.getChildFile ("empty.wav")));
+            expect (! dir.directory.getChildFile ("empty.wav").existsAsFile());
+        }
+
+        //======================================================================
+        beginTest ("AC: sidechain audio is captured and round-trips");
+        {
+            SidechainCapture capture;
+            capture.prepare (sampleRate, 2);
+            capture.setRecording (true);
+
+            juce::AudioBuffer<float> block (2, 512);
+
+            for (int b = 0; b < 20; ++b)
+            {
+                for (int channel = 0; channel < 2; ++channel)
+                    for (int i = 0; i < 512; ++i)
+                        block.setSample (channel, i,
+                                         0.5f * std::sin (juce::MathConstants<float>::twoPi
+                                                          * 220.0f * (float) (b * 512 + i) / (float) sampleRate));
+
+                capture.processBlock (block);
+            }
+
+            capture.setRecording (false);
+
+            expect (capture.hasCapture(), "nothing was captured");
+            expectEquals ((int) capture.getRecordedSamples(), 20 * 512);
+            expect (! capture.isFull(), "a short take reported the buffer as full");
+
+            const auto captured = capture.getCapturedAudio();
+            expectEquals (captured.getNumSamples(), 20 * 512);
+            expectEquals (captured.getNumChannels(), 2);
+            expect (captured.getMagnitude (0, captured.getNumSamples()) > 0.4f,
+                    "the captured audio is not the signal that went in");
+        }
+
+        beginTest ("the sidechain is not captured unless armed");
+        {
+            SidechainCapture capture;
+            capture.prepare (sampleRate, 2);
+
+            juce::AudioBuffer<float> block (2, 512);
+            block.clear();
+            block.setSample (0, 0, 0.9f);
+            capture.processBlock (block);
+
+            expect (! capture.hasCapture(), "captured without being armed");
+        }
+
+        beginTest ("the take stops at the buffer bound rather than wrapping");
+        {
+            SidechainCapture capture;
+            // A deliberately tiny buffer: prepare() sizes it from maxSeconds, so this
+            // drives the same path a two-minute overrun would, in a fraction of a second.
+            capture.prepare (64.0, 1);   // 64 * maxSeconds samples
+            capture.setRecording (true);
+
+            const auto capacity = (int) (64.0 * (double) SidechainCapture::maxSeconds);
+
+            juce::AudioBuffer<float> block (1, capacity);
+            block.clear();
+            for (int i = 0; i < capacity; ++i)
+                block.setSample (0, i, 0.5f);
+
+            capture.processBlock (block);            // exactly fills it
+            capture.processBlock (block);            // and this must not wrap
+
+            expect (capture.isFull(), "the bound was not reported");
+            expect (! capture.isRecording(), "recording continued past the bound");
+            expectEquals ((int) capture.getRecordedSamples(), capacity,
+                          "the take grew past the buffer it was given");
+        }
+
+        beginTest ("a mono sidechain fills both channels rather than leaving one stale");
+        {
+            SidechainCapture capture;
+            capture.prepare (sampleRate, 2);
+            capture.setRecording (true);
+
+            juce::AudioBuffer<float> mono (1, 512);
+            for (int i = 0; i < 512; ++i)
+                mono.setSample (0, i, 0.6f);
+
+            capture.processBlock (mono);
+            capture.setRecording (false);
+
+            const auto captured = capture.getCapturedAudio();
+            expectEquals (captured.getNumChannels(), 2);
+            expectWithinAbsoluteError (captured.getSample (1, 10), 0.6f, 1.0e-4f,
+                                       "the second channel was not filled from the mono source");
+        }
+
+        beginTest ("re-arming the sidechain discards the previous take");
+        {
+            SidechainCapture capture;
+            capture.prepare (sampleRate, 1);
+
+            juce::AudioBuffer<float> block (1, 512);
+            block.clear();
+
+            capture.setRecording (true);
+            capture.processBlock (block);
+            capture.processBlock (block);
+            capture.setRecording (false);
+            expectEquals ((int) capture.getRecordedSamples(), 1024);
+
+            capture.setRecording (true);
+            capture.processBlock (block);
+            capture.setRecording (false);
+            expectEquals ((int) capture.getRecordedSamples(), 512,
+                          "the second take was appended to the first");
+        }
+
+        beginTest ("the transport position at the start of a take is remembered");
+        {
+            SidechainCapture capture;
+            capture.prepare (sampleRate, 1);
+
+            expect (capture.getTransportStartSeconds() < 0.0, "invented a start position");
+
+            capture.setRecording (true, 12.5);
+            expectWithinAbsoluteError (capture.getTransportStartSeconds(), 12.5, 1.0e-9);
+        }
+    }
+
+private:
+    struct ScopedTempDir
+    {
+        ScopedTempDir()
+        {
+            directory = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                            .getChildFile ("acemusic-capture-"
+                                           + juce::String (juce::Random::getSystemRandom().nextInt (1 << 30)));
+            directory.createDirectory();
+        }
+
+        ~ScopedTempDir()    { directory.deleteRecursively(); }
+
+        juce::File directory;
+    };
+};
+
+static CaptureTests captureTests;
+
+} // namespace acemusic

--- a/plugin/tests/GenerationPanelTests.cpp
+++ b/plugin/tests/GenerationPanelTests.cpp
@@ -122,7 +122,8 @@ public:
             expect (panel.getLanguageSelector().getNumItems() >= 51, "expected Auto + 50+ languages");
             expectEquals (panel.getQualitySelector().getNumItems(), 3);
             expectEquals (panel.getQualitySelector().getText(), juce::String ("Standard"));
-            expectEquals (panel.getModeSelector().getNumItems(), 2);
+            // Text to Music, Cover, Complete, Repaint since US-24.3.
+            expectEquals (panel.getModeSelector().getNumItems(), 4);
             expectEquals (panel.getDurationEditor().getText(), juce::String ("60"));
 
             // BPM and seed are blank, meaning Auto/Random.
@@ -694,7 +695,7 @@ public:
 
             PluginEditor editor (processor);
             // The minimum the editor allows, so this is the worst case a user can make.
-            editor.setSize (560, 700);
+            editor.setSize (560, 800);
             auto& panel = editor.getGenerationPanel();
 
             const auto fits = [this] (juce::Label& label, const char* what)
@@ -709,6 +710,106 @@ public:
 
             fits (panel.getSyncLabel(), "the sync indicator");
             fits (panel.getSelectionLabel(), "the selection readout");
+        }
+
+        //======================================================================
+        // US-24.3 — captures and mode availability.
+
+        beginTest ("AC: modes are only offered once their input has been captured");
+        {
+            PluginProcessor processor (nullptr, false);
+            processor.prepareToPlay (44100.0, 512);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 920);
+            auto& panel = editor.getGenerationPanel();
+
+            using Mode = GenerationRequest::Mode;
+
+            // Text to Music needs nothing and is always available.
+            expect (panel.isModeAvailable (Mode::textToMusic));
+
+            // Nothing captured yet, and no sidechain routed in this processor.
+            expect (! panel.isModeAvailable (Mode::complete), "Complete offered with no MIDI");
+            expect (! panel.isModeAvailable (Mode::cover), "Cover offered with no sidechain");
+            expect (! panel.isModeAvailable (Mode::repaint), "Repaint offered with no sidechain");
+
+            // Play something in.
+            processor.getMidiCapture().setRecording (true);
+            {
+                juce::MidiBuffer on;
+                on.addEvent (juce::MidiMessage::noteOn (1, 60, 0.8f), 0);
+                processor.getMidiCapture().processBlock (on, 512);
+
+                juce::MidiBuffer off;
+                off.addEvent (juce::MidiMessage::noteOff (1, 60), 0);
+                processor.getMidiCapture().processBlock (off, 512);
+            }
+            processor.getMidiCapture().setRecording (false);
+
+            expect (panel.isModeAvailable (Mode::complete),
+                    "Complete stayed unavailable after MIDI was captured");
+
+            // Cover still is not: this processor has no sidechain bus enabled, and a
+            // mode that can never be satisfied must not look available.
+            expect (! panel.isModeAvailable (Mode::cover));
+
+            expect (pumpUntil ([&] { return panel.getCaptureLabel().getText().contains ("MIDI"); }, 5000),
+                    "the capture indicator does not mention the MIDI take: "
+                        + panel.getCaptureLabel().getText());
+        }
+
+        beginTest ("with a sidechain routed, Cover and Repaint unlock once it is captured");
+        {
+            PluginProcessor processor (nullptr, false);
+
+            using ChannelSet = juce::AudioChannelSet;
+            expect (processor.setBusesLayout ({ { ChannelSet::stereo(), ChannelSet::stereo() },
+                                                { ChannelSet::stereo() } }));
+            processor.prepareToPlay (44100.0, 512);
+            expect (processor.hasSidechainInput());
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 920);
+            auto& panel = editor.getGenerationPanel();
+
+            using Mode = GenerationRequest::Mode;
+            expect (! panel.isModeAvailable (Mode::cover), "Cover offered before anything was captured");
+
+            processor.getSidechainCapture().setRecording (true);
+            {
+                juce::AudioBuffer<float> block (2, 512);
+                for (int channel = 0; channel < 2; ++channel)
+                    for (int i = 0; i < 512; ++i)
+                        block.setSample (channel, i, 0.4f);
+
+                processor.getSidechainCapture().processBlock (block);
+            }
+            processor.getSidechainCapture().setRecording (false);
+
+            expect (panel.isModeAvailable (Mode::cover), "Cover stayed unavailable after a capture");
+            expect (panel.isModeAvailable (Mode::repaint), "Repaint stayed unavailable after a capture");
+            expect (! panel.isModeAvailable (Mode::complete), "Complete unlocked from sidechain audio");
+        }
+
+        beginTest ("the capture toggles arm the captures they name");
+        {
+            PluginProcessor processor (nullptr, false);
+            processor.prepareToPlay (44100.0, 512);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 920);
+            auto& panel = editor.getGenerationPanel();
+
+            panel.getMidiRecordToggle().setToggleState (true, juce::sendNotificationSync);
+            expect (processor.getMidiCapture().isRecording(), "the MIDI capture was not armed");
+
+            panel.getMidiRecordToggle().setToggleState (false, juce::sendNotificationSync);
+            expect (! processor.getMidiCapture().isRecording(), "the MIDI capture stayed armed");
+
+            // No sidechain routed here, so that toggle must not be offered at all.
+            expect (! panel.getSidechainRecordToggle().isEnabled(),
+                    "sidechain capture was offered with no sidechain bus");
         }
 
         beginTest ("applying a request with its own BPM takes the field off sync");

--- a/plugin/tests/GenerationPanelTests.cpp
+++ b/plugin/tests/GenerationPanelTests.cpp
@@ -792,6 +792,99 @@ public:
             expect (! panel.isModeAvailable (Mode::complete), "Complete unlocked from sidechain audio");
         }
 
+        beginTest ("AC: choosing Complete or Repaint actually submits that mode, not text-to-music");
+        {
+            // The gate being right is not the same as the request being right. This
+            // drives the whole path: pick the mode, check what buildRequest() produces.
+            ScopedClipCleanup cleanup;
+            PluginProcessor processor (std::move (cleanup.properties), false);
+
+            using ChannelSet = juce::AudioChannelSet;
+            expect (processor.setBusesLayout ({ { ChannelSet::stereo(), ChannelSet::stereo() },
+                                                { ChannelSet::stereo() } }));
+            processor.prepareToPlay (44100.0, 512);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 920);
+            auto& panel = editor.getGenerationPanel();
+            panel.getPromptEditor().setText ("a prompt", true);
+
+            const auto modes = GenerationRequest::allModes();
+
+            for (int i = 0; i < modes.size(); ++i)
+            {
+                panel.getModeSelector().setSelectedId (i + 1, juce::sendNotificationSync);
+                expect (panel.buildRequest().mode == modes[i],
+                        "selecting \"" + GenerationRequest::toString (modes[i])
+                            + "\" built a request for \""
+                            + GenerationRequest::toString (panel.buildRequest().mode) + "\"");
+            }
+        }
+
+        beginTest ("AC: Generate becomes available once a source mode has its capture");
+        {
+            // findProblem() rejects a source mode with no path, and the path is only
+            // written at click time — so without care Generate stays dead forever.
+            ScopedClipCleanup cleanup;
+            PluginProcessor processor (std::move (cleanup.properties), false);
+
+            using ChannelSet = juce::AudioChannelSet;
+            expect (processor.setBusesLayout ({ { ChannelSet::stereo(), ChannelSet::stereo() },
+                                                { ChannelSet::stereo() } }));
+            processor.prepareToPlay (44100.0, 512);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 920);
+            auto& panel = editor.getGenerationPanel();
+            panel.getPromptEditor().setText ("restyle this", true);
+
+            // Cover, with nothing captured: the request is not submittable, and says why.
+            panel.getModeSelector().setSelectedId (2, juce::sendNotificationSync);
+            expect (! panel.buildRequest().isValid(), "Cover was submittable with no capture");
+
+            // Capture something.
+            processor.getSidechainCapture().setRecording (true);
+            {
+                juce::AudioBuffer<float> block (2, 512);
+                for (int channel = 0; channel < 2; ++channel)
+                    for (int i = 0; i < 512; ++i)
+                        block.setSample (channel, i, 0.3f);
+
+                processor.getSidechainCapture().processBlock (block);
+            }
+            processor.getSidechainCapture().setRecording (false);
+
+            const auto request = panel.buildRequest();
+            expect (request.mode == GenerationRequest::Mode::cover);
+            expect (request.sourceAudioPath.isNotEmpty(),
+                    "the request names no source, so Generate can never enable");
+            expect (request.isValid(),
+                    "Cover stayed unsubmittable after a capture: " + request.findProblem());
+
+            // Same for Complete once MIDI exists.
+            processor.getMidiCapture().setRecording (true);
+            {
+                juce::MidiBuffer on;
+                on.addEvent (juce::MidiMessage::noteOn (1, 60, 0.8f), 0);
+                processor.getMidiCapture().processBlock (on, 512);
+                juce::MidiBuffer off;
+                off.addEvent (juce::MidiMessage::noteOff (1, 60), 0);
+                processor.getMidiCapture().processBlock (off, 512);
+            }
+            processor.getMidiCapture().setRecording (false);
+
+            panel.getModeSelector().setSelectedId (3, juce::sendNotificationSync);   // Complete
+            const auto complete = panel.buildRequest();
+            expect (complete.mode == GenerationRequest::Mode::complete);
+            expect (complete.isValid(), "Complete stayed unsubmittable: " + complete.findProblem());
+            expect (complete.sourceAudioPath.endsWith ("midi-sketch.wav"),
+                    "Complete pointed at the wrong capture: " + complete.sourceAudioPath);
+
+            // And the two modes must not share a file.
+            expect (complete.sourceAudioPath != request.sourceAudioPath,
+                    "Complete and Cover were pointed at the same capture file");
+        }
+
         beginTest ("the capture toggles arm the captures they name");
         {
             PluginProcessor processor (nullptr, false);

--- a/plugin/tests/GenerationRequestTests.cpp
+++ b/plugin/tests/GenerationRequestTests.cpp
@@ -182,6 +182,92 @@ public:
             expectEquals (reparsed.getProperty ("lyrics", juce::var()).toString(), request.lyrics,
                           "lyrics were mangled by JSON encoding");
         }
+
+        //======================================================================
+        // US-24.3 — modes that need a source.
+
+        beginTest ("every mode but Text to Music needs source audio");
+        {
+            expect (! GenerationRequest::needsSourceAudio (GenerationRequest::Mode::textToMusic));
+            expect (GenerationRequest::needsSourceAudio (GenerationRequest::Mode::cover));
+            expect (GenerationRequest::needsSourceAudio (GenerationRequest::Mode::complete));
+            expect (GenerationRequest::needsSourceAudio (GenerationRequest::Mode::repaint));
+
+            GenerationRequest request;
+            request.prompt = "anything";
+            request.mode = GenerationRequest::Mode::complete;
+
+            expect (! request.isValid(), "Complete was submittable with no sketch");
+            expect (request.findProblem().containsIgnoreCase ("Complete"),
+                    "the problem does not name the mode: " + request.findProblem());
+
+            request.sourceAudioPath = "/tmp/sketch.wav";
+            expect (request.isValid());
+        }
+
+        beginTest ("the task_type sent matches what ACE-Step expects");
+        {
+            // These strings are ACE-Step's, not ours: see TaskType in
+            // src/acemusic/client.py. Getting one wrong is a silent server-side default.
+            expect (GenerationRequest::taskTypeFor (GenerationRequest::Mode::textToMusic).isEmpty(),
+                    "text2music should be omitted, as the Python client omits it");
+            expectEquals (GenerationRequest::taskTypeFor (GenerationRequest::Mode::cover),
+                          juce::String ("cover"));
+            expectEquals (GenerationRequest::taskTypeFor (GenerationRequest::Mode::complete),
+                          juce::String ("complete"));
+            expectEquals (GenerationRequest::taskTypeFor (GenerationRequest::Mode::repaint),
+                          juce::String ("repaint"));
+        }
+
+        beginTest ("Complete sends the rendered sketch as src_audio_path");
+        {
+            GenerationRequest request;
+            request.prompt = "flesh this out";
+            request.mode = GenerationRequest::Mode::complete;
+            request.sourceAudioPath = "/tmp/midi-sketch.wav";
+
+            const juce::var payload = request.toPayload();
+            auto* object = payload.getDynamicObject();
+            expect (object != nullptr);
+            expectEquals (object->getProperty ("task_type").toString(), juce::String ("complete"));
+            expectEquals (object->getProperty ("src_audio_path").toString(),
+                          juce::String ("/tmp/midi-sketch.wav"));
+            expect (! object->hasProperty ("repainting_start"),
+                    "a non-repaint request carried a repaint range");
+        }
+
+        beginTest ("Repaint carries its range, and omits it when it is not set");
+        {
+            GenerationRequest request;
+            request.prompt = "redo this bit";
+            request.mode = GenerationRequest::Mode::repaint;
+            request.sourceAudioPath = "/tmp/sidechain.wav";
+
+            {
+                const juce::var payload = request.toPayload();
+                auto* object = payload.getDynamicObject();
+                expect (! object->hasProperty ("repainting_start"),
+                        "an unset range was sent rather than omitted");
+                expect (! object->hasProperty ("repainting_end"));
+            }
+
+            request.repaintStartSeconds = 4.0;
+            request.repaintEndSeconds = 12.0;
+            expect (request.hasRepaintRange());
+
+            {
+                const juce::var payload = request.toPayload();
+                auto* object = payload.getDynamicObject();
+                expectEquals ((double) object->getProperty ("repainting_start"), 4.0);
+                expectEquals ((double) object->getProperty ("repainting_end"), 12.0);
+            }
+
+            // A backwards or zero-length range is not a range.
+            request.repaintEndSeconds = 4.0;
+            expect (! request.hasRepaintRange(), "a zero-length range was accepted");
+            request.repaintEndSeconds = 1.0;
+            expect (! request.hasRepaintRange(), "a backwards range was accepted");
+        }
     }
 };
 

--- a/plugin/tests/PluginProcessorTests.cpp
+++ b/plugin/tests/PluginProcessorTests.cpp
@@ -40,10 +40,98 @@ public:
         {
             auto owned = makeOfflineProcessor();
             auto& processor = *owned;
-            expect (! processor.acceptsMidi());
+            // acceptsMidi is true since US-24.3 — see its own test above. The plugin
+            // still emits no MIDI and is not a MIDI effect.
             expect (! processor.producesMidi());
             expect (! processor.isMidiEffect());
             expectEquals (processor.getTailLengthSeconds(), 0.0);
+        }
+
+        beginTest ("accepts MIDI, for the Complete-mode sketch");
+        {
+            auto owned = makeOfflineProcessor();
+            expect (owned->acceptsMidi(), "MIDI input is off, so Complete mode has no source");
+            expect (! owned->producesMidi());
+            expect (! owned->isMidiEffect());
+        }
+
+        beginTest ("the sidechain bus is optional, and every layout pluginval tries is accepted");
+        {
+            auto owned = makeOfflineProcessor();
+            auto& processor = *owned;
+
+            using ChannelSet = juce::AudioChannelSet;
+
+            // Off by default, so a host with no sidechain send is unaffected.
+            expect (processor.getBus (true, 1) != nullptr, "no sidechain bus was declared");
+            expect (! processor.getBus (true, 1)->isEnabled(),
+                    "the sidechain is enabled by default, which changes existing sessions");
+            expect (! processor.hasSidechainInput());
+
+            for (const auto& sidechain : { ChannelSet::disabled(), ChannelSet::mono(), ChannelSet::stereo() })
+            {
+                expect (processor.setBusesLayout ({ { ChannelSet::stereo(), sidechain },
+                                                    { ChannelSet::stereo() } }),
+                        "rejected a sidechain layout pluginval will try: "
+                            + sidechain.getDescription());
+            }
+
+            // Something the plugin genuinely cannot handle.
+            expect (! processor.setBusesLayout ({ { ChannelSet::stereo(), ChannelSet::create5point1() },
+                                                  { ChannelSet::stereo() } }),
+                    "accepted a 5.1 sidechain");
+
+            expect (processor.setBusesLayout ({ { ChannelSet::stereo(), ChannelSet::stereo() },
+                                                { ChannelSet::stereo() } }));
+            expect (processor.hasSidechainInput(), "an enabled sidechain was not reported");
+        }
+
+        beginTest ("audio still passes through untouched with MIDI and a sidechain present");
+        {
+            // The regression that matters most in US-24.3: capturing must not colour or
+            // interrupt the audio the host is already sending through the plugin.
+            auto owned = makeOfflineProcessor();
+            auto& processor = *owned;
+
+            using ChannelSet = juce::AudioChannelSet;
+            expect (processor.setBusesLayout ({ { ChannelSet::stereo(), ChannelSet::stereo() },
+                                                { ChannelSet::stereo() } }));
+            processor.prepareToPlay (44100.0, 512);
+
+            // Main input on channels 0-1, sidechain on 2-3.
+            juce::AudioBuffer<float> buffer (4, 512);
+            buffer.clear();
+
+            for (int i = 0; i < 512; ++i)
+            {
+                buffer.setSample (0, i, 0.25f);
+                buffer.setSample (1, i, -0.25f);
+                buffer.setSample (2, i, 0.9f);    // sidechain
+                buffer.setSample (3, i, 0.9f);
+            }
+
+            juce::MidiBuffer midi;
+            midi.addEvent (juce::MidiMessage::noteOn (1, 60, 0.8f), 0);
+
+            processor.getMidiCapture().setRecording (true);
+            processor.getSidechainCapture().setRecording (true);
+            processor.processBlock (buffer, midi);
+
+            for (int i = 0; i < 512; ++i)
+            {
+                expectWithinAbsoluteError (buffer.getSample (0, i), 0.25f, 1.0e-6f,
+                                           "the main input was altered at sample " + juce::String (i));
+                expectWithinAbsoluteError (buffer.getSample (1, i), -0.25f, 1.0e-6f,
+                                           "the main input was altered at sample " + juce::String (i));
+            }
+
+            // And both captures actually saw something.
+            processor.getMidiCapture().setRecording (false);
+            processor.getSidechainCapture().setRecording (false);
+
+            expect (processor.getMidiCapture().hasCapture(), "the MIDI note was not captured");
+            expect (processor.getSidechainCapture().hasCapture(), "the sidechain was not captured");
+            expectEquals ((int) processor.getSidechainCapture().getRecordedSamples(), 512);
         }
 
         beginTest ("supports mono and stereo, rejects mismatched layouts");
@@ -53,13 +141,17 @@ public:
 
             using ChannelSet = juce::AudioChannelSet;
 
-            expect (processor.setBusesLayout ({ { ChannelSet::stereo() }, { ChannelSet::stereo() } }),
+            // Three buses since US-24.3: main in, sidechain in, main out. The sidechain
+            // is disabled here; its own layouts are covered below.
+            const auto off = ChannelSet::disabled();
+
+            expect (processor.setBusesLayout ({ { ChannelSet::stereo(), off }, { ChannelSet::stereo() } }),
                     "stereo in / stereo out rejected");
-            expect (processor.setBusesLayout ({ { ChannelSet::mono() }, { ChannelSet::mono() } }),
+            expect (processor.setBusesLayout ({ { ChannelSet::mono(), off }, { ChannelSet::mono() } }),
                     "mono in / mono out rejected");
-            expect (! processor.setBusesLayout ({ { ChannelSet::stereo() }, { ChannelSet::mono() } }),
+            expect (! processor.setBusesLayout ({ { ChannelSet::stereo(), off }, { ChannelSet::mono() } }),
                     "mismatched stereo in / mono out accepted");
-            expect (! processor.setBusesLayout ({ { ChannelSet::create5point1() }, { ChannelSet::create5point1() } }),
+            expect (! processor.setBusesLayout ({ { ChannelSet::create5point1(), off }, { ChannelSet::create5point1() } }),
                     "5.1 accepted");
         }
 
@@ -112,7 +204,8 @@ public:
             auto owned = makeOfflineProcessor();
             auto& processor = *owned;
 
-            expect (processor.setBusesLayout ({ { juce::AudioChannelSet::disabled() },
+            expect (processor.setBusesLayout ({ { juce::AudioChannelSet::disabled(),
+                                                 juce::AudioChannelSet::disabled() },
                                                { juce::AudioChannelSet::stereo() } }),
                     "disabled input / stereo output rejected");
             expectEquals (processor.getTotalNumInputChannels(), 0);

--- a/plugin/tests/ResultsPanelTests.cpp
+++ b/plugin/tests/ResultsPanelTests.cpp
@@ -93,7 +93,7 @@ public:
               processor (makeSettings (settingsDir), false),
               editor (processor)
         {
-            editor.setSize (720, 700);
+            editor.setSize (720, 920);
             processor.prepareToPlay (44100.0, 512);
         }
 
@@ -550,7 +550,7 @@ public:
 
             {
                 PluginEditor editor (processor);
-                editor.setSize (720, 700);
+                editor.setSize (720, 920);
 
                 expect (pumpUntil ([&] { return editor.getResultsPanel().getNumClipRows() == 2; }));
                 editor.getResultsPanel().getClipRow (0)->getPlayButton().triggerClick();


### PR DESCRIPTION
Implements **US-24.3 — MIDI Input and Sidechain Audio** (#322).

The plugin now accepts MIDI and a sidechain input and can seed a generation from either.

---

## The finding that shaped this story: ACE-Step has no MIDI input

I checked the server rather than assuming. Its task types are `text2music`, `cover`,
`repaint`, `extract`, `lego`, `complete`, `mashup` — and **`complete`, the mode this story
wants MIDI to drive, takes `src_audio_path`.** There is not one reference to MIDI anywhere
in the ACE-Step source, and the platform's own `midi_client.py` runs the other way entirely
(audio → MIDI, via basic-pitch).

So *Record MIDI* captures your performance and the plugin **renders it to a plain tone**,
which is submitted as the melodic reference. That does what the user story asks for
musically — a MIDI sketch becomes full audio — but the model conditions on rendered audio,
not on note data, and the README says so plainly.

---

## Acceptance criteria — evidence

| Criterion | Outcome |
| --- | --- |
| Playing MIDI captures it and enables Complete mode | **Met** — `Capture / AC: playing MIDI into the plugin captures it` and `GenerationPanel / AC: modes are only offered once their input has been captured` |
| Sidechain audio captured and usable as Cover reference | **Met** — round-trips through `SidechainCapture`, and Cover/Repaint unlock only once a take exists |
| Generated audio reflects the melodic content of the MIDI | **Met — verified against a live ACE-Step server.** See below |
| Cover with sidechain produces a restyled version | **NOT VERIFIED.** See below |
| Mode selector shows available modes based on captured inputs | **Met** — a mode with no input is greyed out, and Cover/Repaint stay unavailable when no sidechain is routed at all |

### Live verification — Complete mode ✅

A melody was rendered through the **real `MidiCapture`** (not a fixture) and measured by
librosa as `C4 C4 G4 G4 A4 A4 G4`. Submitting it as `task_type=complete`:

```
sketch     3.52s  top pitch classes: G, A, C, G#
generated  5.12s  top pitch classes: G, A, C, G#

chroma cosine similarity:                            0.847
mean similarity under rotation (unrelated baseline):  0.579
```

Identical top four pitch classes, and similarity well clear of the unrelated baseline.

### Live verification — Cover mode ❌ not verified

The integration is correct: the server **accepts** the task and its log confirms it
consumes the reference —

```
[generate_music] Processing source audio...
[generate_music] cover task: using params.caption='heavy distorted electric guitar, rock'
```

— but the output's harmonic content was **indistinguishable from unrelated**, at both
turbo and standard quality:

| Inference steps | similarity | unrelated baseline |
| --- | --- | --- |
| 8 | 0.623 | 0.620 |
| 60 | 0.647 | 0.637 |

I am reporting this as unverified rather than claiming the criterion. Plausible causes I
did not chase: ACE-Step's cover may condition on style/timbre rather than harmony; the
reference I used is a bare synthesised melody rather than a real track; or parameters like
`style_influence` control adherence. **What is proven is that the plugin submits the mode
correctly and the server uses the file.** What is not proven is the musical claim.

---

## Design notes

**Nothing is synthesised on the audio thread.** `processBlock` only pushes note events into
a lock-free FIFO; draining, rendering and writing happen on the message thread when the
take is disarmed. Far less machinery than a live `juce::Synthesiser`, and the audio
callback still allocates nothing. Events past the FIFO's capacity are **dropped and
counted**, and the indicator reports the count rather than passing the take off as clean.

**The sidechain bus is disabled by default**, so a host with no sidechain send loads the
plugin exactly as before and existing sessions do not change shape.
`isBusesLayoutSupported` accepts it absent, mono or stereo — that is what pluginval fuzzes,
so all three have tests.

**The regression that mattered most** has its own test: audio still passes through
bit-identical with MIDI *and* a sidechain being captured.

`AudioIo::writeWav` was extracted at its third caller, not before.

---

## Known limitations

1. **MIDI reaches the model as rendered audio, not note data** — ACE-Step has no MIDI
   conditioning (above).
2. **Cover's musical behaviour is unverified** (above).
3. Sidechain capture is bounded to `SidechainCapture::maxSeconds`; it stops at the bound
   rather than wrapping, and says so.
4. `src_audio_path` is a **server-side** path. Fine for the local ACE-Step the plugin
   targets; a remote server needs an upload endpoint (US-24.5 territory).
5. **Not verified in a real DAW** — no DAW is installed here. The README carries a manual
   check for MIDI routing and sidechain sends.

Closes #322
