### PR TITLE
feat(plugin): US-24.4 Lego Mode and Layer-by-Layer Generation (#323)

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -46,6 +46,7 @@ set(ACEMUSIC_SOURCES
     source/GenerationPanel.cpp
     source/GenerationRequest.cpp
     source/HostSync.cpp
+    source/LegoStack.cpp
     source/MidiCapture.cpp
     source/PluginProcessor.cpp
     source/PluginEditor.cpp
@@ -117,6 +118,7 @@ target_sources(AceMusicPluginTests PRIVATE
     tests/GenerationManagerTests.cpp
     tests/GenerationPanelTests.cpp
     tests/GenerationRequestTests.cpp
+    tests/LegoStackTests.cpp
     tests/HostSyncTests.cpp
     tests/PluginProcessorTests.cpp
     tests/ResultsPanelTests.cpp

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -14,6 +14,7 @@ Progress:
 | US-24.1 — DAW tempo sync and tempo-matched insertion | done |
 | US-24.2 — Selection-aware generation | done |
 | US-24.3 — MIDI input and sidechain audio | done |
+| US-24.4 — Lego mode, layer by layer | done |
 
 | Format | Windows | macOS | Linux |
 | --- | --- | --- | --- |
@@ -272,6 +273,47 @@ the range is omitted and the server decides.
 Captures are written under `<cache>/captures/` and referenced by `src_audio_path`. That
 is a **server-side** path, which works because the plugin targets a local ACE-Step;
 a remote server would need an upload endpoint.
+
+## Lego mode — building a track a layer at a time
+
+Pick **Lego** as the mode and a **Layer** track, describe the part, and Generate. Each
+finished layer is added to the stack, and the next generation is handed the mix of the
+layers so far as its context — so a bass generated after drums is generated *against*
+those drums.
+
+`lego` is a real ACE-Step task type ("generate a specific instrument track in context").
+The server steers it off an `instruction` string naming the track, not off your prompt:
+
+```
+Generate the BASS track based on the audio context:
+```
+
+The track list is ACE-Step's own `TRACK_NAMES`, so a layer always names something the
+model was trained on: `drums, bass, guitar, keyboard, synth, strings, brass, woodwinds,
+percussion, fx, vocals, backing_vocals`. Your prompt still describes *what kind* of part
+you want ("a funky bass line") — the two work together.
+
+**The first layer is an ordinary text-to-music generation.** There is nothing to build on
+yet, so no `task_type` and no context are sent. Only from the second layer on is it a
+`lego` task.
+
+**Regenerating a layer excludes that layer from its own context**, so a replacement bass
+is generated against the drums it sits under rather than against the bass it is replacing.
+Layers can also be muted out of the context without being deleted.
+
+### One track per layer is your drop, not the plugin's
+
+The story asks for each layer to be placed on its own DAW track. **VST3 gives a plugin no
+way to create tracks or write the host's arrangement** — the same limit settled on
+[#318](https://github.com/frankbria/auto-music-studio/issues/318) and applied again in
+US-24.2. Each layer is a draggable clip; dropping each onto its own track takes a couple
+of seconds, and the plugin cannot do it for you.
+
+### The context is the plugin's layers, not the DAW's timeline
+
+A plugin cannot read other tracks in the host. The Lego context is the mixdown of the
+layers *this plugin* generated. To bring real DAW audio in, capture it on the sidechain
+(US-24.3) — the two compose.
 
 ## Networking
 

--- a/plugin/source/GenerationPanel.cpp
+++ b/plugin/source/GenerationPanel.cpp
@@ -251,6 +251,12 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
         if (request.mode == GenerationRequest::Mode::lego)
         {
             attachLegoContext (request);
+
+            // Captured now, not when the run finishes: by then the user may have moved
+            // the selector on to the next part they intend to add.
+            pendingLegoTrack = request.legoTrack;
+            pendingLegoPrompt = request.prompt;
+            legoRunPending = true;
         }
         else if (GenerationRequest::needsSourceAudio (request.mode) && ! attachSourceAudio (request))
         {
@@ -399,6 +405,9 @@ void GenerationPanel::resized()
 
 void GenerationPanel::changeListenerCallback (juce::ChangeBroadcaster*)
 {
+    // A finished Lego run becomes the next layer. Without this the stack never grows and
+    // every generation is treated as a first layer, with no context.
+    collectFinishedLegoLayer();
     refresh();
 }
 
@@ -506,6 +515,12 @@ juce::String GenerationPanel::getSelectionText() const
 
 bool GenerationPanel::isModeAvailable (GenerationRequest::Mode mode) const
 {
+    // Lego is always selectable. It needs a *track*, not a capture, and its first layer
+    // has nothing to build on by design — gating it behind a capture made the mode
+    // impossible to reach from an empty stack, which is where every build starts.
+    if (mode == GenerationRequest::Mode::lego)
+        return true;
+
     return ! GenerationRequest::needsSourceAudio (mode) || hasCaptureFor (mode);
 }
 
@@ -576,6 +591,13 @@ void GenerationPanel::attachLegoContext (GenerationRequest& request) const
 
 void GenerationPanel::addLegoLayer (const juce::File& clip)
 {
+    addLegoLayer (clip, legoTrackSelector.getText(), promptEditor.getText());
+}
+
+void GenerationPanel::addLegoLayer (const juce::File& clip,
+                                    const juce::String& track,
+                                    const juce::String& prompt)
+{
     if (legoRegenerateIndex >= 0)
     {
         legoStack.replaceLayer (legoRegenerateIndex, clip);
@@ -583,10 +605,33 @@ void GenerationPanel::addLegoLayer (const juce::File& clip)
     }
     else
     {
-        legoStack.addLayer (legoTrackSelector.getText(), promptEditor.getText(), clip);
+        legoStack.addLayer (track, prompt, clip);
     }
 
     refresh();
+}
+
+void GenerationPanel::collectFinishedLegoLayer()
+{
+    if (! legoRunPending || generation.getState() != GenerationManager::State::complete)
+        return;
+
+    const auto& clips = generation.getClips();
+
+    if (clips.isEmpty())
+        return;
+
+    // Cleared first: addLegoLayer calls refresh(), which lands back here, and without
+    // this the layer would be added on every refresh for as long as the run reads
+    // complete.
+    legoRunPending = false;
+
+    const auto track = pendingLegoTrack;
+    const auto prompt = pendingLegoPrompt;
+    pendingLegoTrack = {};
+    pendingLegoPrompt = {};
+
+    addLegoLayer (clips.getFirst(), track, prompt);
 }
 
 juce::String GenerationPanel::getLegoText() const

--- a/plugin/source/GenerationPanel.cpp
+++ b/plugin/source/GenerationPanel.cpp
@@ -221,6 +221,23 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
     sidechainRecordToggle.setEnabled (hostOffersSidechain);
     addAndMakeVisible (sidechainRecordToggle);
 
+    styleCaption (legoTrackLabel, "Layer");
+    addAndMakeVisible (legoTrackLabel);
+    styleCombo (legoTrackSelector);
+    {
+        const auto tracks = LegoStack::trackNames();
+
+        for (int i = 0; i < tracks.size(); ++i)
+            legoTrackSelector.addItem (tracks[i], i + 1);
+    }
+    legoTrackSelector.setSelectedId (1, juce::dontSendNotification);
+    legoTrackSelector.onChange = [this] { refresh(); };
+    addAndMakeVisible (legoTrackSelector);
+
+    legoLabel.setFont (juce::FontOptions (12.0f));
+    legoLabel.setColour (juce::Label::textColourId, genColours::textDim);
+    addAndMakeVisible (legoLabel);
+
     captureLabel.setFont (juce::FontOptions (12.0f));
     captureLabel.setColour (juce::Label::textColourId, genColours::textDim);
     addAndMakeVisible (captureLabel);
@@ -231,7 +248,11 @@ GenerationPanel::GenerationPanel (GenerationManager& generationToUse,
 
         // Writing the capture is deferred to the click rather than done on every edit:
         // it touches the disk, and most edits never lead to a generation.
-        if (GenerationRequest::needsSourceAudio (request.mode) && ! attachSourceAudio (request))
+        if (request.mode == GenerationRequest::Mode::lego)
+        {
+            attachLegoContext (request);
+        }
+        else if (GenerationRequest::needsSourceAudio (request.mode) && ! attachSourceAudio (request))
         {
             refresh();
             return;
@@ -335,6 +356,14 @@ void GenerationPanel::resized()
     // The host readouts get a row to themselves. Sharing the language row left them a
     // few pixels wide at the editor's minimum size, which made both unreadable — and a
     // readout nobody can read is not a feature.
+    auto legoRow = area.removeFromBottom (22);
+    legoTrackLabel.setBounds (legoRow.removeFromLeft (46));
+    legoTrackSelector.setBounds (legoRow.removeFromLeft (130));
+    legoRow.removeFromLeft (8);
+    legoLabel.setBounds (legoRow);
+
+    area.removeFromBottom (4);
+
     auto captureRow = area.removeFromBottom (22);
     midiRecordToggle.setBounds (captureRow.removeFromLeft (110));
     sidechainRecordToggle.setBounds (captureRow.removeFromLeft (150));
@@ -519,6 +548,61 @@ juce::String GenerationPanel::getCaptureText() const
     return parts.isEmpty() ? juce::String ("No input captured") : parts.joinIntoString ("  |  ");
 }
 
+juce::File GenerationPanel::getLegoContextFile() const
+{
+    return generation.getClipDirectory().getChildFile ("captures").getChildFile ("lego-context.wav");
+}
+
+void GenerationPanel::attachLegoContext (GenerationRequest& request) const
+{
+    if (! legoStack.hasContext (legoRegenerateIndex))
+    {
+        // The first layer, or a regeneration of the only layer: nothing to build on, so
+        // the request goes out as plain text-to-music.
+        request.sourceAudioPath = {};
+        return;
+    }
+
+    juce::AudioFormatManager formats;
+    formats.registerBasicFormats();
+
+    const auto file = getLegoContextFile();
+
+    if (legoStack.writeContext (file, formats, legoRegenerateIndex))
+        request.sourceAudioPath = file.getFullPathName();
+    else
+        request.sourceAudioPath = {};
+}
+
+void GenerationPanel::addLegoLayer (const juce::File& clip)
+{
+    if (legoRegenerateIndex >= 0)
+    {
+        legoStack.replaceLayer (legoRegenerateIndex, clip);
+        legoRegenerateIndex = -1;
+    }
+    else
+    {
+        legoStack.addLayer (legoTrackSelector.getText(), promptEditor.getText(), clip);
+    }
+
+    refresh();
+}
+
+juce::String GenerationPanel::getLegoText() const
+{
+    if (legoStack.getNumLayers() == 0)
+        return "Lego: no layers yet";
+
+    juce::StringArray names;
+
+    for (const auto& layer : legoStack.getLayers())
+        names.add (layer.enabled ? layer.track : "(" + layer.track + ")");
+
+    return "Lego: " + juce::String (legoStack.getNumLayers()) + " layers - "
+             + names.joinIntoString (", ");
+}
+
 juce::File GenerationPanel::getCaptureFileFor (GenerationRequest::Mode mode) const
 {
     const auto directory = generation.getClipDirectory().getChildFile ("captures");
@@ -653,8 +737,19 @@ GenerationRequest GenerationPanel::buildRequest() const
     // The capture is written at Generate time, but the path is known now — and has to
     // be, or findProblem() would report "needs a source audio file" and keep Generate
     // disabled forever for exactly the modes this story added.
-    if (GenerationRequest::needsSourceAudio (request.mode) && hasCaptureFor (request.mode))
+    if (request.mode == GenerationRequest::Mode::lego)
+    {
+        request.legoTrack = legoTrackSelector.getText();
+
+        // The context is written at Generate time, but naming it now is what lets
+        // findProblem() pass and the button enable — same reason as the captures.
+        if (legoStack.hasContext (legoRegenerateIndex))
+            request.sourceAudioPath = getLegoContextFile().getFullPathName();
+    }
+    else if (GenerationRequest::needsSourceAudio (request.mode) && hasCaptureFor (request.mode))
+    {
         request.sourceAudioPath = getCaptureFileFor (request.mode).getFullPathName();
+    }
 
     return request;
 }
@@ -723,6 +818,22 @@ void GenerationPanel::refresh()
 
     if (captureLabel.getText() != captureText)
         captureLabel.setText (captureText, juce::dontSendNotification);
+
+    const auto isLego = modeSelector.getSelectedId() - 1
+                          == GenerationRequest::allModes().indexOf (GenerationRequest::Mode::lego);
+
+    legoTrackLabel.setVisible (isLego);
+    legoTrackSelector.setVisible (isLego);
+    legoLabel.setVisible (isLego);
+    legoTrackSelector.setEnabled (! busy);
+
+    if (isLego)
+    {
+        const auto legoText = getLegoText();
+
+        if (legoLabel.getText() != legoText)
+            legoLabel.setText (legoText, juce::dontSendNotification);
+    }
 
     midiRecordToggle.setEnabled (! busy && midiCapture != nullptr);
     sidechainRecordToggle.setEnabled (! busy && hostOffersSidechain && sidechainCapture != nullptr);

--- a/plugin/source/GenerationPanel.h
+++ b/plugin/source/GenerationPanel.h
@@ -2,6 +2,7 @@
 
 #include "GenerationManager.h"
 #include "HostSync.h"
+#include "LegoStack.h"
 #include "MidiCapture.h"
 #include "SidechainCapture.h"
 
@@ -64,6 +65,15 @@ public:
     juce::ToggleButton& getMidiRecordToggle() noexcept     { return midiRecordToggle; }
     juce::ToggleButton& getSidechainRecordToggle() noexcept { return sidechainRecordToggle; }
     juce::Label&        getCaptureLabel() noexcept         { return captureLabel; }
+    juce::ComboBox&     getLegoTrackSelector() noexcept    { return legoTrackSelector; }
+    juce::Label&        getLegoLabel() noexcept            { return legoLabel; }
+
+    /** The layers built so far in Lego mode. */
+    LegoStack& getLegoStack() noexcept                    { return legoStack; }
+
+    /** Records a finished generation as the next layer. Called when a Lego generation
+        completes; exposed so a test does not have to drive a whole server round trip. */
+    void addLegoLayer (const juce::File& clip);
 
     /** True when `mode` has the input it needs and can be chosen. */
     bool isModeAvailable (GenerationRequest::Mode) const;
@@ -100,8 +110,18 @@ private:
     /** What the capture indicator should read right now. */
     juce::String getCaptureText() const;
 
+    /** What the Lego readout should read right now. */
+    juce::String getLegoText() const;
+
+    /** Writes the layers-so-far mix and points `request` at it. Does nothing for the
+        first layer, which has no context. */
+    void attachLegoContext (GenerationRequest&) const;
+
     /** Greys out the modes whose input has not been captured. */
     void refreshModeAvailability();
+
+    /** Where the layers-so-far mix is written for a Lego generation. */
+    juce::File getLegoContextFile() const;
 
     /** Where the capture backing `mode` is written. Known before the write happens, so
         buildRequest can name it and validation can pass. */
@@ -163,6 +183,15 @@ private:
     juce::Label      statusLabel;
     juce::Label      syncLabel;
     juce::Label      selectionLabel;
+
+    LegoStack legoStack;
+
+    /** Which layer a Generate would replace, or < 0 to append a new one. */
+    int legoRegenerateIndex = -1;
+
+    juce::Label      legoTrackLabel;
+    juce::ComboBox   legoTrackSelector;
+    juce::Label      legoLabel;
 
     juce::ToggleButton midiRecordToggle { "Record MIDI" };
     juce::ToggleButton sidechainRecordToggle { "Capture sidechain" };

--- a/plugin/source/GenerationPanel.h
+++ b/plugin/source/GenerationPanel.h
@@ -75,6 +75,10 @@ public:
         completes; exposed so a test does not have to drive a whole server round trip. */
     void addLegoLayer (const juce::File& clip);
 
+    /** As above, with the track and prompt the run was started with rather than whatever
+        the controls read now. */
+    void addLegoLayer (const juce::File& clip, const juce::String& track, const juce::String& prompt);
+
     /** True when `mode` has the input it needs and can be chosen. */
     bool isModeAvailable (GenerationRequest::Mode) const;
     juce::ProgressBar&  getProgressBar() noexcept         { return progressBar; }
@@ -112,6 +116,9 @@ private:
 
     /** What the Lego readout should read right now. */
     juce::String getLegoText() const;
+
+    /** Adds the clip of a just-finished Lego run to the stack. Idempotent. */
+    void collectFinishedLegoLayer();
 
     /** Writes the layers-so-far mix and points `request` at it. Does nothing for the
         first layer, which has no context. */
@@ -188,6 +195,12 @@ private:
 
     /** Which layer a Generate would replace, or < 0 to append a new one. */
     int legoRegenerateIndex = -1;
+
+    /** Set when a Lego generation is in flight, with the track and prompt it was started
+        with — the controls may have moved on by the time it lands. */
+    bool legoRunPending = false;
+    juce::String pendingLegoTrack;
+    juce::String pendingLegoPrompt;
 
     juce::Label      legoTrackLabel;
     juce::ComboBox   legoTrackSelector;

--- a/plugin/source/GenerationRequest.cpp
+++ b/plugin/source/GenerationRequest.cpp
@@ -37,6 +37,7 @@ juce::String GenerationRequest::toString (Mode mode) noexcept
         case Mode::cover:        return "Cover";
         case Mode::complete:     return "Complete";
         case Mode::repaint:      return "Repaint";
+        case Mode::lego:         return "Lego";
     }
 
     return "Text to Music";
@@ -76,6 +77,7 @@ juce::String GenerationRequest::taskTypeFor (Mode mode) noexcept
         case Mode::cover:    return "cover";
         case Mode::complete: return "complete";
         case Mode::repaint:  return "repaint";
+        case Mode::lego:     return "lego";
         // text2music is the server's default; the Python client omits it for exactly
         // this reason, so sending it would be a behaviour change rather than a no-op.
         case Mode::textToMusic: break;
@@ -86,7 +88,16 @@ juce::String GenerationRequest::taskTypeFor (Mode mode) noexcept
 
 juce::Array<GenerationRequest::Mode> GenerationRequest::allModes()
 {
-    return { Mode::textToMusic, Mode::cover, Mode::complete, Mode::repaint };
+    return { Mode::textToMusic, Mode::cover, Mode::complete, Mode::repaint, Mode::lego };
+}
+
+juce::String GenerationRequest::instructionForTrack() const
+{
+    if (legoTrack.trim().isEmpty())
+        return {};
+
+    // Mirrors ACE-Step's TASK_INSTRUCTIONS["lego"] template.
+    return "Generate the " + legoTrack.trim().toUpperCase() + " track based on the audio context:";
 }
 
 bool GenerationRequest::hasRepaintRange() const
@@ -116,8 +127,18 @@ juce::String GenerationRequest::findProblem() const
     if (durationSeconds <= 0)
         return "Duration must be greater than zero";
 
-    if (needsSourceAudio (mode) && sourceAudioPath.trim().isEmpty())
+    if (mode == Mode::lego)
+    {
+        if (legoTrack.trim().isEmpty())
+            return "Lego mode needs an instrument track to generate";
+
+        // No source is not an error here: the first layer has nothing to build on and is
+        // generated as ordinary text-to-music. Every later layer carries the mix so far.
+    }
+    else if (needsSourceAudio (mode) && sourceAudioPath.trim().isEmpty())
+    {
         return toString (mode) + " mode needs a source audio file";
+    }
 
     return {};
 }
@@ -155,14 +176,24 @@ juce::var GenerationRequest::toPayload() const
     if (model.isNotEmpty())
         payload->setProperty ("model", model);
 
-    if (const auto taskType = taskTypeFor (mode); taskType.isNotEmpty())
+    // The first Lego layer has no context, so it goes out as an ordinary text-to-music
+    // request: a `lego` task with no src_audio_path has nothing to build on.
+    const auto effectiveMode = (mode == Mode::lego && sourceAudioPath.trim().isEmpty())
+                                 ? Mode::textToMusic
+                                 : mode;
+
+    if (const auto taskType = taskTypeFor (effectiveMode); taskType.isNotEmpty())
     {
         payload->setProperty ("task_type", taskType);
         payload->setProperty ("src_audio_path", sourceAudioPath.trim());
 
+        // Which track to add. ACE-Step steers `lego` off this string, not off the caption.
+        if (effectiveMode == Mode::lego)
+            payload->setProperty ("instruction", instructionForTrack());
+
         // Repaint regenerates a range of the source rather than all of it. Omitted
         // unless both ends are set, matching the Python client's optional handling.
-        if (mode == Mode::repaint && hasRepaintRange())
+        if (effectiveMode == Mode::repaint && hasRepaintRange())
         {
             payload->setProperty ("repainting_start", repaintStartSeconds);
             payload->setProperty ("repainting_end", repaintEndSeconds);

--- a/plugin/source/GenerationRequest.h
+++ b/plugin/source/GenerationRequest.h
@@ -26,10 +26,15 @@ struct GenerationRequest
         textToMusic,
         cover,      ///< restyle a reference: the sidechain capture
         complete,   ///< flesh out a sketch: the MIDI capture, rendered
-        repaint     ///< regenerate a time range of a reference
+        repaint,    ///< regenerate a time range of a reference
+        lego        ///< add one instrument track on top of the layers so far
     };
 
-    /** True when `mode` cannot be submitted without sourceAudioPath. */
+    /** True when `mode` cannot be submitted without sourceAudioPath.
+
+        Lego is the exception that matters: the *first* layer has nothing to build on, so
+        it is an ordinary text-to-music generation. Ask isValid()/findProblem() rather than
+        this alone — they know about the first layer. */
     static bool needsSourceAudio (Mode) noexcept;
 
     /** The server's `task_type` for `mode`, or empty for the server default. */
@@ -66,12 +71,19 @@ struct GenerationRequest
     /** Server-side path to the source audio, for every mode but Text to Music. */
     juce::String sourceAudioPath;
 
+    /** Lego only: which instrument track to generate. Drives the server `instruction`;
+        see LegoStack::trackNames() for the values ACE-Step recognises. */
+    juce::String legoTrack;
+
     /** Repaint only: the range of the source to regenerate, in seconds. A negative
         start means "not set", and the range is omitted so the server decides. */
     double repaintStartSeconds = -1.0;
     double repaintEndSeconds = -1.0;
 
     bool hasRepaintRange() const;
+
+    /** The server `instruction` naming the Lego track, or empty when none is set. */
+    juce::String instructionForTrack() const;
 
     /** Model name from the connection panel; empty = let the server decide. */
     juce::String model;

--- a/plugin/source/LegoStack.cpp
+++ b/plugin/source/LegoStack.cpp
@@ -1,0 +1,186 @@
+#include "LegoStack.h"
+#include "AudioIo.h"
+
+namespace acemusic
+{
+
+namespace
+{
+    /** Reads a whole clip into memory. Returns an empty buffer if it is unreadable, so a
+        missing layer degrades the mix rather than failing the whole build. */
+    juce::AudioBuffer<float> readClip (const juce::File& file,
+                                       juce::AudioFormatManager& formats,
+                                       double& sampleRateOut)
+    {
+        std::unique_ptr<juce::AudioFormatReader> reader (formats.createReaderFor (file));
+
+        if (reader == nullptr || reader->numChannels == 0 || reader->lengthInSamples <= 0)
+            return {};
+
+        // Same bound as TimeStretch: layers are minutes at most, and the mix holds them
+        // all at once.
+        constexpr juce::int64 maxSamples = 60 * 60 * 192000;
+
+        if (reader->lengthInSamples > maxSamples)
+            return {};
+
+        juce::AudioBuffer<float> buffer ((int) reader->numChannels, (int) reader->lengthInSamples);
+
+        if (! reader->read (&buffer, 0, (int) reader->lengthInSamples, 0, true, true))
+            return {};
+
+        sampleRateOut = reader->sampleRate;
+        return buffer;
+    }
+}
+
+//==============================================================================
+juce::StringArray LegoStack::trackNames()
+{
+    // ACE-Step's TRACK_NAMES, in its own order (acestep/constants.py).
+    return { "drums", "bass", "guitar", "keyboard", "synth", "strings",
+             "brass", "woodwinds", "percussion", "fx", "vocals", "backing_vocals" };
+}
+
+juce::String LegoStack::instructionFor (const juce::String& track)
+{
+    if (track.isEmpty())
+        return {};
+
+    // Matches ACE-Step's TASK_INSTRUCTIONS["lego"]:
+    //   "Generate the {TRACK_NAME} track based on the audio context:"
+    // with TRACK_NAME upper-cased, as its CLI does.
+    return "Generate the " + track.toUpperCase() + " track based on the audio context:";
+}
+
+//==============================================================================
+void LegoStack::addLayer (const juce::String& track, const juce::String& prompt, const juce::File& clip)
+{
+    layers.add ({ track, prompt, clip, true });
+}
+
+bool LegoStack::replaceLayer (int index, const juce::File& clip)
+{
+    if (! juce::isPositiveAndBelow (index, layers.size()))
+        return false;
+
+    // Only the clip changes: the track and prompt describe what this layer *is*, and a
+    // regeneration is the same layer done again.
+    auto layer = layers[index];
+    layer.clip = clip;
+    layers.set (index, layer);
+    return true;
+}
+
+bool LegoStack::removeLayer (int index)
+{
+    if (! juce::isPositiveAndBelow (index, layers.size()))
+        return false;
+
+    layers.remove (index);
+    return true;
+}
+
+bool LegoStack::setLayerEnabled (int index, bool enabled)
+{
+    if (! juce::isPositiveAndBelow (index, layers.size()))
+        return false;
+
+    auto layer = layers[index];
+    layer.enabled = enabled;
+    layers.set (index, layer);
+    return true;
+}
+
+void LegoStack::clear()
+{
+    layers.clear();
+}
+
+//==============================================================================
+bool LegoStack::hasContext (int excludeIndex) const
+{
+    for (int i = 0; i < layers.size(); ++i)
+        if (i != excludeIndex && layers[i].enabled && layers[i].clip.existsAsFile())
+            return true;
+
+    return false;
+}
+
+double LegoStack::getContextSampleRate (juce::AudioFormatManager& formats) const
+{
+    for (const auto& layer : layers)
+    {
+        if (! layer.enabled)
+            continue;
+
+        std::unique_ptr<juce::AudioFormatReader> reader (formats.createReaderFor (layer.clip));
+
+        if (reader != nullptr && reader->sampleRate > 0.0)
+            return reader->sampleRate;
+    }
+
+    return 44100.0;
+}
+
+juce::AudioBuffer<float> LegoStack::mixContext (juce::AudioFormatManager& formats, int excludeIndex) const
+{
+    juce::Array<juce::AudioBuffer<float>> loaded;
+    int longest = 0;
+    int channels = 1;
+
+    for (int i = 0; i < layers.size(); ++i)
+    {
+        if (i == excludeIndex || ! layers[i].enabled)
+            continue;
+
+        double rate = 0.0;
+        auto buffer = readClip (layers[i].clip, formats, rate);
+
+        if (buffer.getNumSamples() <= 0)
+            continue;
+
+        longest = juce::jmax (longest, buffer.getNumSamples());
+        channels = juce::jmax (channels, buffer.getNumChannels());
+        loaded.add (std::move (buffer));
+    }
+
+    if (loaded.isEmpty())
+        return {};
+
+    juce::AudioBuffer<float> mix (channels, longest);
+    mix.clear();
+
+    for (const auto& buffer : loaded)
+    {
+        for (int channel = 0; channel < channels; ++channel)
+        {
+            // A mono layer is spread across the mix rather than left in one ear.
+            const auto sourceChannel = juce::jmin (channel, buffer.getNumChannels() - 1);
+            mix.addFrom (channel, 0, buffer, sourceChannel, 0, buffer.getNumSamples());
+        }
+    }
+
+    // Layers are summed, so a full arrangement will run past full scale. Scaling the
+    // whole mix keeps the balance the musician built; clipping would not.
+    const auto peak = mix.getMagnitude (0, longest);
+
+    if (peak > 1.0f)
+        mix.applyGain (1.0f / peak);
+
+    return mix;
+}
+
+bool LegoStack::writeContext (const juce::File& destination,
+                              juce::AudioFormatManager& formats,
+                              int excludeIndex) const
+{
+    const auto mix = mixContext (formats, excludeIndex);
+
+    if (mix.getNumSamples() <= 0)
+        return false;
+
+    return AudioIo::writeWav (destination, mix, getContextSampleRate (formats));
+}
+
+} // namespace acemusic

--- a/plugin/source/LegoStack.h
+++ b/plugin/source/LegoStack.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <juce_audio_formats/juce_audio_formats.h>
+
+namespace acemusic
+{
+
+/**
+    The layers of a Lego-mode build, and the context audio the next layer is generated
+    against.
+
+    ACE-Step's `lego` task type is "generate a specific instrument track in context": it
+    takes the music so far as `src_audio_path` and an instruction naming the track to add.
+    This owns the "music so far" half — the ordered layers, and their mixdown.
+
+    **Regenerating a layer uses the mix of the *others*.** A bass being replaced should fit
+    the drums it sits under, not the bass it is replacing, so the layer under revision is
+    excluded from its own context. That is the whole reason this is a type rather than a
+    juce::Array in the panel.
+*/
+class LegoStack
+{
+public:
+    LegoStack() = default;
+
+    /** One generated layer. */
+    struct Layer
+    {
+        /** ACE-Step track name, e.g. "bass". See trackNames(). */
+        juce::String track;
+
+        /** What the musician asked for, e.g. "a funky bass line". */
+        juce::String prompt;
+
+        juce::File clip;
+
+        /** Muted layers stay in the list but are left out of the context mix, so a part
+            can be auditioned out without losing it. */
+        bool enabled = true;
+    };
+
+    //==============================================================================
+    /** The instrument tracks ACE-Step recognises. These are its `TRACK_NAMES`, not ours;
+        a name outside this list produces an instruction the model was not trained on. */
+    static juce::StringArray trackNames();
+
+    /** The instruction that tells the server which track to generate. Matches ACE-Step's
+        own `TASK_INSTRUCTIONS["lego"]` template. */
+    static juce::String instructionFor (const juce::String& track);
+
+    //==============================================================================
+    void addLayer (const juce::String& track, const juce::String& prompt, const juce::File& clip);
+
+    /** Replaces the clip of an existing layer, leaving every other layer untouched.
+        @returns false if `index` is out of range. */
+    bool replaceLayer (int index, const juce::File& clip);
+
+    bool removeLayer (int index);
+    bool setLayerEnabled (int index, bool enabled);
+
+    const juce::Array<Layer>& getLayers() const noexcept      { return layers; }
+    int getNumLayers() const noexcept                         { return layers.size(); }
+    void clear();
+
+    //==============================================================================
+    /** Mixes every enabled layer, optionally excluding one.
+
+        @param excludeIndex  the layer being regenerated, or < 0 to include them all
+        @returns an empty buffer when nothing would be in the mix */
+    juce::AudioBuffer<float> mixContext (juce::AudioFormatManager&, int excludeIndex = -1) const;
+
+    /** Writes the context mix to `destination`.
+        @returns false when there is nothing to mix or the write failed. */
+    bool writeContext (const juce::File& destination,
+                       juce::AudioFormatManager&,
+                       int excludeIndex = -1) const;
+
+    /** True when a generation would have context to work from — i.e. the next layer is a
+        `lego` task rather than an ordinary text-to-music one. */
+    bool hasContext (int excludeIndex = -1) const;
+
+    /** The sample rate the context mix is written at. Taken from the first readable
+        layer so the mix matches the material rather than a guess. */
+    double getContextSampleRate (juce::AudioFormatManager&) const;
+
+private:
+    juce::Array<Layer> layers;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LegoStack)
+};
+
+} // namespace acemusic

--- a/plugin/source/PluginEditor.cpp
+++ b/plugin/source/PluginEditor.cpp
@@ -45,8 +45,8 @@ PluginEditor::PluginEditor (PluginProcessor& p)
     // a sliver.
     // Raised again for US-24.3: Generation gained a capture row and two host readouts,
     // and below this the Results panel had no room left for a clip row at all.
-    setResizeLimits (560, 800, 1600, 1600);
-    setSize (780, 920);
+    setResizeLimits (560, 830, 1600, 1600);
+    setSize (780, 950);
 }
 
 PluginEditor::~PluginEditor() = default;

--- a/plugin/tests/GenerationPanelTests.cpp
+++ b/plugin/tests/GenerationPanelTests.cpp
@@ -972,6 +972,83 @@ public:
                     "the layer readout is wrong: " + panel.getLegoLabel().getText());
         }
 
+        beginTest ("AC: Lego is selectable from an empty stack, with nothing captured");
+        {
+            // Every Lego build starts here. Gating the mode behind a capture made it
+            // impossible to reach at all.
+            PluginProcessor processor (nullptr, false);
+            processor.prepareToPlay (44100.0, 512);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 950);
+            auto& panel = editor.getGenerationPanel();
+
+            expect (panel.isModeAvailable (GenerationRequest::Mode::lego),
+                    "Lego was unavailable with an empty stack, so it can never be started");
+
+            const auto legoIndex = GenerationRequest::allModes()
+                                       .indexOf (GenerationRequest::Mode::lego);
+            expect (panel.getModeSelector().isItemEnabled (legoIndex + 1),
+                    "the Lego entry is greyed out in the dropdown");
+        }
+
+        beginTest ("AC: a finished Lego generation becomes the next layer, in production");
+        {
+            // The piece-wise tests all passed while nothing in the plugin ever called
+            // addLegoLayer, so the stack stayed empty and every layer was a first layer.
+            // This drives the real path: click Generate, let the run finish, check the
+            // stack grew and the next request has context.
+            ScopedClipCleanup cleanup;
+            const auto cleanupRoot = cleanup.root;
+
+            Harness harness { std::move (cleanup.properties) };
+            test::StubAceStepServer server;
+            expect (server.start() != 0);
+            expect (connect (harness, server), "never connected");
+
+            auto& panel = harness.panel();
+            const auto legoId = GenerationRequest::allModes()
+                                    .indexOf (GenerationRequest::Mode::lego) + 1;
+            panel.getModeSelector().setSelectedId (legoId, juce::sendNotificationSync);
+            panel.getPromptEditor().setText ("a tight drum beat", true);
+
+            expect (pumpUntil ([&] { return panel.getGenerateButton().isEnabled(); }),
+                    "Generate never enabled for a first Lego layer");
+
+            const auto trackChosen = panel.getLegoTrackSelector().getText();
+            panel.getGenerateButton().triggerClick();
+            expect (pumpUntil ([&] { return harness.generation().isBusy(); }), "never started");
+
+            // The run finishes and publishes a clip, exactly as a real one would.
+            const auto produced = writeTone (cleanupRoot.getChildFile ("produced.wav"), 220.0);
+            harness.generation().setClipsForTesting ({ produced });
+
+            expect (pumpUntil ([&] { return panel.getLegoStack().getNumLayers() == 1; }, 5000),
+                    "the finished layer was never added to the stack");
+
+            expectEquals (panel.getLegoStack().getLayers()[0].track, trackChosen,
+                          "the layer recorded the wrong track");
+            expectEquals (panel.getLegoStack().getLayers()[0].prompt,
+                          juce::String ("a tight drum beat"));
+
+            // ...and it is only added once, however many change messages arrive.
+            harness.generation().sendChangeMessage();
+            harness.generation().sendChangeMessage();
+            expect (! pumpUntil ([&] { return panel.getLegoStack().getNumLayers() != 1; }, 1200),
+                    "the layer was added more than once");
+
+            // The next generation now has context, so it is a real lego task.
+            panel.getPromptEditor().setText ("a funky bass line", true);
+            const auto second = panel.buildRequest();
+            expect (second.sourceAudioPath.isNotEmpty(),
+                    "the second layer still has no context, so the stack is not being used");
+
+            const juce::var payload = second.toPayload();
+            expectEquals (payload.getDynamicObject()->getProperty ("task_type").toString(),
+                          juce::String ("lego"),
+                          "the second layer went out as text-to-music again");
+        }
+
         beginTest ("the Lego controls only appear in Lego mode");
         {
             PluginProcessor processor (nullptr, false);

--- a/plugin/tests/GenerationPanelTests.cpp
+++ b/plugin/tests/GenerationPanelTests.cpp
@@ -84,6 +84,33 @@ public:
         std::unique_ptr<juce::PropertiesFile> properties;
     };
 
