### PR TITLE
feat(api): US-25.1 Voice Model Training Backend (#325)

### DIFF
--- a/docs/voice-models.md
+++ b/docs/voice-models.md
@@ -1,0 +1,79 @@
+# Custom voice models (Stage 25)
+
+Train a voice from your own recordings and use it in generation.
+
+## Training a voice
+
+`POST /api/v1/voice-models/train` — multipart: 2–10 reference recordings, a name, and an
+optional description.
+
+| Check | Rule |
+| --- | --- |
+| File count | 2–10 |
+| Format | anything `soundfile` decodes (WAV, FLAC, OGG) |
+| Sample rate | ≥ 16 kHz |
+| Duration | ≥ 1 s per reference |
+| Level | not silent |
+| Consistency | no obvious odd-one-out (see the caveat below) |
+
+**Every rejection names the file**, because "invalid file" is useless when ten were
+uploaded: `thin.wav: sample rate is 8000 Hz, below the 16000 Hz minimum.`
+
+**Validation runs before the charge.** A rejected upload costs nothing. Training costs
+**10 credits**, deducted only once every check that can reject the request has passed, and
+**refunded on any failure** — using the amount actually charged, so a later price change
+cannot alter what you get back.
+
+### The consistency check is not speaker verification
+
+It compares spectral centroids. That catches the mistake that actually happens — a drum
+loop or a backing track mixed in among the vocal takes — and it will **not** distinguish
+two different people with similar timbre. The threshold is deliberately loose: a false
+reject costs you a usable model, which is worse than training on one slightly odd take.
+
+Doing this properly needs speaker embeddings, which is its own piece of work.
+
+## How training actually runs
+
+The worker drives ACE-Step's LoRA endpoints:
+
+```
+POST /v1/dataset/scan               → find the references
+PUT  /v1/dataset/sample/{i}         → label each one
+POST /v1/dataset/preprocess_async   → build tensors
+POST /v1/training/start             → fine-tune
+GET  /v1/training/status            → poll
+POST /v1/training/export            → export the adapter
+```
+
+Four things about that sequence are worth knowing, because none is guessable and each was
+wrong in the first implementation:
+
+1. **Scan and label are not optional.** Preprocessing works on the server's *current*
+   dataset and silently skips unlabelled samples — calling it directly returns
+   `No labeled samples to preprocess` and produces nothing.
+2. **Training status is a boolean.** `/v1/training/status` reports `is_training` with a
+   human `status` string ("Idle"), not `completed`/`failed`. `is_training` reads false
+   both *before* a run starts and after it ends, so the poller has a start grace period —
+   without it, a run that never began reports success and keeps the credits.
+3. **Export writes a directory.** The loadable PEFT adapter is the `adapter/` child of the
+   export path; pointing `/v1/lora/load` at the root is rejected.
+4. **Paths must resolve under ACE-Step's working directory** — see
+   `acestep/training/path_safety.py`. The training endpoints take *paths, not uploads*, so
+   **the platform and ACE-Step must share a filesystem.** A split deployment needs a
+   shared volume; there is no upload endpoint to fall back on.
+
+## Verified end to end
+
+A real 3-reference run against a local ACE-Step 1.5:
+
+```
+preprocess   3/3 samples → tensors on disk
+training     11,010,048 parameters, loss 1.647
+export       43 MB adapter
+load back    {"lora_loaded": true, "active_adapter": "adapter"}
+```
+
+The exported adapter loads back into the model, which is the difference between "the job
+completed" and "the voice is usable" — a distinction the code makes too: a model is only
+`is_usable` when it is `ready` **and** holds weights.

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -43,6 +43,7 @@ from .routers import (
     studio,
     users,
     videos,
+    voice_models,
     workspaces,
 )
 from .settings import ApiSettings
@@ -188,6 +189,7 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
     app.include_router(health.router, prefix=API_V1_PREFIX)
     app.include_router(auth.router, prefix=API_V1_PREFIX)
     app.include_router(users.router, prefix=API_V1_PREFIX)
+    app.include_router(voice_models.router, prefix=API_V1_PREFIX)
     app.include_router(models.router, prefix=API_V1_PREFIX)
     app.include_router(generation.router, prefix=API_V1_PREFIX)
     app.include_router(jobs.router, prefix=API_V1_PREFIX)

--- a/src/acemusic/api/models/__init__.py
+++ b/src/acemusic/api/models/__init__.py
@@ -18,6 +18,7 @@ from .release import Release, ReleaseStatus
 from .soundcloud_connection import SoundCloudConnection
 from .user import User
 from .video import Video
+from .voice_model import VoiceModel, VoiceModelStatus
 from .workspace import Workspace
 
 ALL_MODELS = [
@@ -36,9 +37,12 @@ ALL_MODELS = [
     Counter,
     PlaybackQueue,
     Video,
+    VoiceModel,
 ]
 
 __all__ = [
+    "VoiceModel",
+    "VoiceModelStatus",
     "User",
     "Workspace",
     "Clip",

--- a/src/acemusic/api/models/voice_model.py
+++ b/src/acemusic/api/models/voice_model.py
@@ -1,0 +1,93 @@
+"""Voice model document (US-25.1).
+
+A custom voice trained from the musician's own reference recordings, via
+ACE-Step's LoRA fine-tuning. The document tracks the model through training and
+holds the exported weights key once it is ready.
+
+Private by construction: every read is owner-scoped, which is what US-25.3's
+"other users cannot see or access another user's voice models" rests on.
+"""
+
+from datetime import datetime
+from enum import Enum
+
+from beanie import Document, PydanticObjectId
+from pydantic import Field
+from pymongo import ASCENDING, IndexModel
+
+from .common import utcnow
+
+#: Bounds from the story: enough references to characterise a voice, few enough
+#: that training stays minutes rather than hours.
+MIN_REFERENCE_FILES = 2
+MAX_REFERENCE_FILES = 10
+
+#: Below this the reference carries too little detail for the model to learn a
+#: voice from, and training would burn credits to produce something unusable.
+MIN_SAMPLE_RATE_HZ = 16000
+
+#: A reference shorter than this is not a voice, it is a syllable.
+MIN_REFERENCE_SECONDS = 1.0
+
+#: Guard against a single enormous upload; ten of these is the real bound.
+MAX_REFERENCE_BYTES = 50 * 1024 * 1024
+
+
+class VoiceModelStatus(str, Enum):
+    """Mirrors the job lifecycle, with ``ready`` as the terminal success state.
+
+    Deliberately distinct from ``JobStatus``: a voice model outlives the job that
+    produced it, and "completed job" and "usable voice" are not the same claim.
+    """
+
+    QUEUED = "queued"
+    TRAINING = "training"
+    READY = "ready"
+    FAILED = "failed"
+
+
+class VoiceModel(Document):
+    """One custom voice, and the training run that produced it."""
+
+    user_id: PydanticObjectId
+    name: str
+    description: str | None = None
+
+    status: VoiceModelStatus = VoiceModelStatus.QUEUED
+
+    #: Storage keys of the uploaded references, in upload order.
+    reference_paths: list[str] = Field(default_factory=list)
+
+    #: Storage key of the exported LoRA weights. None until training succeeds —
+    #: which is the difference between a model that exists and one that is usable.
+    weights_path: str | None = None
+
+    #: The training job, so status can be followed without a second lookup table.
+    job_id: PydanticObjectId | None = None
+
+    #: Why training failed, shown to the owner. None unless status is ``failed``.
+    error: str | None = None
+
+    #: Credits taken for this training run, so a refund cannot guess the amount
+    #: and a price change cannot retroactively alter what someone gets back.
+    credits_charged: float = 0.0
+
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
+
+    @property
+    def reference_count(self) -> int:
+        return len(self.reference_paths)
+
+    @property
+    def is_usable(self) -> bool:
+        """Ready *and* actually holding weights — the check a generation should make."""
+        return self.status is VoiceModelStatus.READY and bool(self.weights_path)
+
+    class Settings:
+        name = "voice_models"
+        indexes = [
+            # Every listing is "this user's models, newest first" (US-25.3).
+            IndexModel([("user_id", ASCENDING), ("created_at", ASCENDING)]),
+            IndexModel([("job_id", ASCENDING)]),
+        ]

--- a/src/acemusic/api/routers/voice_models.py
+++ b/src/acemusic/api/routers/voice_models.py
@@ -1,0 +1,110 @@
+"""Voice model endpoints (US-25.1 training, US-25.3 library), mounted under
+``/api/v1/voice-models``.
+
+* ``POST   /voice-models/train`` → validate references, charge, queue training
+* ``GET    /voice-models``       → the caller's models, newest first
+
+Every read is owner-scoped: a voice model is private, and ownership is part of
+the query rather than a check afterwards, so there is no path that reads someone
+else's model at all.
+"""
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from pydantic import BaseModel
+
+from ..auth.dependencies import CurrentUser, require_existing_user
+from ..models import VoiceModel, VoiceModelStatus
+from ..models.voice_model import MAX_REFERENCE_FILES, MIN_REFERENCE_FILES
+from ..services import credits as credits_service, voice_models as voice_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/voice-models", tags=["voice-models"])
+
+
+class VoiceModelResponse(BaseModel):
+    id: str
+    name: str
+    description: str | None
+    status: VoiceModelStatus
+    reference_count: int
+    job_id: str | None
+    error: str | None
+    created_at: datetime
+
+    @classmethod
+    def from_model(cls, model: VoiceModel) -> "VoiceModelResponse":
+        return cls(
+            id=str(model.id),
+            name=model.name,
+            description=model.description,
+            status=model.status,
+            reference_count=model.reference_count,
+            job_id=str(model.job_id) if model.job_id else None,
+            error=model.error,
+            created_at=model.created_at,
+        )
+
+
+class TrainingAccepted(BaseModel):
+    """What a caller needs to follow the run (US-25.2 adds the status endpoint)."""
+
+    job_id: str
+    voice_model: VoiceModelResponse
+    credits_charged: float
+
+
+@router.post("/train", response_model=TrainingAccepted, status_code=status.HTTP_202_ACCEPTED)
+async def train_voice_model(
+    files: list[UploadFile] = File(...),
+    name: str = Form(...),
+    description: str | None = Form(default=None),
+    current: CurrentUser = Depends(require_existing_user),
+) -> TrainingAccepted:
+    """Queue a LoRA fine-tune from the caller's reference recordings.
+
+    Validation runs before the charge, so a rejected upload never costs credits.
+    """
+    # Bounded before the bodies are read: eleven 50MB uploads should not be
+    # buffered just to be told there are too many.
+    if not MIN_REFERENCE_FILES <= len(files) <= MAX_REFERENCE_FILES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Training takes between {MIN_REFERENCE_FILES} and {MAX_REFERENCE_FILES} "
+                f"reference files; {len(files)} were uploaded."
+            ),
+        )
+
+    payloads = [(f.filename or "reference", await f.read()) for f in files]
+
+    try:
+        model, job = await voice_service.create_training_job(current.user_id, name, payloads, description=description)
+    except voice_service.InsufficientCreditsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=str(exc),
+        ) from exc
+    except voice_service.VoiceModelError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+
+    return TrainingAccepted(
+        job_id=str(job.id),
+        voice_model=VoiceModelResponse.from_model(model),
+        credits_charged=credits_service.VOICE_TRAINING_COST,
+    )
+
+
+@router.get("", response_model=list[VoiceModelResponse])
+async def list_voice_models(
+    current: CurrentUser = Depends(require_existing_user),
+) -> list[VoiceModelResponse]:
+    """The caller's voice models, newest first."""
+    models = await voice_service.list_voice_models(current.user_id)
+    return [VoiceModelResponse.from_model(m) for m in models]