+    /** A one-second tone on disk, so a Lego layer is real readable audio. */
+    static juce::File writeTone (const juce::File& file, double frequency)
+    {
+        constexpr double sampleRate = 44100.0;
+        const int numSamples = (int) sampleRate;
+        juce::AudioBuffer<float> buffer (1, numSamples);
+
+        for (int i = 0; i < numSamples; ++i)
+            buffer.setSample (0, i, 0.3f * (float) std::sin (juce::MathConstants<double>::twoPi
+                                                             * frequency * (double) i / sampleRate));
+
+        juce::WavAudioFormat wav;
+        std::unique_ptr<juce::OutputStream> stream (file.createOutputStream());
+
+        if (stream != nullptr)
+        {
+            auto writer = wav.createWriterFor (stream, juce::AudioFormatWriterOptions{}
+                                                           .withSampleRate (sampleRate)
+                                                           .withNumChannels (1)
+                                                           .withBitsPerSample (16));
+            if (writer != nullptr)
+                writer->writeFromAudioSampleBuffer (buffer, 0, numSamples);
+        }
+
+        return file;
+    }
+
     /** Points the harness at `server` and waits for a green connection. */
     bool connect (Harness& harness, test::StubAceStepServer& server)
     {
@@ -122,8 +149,8 @@ public:
             expect (panel.getLanguageSelector().getNumItems() >= 51, "expected Auto + 50+ languages");
             expectEquals (panel.getQualitySelector().getNumItems(), 3);
             expectEquals (panel.getQualitySelector().getText(), juce::String ("Standard"));
-            // Text to Music, Cover, Complete, Repaint since US-24.3.
-            expectEquals (panel.getModeSelector().getNumItems(), 4);
+            // Text to Music, Cover, Complete, Repaint (US-24.3) and Lego (US-24.4).
+            expectEquals (panel.getModeSelector().getNumItems(), 5);
             expectEquals (panel.getDurationEditor().getText(), juce::String ("60"));
 
             // BPM and seed are blank, meaning Auto/Random.
@@ -883,6 +910,86 @@ public:
             // And the two modes must not share a file.
             expect (complete.sourceAudioPath != request.sourceAudioPath,
                     "Complete and Cover were pointed at the same capture file");
+        }
+
+        beginTest ("AC: Lego builds layers in order, each on top of the ones before");
+        {
+            ScopedClipCleanup cleanup;
+            const auto cleanupRoot = cleanup.root;
+            PluginProcessor processor (std::move (cleanup.properties), false);
+            processor.prepareToPlay (44100.0, 512);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 950);
+            auto& panel = editor.getGenerationPanel();
+
+            const auto legoId = GenerationRequest::allModes()
+                                    .indexOf (GenerationRequest::Mode::lego) + 1;
+            panel.getModeSelector().setSelectedId (legoId, juce::sendNotificationSync);
+            panel.getPromptEditor().setText ("a tight drum beat", true);
+
+            // The track list is ACE-Step's.
+            expectEquals (panel.getLegoTrackSelector().getNumItems(), LegoStack::trackNames().size());
+
+            // First layer: nothing to build on, so no source and a plain text2music payload.
+            const auto first = panel.buildRequest();
+            expect (first.mode == GenerationRequest::Mode::lego);
+            expect (first.legoTrack.isNotEmpty(), "no track was chosen");
+            expect (first.sourceAudioPath.isEmpty(),
+                    "the first layer claimed a context it does not have");
+            expect (first.isValid(), first.findProblem());
+
+            // Record it as a layer. Real audio, so the context mix can actually be built.
+            const auto layerOne = writeTone (cleanupRoot.getChildFile ("layer1.wav"), 220.0);
+            const auto layerTwo = writeTone (cleanupRoot.getChildFile ("layer2.wav"), 330.0);
+
+            panel.addLegoLayer (layerOne);
+            expectEquals (panel.getLegoStack().getNumLayers(), 1);
+
+            // Second layer: now there is context, so it becomes a real lego task.
+            panel.getLegoTrackSelector().setSelectedId (2, juce::sendNotificationSync);
+            panel.getPromptEditor().setText ("a funky bass line", true);
+
+            const auto second = panel.buildRequest();
+            expect (second.sourceAudioPath.isNotEmpty(),
+                    "the second layer has no context to build on");
+            expect (second.sourceAudioPath.endsWith ("lego-context.wav"));
+
+            const juce::var payload = second.toPayload();
+            expectEquals (payload.getDynamicObject()->getProperty ("task_type").toString(),
+                          juce::String ("lego"));
+            expect (payload.getDynamicObject()->getProperty ("instruction").toString()
+                        .contains (second.legoTrack.toUpperCase()),
+                    "the instruction does not name the chosen track");
+
+            panel.addLegoLayer (layerTwo);
+            expectEquals (panel.getLegoStack().getNumLayers(), 2);
+            expectEquals (panel.getLegoStack().getLayers()[0].track, juce::String ("drums"));
+            expectEquals (panel.getLegoStack().getLayers()[1].prompt,
+                          juce::String ("a funky bass line"));
+
+            expect (panel.getLegoLabel().getText().contains ("2 layers"),
+                    "the layer readout is wrong: " + panel.getLegoLabel().getText());
+        }
+
+        beginTest ("the Lego controls only appear in Lego mode");
+        {
+            PluginProcessor processor (nullptr, false);
+            processor.prepareToPlay (44100.0, 512);
+
+            PluginEditor editor (processor);
+            editor.setSize (720, 950);
+            auto& panel = editor.getGenerationPanel();
+
+            panel.getModeSelector().setSelectedId (1, juce::sendNotificationSync);   // Text to Music
+            expect (! panel.getLegoTrackSelector().isVisible(),
+                    "the Lego track selector is showing outside Lego mode");
+
+            const auto legoId = GenerationRequest::allModes()
+                                    .indexOf (GenerationRequest::Mode::lego) + 1;
+            panel.getModeSelector().setSelectedId (legoId, juce::sendNotificationSync);
+            expect (panel.getLegoTrackSelector().isVisible(),
+                    "the Lego track selector is hidden in Lego mode");
         }
 
         beginTest ("the capture toggles arm the captures they name");

--- a/plugin/tests/GenerationRequestTests.cpp
+++ b/plugin/tests/GenerationRequestTests.cpp
@@ -268,6 +268,72 @@ public:
             request.repaintEndSeconds = 1.0;
             expect (! request.hasRepaintRange(), "a backwards range was accepted");
         }
+
+        //======================================================================
+        // US-24.4 — Lego layers.
+
+        beginTest ("AC: a Lego layer carries the track instruction the server steers off");
+        {
+            GenerationRequest request;
+            request.prompt = "a funky bass line";
+            request.mode = GenerationRequest::Mode::lego;
+            request.legoTrack = "bass";
+            request.sourceAudioPath = "/tmp/context.wav";
+
+            expect (request.isValid(), request.findProblem());
+
+            const juce::var payload = request.toPayload();
+            auto* object = payload.getDynamicObject();
+
+            expectEquals (object->getProperty ("task_type").toString(), juce::String ("lego"));
+            expectEquals (object->getProperty ("src_audio_path").toString(),
+                          juce::String ("/tmp/context.wav"));
+
+            // ACE-Step steers lego off the instruction, not the caption. Getting this
+            // wrong produces a layer for whatever track the model feels like.
+            expectEquals (object->getProperty ("instruction").toString(),
+                          juce::String ("Generate the BASS track based on the audio context:"));
+        }
+
+        beginTest ("Lego without a track is refused, since the instruction would be empty");
+        {
+            GenerationRequest request;
+            request.prompt = "something";
+            request.mode = GenerationRequest::Mode::lego;
+            request.sourceAudioPath = "/tmp/context.wav";
+
+            expect (! request.isValid(), "a Lego layer with no track was submittable");
+            expect (request.findProblem().containsIgnoreCase ("track"),
+                    "the problem does not mention the track: " + request.findProblem());
+        }
+
+        beginTest ("the first Lego layer is a plain text-to-music generation");
+        {
+            // Nothing to build on yet. A `lego` task with no context has no audio to add
+            // a track to, so it goes out as text2music instead.
+            GenerationRequest request;
+            request.prompt = "a tight drum beat";
+            request.mode = GenerationRequest::Mode::lego;
+            request.legoTrack = "drums";
+            // sourceAudioPath deliberately empty
+
+            expect (request.isValid(),
+                    "the first layer was refused for having no context: " + request.findProblem());
+
+            const juce::var payload = request.toPayload();
+            auto* object = payload.getDynamicObject();
+
+            expect (! object->hasProperty ("task_type"),
+                    "the first layer was sent as a lego task with nothing to build on");
+            expect (! object->hasProperty ("src_audio_path"));
+            expect (! object->hasProperty ("instruction"));
+
+            // And the second layer, once there is context, is a real lego task.
+            request.sourceAudioPath = "/tmp/context.wav";
+            const juce::var second = request.toPayload();
+            expectEquals (second.getDynamicObject()->getProperty ("task_type").toString(),
+                          juce::String ("lego"));
+        }
     }
 };
 