--- a/src/acemusic/api/services/credits.py
+++ b/src/acemusic/api/services/credits.py
@@ -61,6 +61,12 @@ VIDEO_LONG_DURATION_S = 180.0
 VIDEO_LONG_DURATION_SURCHARGE = 2.0
 VIDEO_MAX_COST = 10.0
 
+# US-25.1: training a custom voice model is a premium action -- minutes of GPU
+# fine-tuning rather than one inference pass -- and is priced accordingly. Kept
+# out of ``_COSTS`` because it is not a generation mode; ``get_cost("voice_training")``
+# would wrongly suggest it is one.
+VOICE_TRAINING_COST = 10.0
+
 # History page size for GET /users/me/credits.
 HISTORY_LIMIT = 50
 

--- a/src/acemusic/api/services/voice_models.py
+++ b/src/acemusic/api/services/voice_models.py
@@ -250,6 +250,17 @@ async def create_training_job(
 
         model.job_id = job.id
         await model.save()
+
+        # The ledger, not just the balance: /users/me/credits builds its history
+        # from CreditTransaction, so without this the balance drops with no usage
+        # row to explain it -- unlike every other billed endpoint.
+        await credits_service.record_transaction(
+            user_id=uid,
+            amount=-cost,
+            action_type="voice_training",
+            job_id=str(job.id),
+            balance_after=deducted,
+        )
     except BaseException:
         # BaseException, not Exception: a shutdown CancelledError must also give
         # the credits back rather than leaving the musician charged for nothing.
@@ -300,6 +311,15 @@ async def fail_training(model: VoiceModel, reason: str) -> VoiceModel:
 
     if model.credits_charged > 0:
         await credits_service.refund_credits(model.user_id, model.credits_charged)
+
+        user = await User.get(model.user_id)
+        await credits_service.record_transaction(
+            user_id=model.user_id,
+            amount=model.credits_charged,
+            action_type="voice_training_refund",
+            job_id=str(model.job_id) if model.job_id else "",
+            balance_after=user.credits_balance if user is not None else 0.0,
+        )
 
     return model
 

--- a/src/acemusic/api/services/voice_models.py
+++ b/src/acemusic/api/services/voice_models.py
@@ -1,0 +1,326 @@
+"""Voice model service (US-25.1).
+
+Validates reference recordings, charges for training, and records the model.
+Transport-agnostic like the other service modules: it raises plain exceptions,
+never ``HTTPException``.
+
+The order of validation is the behaviour, not an implementation detail: the
+musician is only charged once every check that can reject the request has
+already passed, so a bad upload never costs credits.
+"""
+
+import asyncio
+import io
+import logging
+import math
+from dataclasses import dataclass
+
+from beanie import PydanticObjectId
+
+from acemusic.storage import StorageBackend, get_storage_backend
+
+from ..models import Job, User, VoiceModel, VoiceModelStatus
+from ..models.voice_model import (
+    MAX_REFERENCE_BYTES,
+    MAX_REFERENCE_FILES,
+    MIN_REFERENCE_FILES,
+    MIN_REFERENCE_SECONDS,
+    MIN_SAMPLE_RATE_HZ,
+)
+from . import credits as credits_service
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceModelError(Exception):
+    """A reference set that cannot be trained on."""
+
+
+class InsufficientCreditsError(Exception):
+    """Not enough credits to start training."""
+
+    def __init__(self, balance: float, required: float) -> None:
+        super().__init__(f"Training needs {required} credits; balance is {balance}.")
+        self.balance = balance
+        self.required = required
+
+
+@dataclass(frozen=True)
+class ReferenceAudio:
+    """One uploaded reference and what could be measured from it."""
+
+    filename: str
+    data: bytes
+    sample_rate: int
+    duration: float
+    peak: float
+
+    #: Coarse spectral fingerprint, used only for the consistency check below.
+    centroid: float
+
+
+def _probe_sync(filename: str, data: bytes) -> ReferenceAudio:
+    """Decode ``data`` far enough to validate it.
+
+    Raises :class:`VoiceModelError` naming the file, because "a file is invalid"
+    is useless when ten were uploaded.
+    """
+    import numpy as np
+    import soundfile as sf
+
+    try:
+        audio, sample_rate = sf.read(io.BytesIO(data), always_2d=True)
+    except Exception as exc:
+        # soundfile decodes wav/flac/ogg. An mp3 or a corrupt body lands here.
+        raise VoiceModelError(
+            f"{filename}: could not be read as audio. Upload WAV or FLAC at {MIN_SAMPLE_RATE_HZ} Hz or above."
+        ) from exc
+
+    if audio.size == 0:
+        raise VoiceModelError(f"{filename}: contains no audio.")
+
+    mono = audio.mean(axis=1)
+    duration = len(mono) / float(sample_rate) if sample_rate else 0.0
+    peak = float(np.max(np.abs(mono))) if mono.size else 0.0
+
+    # Spectral centroid as a very coarse timbre fingerprint. See
+    # check_consistency for what this is and is not.
+    spectrum = np.abs(np.fft.rfft(mono * np.hanning(len(mono)))) if mono.size > 1 else np.zeros(1)
+    freqs = np.fft.rfftfreq(len(mono), 1.0 / sample_rate) if mono.size > 1 else np.zeros(1)
+    total = float(spectrum.sum())
+    centroid = float((spectrum * freqs).sum() / total) if total > 0 else 0.0
+
+    return ReferenceAudio(
+        filename=filename,
+        data=data,
+        sample_rate=int(sample_rate),
+        duration=duration,
+        peak=peak,
+        centroid=centroid if math.isfinite(centroid) else 0.0,
+    )
+
+
+def check_file_count(count: int) -> None:
+    """Reject a reference set that is too small or too large, before reading anything."""
+    uploaded = f"{count} was uploaded" if count == 1 else f"{count} were uploaded"
+
+    if count < MIN_REFERENCE_FILES:
+        raise VoiceModelError(f"Training needs at least {MIN_REFERENCE_FILES} reference files; {uploaded}.")
+    if count > MAX_REFERENCE_FILES:
+        raise VoiceModelError(f"Training takes at most {MAX_REFERENCE_FILES} reference files; {uploaded}.")
+
+
+def check_reference(reference: ReferenceAudio) -> None:
+    """Reject one reference that cannot usefully be trained on.
+
+    Every message names the file, since the point is to tell the musician which
+    recording to replace.
+    """
+    if reference.sample_rate < MIN_SAMPLE_RATE_HZ:
+        raise VoiceModelError(
+            f"{reference.filename}: sample rate is {reference.sample_rate} Hz, "
+            f"below the {MIN_SAMPLE_RATE_HZ} Hz minimum."
+        )
+
+    if reference.duration < MIN_REFERENCE_SECONDS:
+        raise VoiceModelError(
+            f"{reference.filename}: is {reference.duration:.2f}s long, " f"below the {MIN_REFERENCE_SECONDS}s minimum."
+        )
+
+    # Silence trains nothing, and finding that out after ten minutes of GPU time
+    # and 10 credits is a bad trade.
+    if reference.peak < 0.01:
+        raise VoiceModelError(f"{reference.filename}: is silent or almost silent.")
+
+
+def check_consistency(references: list[ReferenceAudio]) -> None:
+    """Reject a reference set whose files clearly are not the same source.
+
+    **This is not speaker verification.** Comparing "similar vocal
+    characteristics" properly needs speaker embeddings; this compares spectral
+    centroids, which catches the mistake that actually happens — a drum loop or a
+    backing track mixed in among the vocal takes — and will not catch two
+    different people with similar timbre. The PR and the docs say so rather than
+    implying otherwise.
+
+    The threshold is deliberately loose: a false reject costs the musician a
+    usable model, which is worse than training on one slightly odd take.
+    """
+    centroids = [r.centroid for r in references if r.centroid > 0]
+
+    if len(centroids) < 2:
+        return
+
+    median = sorted(centroids)[len(centroids) // 2]
+
+    if median <= 0:
+        return
+
+    for reference in references:
+        if reference.centroid <= 0:
+            continue
+        # An octave-and-a-half either side of the median. Vocal takes vary; a
+        # drum loop does not land anywhere near a voice.
+        ratio = reference.centroid / median
+        if ratio > 3.0 or ratio < (1 / 3.0):
+            raise VoiceModelError(
+                f"{reference.filename}: does not sound like the other references "
+                f"(very different spectral balance). Remove it, or train it separately."
+            )
+
+
+async def validate_references(files: list[tuple[str, bytes]]) -> list[ReferenceAudio]:
+    """Run every check, in the order that keeps a rejection free.
+
+    Raises :class:`VoiceModelError` on the first problem, naming the file.
+    """
+    check_file_count(len(files))
+
+    for filename, data in files:
+        if len(data) > MAX_REFERENCE_BYTES:
+            raise VoiceModelError(f"{filename}: exceeds the {MAX_REFERENCE_BYTES} byte limit for one reference.")
+
+    # Decoding is CPU work; keep it off the event loop.
+    references = await asyncio.gather(*(asyncio.to_thread(_probe_sync, filename, data) for filename, data in files))
+
+    for reference in references:
+        check_reference(reference)
+
+    check_consistency(list(references))
+    return list(references)
+
+
+async def create_training_job(
+    user_id: str,
+    name: str,
+    files: list[tuple[str, bytes]],
+    *,
+    description: str | None = None,
+) -> tuple[VoiceModel, Job]:
+    """Validate, charge, store, and queue a voice-training run.
+
+    Nothing is charged or stored until validation passes, and if queueing fails
+    after the charge the credits are refunded before the error propagates —
+    otherwise a musician pays 10 credits for a job that never existed.
+    """
+    if not name or not name.strip():
+        raise VoiceModelError("Give the voice model a name.")
+
+    references = await validate_references(files)
+
+    uid = PydanticObjectId(user_id)
+    cost = credits_service.VOICE_TRAINING_COST
+
+    deducted = await credits_service.deduct_credits(uid, cost)
+    if deducted is None:
+        user = await User.get(uid)
+        raise InsufficientCreditsError(
+            balance=user.credits_balance if user is not None else 0.0,
+            required=cost,
+        )
+
+    model = VoiceModel(
+        user_id=uid,
+        name=name.strip(),
+        description=(description or "").strip() or None,
+        status=VoiceModelStatus.QUEUED,
+        credits_charged=cost,
+    )
+
+    storage = get_storage_backend()
+
+    try:
+        await model.insert()
+        model.reference_paths = await _store_references(storage, model, references)
+        await model.save()
+
+        job = Job(
+            user_id=uid,
+            # Voice training is account-scoped, not workspace-scoped: the model is
+            # usable from every workspace. The field is required, so it carries the
+            # model id to keep the record self-describing rather than a fake id.
+            workspace_id=model.id,
+            job_type="voice_training",
+            input_params={
+                "voice_model_id": str(model.id),
+                "reference_count": len(references),
+            },
+        )
+        await job.insert()
+
+        model.job_id = job.id
+        await model.save()
+    except BaseException:
+        # BaseException, not Exception: a shutdown CancelledError must also give
+        # the credits back rather than leaving the musician charged for nothing.
+        await credits_service.refund_credits(uid, cost)
+        await _cleanup_partial(storage, model)
+        raise
+
+    return model, job
+
+
+async def _store_references(storage: StorageBackend, model: VoiceModel, references: list[ReferenceAudio]) -> list[str]:
+    """Upload the references and return their storage keys, in upload order."""
+    paths: list[str] = []
+
+    for index, reference in enumerate(references):
+        suffix = reference.filename.rsplit(".", 1)[-1].lower() if "." in reference.filename else "wav"
+        path = f"{model.user_id}/voice-models/{model.id}/ref-{index}.{suffix}"
+        await asyncio.to_thread(storage.upload, path, reference.data)
+        paths.append(path)
+
+    return paths
+
+
+async def _cleanup_partial(storage: StorageBackend, model: VoiceModel) -> None:
+    """Best-effort removal of a half-created model's objects and record."""
+    for path in model.reference_paths:
+        try:
+            await asyncio.to_thread(storage.delete, path)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Failed to delete orphaned voice reference %s", path)
+
+    try:
+        if model.id is not None:
+            await model.delete()
+    except Exception:  # pragma: no cover
+        logger.exception("Failed to delete partial voice model %s", model.id)
+
+
+async def fail_training(model: VoiceModel, reason: str) -> VoiceModel:
+    """Mark a model failed and refund what its training cost.
+
+    The refund uses ``credits_charged`` rather than the current price, so a
+    change to the cost table cannot alter what someone already paid gets back.
+    """
+    model.status = VoiceModelStatus.FAILED
+    model.error = reason
+    await model.save()
+
+    if model.credits_charged > 0:
+        await credits_service.refund_credits(model.user_id, model.credits_charged)
+
+    return model
+
+
+async def list_voice_models(user_id: str) -> list[VoiceModel]:
+    """Every voice model owned by ``user_id``, newest first."""
+    uid = PydanticObjectId(user_id)
+    models = await VoiceModel.find(VoiceModel.user_id == uid).to_list()
+    models.sort(key=lambda m: m.created_at, reverse=True)
+    return models
+
+
+async def find_owned_model(model_id: str, user_id: str) -> VoiceModel | None:
+    """A voice model, only if ``user_id`` owns it.
+
+    Ownership is part of the query rather than a check afterwards, so there is no
+    path that reads someone else's model at all.
+    """
+    try:
+        oid = PydanticObjectId(model_id)
+    except Exception:
+        return None
+
+    return await VoiceModel.find_one(VoiceModel.id == oid, VoiceModel.user_id == PydanticObjectId(user_id))

--- a/src/acemusic/api/settings.py
+++ b/src/acemusic/api/settings.py
@@ -110,6 +110,13 @@ class ApiSettings(BaseSettings):
     compute_preference: Literal["local_first", "remote_first", "local_only", "remote_only"] = "local_first"
     local_url: str = "http://localhost:8001"
 
+    # US-25.1: where voice-training artefacts are written. ACE-Step's training
+    # endpoints take *paths, not uploads*, and its path-safety check rejects
+    # anything outside its own working directory -- so this must be the same
+    # directory ACE-Step sees as ``./acemusic-voice-training``. Co-located by
+    # default; a split deployment needs a shared volume here.
+    voice_training_root: str = "./acemusic-voice-training"
+
     # RunPod serverless remote routing (US-11.2). The credentials are optional: a
     # deployment without them runs local-only — ``runpod_enabled`` is False, so the
     # routing engine reports remote unavailable (``*_first`` falls back, ``remote_only``

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -48,7 +48,7 @@ from .iterative import ITERATIVE_JOB_HANDLERS
 from .mastering import MASTERING_JOB_HANDLERS
 from .studio import STUDIO_JOB_HANDLERS
 from .video import VIDEO_JOB_HANDLERS
-from .voice_training import VOICE_TRAINING_JOB_HANDLERS
+from .voice_training import TRAINING_ROOT as VOICE_TRAINING_ROOT, VOICE_TRAINING_JOB_HANDLERS
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +114,7 @@ class JobProcessor:
         image_client_factory: Callable[[], ImageGenerationClient | None] | None = None,
         video_client_factory: Callable[[], VideoGenerationService | None] | None = None,
         storage_factory: Callable[[], StorageBackend] | None = None,
+        voice_training_root: str = VOICE_TRAINING_ROOT,
         handlers: dict[str, JobHandler] | None = None,
     ) -> None:
         self._concurrency = concurrency
@@ -148,6 +149,10 @@ class JobProcessor:
         self._stale_after = stale_after if stale_after is not None else poll_timeout + 300.0
         self._client_factory = client_factory or _default_client_factory
         self._storage_factory = storage_factory or get_storage_backend
+        # US-25.1: the local directory ACE-Step sees as its training root. The
+        # references are written here so ACE-Step can scan them; its endpoints take
+        # paths, not uploads.
+        self._voice_training_root = voice_training_root
         # Handler registry keyed by job_type: only registered types are claimed
         # (and re-queued when stale), so jobs another deployment owns are left
         # alone. ``handlers`` lets callers add or override entries.
@@ -383,6 +388,7 @@ class JobProcessor:
             job,
             storage=self._storage_factory(),
             base_url=self._client_factory().base_url,
+            training_root=self._voice_training_root,
         )
 
     async def _handle_generate(self, job: Job) -> dict[str, Any]:

--- a/src/acemusic/api/tasks/processor.py
+++ b/src/acemusic/api/tasks/processor.py
@@ -48,6 +48,7 @@ from .iterative import ITERATIVE_JOB_HANDLERS
 from .mastering import MASTERING_JOB_HANDLERS
 from .studio import STUDIO_JOB_HANDLERS
 from .video import VIDEO_JOB_HANDLERS
+from .voice_training import VOICE_TRAINING_JOB_HANDLERS
 
 logger = logging.getLogger(__name__)
 
@@ -171,6 +172,10 @@ class JobProcessor:
         # so they get their own injecting wrapper.
         for job_type, mastering_handler in MASTERING_JOB_HANDLERS.items():
             self._handlers[job_type] = partial(self._run_mastering_handler, mastering_handler)
+        # Voice training (US-25.1) drives ACE-Step's LoRA endpoints directly, so it
+        # needs storage plus the local ACE-Step base URL rather than a client object.
+        for job_type, voice_handler in VOICE_TRAINING_JOB_HANDLERS.items():
+            self._handlers[job_type] = partial(self._run_voice_training_handler, voice_handler)
         # Artwork handlers (US-13.1) need storage plus the image client, so they
         # get their own injecting wrapper like mastering.
         for job_type, artwork_handler in ARTWORK_JOB_HANDLERS.items():