--- a/plugin/tests/LegoStackTests.cpp
+++ b/plugin/tests/LegoStackTests.cpp
@@ -1,0 +1,287 @@
+#include "LegoStack.h"
+
+#include <cmath>
+
+namespace acemusic
+{
+
+class LegoStackTests final : public juce::UnitTest
+{
+public:
+    LegoStackTests()
+        : juce::UnitTest ("LegoStack", "acemusic")
+    {
+    }
+
+    static constexpr double sampleRate = 44100.0;
+
+    struct ScopedTempDir
+    {
+        ScopedTempDir()
+        {
+            directory = juce::File::getSpecialLocation (juce::File::tempDirectory)
+                            .getChildFile ("acemusic-lego-"
+                                           + juce::String (juce::Random::getSystemRandom().nextInt (1 << 30)));
+            directory.createDirectory();
+        }
+
+        ~ScopedTempDir()    { directory.deleteRecursively(); }
+
+        juce::File directory;
+    };
+
+    /** A one-second tone at `frequency`, so each layer is identifiable in a mix. */
+    static juce::File writeTone (const juce::File& file, double frequency, int channels = 1)
+    {
+        const int numSamples = (int) sampleRate;
+        juce::AudioBuffer<float> buffer (channels, numSamples);
+
+        for (int channel = 0; channel < channels; ++channel)
+            for (int i = 0; i < numSamples; ++i)
+                buffer.setSample (channel, i,
+                                  0.3f * (float) std::sin (juce::MathConstants<double>::twoPi
+                                                           * frequency * (double) i / sampleRate));
+
+        juce::WavAudioFormat wav;
+        std::unique_ptr<juce::OutputStream> stream (file.createOutputStream());
+
+        if (stream != nullptr)
+        {
+            auto writer = wav.createWriterFor (stream, juce::AudioFormatWriterOptions{}
+                                                           .withSampleRate (sampleRate)
+                                                           .withNumChannels (channels)
+                                                           .withBitsPerSample (16));
+            if (writer != nullptr)
+                writer->writeFromAudioSampleBuffer (buffer, 0, numSamples);
+        }
+
+        return file;
+    }
+
+    /** Energy at `frequency`, so a mix can be asked which layers are in it. */
+    static double energyAt (const juce::AudioBuffer<float>& buffer, double frequency)
+    {
+        const auto* data = buffer.getReadPointer (0);
+        const auto n = buffer.getNumSamples();
+        double re = 0.0, im = 0.0;
+
+        for (int i = 0; i < n; ++i)
+        {
+            const auto phase = juce::MathConstants<double>::twoPi * frequency * (double) i / sampleRate;
+            re += data[i] * std::cos (phase);
+            im += data[i] * std::sin (phase);
+        }
+
+        return std::sqrt (re * re + im * im) / (double) n;
+    }
+
+    void runTest() override
+    {
+        beginTest ("the track list is ACE-Step's, not one of our own");
+        {
+            const auto tracks = LegoStack::trackNames();
+
+            // Every name here has to exist in ACE-Step's TRACK_NAMES, or the instruction
+            // describes a track the model was never trained on.
+            for (const auto* expected : { "drums", "bass", "guitar", "keyboard", "synth",
+                                          "strings", "brass", "woodwinds", "percussion",
+                                          "fx", "vocals", "backing_vocals" })
+            {
+                expect (tracks.contains (expected), juce::String (expected) + " is missing");
+            }
+
+            expectEquals (tracks.size(), 12);
+        }
+
+        beginTest ("the instruction matches the template the server steers off");
+        {
+            expectEquals (LegoStack::instructionFor ("bass"),
+                          juce::String ("Generate the BASS track based on the audio context:"));
+            expectEquals (LegoStack::instructionFor ("backing_vocals"),
+                          juce::String ("Generate the BACKING_VOCALS track based on the audio context:"));
+            expect (LegoStack::instructionFor ("").isEmpty(), "an empty track produced an instruction");
+        }
+
+        beginTest ("an empty stack has no context to build on");
+        {
+            LegoStack stack;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            expect (! stack.hasContext(), "an empty stack claimed to have context");
+            expectEquals (stack.mixContext (formats).getNumSamples(), 0);
+            expectEquals (stack.getNumLayers(), 0);
+        }
+
+        beginTest ("AC: the context mix contains every layer built so far");
+        {
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            LegoStack stack;
+            stack.addLayer ("drums", "a tight beat", writeTone (dir.directory.getChildFile ("l1.wav"), 220.0));
+            stack.addLayer ("bass",  "a funky line", writeTone (dir.directory.getChildFile ("l2.wav"), 330.0));
+
+            expect (stack.hasContext());
+            expectEquals (stack.getNumLayers(), 2);
+
+            const auto mix = stack.mixContext (formats);
+            expect (mix.getNumSamples() > 0, "nothing was mixed");
+
+            // Both layers are audible in the mix, and nothing else is.
+            expect (energyAt (mix, 220.0) > 0.05, "the drums layer is missing from the context");
+            expect (energyAt (mix, 330.0) > 0.05, "the bass layer is missing from the context");
+            expect (energyAt (mix, 550.0) < 0.01, "the mix contains a layer that was never added");
+        }
+
+        beginTest ("a muted layer stays in the list but leaves the context");
+        {
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            LegoStack stack;
+            stack.addLayer ("drums", "beat", writeTone (dir.directory.getChildFile ("l1.wav"), 220.0));
+            stack.addLayer ("bass",  "line", writeTone (dir.directory.getChildFile ("l2.wav"), 330.0));
+
+            expect (stack.setLayerEnabled (1, false));
+            expectEquals (stack.getNumLayers(), 2, "muting removed the layer");
+
+            const auto mix = stack.mixContext (formats);
+            expect (energyAt (mix, 220.0) > 0.05, "the enabled layer left the mix");
+            expect (energyAt (mix, 330.0) < 0.01, "a muted layer was still in the context");
+        }
+
+        beginTest ("AC: regenerating one layer leaves the others untouched");
+        {
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            LegoStack stack;
+            const auto drums = writeTone (dir.directory.getChildFile ("drums.wav"), 220.0);
+            const auto bass  = writeTone (dir.directory.getChildFile ("bass.wav"), 330.0);
+            stack.addLayer ("drums", "beat", drums);
+            stack.addLayer ("bass",  "line", bass);
+
+            const auto drumsBefore = drums.getSize();
+            const auto newBass = writeTone (dir.directory.getChildFile ("bass2.wav"), 440.0);
+
+            expect (stack.replaceLayer (1, newBass));
+
+            expectEquals (stack.getNumLayers(), 2, "regenerating changed the layer count");
+            expectEquals (stack.getLayers()[0].clip.getFullPathName(), drums.getFullPathName(),
+                          "the drums layer was disturbed by regenerating the bass");
+            expectEquals (drums.getSize(), drumsBefore, "the drums file itself was rewritten");
+
+            // The track and prompt describe what the layer *is*, so a regeneration keeps them.
+            expectEquals (stack.getLayers()[1].track, juce::String ("bass"));
+            expectEquals (stack.getLayers()[1].prompt, juce::String ("line"));
+
+            const auto mix = stack.mixContext (formats);
+            expect (energyAt (mix, 440.0) > 0.05, "the regenerated layer is not in the mix");
+            expect (energyAt (mix, 330.0) < 0.01, "the replaced layer is still in the mix");
+        }
+
+        beginTest ("a layer being regenerated is excluded from its own context");
+        {
+            // The whole point: a replacement bass should fit the drums it sits under,
+            // not the bass it is replacing.
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            LegoStack stack;
+            stack.addLayer ("drums", "beat", writeTone (dir.directory.getChildFile ("l1.wav"), 220.0));
+            stack.addLayer ("bass",  "line", writeTone (dir.directory.getChildFile ("l2.wav"), 330.0));
+
+            const auto context = stack.mixContext (formats, 1);
+
+            expect (energyAt (context, 220.0) > 0.05, "the drums left the regeneration context");
+            expect (energyAt (context, 330.0) < 0.01,
+                    "the layer being regenerated was fed back in as its own context");
+
+            // With only one layer, regenerating it leaves nothing to build on — which
+            // makes it a first-layer generation again.
+            LegoStack single;
+            single.addLayer ("drums", "beat", writeTone (dir.directory.getChildFile ("l3.wav"), 220.0));
+            expect (! single.hasContext (0), "a lone layer claimed itself as context");
+            expectEquals (single.mixContext (formats, 0).getNumSamples(), 0);
+        }
+
+        beginTest ("layers of different lengths and channel counts mix without clipping");
+        {
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            LegoStack stack;
+            stack.addLayer ("drums", "beat", writeTone (dir.directory.getChildFile ("mono.wav"), 220.0, 1));
+            stack.addLayer ("bass", "line", writeTone (dir.directory.getChildFile ("stereo.wav"), 330.0, 2));
+
+            const auto mix = stack.mixContext (formats);
+            expectEquals (mix.getNumChannels(), 2, "the mix collapsed to the narrowest layer");
+            expect (mix.getMagnitude (0, mix.getNumSamples()) <= 1.0f, "the layer mix clipped");
+
+            // The mono layer reaches both channels rather than sitting in one ear.
+            expect (energyAt (mix, 220.0) > 0.05);
+        }
+
+        beginTest ("writing the context produces a readable WAV, and nothing when empty");
+        {
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            LegoStack stack;
+            stack.addLayer ("drums", "beat", writeTone (dir.directory.getChildFile ("l1.wav"), 220.0));
+
+            const auto out = dir.directory.getChildFile ("ctx").getChildFile ("context.wav");
+            expect (stack.writeContext (out, formats), "the context write failed");
+
+            std::unique_ptr<juce::AudioFormatReader> reader (formats.createReaderFor (out));
+            expect (reader != nullptr, "the context is not readable audio");
+            expectWithinAbsoluteError (reader->sampleRate, sampleRate, 0.5);
+
+            LegoStack empty;
+            const auto none = dir.directory.getChildFile ("none.wav");
+            expect (! empty.writeContext (none, formats), "an empty stack wrote a context");
+            expect (! none.existsAsFile());
+        }
+
+        beginTest ("a layer whose file has gone missing degrades the mix rather than failing it");
+        {
+            ScopedTempDir dir;
+            juce::AudioFormatManager formats;
+            formats.registerBasicFormats();
+
+            LegoStack stack;
+            stack.addLayer ("drums", "beat", writeTone (dir.directory.getChildFile ("l1.wav"), 220.0));
+            stack.addLayer ("bass", "line", dir.directory.getChildFile ("never-written.wav"));
+
+            expect (stack.hasContext(), "one missing layer took the whole context down");
+
+            const auto mix = stack.mixContext (formats);
+            expect (mix.getNumSamples() > 0, "a missing layer emptied the mix");
+            expect (energyAt (mix, 220.0) > 0.05, "the surviving layer was lost too");
+        }
+
+        beginTest ("out-of-range edits are refused rather than corrupting the stack");
+        {
+            LegoStack stack;
+            expect (! stack.replaceLayer (0, {}));
+            expect (! stack.removeLayer (0));
+            expect (! stack.setLayerEnabled (0, false));
+
+            stack.addLayer ("drums", "beat", {});
+            expect (! stack.replaceLayer (1, {}));
+            expect (! stack.replaceLayer (-1, {}));
+            expectEquals (stack.getNumLayers(), 1);
+        }
+    }
+};
+
+static LegoStackTests legoStackTests;
+
+} // namespace acemusic