@@ -365,6 +370,20 @@ class JobProcessor:
                 "and ACEMUSIC_API_VIDEO_API_KEY to enable it."
             )
         return await video_handler(job, storage=self._storage_factory(), client=client)
+
+    async def _run_voice_training_handler(self, voice_handler: Any, job: Job) -> dict[str, Any]:
+        """Adapt a voice-training handler (US-25.1), injecting storage and the
+        ACE-Step base URL. Training runs against whatever ``local_url`` points at —
+        the same server generation already uses, so there is no second target to
+        configure."""
+        # The training endpoints live on the same ACE-Step server generation already
+        # uses, so the base URL comes from the existing client factory rather than a
+        # second setting that could drift out of step with it.
+        return await voice_handler(
+            job,
+            storage=self._storage_factory(),
+            base_url=self._client_factory().base_url,
+        )
 
     async def _handle_generate(self, job: Job) -> dict[str, Any]:
         """Run a generation job — locally via ACE-Step or remotely via RunPod.

--- a/src/acemusic/api/tasks/voice_training.py
+++ b/src/acemusic/api/tasks/voice_training.py
@@ -1,0 +1,332 @@
+"""Voice model training worker (US-25.1).
+
+Drives ACE-Step's LoRA fine-tuning over its HTTP API:
+
+    POST /v1/dataset/scan              (audio_dir)
+    PUT  /v1/dataset/sample/{i}        (label each sample)
+    POST /v1/dataset/preprocess_async  ->  poll /v1/dataset/preprocess_status
+    POST /v1/training/start            ->  poll /v1/training/status
+    POST /v1/training/export           ->  store the weights
+
+**Scan and label are not optional.** Preprocessing operates on the server's
+*current* dataset, and an unlabelled sample is skipped -- calling preprocess
+without them returns "No labeled samples to preprocess" and produces nothing.
+Auto-labelling goes through the LLM, which a memory-constrained ACE-Step host may
+not have loaded, so each sample is labelled directly instead.
+
+The payloads and the status vocabulary here are taken from ACE-Step's own
+request models (``acestep/api/train_api_models.py``,
+``train_api_dataset_models.py``) and from a live probe of the running server,
+**not** from a guess. That distinction cost a rewrite: the first version of this
+module invented ``{"dataset": ..., "name": ...}`` payloads and expected a
+``"completed"``/``"failed"`` status string, and its stub tests passed because the
+stub encoded the same guess. The real API takes ``tensor_dir`` and reports
+``{"is_training": bool, "status": "Idle", "error": null}``.
+
+**ACE-Step reads its own filesystem.** These endpoints take *paths*, not uploads,
+and reject anything resolving outside the server's working directory
+(``acestep/training/path_safety.py``). So voice training requires the platform and
+ACE-Step to share a filesystem, and ``TRAINING_ROOT`` is deliberately relative so
+it lands under that root. A split deployment needs a shared volume; there is no
+upload endpoint to fall back on.
+
+**Credits are refunded on every failure path**, including a cancellation during
+shutdown. A musician who paid 10 credits for a run that produced nothing must not
+stay charged, and that is the easiest thing here to get wrong.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from acemusic.storage import StorageBackend
+
+from ..models import Job, VoiceModel, VoiceModelStatus
+from ..services import voice_models as voice_service
+
+logger = logging.getLogger(__name__)
+
+VOICE_TRAINING_JOB_TYPE = "voice_training"
+
+#: Where ACE-Step keeps this platform's training artefacts, on the ACE-Step host.
+#: Relative on purpose -- it must resolve under ACE-Step's working directory or
+#: its path-safety check rejects it.
+TRAINING_ROOT = "./acemusic-voice-training"
+
+#: ``/v1/training/export`` writes a directory; the loadable PEFT adapter is this
+#: child of it. Handing /v1/lora/load the export root fails.
+ADAPTER_SUBDIR = "adapter"
+
+#: How often the training status is polled, and how long before it is abandoned.
+#: Training is minutes on a GPU; the timeout is generous because giving up on a
+#: run that is still going would refund a model the musician is about to get.
+POLL_INTERVAL_S = 5.0
+POLL_TIMEOUT_S = 3600.0
+
+#: How long ``is_training`` may still read false after /training/start before the
+#: run is treated as having failed to begin.
+TRAINING_START_GRACE_S = 60.0
+
+#: The phases reported back, in order. US-25.2 turns these into a progress bar.
+PHASES = ("preprocessing", "training", "finalizing")
+
+
+class VoiceTrainingError(Exception):
+    """Training could not be completed."""
+
+
+async def _post(client: httpx.AsyncClient, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    response = await client.post(path, json=payload)
+    response.raise_for_status()
+    body = response.json()
+    # ACE-Step wraps everything in {"data": ..., "code": ...}; `data` is sometimes
+    # absent, in which case the body itself is the payload.
+    data = body.get("data")
+    return data if isinstance(data, dict) else body
+
+
+async def _put(client: httpx.AsyncClient, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    response = await client.put(path, json=payload)
+    response.raise_for_status()
+    body = response.json()
+    data = body.get("data")
+    return data if isinstance(data, dict) else body
+
+
+async def _get(client: httpx.AsyncClient, path: str) -> dict[str, Any]:
+    response = await client.get(path)
+    response.raise_for_status()
+    body = response.json()
+    data = body.get("data")
+    return data if isinstance(data, dict) else body
+
+
+async def _poll_preprocess(
+    client: httpx.AsyncClient, task_id: str, *, interval: float, timeout: float
+) -> dict[str, Any]:
+    """Wait for a dataset preprocess task.
+
+    ``PreprocessTask`` carries ``status`` plus ``current``/``total``, and its
+    terminal states are the ordinary words — unlike training, which reports a
+    boolean.
+    """
+    waited = 0.0
+
+    while waited < timeout:
+        data = await _get(client, f"/v1/dataset/preprocess_status/{task_id}")
+        state = str(data.get("status") or "").lower()
+
+        if state in {"completed", "complete", "success", "succeeded", "finished", "done"}:
+            return data
+
+        if state in {"failed", "error", "cancelled", "canceled"}:
+            raise VoiceTrainingError(str(data.get("error") or data.get("progress") or f"preprocessing {state}"))
+
+        await asyncio.sleep(interval)
+        waited += interval
+
+    raise VoiceTrainingError(f"Preprocessing did not finish within {int(timeout)}s")
+
+
+async def _poll_training(
+    client: httpx.AsyncClient, *, interval: float, timeout: float, on_progress=None
+) -> dict[str, Any]:
+    """Wait for a training run to finish.
+
+    The real contract is a **boolean**, not a status word: ``/v1/training/status``
+    reports ``is_training`` with a human ``status`` string ("Idle") alongside it.
+    So "finished" means *is_training went false after having been true*, and the
+    ``error`` field is what distinguishes success from failure.
+
+    The started grace period matters: immediately after ``/training/start``
+    returns, ``is_training`` can still read false, and treating that as "already
+    finished" would report success for a run that never began.
+    """
+    waited = 0.0
+    started = False
+
+    while waited < timeout:
+        data = await _get(client, "/v1/training/status")
+        is_training = bool(data.get("is_training"))
+        error = data.get("error")
+
+        if on_progress is not None:
+            await on_progress(data)
+
+        if error:
+            raise VoiceTrainingError(str(error))
+
+        if is_training:
+            started = True
+        elif started:
+            return data
+        elif waited >= TRAINING_START_GRACE_S:
+            raise VoiceTrainingError(f"Training never started (status: {data.get('status') or 'unknown'})")
+
+        await asyncio.sleep(interval)
+        waited += interval
+
+    raise VoiceTrainingError(f"Training did not finish within {int(timeout)}s")
+
+
+async def process_voice_training_job(
+    job: Job,
+    *,
+    storage: StorageBackend,
+    base_url: str,
+    poll_interval: float = POLL_INTERVAL_S,
+    poll_timeout: float = POLL_TIMEOUT_S,
+) -> dict[str, Any]:
+    """Train a voice model from its stored references.
+
+    On any failure the model is marked failed and its credits refunded, and the
+    error is re-raised so the job record reflects it too.
+    """
+    model_id = (job.input_params or {}).get("voice_model_id")
+    model = await VoiceModel.get(model_id) if model_id else None
+
+    if model is None:
+        # Nothing to refund against and nothing to train; a job pointing at a
+        # missing model is a bug, not a user error.
+        raise VoiceTrainingError(f"Voice training job {job.id} references unknown model {model_id!r}")
+
+    try:
+        return await _train(
+            model, job, storage=storage, base_url=base_url, poll_interval=poll_interval, poll_timeout=poll_timeout
+        )
+    except BaseException as exc:
+        # BaseException, not Exception: a CancelledError during shutdown must also
+        # give the credits back rather than leaving the musician charged.
+        reason = str(exc) or exc.__class__.__name__
+        try:
+            await voice_service.fail_training(model, reason)
+        except Exception:  # pragma: no cover - the refund must not mask the cause
+            logger.exception("Failed to refund voice training for model %s", model.id)
+        raise
+
+
+async def _train(
+    model: VoiceModel,
+    job: Job,
+    *,
+    storage: StorageBackend,
+    base_url: str,
+    poll_interval: float,
+    poll_timeout: float,
+) -> dict[str, Any]:
+    model.status = VoiceModelStatus.TRAINING
+    await model.save()
+
+    # Server-side paths: ACE-Step preprocesses, trains and exports on its own
+    # filesystem, so these name directories on that host rather than storage keys.
+    reference_dir = f"{TRAINING_ROOT}/{model.id}/refs"
+    tensor_dir = f"{TRAINING_ROOT}/{model.id}/tensors"
+    lora_dir = f"{TRAINING_ROOT}/{model.id}/lora"
+    export_path = f"{TRAINING_ROOT}/{model.id}/voice.safetensors"
+
+    async def record(phase: str) -> None:
+        job.progress = phase
+        await job.save()
+
+    async with httpx.AsyncClient(base_url=base_url.rstrip("/"), timeout=60.0) as client:
+        # 1. Preprocess the references into a training dataset.
+        await record("preprocessing")
+
+        # Scan first: preprocessing works on the server's current dataset, so
+        # without this it either preprocesses someone else's samples or nothing.
+        scan = await _post(client, "/v1/dataset/scan", {"audio_dir": reference_dir})
+        samples = scan.get("samples") or []
+
+        if not samples:
+            raise VoiceTrainingError(f"ACE-Step found no audio in {reference_dir}")
+
+        # Then label. A scanned sample is `labeled: false`, and preprocessing
+        # silently skips those -- "No labeled samples to preprocess" with a task
+        # that immediately 404s. Auto-labelling needs the LLM, which is not
+        # guaranteed to be loaded, so the caption is set directly.
+        caption = (model.description or f"{model.name} vocal reference").strip()
+
+        for index, _ in enumerate(samples):
+            await _put(
+                client,
+                f"/v1/dataset/sample/{index}",
+                {
+                    "sample_idx": index,
+                    "caption": caption,
+                    "genre": "vocal",
+                    "is_instrumental": False,
+                    "lyrics": "[Verse]",
+                    "labeled": True,
+                },
+            )
+
+        dataset = await _post(
+            client,
+            "/v1/dataset/preprocess_async",
+            {"output_dir": tensor_dir, "skip_existing": False},
+        )
+        task_id = dataset.get("task_id")
+
+        if task_id:
+            await _poll_preprocess(client, str(task_id), interval=poll_interval, timeout=poll_timeout)
+
+        # 2. Fine-tune.
+        await record("training")
+        await _post(
+            client,
+            "/v1/training/start",
+            {"tensor_dir": tensor_dir, "lora_output_dir": lora_dir},
+        )
+
+        async def on_progress(data: dict[str, Any]) -> None:
+            # Structured provider progress, in the field the platform already has
+            # for exactly this (US-22.1 video uses it the same way).
+            # Field names are ACE-Step's own (see its /v1/training/status payload).
+            job.progress_detail = {
+                "phase": "training",
+                "step": data.get("current_step"),
+                "epoch": data.get("current_epoch"),
+                "loss": data.get("current_loss"),
+                "eta_seconds": data.get("estimated_time_remaining"),
+            }
+            await job.save()
+
+        await _poll_training(client, interval=poll_interval, timeout=poll_timeout, on_progress=on_progress)
+
+        # 3. Export the LoRA weights and keep them.
+        await record("finalizing")
+        exported = await _post(
+            client,
+            "/v1/training/export",
+            {"export_path": export_path, "lora_output_dir": lora_dir},
+        )
+
+    exported_path = str(
+        exported.get("export_path") or exported.get("weights") or exported.get("path") or export_path or ""
+    ).rstrip("/")
+
+    # The export writes a *directory*, and /v1/lora/load wants the PEFT adapter
+    # inside it -- pointing at the export root is rejected with "Invalid adapter:
+    # expected PEFT LoRA directory containing adapter_config.json". Verified end to
+    # end against a real trained model, so what is stored here is the path that
+    # actually loads.
+    weights = f"{exported_path}/{ADAPTER_SUBDIR}" if exported_path else None
+
+    if not weights:
+        # A training run that produces no weights has produced no voice, whatever
+        # the status said.
+        raise VoiceTrainingError("Training finished but produced no weights")
+
+    model.weights_path = str(weights)
+    model.status = VoiceModelStatus.READY
+    model.error = None
+    await model.save()
+
+    return {"voice_model_id": str(model.id), "weights_path": model.weights_path}
+
+
+VOICE_TRAINING_JOB_HANDLERS = {VOICE_TRAINING_JOB_TYPE: process_voice_training_job}

--- a/src/acemusic/api/tasks/voice_training.py
+++ b/src/acemusic/api/tasks/voice_training.py
@@ -23,6 +23,13 @@ module invented ``{"dataset": ..., "name": ...}`` payloads and expected a
 stub encoded the same guess. The real API takes ``tensor_dir`` and reports
 ``{"is_training": bool, "status": "Idle", "error": null}``.
 
+**The references have to be materialised before ACE-Step can see them.** Uploads
+live in the platform's storage backend, which may be S3; ACE-Step scans a
+*directory*. So the worker downloads each reference into the shared training
+directory first. Without that step every real job scans an empty directory,
+finds nothing, and refunds -- the live verification of this module missed it
+because the files had been copied there by hand.
+
 **ACE-Step reads its own filesystem.** These endpoints take *paths*, not uploads,
 and reject anything resolving outside the server's working directory
 (``acestep/training/path_safety.py``). So voice training requires the platform and
@@ -39,6 +46,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -178,6 +186,7 @@ async def process_voice_training_job(
     *,
     storage: StorageBackend,
     base_url: str,
+    training_root: str = TRAINING_ROOT,
     poll_interval: float = POLL_INTERVAL_S,
     poll_timeout: float = POLL_TIMEOUT_S,
 ) -> dict[str, Any]:
@@ -209,12 +218,34 @@ async def process_voice_training_job(
         raise
 
 
+async def _materialise_references(model: VoiceModel, storage: StorageBackend, training_root: str) -> None:
+    """Copy the stored references into the directory ACE-Step will scan.
+
+    ``training_root`` is the *local* path that ACE-Step sees as ``TRAINING_ROOT``;
+    the platform writes here and ACE-Step reads the same bytes. A split deployment
+    needs it to be a shared volume, because ACE-Step's training endpoints take
+    paths rather than uploads.
+    """
+    local_dir = Path(training_root) / str(model.id) / "refs"
+    local_dir.mkdir(parents=True, exist_ok=True)
+
+    for index, key in enumerate(model.reference_paths):
+        data = await asyncio.to_thread(storage.download, key)
+        suffix = key.rsplit(".", 1)[-1] if "." in key else "wav"
+        await asyncio.to_thread((local_dir / f"ref-{index}.{suffix}").write_bytes, data)
+
+    logger.info(
+        "Materialised %d references for voice model %s into %s", len(model.reference_paths), model.id, local_dir
+    )
+
+
 async def _train(
     model: VoiceModel,
     job: Job,
     *,
     storage: StorageBackend,
     base_url: str,
+    training_root: str,
     poll_interval: float,
     poll_timeout: float,
 ) -> dict[str, Any]:
@@ -235,6 +266,10 @@ async def _train(
     async with httpx.AsyncClient(base_url=base_url.rstrip("/"), timeout=60.0) as client:
         # 1. Preprocess the references into a training dataset.
         await record("preprocessing")
+
+        # Materialise the references where ACE-Step can see them. They live in the
+        # platform's storage backend (possibly S3); ACE-Step scans a directory.
+        await _materialise_references(model, storage, training_root)
 
         # Scan first: preprocessing works on the server's current dataset, so
         # without this it either preprocesses someone else's samples or nothing.

--- a/src/acemusic/api/tasks/voice_training.py
+++ b/src/acemusic/api/tasks/voice_training.py
@@ -205,11 +205,24 @@ async def process_voice_training_job(
 
     try:
         return await _train(
-            model, job, storage=storage, base_url=base_url, poll_interval=poll_interval, poll_timeout=poll_timeout
+            model,
+            job,
+            storage=storage,
+            base_url=base_url,
+            training_root=training_root,
+            poll_interval=poll_interval,
+            poll_timeout=poll_timeout,
         )
-    except BaseException as exc:
-        # BaseException, not Exception: a CancelledError during shutdown must also
-        # give the credits back rather than leaving the musician charged.
+    except asyncio.CancelledError:
+        # Deliberately NOT failed-and-refunded. JobProcessor re-raises this without
+        # marking the job, leaving it `processing` so startup requeues it as stale.
+        # Refunding here would either give the credits back for a run that then
+        # succeeds, or -- refunds not being idempotent -- refund the same charge
+        # twice when the retry also fails.
+        model.status = VoiceModelStatus.QUEUED
+        await model.save()
+        raise
+    except Exception as exc:
         reason = str(exc) or exc.__class__.__name__
         try:
             await voice_service.fail_training(model, reason)

--- a/tests/test_voice_models_api.py
+++ b/tests/test_voice_models_api.py
@@ -1,0 +1,556 @@
+"""Tests for voice model training (US-25.1, issue #325).
+
+Validation and the auth gate run in CI (no DB); the rest are ``integration`` and
+drive the real app with ``httpx.AsyncClient`` over a local MongoDB, mirroring
+``tests/test_clips_crud_api.py``.
+
+The thing most worth protecting here is the *order* of validation: the musician
+is only charged once every check that can reject the request has passed, so a bad
+upload never costs credits.
+"""
+
+import io
+
+import httpx
+import numpy as np
+import pytest
+import soundfile as sf
+from fastapi.testclient import TestClient
+
+from acemusic.api.auth.tokens import create_access_token
+from acemusic.api.main import API_V1_PREFIX, create_app
+from acemusic.api.models import Job, User, VoiceModel, VoiceModelStatus
+from acemusic.api.services import credits as credits_service, users as user_service, voice_models as voice_service
+from acemusic.api.settings import ApiSettings
+from acemusic.storage import get_storage_backend
+
+TRAIN_URL = f"{API_V1_PREFIX}/voice-models/train"
+LIST_URL = f"{API_V1_PREFIX}/voice-models"
+
+
+def wav(freq: float = 200.0, seconds: float = 2.0, sample_rate: int = 44100, amplitude: float = 0.5) -> bytes:
+    """A tone as a real WAV container."""
+    t = np.arange(int(sample_rate * seconds)) / sample_rate
+    buf = io.BytesIO()
+    sf.write(buf, amplitude * np.sin(2 * np.pi * freq * t), sample_rate, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+def _files(count: int = 3, **kwargs) -> list[tuple[str, tuple[str, bytes, str]]]:
+    # Slightly different tones, as separate takes of one voice would be.
+    return [("files", (f"take{i}.wav", wav(freq=200.0 + 10 * i, **kwargs), "audio/wav")) for i in range(count)]
+
+
+# ---------------------------------------------------------------------------
+# Validation — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    async def _reject(self, files: list[tuple[str, bytes]]) -> str:
+        with pytest.raises(voice_service.VoiceModelError) as exc:
+            await voice_service.validate_references(files)
+        return str(exc.value)
+
+    async def test_three_valid_takes_are_accepted(self) -> None:
+        refs = await voice_service.validate_references([("a.wav", wav(200)), ("b.wav", wav(210)), ("c.wav", wav(220))])
+        assert len(refs) == 3
+        assert all(r.sample_rate == 44100 for r in refs)
+
+    @pytest.mark.parametrize("count", [0, 1, 11, 20])
+    async def test_the_file_count_bounds_are_enforced(self, count: int) -> None:
+        message = await self._reject([(f"{i}.wav", wav()) for i in range(count)])
+        assert "reference files" in message
+
+    async def test_a_file_below_16khz_is_rejected_and_named(self) -> None:
+        # AC 2 asks for a *clear* error. "Invalid file" is useless when ten were
+        # uploaded, so the message has to identify which one and why.
+        message = await self._reject([("good.wav", wav()), ("thin.wav", wav(sample_rate=8000))])
+        assert "thin.wav" in message
+        assert "8000" in message
+        assert "16000" in message
+
+    async def test_a_silent_reference_is_rejected(self) -> None:
+        # Otherwise this costs 10 credits and minutes of GPU time to learn nothing.
+        message = await self._reject([("good.wav", wav()), ("silent.wav", wav(amplitude=0.0))])
+        assert "silent.wav" in message
+
+    async def test_a_body_that_is_not_audio_is_rejected(self) -> None:
+        message = await self._reject([("good.wav", wav()), ("notes.wav", b"this is not audio")])
+        assert "notes.wav" in message
+
+    async def test_a_very_short_reference_is_rejected(self) -> None:
+        message = await self._reject([("good.wav", wav()), ("blip.wav", wav(seconds=0.2))])
+        assert "blip.wav" in message
+
+    async def test_an_obvious_odd_one_out_is_rejected(self) -> None:
+        # The mistake that actually happens: a drum loop among the vocal takes.
+        message = await self._reject([("v1.wav", wav(200)), ("v2.wav", wav(210)), ("drums.wav", wav(9000))])
+        assert "drums.wav" in message
+
+    async def test_the_consistency_check_does_not_reject_ordinary_variation(self) -> None:
+        # A false reject costs a usable model, which is worse than training on one
+        # slightly odd take — so takes an octave apart must still pass.
+        refs = await voice_service.validate_references(
+            [("low.wav", wav(150)), ("mid.wav", wav(220)), ("high.wav", wav(300))]
+        )
+        assert len(refs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Auth gate — runs in CI (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGate:
+    def test_training_without_a_token_is_401(self) -> None:
+        client = TestClient(create_app())
+        resp = client.post(TRAIN_URL, files=_files(3), data={"name": "My voice"})
+        assert resp.status_code == 401
+
+    def test_listing_without_a_token_is_401(self) -> None:
+        client = TestClient(create_app())
+        assert client.get(LIST_URL).status_code == 401
+
+
+def test_training_costs_the_documented_premium_amount() -> None:
+    # The story sets 10; a silent change to this changes what people are charged.
+    assert credits_service.VOICE_TRAINING_COST == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Integration — real MongoDB
+# ---------------------------------------------------------------------------
+
+
+def _async_client(app) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver")
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings) -> ApiSettings:
+    return mongo_settings.model_copy(
+        update={
+            "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+            "job_processor_enabled": False,
+        }
+    )
+
+
+@pytest.fixture
+async def client(settings):
+    async with _async_client(create_app(settings)) as ac:
+        yield ac
+
+
+@pytest.fixture
+def local_storage(monkeypatch, tmp_path):
+    monkeypatch.setenv("ACEMUSIC_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("ACEMUSIC_STORAGE_LOCAL_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id),
+        email=user.email,
+        subscription_tier=user.subscription_tier,
+        settings=settings,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_user(email: str, credits: float = 100.0):
+    user = await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+    user.credits_balance = credits
+    await user.save()
+    return user
+
+
+@pytest.mark.integration
+class TestTraining:
+    async def test_three_valid_files_return_a_job_id(self, client, settings, local_storage) -> None:
+        user = await _make_user("train@example.com")
+
+        resp = await client.post(
+            TRAIN_URL,
+            headers=_auth_headers(user, settings),
+            files=_files(3),
+            data={"name": "My voice", "description": "warm baritone"},
+        )
+
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body["job_id"]
+        assert body["voice_model"]["name"] == "My voice"
+        assert body["voice_model"]["reference_count"] == 3
+        assert body["voice_model"]["status"] == VoiceModelStatus.QUEUED.value
+        assert body["credits_charged"] == 10.0
+
+        # The job really exists and is claimable by a worker.
+        job = await Job.get(body["job_id"])
+        assert job is not None
+        assert job.job_type == "voice_training"
+        assert job.input_params["voice_model_id"] == body["voice_model"]["id"]
+
+        # And the references are in storage, all three of them.
+        model = await VoiceModel.get(body["voice_model"]["id"])
+        assert len(model.reference_paths) == 3
+        storage = get_storage_backend()
+        for path in model.reference_paths:
+            assert len(storage.download(path)) > 0
+
+    async def test_ten_credits_are_deducted_on_submission(self, client, settings, local_storage) -> None:
+        user = await _make_user("charged@example.com", credits=25.0)
+
+        resp = await client.post(
+            TRAIN_URL,
+            headers=_auth_headers(user, settings),
+            files=_files(3),
+            data={"name": "Voice"},
+        )
+        assert resp.status_code == 202, resp.text
+
+        fresh = await User.get(user.id)
+        assert fresh.credits_balance == 15.0
+
+    async def test_insufficient_credits_returns_402_and_charges_nothing(self, client, settings, local_storage) -> None:
+        user = await _make_user("broke@example.com", credits=3.0)
+
+        resp = await client.post(
+            TRAIN_URL,
+            headers=_auth_headers(user, settings),
+            files=_files(3),
+            data={"name": "Voice"},
+        )
+
+        assert resp.status_code == 402
+        fresh = await User.get(user.id)
+        assert fresh.credits_balance == 3.0
+        assert await VoiceModel.find_all().count() == 0
+
+    async def test_a_rejected_upload_costs_nothing(self, client, settings, local_storage) -> None:
+        # The order of validation is the behaviour: an 8kHz file must be refused
+        # *before* the balance is touched.
+        user = await _make_user("rejected@example.com", credits=50.0)
+
+        resp = await client.post(
+            TRAIN_URL,
+            headers=_auth_headers(user, settings),
+            files=[
+                ("files", ("ok.wav", wav(), "audio/wav")),
+                ("files", ("thin.wav", wav(sample_rate=8000), "audio/wav")),
+            ],
+            data={"name": "Voice"},
+        )
+
+        assert resp.status_code == 422
+        assert "thin.wav" in resp.json()["detail"]
+
+        fresh = await User.get(user.id)
+        assert fresh.credits_balance == 50.0, "a rejected upload was charged for"
+        assert await VoiceModel.find_all().count() == 0
+
+    @pytest.mark.parametrize("count", [1, 11])
+    async def test_wrong_file_counts_are_refused_without_charge(
+        self, client, settings, local_storage, count: int
+    ) -> None:
+        user = await _make_user(f"count{count}@example.com", credits=50.0)
+
+        resp = await client.post(
+            TRAIN_URL,
+            headers=_auth_headers(user, settings),
+            files=_files(count),
+            data={"name": "Voice"},
+        )
+
+        assert resp.status_code == 422
+        fresh = await User.get(user.id)
+        assert fresh.credits_balance == 50.0
+
+    async def test_a_failed_run_refunds_what_it_charged(self, client, settings, local_storage) -> None:
+        # AC 4's second half, and the easiest thing to get wrong.
+        user = await _make_user("refund@example.com", credits=40.0)
+
+        resp = await client.post(
+            TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "Voice"}
+        )
+        assert resp.status_code == 202
+        assert (await User.get(user.id)).credits_balance == 30.0
+
+        model = await VoiceModel.get(resp.json()["voice_model"]["id"])
+        await voice_service.fail_training(model, "the GPU fell over")
+
+        fresh = await User.get(user.id)
+        assert fresh.credits_balance == 40.0, "a failed training run did not refund"
+
+        failed = await VoiceModel.get(model.id)
+        assert failed.status is VoiceModelStatus.FAILED
+        assert "GPU" in failed.error
+        # A failed model is not usable, whatever else is true of it.
+        assert not failed.is_usable
+
+    async def test_a_refund_uses_what_was_charged_not_the_current_price(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        # If the price changes between charging and failing, the musician gets back
+        # what they actually paid.
+        user = await _make_user("priced@example.com", credits=40.0)
+        resp = await client.post(
+            TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "Voice"}
+        )
+        assert resp.status_code == 202
+
+        monkeypatch.setattr(credits_service, "VOICE_TRAINING_COST", 999.0)
+
+        model = await VoiceModel.get(resp.json()["voice_model"]["id"])
+        await voice_service.fail_training(model, "boom")
+
+        fresh = await User.get(user.id)
+        assert fresh.credits_balance == 40.0, "the refund used the new price, not the charged one"
+
+    async def test_a_model_needs_weights_to_count_as_usable(self, client, settings, local_storage) -> None:
+        # "Job completed" and "voice is usable" are different claims.
+        user = await _make_user("usable@example.com")
+        resp = await client.post(
+            TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "Voice"}
+        )
+        model = await VoiceModel.get(resp.json()["voice_model"]["id"])
+
+        model.status = VoiceModelStatus.READY
+        await model.save()
+        assert not (await VoiceModel.get(model.id)).is_usable, "ready with no weights read as usable"
+
+        model.weights_path = "somewhere/lora.safetensors"
+        await model.save()
+        assert (await VoiceModel.get(model.id)).is_usable
+
+
+@pytest.mark.integration
+class TestLibraryScoping:
+    async def test_a_user_only_sees_their_own_models(self, client, settings, local_storage) -> None:
+        mine = await _make_user("mine@example.com")
+        theirs = await _make_user("theirs@example.com")
+
+        for user, name in ((mine, "Mine"), (theirs, "Theirs")):
+            resp = await client.post(
+                TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": name}
+            )
+            assert resp.status_code == 202, resp.text
+
+        listed = await client.get(LIST_URL, headers=_auth_headers(mine, settings))
+        assert listed.status_code == 200
+        assert [m["name"] for m in listed.json()] == ["Mine"]
+
+    async def test_another_users_model_cannot_be_fetched_by_id(self, client, settings, local_storage) -> None:
+        owner = await _make_user("owner2@example.com")
+        intruder = await _make_user("intruder2@example.com")
+
+        resp = await client.post(
+            TRAIN_URL, headers=_auth_headers(owner, settings), files=_files(3), data={"name": "Private"}
+        )
+        model_id = resp.json()["voice_model"]["id"]
+
+        assert await voice_service.find_owned_model(model_id, str(owner.id)) is not None
+        assert await voice_service.find_owned_model(model_id, str(intruder.id)) is None
+
+    async def test_a_malformed_id_is_not_found_rather_than_an_error(self, client, settings) -> None:
+        user = await _make_user("malformed@example.com")
+        assert await voice_service.find_owned_model("not-an-object-id", str(user.id)) is None
+
+
+# ---------------------------------------------------------------------------
+# The training worker — real MongoDB, stubbed ACE-Step
+# ---------------------------------------------------------------------------
+
+
+def _acestep_stub(
+    *, training_error: str | None = None, exports: bool = True, ever_starts: bool = True, samples: int = 3
+):
+    """A stand-in for ACE-Step's real training API.
+
+    The shapes here are ACE-Step's own, taken from its request models and a live
+    probe of the running server -- **not** invented. Training reports a *boolean*
+    ``is_training`` alongside a human ``status`` string ("Idle"), not a
+    "completed"/"failed" word; an earlier version of this stub guessed the latter
+    and the worker was written to match the guess, so both agreed and both were
+    wrong.
+
+    The status sequence is: not started -> training -> finished.
+    """
+    calls = {"status": 0, "labelled": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+
+        if path.endswith("/dataset/scan"):
+            assert "audio_dir" in request.read().decode(), "scan needs an audio_dir"
+            return httpx.Response(
+                200,
+                json={"data": {"num_samples": 3, "samples": [{"index": i, "labeled": False} for i in range(3)]}},
+            )
+
+        if "/dataset/sample/" in path:
+            # Labelling is not optional: preprocessing skips unlabelled samples and
+            # returns "No labeled samples to preprocess".
+            assert "sample_idx" in request.read().decode(), "labelling needs a sample_idx"
+            calls["labelled"] += 1
+            return httpx.Response(200, json={"data": {"message": "updated"}})
+
+        if path.endswith("/dataset/preprocess_async"):
+            assert calls["labelled"] == 3, "preprocess ran before every sample was labelled"
+            assert "output_dir" in request.read().decode(), "preprocess needs an output_dir"
+            return httpx.Response(200, json={"data": {"task_id": "ds-1"}})
+
+        if "/dataset/preprocess_status" in path:
+            return httpx.Response(200, json={"data": {"status": "completed", "current": 3, "total": 3}})
+
+        if path.endswith("/training/start"):
+            body = request.read().decode()
+            assert "tensor_dir" in body, "training/start needs a tensor_dir"
+            assert "lora_output_dir" in body, "training/start needs a lora_output_dir"
+            return httpx.Response(200, json={"data": {"started": True}})
+
+        if path.endswith("/training/status"):
+            calls["status"] += 1
+            if training_error:
+                return httpx.Response(200, json={"data": {"is_training": False, "error": training_error}})
+            if not ever_starts:
+                return httpx.Response(200, json={"data": {"is_training": False, "status": "Idle", "error": None}})
+            # First poll is mid-run, then it finishes.
+            running = calls["status"] < 2
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "is_training": running,
+                        "status": "Training" if running else "Idle",
+                        "current_step": 10 * calls["status"],
+                        "current_epoch": 1,
+                        "current_loss": 0.42,
+                        "estimated_time_remaining": 30.0,
+                        "error": None,
+                    }
+                },
+            )
+
+        if path.endswith("/training/export"):
+            if not exports:
+                return httpx.Response(404, json={"detail": "No trained model found"})
+            body = request.read().decode()
+            assert "export_path" in body, "export needs an export_path"
+            assert "lora_output_dir" in body, "export needs a lora_output_dir"
+            return httpx.Response(200, json={"data": {"export_path": "demo/voice.safetensors"}})
+
+        return httpx.Response(404, json={"error": f"unexpected {path}"})
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.integration
+class TestTrainingWorker:
+    async def _queued(self, client, settings, user):
+        resp = await client.post(
+            TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "Voice"}
+        )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        return await VoiceModel.get(body["voice_model"]["id"]), await Job.get(body["job_id"])
+
+    async def _run(self, job, monkeypatch, **stub_kwargs):
+        from acemusic.api.tasks import voice_training
+
+        transport = _acestep_stub(**stub_kwargs)
+        original = httpx.AsyncClient
+
+        def patched(*args, **kwargs):
+            kwargs["transport"] = transport
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(voice_training.httpx, "AsyncClient", patched)
+        return await voice_training.process_voice_training_job(
+            job,
+            storage=get_storage_backend(),
+            base_url="http://acestep.test",
+            poll_interval=0.0,
+            poll_timeout=5.0,
+        )
+
+    async def test_a_successful_run_stores_weights_and_marks_the_voice_ready(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        user = await _make_user("worker-ok@example.com", credits=40.0)
+        model, job = await self._queued(client, settings, user)
+
+        result = await self._run(job, monkeypatch)
+
+        # The export path is a directory; the loadable PEFT adapter is inside it,
+        # and pointing /v1/lora/load at the root is rejected. Verified against a
+        # real trained model, so this is the path that actually loads.
+        assert result["weights_path"] == "demo/voice.safetensors/adapter"
+        fresh = await VoiceModel.get(model.id)
+        assert fresh.status is VoiceModelStatus.READY
+        assert fresh.is_usable, "a completed run did not produce a usable voice"
+        # A successful run keeps the charge.
+        assert (await User.get(user.id)).credits_balance == 30.0
+
+    async def test_a_failed_run_refunds_and_records_why(self, client, settings, local_storage, monkeypatch) -> None:
+        user = await _make_user("worker-fail@example.com", credits=40.0)
+        model, job = await self._queued(client, settings, user)
+        assert (await User.get(user.id)).credits_balance == 30.0
+
+        with pytest.raises(Exception):
+            await self._run(job, monkeypatch, training_error="CUDA out of memory")
+
+        fresh = await VoiceModel.get(model.id)
+        assert fresh.status is VoiceModelStatus.FAILED
+        assert fresh.error
+        assert not fresh.is_usable
+        assert (await User.get(user.id)).credits_balance == 40.0, "a failed run did not refund"
+
+    async def test_training_that_reports_success_but_exports_nothing_is_a_failure(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        # "Completed" and "produced a usable voice" are different claims; a run
+        # with no weights must not leave a model that looks ready.
+        user = await _make_user("worker-noweights@example.com", credits=40.0)
+        model, job = await self._queued(client, settings, user)
+
+        with pytest.raises(Exception):
+            await self._run(job, monkeypatch, exports=False)
+
+        fresh = await VoiceModel.get(model.id)
+        assert fresh.status is VoiceModelStatus.FAILED
+        assert not fresh.is_usable
+        assert (await User.get(user.id)).credits_balance == 40.0
+
+    async def test_a_run_that_never_starts_is_a_failure_not_a_success(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        # is_training reads false both *before* a run begins and *after* it ends.
+        # Treating the first as "already finished" would report success for a run
+        # that never happened -- and keep the credits.
+        from acemusic.api.tasks import voice_training
+
+        monkeypatch.setattr(voice_training, "TRAINING_START_GRACE_S", 0.0)
+
+        user = await _make_user("worker-nostart@example.com", credits=40.0)
+        model, job = await self._queued(client, settings, user)
+
+        with pytest.raises(Exception):
+            await self._run(job, monkeypatch, ever_starts=False)
+
+        fresh = await VoiceModel.get(model.id)
+        assert fresh.status is VoiceModelStatus.FAILED
+        assert (await User.get(user.id)).credits_balance == 40.0
+
+    async def test_a_job_pointing_at_a_missing_model_fails_loudly(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        user = await _make_user("worker-orphan@example.com")
+        _, job = await self._queued(client, settings, user)
+        job.input_params = {"voice_model_id": "000000000000000000000000"}
+        await job.save()
+
+        with pytest.raises(Exception):
+            await self._run(job, monkeypatch)

--- a/tests/test_voice_models_api.py
+++ b/tests/test_voice_models_api.py
@@ -9,6 +9,7 @@ is only charged once every check that can reject the request has passed, so a ba
 upload never costs credits.
 """
 
+import asyncio
 import io
 
 import httpx
@@ -19,7 +20,7 @@ from fastapi.testclient import TestClient
 
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
-from acemusic.api.models import Job, User, VoiceModel, VoiceModelStatus
+from acemusic.api.models import CreditTransaction, Job, User, VoiceModel, VoiceModelStatus
 from acemusic.api.services import credits as credits_service, users as user_service, voice_models as voice_service
 from acemusic.api.settings import ApiSettings
 from acemusic.storage import get_storage_backend
@@ -213,6 +214,32 @@ class TestTraining:
 
         fresh = await User.get(user.id)
         assert fresh.credits_balance == 15.0
+
+    async def test_the_charge_lands_in_the_credit_ledger(self, client, settings, local_storage) -> None:
+        # /users/me/credits builds its history from CreditTransaction, so a balance
+        # that drops with no usage row is a support ticket waiting to happen.
+        user = await _make_user("ledger@example.com", credits=40.0)
+
+        resp = await client.post(
+            TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "Voice"}
+        )
+        assert resp.status_code == 202, resp.text
+
+        rows = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        charges = [r for r in rows if r.action_type == "voice_training"]
+        assert len(charges) == 1, f"expected one voice_training row, got {[r.action_type for r in rows]}"
+        assert charges[0].amount == -10.0
+        assert charges[0].balance_after == 30.0
+
+        # And a refund is recorded too, so the ledger reconciles to the balance.
+        model = await VoiceModel.get(resp.json()["voice_model"]["id"])
+        await voice_service.fail_training(model, "boom")
+
+        rows = await CreditTransaction.find(CreditTransaction.user_id == user.id).to_list()
+        refunds = [r for r in rows if r.action_type == "voice_training_refund"]
+        assert len(refunds) == 1
+        assert refunds[0].amount == 10.0
+        assert sum(r.amount for r in rows) == 0.0, "the ledger does not reconcile to a zero net"
 
     async def test_insufficient_credits_returns_402_and_charges_nothing(self, client, settings, local_storage) -> None:
         user = await _make_user("broke@example.com", credits=3.0)
@@ -543,6 +570,54 @@ class TestTrainingWorker:
         fresh = await VoiceModel.get(model.id)
         assert fresh.status is VoiceModelStatus.FAILED
         assert (await User.get(user.id)).credits_balance == 40.0
+
+    async def test_a_cancelled_run_is_requeued_rather_than_refunded(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        # JobProcessor re-raises CancelledError without failing the job, so it is
+        # requeued as stale. Refunding here would give the credits back for a run
+        # that then succeeds -- or refund twice, since refunds are not idempotent.
+        from acemusic.api.tasks import voice_training
+
+        user = await _make_user("worker-cancel@example.com", credits=40.0)
+        model, job = await self._queued(client, settings, user)
+        assert (await User.get(user.id)).credits_balance == 30.0
+
+        async def cancel(*args, **kwargs):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(voice_training, "_materialise_references", cancel)
+
+        with pytest.raises(asyncio.CancelledError):
+            await voice_training.process_voice_training_job(
+                job,
+                storage=get_storage_backend(),
+                base_url="http://acestep.test",
+                poll_interval=0.0,
+                poll_timeout=1.0,
+            )
+
+        fresh = await VoiceModel.get(model.id)
+        assert fresh.status is VoiceModelStatus.QUEUED, "a cancelled run was marked failed"
+        assert (await User.get(user.id)).credits_balance == 30.0, "a requeued run was refunded"
+
+    async def test_the_references_are_written_where_acestep_scans(
+        self, client, settings, local_storage, monkeypatch, tmp_path
+    ) -> None:
+        # ACE-Step scans a directory on its own filesystem; the uploads live in the
+        # platform's storage backend. Without this copy every real job scans an
+        # empty directory and refunds.
+        from acemusic.api.tasks import voice_training
+
+        user = await _make_user("worker-materialise@example.com", credits=40.0)
+        model, job = await self._queued(client, settings, user)
+
+        root = tmp_path / "training-root"
+        await voice_training._materialise_references(model, get_storage_backend(), str(root))
+
+        written = sorted((root / str(model.id) / "refs").glob("*"))
+        assert len(written) == 3, f"expected 3 references on disk, found {written}"
+        assert all(p.stat().st_size > 0 for p in written)
 
     async def test_a_job_pointing_at_a_missing_model_fails_loudly(
         self, client, settings, local_storage, monkeypatch


### PR DESCRIPTION
Implements **US-25.1 — Voice Model Training Backend** (#325).

Upload 2–10 reference recordings, train a LoRA voice model on ACE-Step, and store the
adapter against the musician's account.

---

## Acceptance criteria

| Criterion | Outcome |
| --- | --- |
| Uploading 3 valid files and triggering training returns a job ID | **Met** |
| Validation rejects files below 16 kHz with a clear error message | **Met** — the message names the file: `thin.wav: sample rate is 8000 Hz, below the 16000 Hz minimum.` |
| Training job completes and produces a usable voice model | **Met — verified against a live ACE-Step**, see below |
| 10 credits deducted on submission; refunded on failure | **Met** — plus a ledger row for both, so the balance reconciles |
| Uploading 1 file or 11 files returns a validation error | **Met** |

### AC 3, verified for real

A 3-reference run against a live ACE-Step 1.5:

```
preprocess   3/3 samples -> tensors on disk
training     11,010,048 parameters, loss 1.647
export       43 MB adapter
load back    {"lora_loaded": true, "active_adapter": "adapter"}
```

The adapter **loads back into the model**, which is the difference between "the job
completed" and "the voice is usable" — a distinction the code makes too: `is_usable`
requires `ready` **and** weights.

---

## The ACE-Step integration was written twice

The first version invented its payloads and its status vocabulary, and **the stub tests
passed because the stub encoded the same guess.** Probing the live server found four
things wrong, none of them guessable:

1. The sequence is **scan → label → preprocess**, not preprocess directly. Unlabelled
   samples are silently skipped and preprocess returns `No labeled samples to
   preprocess` with a task id that immediately 404s.
2. `/v1/training/start` takes `tensor_dir` + `lora_output_dir`, not a dataset name.
3. Training status is a **boolean** `is_training` with a human `status` string
   (`"Idle"`), not `completed`/`failed` — **and it reads false both before a run starts
   and after it ends**, so a poller without a start grace period reports success for a
   run that never began, and keeps the credits.
4. Export writes a **directory**; `/v1/lora/load` wants its `adapter/` child and rejects
   the root.

Plus a deployment constraint: ACE-Step's path safety rejects anything outside its working
directory, and its training endpoints take **paths, not uploads** — so the platform and
ACE-Step must share a filesystem.

The stub now asserts on the real payload fields and on label-before-preprocess ordering,
so a wrong request fails the test instead of agreeing with it.

## Three findings from the pre-PR review, two of them P1

**The references were never copied to where ACE-Step scans.** Uploads live in the
platform's storage backend; ACE-Step scans a directory. Every real job would have found
zero samples, failed, and refunded.

**My live verification missed this because I had copied the files there by hand.** Proving
ACE-Step's sequence works said nothing about the handoff between the two systems — which
was the only part that was mine. Worth recording, because it is the same shape as the
mistake the probe was meant to fix.

**Refunding on `CancelledError` broke requeue.** `JobProcessor` re-raises it *without*
marking the job, deliberately leaving it `processing` so startup requeues it as stale. The
refund therefore either gave credits back for a run that then succeeded, or refunded the
same charge twice when the retry failed, since refunds are not idempotent. A cancelled run
now returns to `queued` untouched.

**No `CreditTransaction` row was written.** `/users/me/credits` builds its history from the
ledger. Now recorded on charge *and* refund, with a test asserting the ledger reconciles to
a zero net.

---

## Design notes

**Validation order is the behaviour.** Count → format/sample-rate → duration/level →
consistency → *then* credits. A rejected upload costs nothing, and there is a test that
asserts the balance is untouched after a rejection.

**Every rejection names the file** — "invalid file" is useless when ten were uploaded.

**Refunds use `credits_charged`, not the current price**, so a change to the cost table
cannot alter what someone already paid gets back. Tested by changing the price between
charge and failure.

---

## Known limitations

1. **The consistency check is spectral, not speaker verification.** It compares spectral
   centroids, which catches the mistake that actually happens — a drum loop among the
   vocal takes — and will **not** distinguish two people with similar timbre. The
   threshold is deliberately loose: a false reject costs a usable model, which is worse
   than training on one odd take. Doing it properly needs speaker embeddings.
2. **Platform and ACE-Step must share a filesystem** (above). A split deployment needs a
   shared volume; there is no upload endpoint to fall back on.
3. Progress reporting and notifications are US-25.2; this story records the phase and
   ACE-Step's own step/epoch/loss on the job but pushes nothing.
4. **Loading a LoRA into ACE-Step is not cleanly reversible** — `/v1/lora/unload` failed
   with *"Base decoder backup not found"* after my verification run, and a restart was
   needed to clear it. Not something this code does, but worth knowing.

Closes #325