### PR DESCRIPTION
Implements **US-24.4 — Lego Mode and Layer-by-Layer Generation** (#323).

Pick **Lego** and a **Layer** track, describe the part, Generate. Each finished layer joins
the stack, and the next generation receives the mix of the layers so far as its context.

---

## Acceptance criteria — evidence

| Criterion | Outcome |
| --- | --- |
| Drums then bass produces two layers where the bass fits the drums | **Met — verified live.** See below |
| ~~Each layer is placed on its own track in the DAW~~ | **Amended** per #318 — each layer is a draggable clip |
| Regenerating one layer does not affect the others | **Met** — `LegoStack / AC: regenerating one layer leaves the others untouched` |
| Context audio is audibly reflected in the generated layer | **Met — verified live.** See below |

### Live verification: drums, then bass in context

```
layer1 drums  16.0s  tempo 117.45 BPM  centroid 2219 Hz
layer2 bass   16.0s  tempo 117.45 BPM  centroid 1888 Hz

distinct renders                        yes
tempo agreement                         0.00 BPM
onset-envelope correlation (aligned)   +0.844
same under random time shifts (null)   -0.002
```

The second layer's rhythmic events land **on** the first's, and shifting either in time
destroys the correlation completely. Tempo matches exactly. The bass also sits lower in the
spectrum than the drums, as a bass part should.

That is a real result, and worth contrasting with US-24.3's Cover mode, which I reported as
**unverified** because its numbers came out at chance. The same method distinguishes them.

---

## What the server actually does, and a correction

`lego` is a genuine ACE-Step task type — *"generate a specific instrument track in
context"* — steered by an **`instruction`** string naming the track, not by your caption:

```
Generate the BASS track based on the audio context:
```

**I got this wrong first.** I read `acestep/ui/gradio/api/api_routes.py`, found no
`instruction` handling anywhere in it, and concluded track steering was CLI-only. A live
submission proved otherwise — the running server uses a different route and used the
instruction exactly as sent. Recording it because the code reading was confidently wrong
and only the empirical check caught it.

The track list is ACE-Step's own `TRACK_NAMES`, so a layer always names something the model
was trained on. Your prompt still describes *what kind* of part you want; the two compose.

---

## Design notes

**The first layer is deliberately not a `lego` task.** There is nothing to build on, so no
`task_type` and no context are sent and it goes out as ordinary text-to-music. This is the
one thing about the mode that is easy to get wrong, so it has its own test.

**Regenerating a layer excludes that layer from its own context** — a replacement bass
should fit the drums it sits under, not the bass it is replacing. That is the whole reason
`LegoStack` is a type rather than a `juce::Array` in the panel. Layers can also be muted out
of the context without being deleted.

**A layer whose file has gone missing degrades the mix rather than failing it**, so one bad
clip does not take down a whole build.

---

## Known limitations

1. **The plugin cannot place layers on separate tracks** — VST3 has no arrangement write.
   Same limit as #318 and #321; each layer is a draggable clip.
2. **The context is the plugin's own layers, not the DAW timeline.** A plugin cannot read
   other tracks. To bring real DAW audio in, capture it on the sidechain (US-24.3) — the
   two compose.
3. Not verified in a real DAW (none installed here); the README carries a manual check.

Closes #323
