### PR TITLE
feat: US-25.2 Training Progress and Notifications (#326)

### DIFF
--- a/src/acemusic/api/models/notification_event.py
+++ b/src/acemusic/api/models/notification_event.py
@@ -19,8 +19,14 @@ class NotificationEvent(Document):
     """A recorded status-change event awaiting (future) delivery."""
 
     user_id: PydanticObjectId
-    release_id: PydanticObjectId
-    event_type: str  # e.g. "status_live", "status_rejected"
+
+    # Exactly one of these identifies what the event is about. Two nullable keys
+    # rather than a generic subject: the release path (US-21.x) is shipped and
+    # working, and rewriting it to carry voice models is not what US-25.2 needs.
+    release_id: PydanticObjectId | None = None
+    voice_model_id: PydanticObjectId | None = None
+
+    event_type: str  # e.g. "status_live", "status_rejected", "voice_training_complete"
     channel: str
     payload: dict = Field(default_factory=dict)
     created_at: datetime = Field(default_factory=utcnow)

--- a/src/acemusic/api/routers/voice_models.py
+++ b/src/acemusic/api/routers/voice_models.py
@@ -1,8 +1,9 @@
 """Voice model endpoints (US-25.1 training, US-25.3 library), mounted under
 ``/api/v1/voice-models``.
 
-* ``POST   /voice-models/train`` → validate references, charge, queue training
-* ``GET    /voice-models``       → the caller's models, newest first
+* ``POST   /voice-models/train``                  → validate, charge, queue training
+* ``GET    /voice-models/train/{job_id}/status``  → phase, progress, ETA (US-25.2)
+* ``GET    /voice-models``                        → the caller's models, newest first
 
 Every read is owner-scoped: a voice model is private, and ownership is part of
 the query rather than a check afterwards, so there is no path that reads someone
@@ -98,6 +99,58 @@ async def train_voice_model(
         job_id=str(job.id),
         voice_model=VoiceModelResponse.from_model(model),
         credits_charged=credits_service.VOICE_TRAINING_COST,
+    )
+
+
+class TrainingStatusResponse(BaseModel):
+    """Where a training run has got to.
+
+    ``progress`` is **null** when no total is knowable rather than a fabricated
+    number: ACE-Step reports steps and epochs, not a fraction, and a progress bar
+    that lies is worse than one that says "working".
+    """
+
+    job_id: str
+    voice_model_id: str
+    status: VoiceModelStatus
+    phase: str
+    progress: float | None = None
+    eta_seconds: float | None = None
+    step: int | None = None
+    epoch: int | None = None
+    loss: float | None = None
+    error: str | None = None
+
+
+@router.get("/train/{job_id}/status", response_model=TrainingStatusResponse)
+async def get_training_status(
+    job_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> TrainingStatusResponse:
+    """Progress of a training run.
+
+    Resolved through the voice model's owner, so another user's run 404s rather
+    than leaking that it exists.
+    """
+    found = await voice_service.find_model_for_job(job_id, current.user_id)
+
+    if found is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Training job not found.")
+
+    model, job = found
+    progress = voice_service.describe_progress(job, model)
+
+    return TrainingStatusResponse(
+        job_id=str(job.id),
+        voice_model_id=str(model.id),
+        status=model.status,
+        phase=progress["phase"],
+        progress=progress.get("progress"),
+        eta_seconds=progress.get("eta_seconds"),
+        step=progress.get("step"),
+        epoch=progress.get("epoch"),
+        loss=progress.get("loss"),
+        error=progress.get("error"),
     )
 
 

--- a/src/acemusic/api/services/voice_models.py
+++ b/src/acemusic/api/services/voice_models.py
@@ -19,7 +19,7 @@ from beanie import PydanticObjectId
 
 from acemusic.storage import StorageBackend, get_storage_backend
 
-from ..models import Job, User, VoiceModel, VoiceModelStatus
+from ..models import Job, NotificationEvent, User, VoiceModel, VoiceModelStatus
 from ..models.voice_model import (
     MAX_REFERENCE_BYTES,
     MAX_REFERENCE_FILES,
@@ -322,6 +322,96 @@ async def fail_training(model: VoiceModel, reason: str) -> VoiceModel:
         )
 
     return model
+
+
+#: Phases the worker reports, in order. Anything else is treated as unknown rather
+#: than silently mapped onto one of these.
+TRAINING_PHASES = ("preprocessing", "training", "finalizing")
+
+
+async def notify_training_finished(model: VoiceModel, *, succeeded: bool) -> NotificationEvent:
+    """Record the in-app notification for a finished training run.
+
+    Recorded, not delivered: ``delivered_at`` is left for the delivery worker the
+    platform does not have yet. Email is listed as optional in the story and there
+    is no mail path here, so none is claimed.
+    """
+    event = NotificationEvent(
+        user_id=model.user_id,
+        voice_model_id=model.id,
+        event_type="voice_training_complete" if succeeded else "voice_training_failed",
+        channel="in_app",
+        payload={
+            "voice_model_id": str(model.id),
+            "name": model.name,
+            # The reason matters more than the fact on a failure: "training failed"
+            # with no cause is not actionable.
+            **({} if succeeded else {"error": model.error or "Training failed"}),
+        },
+    )
+    await event.insert()
+    return event
+
+
+def describe_progress(job: Job | None, model: VoiceModel) -> dict:
+    """What the status endpoint reports for a training run.
+
+    The percentage is **derived, not invented**. ACE-Step reports steps and epochs,
+    not a fraction, so where no total is knowable this is ``None`` rather than a
+    number that looks authoritative and is not — a progress bar that lies is worse
+    than one that says "working".
+    """
+    detail = (job.progress_detail if job else None) or {}
+    phase = (job.progress if job else None) or None
+
+    if model.status is VoiceModelStatus.READY:
+        return {"phase": "complete", "progress": 100.0, "eta_seconds": 0.0, "status": model.status.value}
+
+    if model.status is VoiceModelStatus.FAILED:
+        return {
+            "phase": "failed",
+            "progress": None,
+            "eta_seconds": None,
+            "status": model.status.value,
+            "error": model.error,
+        }
+
+    step = detail.get("step")
+    total = detail.get("total_steps")
+    progress = None
+
+    if isinstance(step, (int, float)) and isinstance(total, (int, float)) and total > 0:
+        progress = round(min(100.0, max(0.0, 100.0 * float(step) / float(total))), 1)
+
+    return {
+        "phase": phase if phase in TRAINING_PHASES else (phase or "queued"),
+        "progress": progress,
+        "eta_seconds": detail.get("eta_seconds"),
+        "status": model.status.value,
+        "step": step,
+        "epoch": detail.get("epoch"),
+        "loss": detail.get("loss"),
+    }
+
+
+async def find_model_for_job(job_id: str, user_id: str) -> tuple[VoiceModel, Job] | None:
+    """The voice model and job for ``job_id``, only if ``user_id`` owns the model.
+
+    Ownership is resolved through the *model*, so another user's training run is
+    indistinguishable from one that does not exist.
+    """
+    try:
+        oid = PydanticObjectId(job_id)
+    except Exception:
+        return None
+
+    model = await VoiceModel.find_one(VoiceModel.job_id == oid, VoiceModel.user_id == PydanticObjectId(user_id))
+
+    if model is None:
+        return None
+
+    job = await Job.get(oid)
+    return (model, job) if job is not None else None
 
 
 async def list_voice_models(user_id: str) -> list[VoiceModel]:

--- a/src/acemusic/api/tasks/voice_training.py
+++ b/src/acemusic/api/tasks/voice_training.py
@@ -375,7 +375,14 @@ async def _train(
     model.error = None
     await model.save()
 
-    await voice_service.notify_training_finished(model, succeeded=True)
+    # Best-effort, and deliberately after the model is saved READY. A transient
+    # notification_events insert failure raised from here would propagate into
+    # process_voice_training_job's failure path and turn a completed run into a
+    # failed, refunded one -- undoing a training run that actually worked.
+    try:
+        await voice_service.notify_training_finished(model, succeeded=True)
+    except Exception:
+        logger.exception("Voice model %s trained but its notification could not be recorded", model.id)
 
     return {"voice_model_id": str(model.id), "weights_path": model.weights_path}
 

--- a/src/acemusic/api/tasks/voice_training.py
+++ b/src/acemusic/api/tasks/voice_training.py
@@ -226,6 +226,7 @@ async def process_voice_training_job(
         reason = str(exc) or exc.__class__.__name__
         try:
             await voice_service.fail_training(model, reason)
+            await voice_service.notify_training_finished(model, succeeded=False)
         except Exception:  # pragma: no cover - the refund must not mask the cause
             logger.exception("Failed to refund voice training for model %s", model.id)
         raise
@@ -373,6 +374,8 @@ async def _train(
     model.status = VoiceModelStatus.READY
     model.error = None
     await model.save()
+
+    await voice_service.notify_training_finished(model, succeeded=True)
 
     return {"voice_model_id": str(model.id), "weights_path": model.weights_path}
 

--- a/tests/test_voice_models_api.py
+++ b/tests/test_voice_models_api.py
@@ -16,6 +16,7 @@ import httpx
 import numpy as np
 import pytest
 import soundfile as sf
+from beanie import PydanticObjectId
 from fastapi.testclient import TestClient
 
 from acemusic.api.auth.tokens import create_access_token
@@ -629,3 +630,167 @@ class TestTrainingWorker:
 
         with pytest.raises(Exception):
             await self._run(job, monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# US-25.2 — training progress and notifications
+# ---------------------------------------------------------------------------
+
+STATUS_URL = f"{API_V1_PREFIX}/voice-models/train"
+
+
+def test_a_percentage_is_never_fabricated() -> None:
+    # ACE-Step reports steps and epochs, not a fraction. Where no total is
+    # knowable the field must be null -- a progress bar that lies is worse than
+    # one that says "working".
+    from acemusic.api.models import Job as JobModel
+
+    # model_construct: a Beanie Document cannot be instantiated without init, and
+    # describe_progress is a pure function that never touches the database.
+    model = VoiceModel.model_construct(user_id=PydanticObjectId(), name="V", status=VoiceModelStatus.TRAINING)
+
+    job = JobModel.model_construct(progress="training", progress_detail={"step": 40, "eta_seconds": 12.0})
+    without_total = voice_service.describe_progress(job, model)
+    assert without_total["progress"] is None, "invented a percentage with no total to divide by"
+    assert without_total["step"] == 40
+    assert without_total["eta_seconds"] == 12.0
+
+    job = JobModel.model_construct(progress="training", progress_detail={"step": 40, "total_steps": 80})
+    with_total = voice_service.describe_progress(job, model)
+    assert with_total["progress"] == 50.0
+
+    # And a percentage can never exceed 100 or go negative, whatever the server says.
+    job = JobModel.model_construct(progress="training", progress_detail={"step": 999, "total_steps": 10})
+    assert voice_service.describe_progress(job, model)["progress"] == 100.0
+
+
+def test_terminal_states_report_themselves_plainly() -> None:
+    ready = VoiceModel.model_construct(user_id=PydanticObjectId(), name="V", status=VoiceModelStatus.READY)
+    assert voice_service.describe_progress(None, ready)["progress"] == 100.0
+    assert voice_service.describe_progress(None, ready)["phase"] == "complete"
+
+    failed = VoiceModel.model_construct(
+        user_id=PydanticObjectId(), name="V", status=VoiceModelStatus.FAILED, error="CUDA out of memory"
+    )
+    described = voice_service.describe_progress(None, failed)
+    assert described["phase"] == "failed"
+    # A failure has no percentage; 0 or 100 would both be misleading.
+    assert described["progress"] is None
+    assert described["error"] == "CUDA out of memory"
+
+
+class TestStatusAuthGate:
+    def test_status_without_a_token_is_401(self) -> None:
+        client = TestClient(create_app())
+        assert client.get(f"{STATUS_URL}/{PydanticObjectId()}/status").status_code == 401
+
+
+@pytest.mark.integration
+class TestTrainingStatus:
+    async def _queued(self, client, settings, user):
+        resp = await client.post(
+            TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "Voice"}
+        )
+        assert resp.status_code == 202, resp.text
+        return resp.json()
+
+    async def test_status_tracks_the_run_through_its_phases(self, client, settings, local_storage) -> None:
+        user = await _make_user("status@example.com")
+        body = await self._queued(client, settings, user)
+        job_id = body["job_id"]
+
+        first = await client.get(f"{STATUS_URL}/{job_id}/status", headers=_auth_headers(user, settings))
+        assert first.status_code == 200, first.text
+        assert first.json()["status"] == VoiceModelStatus.QUEUED.value
+
+        # The worker records the phase and ACE-Step's own counters as it goes.
+        job = await Job.get(job_id)
+        job.progress = "training"
+        job.progress_detail = {"step": 5, "total_steps": 10, "eta_seconds": 30.0, "epoch": 1, "loss": 0.4}
+        await job.save()
+        model = await VoiceModel.get(body["voice_model"]["id"])
+        model.status = VoiceModelStatus.TRAINING
+        await model.save()
+
+        during = await client.get(f"{STATUS_URL}/{job_id}/status", headers=_auth_headers(user, settings))
+        payload = during.json()
+        assert payload["phase"] == "training"
+        assert payload["progress"] == 50.0
+        assert payload["eta_seconds"] == 30.0
+        assert payload["epoch"] == 1
+
+        model.status = VoiceModelStatus.READY
+        model.weights_path = "somewhere/adapter"
+        await model.save()
+
+        done = await client.get(f"{STATUS_URL}/{job_id}/status", headers=_auth_headers(user, settings))
+        assert done.json()["phase"] == "complete"
+        assert done.json()["progress"] == 100.0
+
+    async def test_another_users_training_run_is_not_found(self, client, settings, local_storage) -> None:
+        owner = await _make_user("statusowner@example.com")
+        intruder = await _make_user("statusintruder@example.com")
+        body = await self._queued(client, settings, owner)
+
+        resp = await client.get(f"{STATUS_URL}/{body['job_id']}/status", headers=_auth_headers(intruder, settings))
+        # 404, not 403: another user's run should be indistinguishable from one
+        # that does not exist.
+        assert resp.status_code == 404
+
+    async def test_an_unknown_or_malformed_job_is_404(self, client, settings, local_storage) -> None:
+        user = await _make_user("statusmissing@example.com")
+        headers = _auth_headers(user, settings)
+
+        assert (await client.get(f"{STATUS_URL}/{PydanticObjectId()}/status", headers=headers)).status_code == 404
+        assert (await client.get(f"{STATUS_URL}/not-an-id/status", headers=headers)).status_code == 404
+
+
+@pytest.mark.integration
+class TestTrainingNotifications:
+    async def test_a_finished_run_records_an_in_app_notification(self, client, settings, local_storage) -> None:
+        from acemusic.api.models import NotificationEvent
+
+        user = await _make_user("notify@example.com")
+        resp = await client.post(
+            TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "My voice"}
+        )
+        model = await VoiceModel.get(resp.json()["voice_model"]["id"])
+
+        await voice_service.notify_training_finished(model, succeeded=True)
+
+        events = await NotificationEvent.find(NotificationEvent.user_id == user.id).to_list()
+        assert len(events) == 1
+        assert events[0].event_type == "voice_training_complete"
+        assert events[0].voice_model_id == model.id
+        assert events[0].payload["name"] == "My voice"
+        # Recorded, not delivered: there is no delivery worker yet.
+        assert events[0].delivered_at is None
+
+    async def test_a_failed_run_records_why(self, client, settings, local_storage) -> None:
+        from acemusic.api.models import NotificationEvent
+
+        user = await _make_user("notifyfail@example.com")
+        resp = await client.post(TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "V"})
+        model = await VoiceModel.get(resp.json()["voice_model"]["id"])
+        await voice_service.fail_training(model, "CUDA out of memory")
+        await voice_service.notify_training_finished(await VoiceModel.get(model.id), succeeded=False)
+
+        events = await NotificationEvent.find(NotificationEvent.user_id == user.id).to_list()
+        assert len(events) == 1
+        assert events[0].event_type == "voice_training_failed"
+        # "Training failed" with no cause is not actionable.
+        assert "CUDA" in events[0].payload["error"]
+
+    async def test_release_notifications_still_work_unchanged(self, client, settings) -> None:
+        # release_id became optional so voice models could share the model; the
+        # distribution path (US-21.x) must be untouched by that.
+        from acemusic.api.models import NotificationEvent
+
+        user = await _make_user("release-notify@example.com")
+        release_id = PydanticObjectId()
+        event = NotificationEvent(user_id=user.id, release_id=release_id, event_type="status_live", channel="in_app")
+        await event.insert()
+
+        stored = await NotificationEvent.get(event.id)
+        assert stored.release_id == release_id
+        assert stored.voice_model_id is None

--- a/tests/test_voice_models_api.py
+++ b/tests/test_voice_models_api.py
@@ -620,6 +620,31 @@ class TestTrainingWorker:
         assert len(written) == 3, f"expected 3 references on disk, found {written}"
         assert all(p.stat().st_size > 0 for p in written)
 
+    async def test_a_notification_failure_does_not_undo_a_successful_run(
+        self, client, settings, local_storage, monkeypatch
+    ) -> None:
+        # The notification is recorded after the model is saved READY. If it raised
+        # from there it would land in the failure path and refund a run that
+        # actually worked -- undoing a real training run over a transient insert.
+        from acemusic.api.services import voice_models as vs
+
+        user = await _make_user("worker-notifyfail@example.com", credits=40.0)
+        model, job = await self._queued(client, settings, user)
+
+        async def boom(*args, **kwargs):
+            raise RuntimeError("notification_events unavailable")
+
+        monkeypatch.setattr(vs, "notify_training_finished", boom)
+
+        result = await self._run(job, monkeypatch)
+
+        assert result["weights_path"], "a notification failure lost the training result"
+        fresh = await VoiceModel.get(model.id)
+        assert fresh.status is VoiceModelStatus.READY, "a notification failure marked the run failed"
+        assert fresh.is_usable
+        # And the charge stands, because the run succeeded.
+        assert (await User.get(user.id)).credits_balance == 30.0
+
     async def test_a_job_pointing_at_a_missing_model_fails_loudly(
         self, client, settings, local_storage, monkeypatch
     ) -> None:

--- a/web/app/api/voice-models/route.ts
+++ b/web/app/api/voice-models/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/voice-models (US-25.2/25.3). The client holds
+// the access token in memory and sends it as a Bearer header; this route forwards
+// it so the backend URL stays server-side. Status and body pass through verbatim.
+
+const TARGET = `${BACKEND_URL}/api/v1/voice-models`
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  let res: Response
+  try {
+    res = await fetch(TARGET, {
+      headers: { authorization: auth, accept: "application/json" },
+      cache: "no-store",
+    })
+  } catch {
+    return NextResponse.json(
+      { detail: "Voice model service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/api/voice-models/train/[jobId]/status/route.ts
+++ b/web/app/api/voice-models/train/[jobId]/status/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for GET /api/v1/voice-models/train/{jobId}/status (US-25.2).
+// 404 passes through verbatim: the backend returns it for another user's run as
+// well as a missing one, and flattening that here would leak which is which.
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ jobId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { jobId } = await params
+
+  let res: Response
+  try {
+    res = await fetch(
+      `${BACKEND_URL}/api/v1/voice-models/train/${encodeURIComponent(jobId)}/status`,
+      { headers: { authorization: auth, accept: "application/json" }, cache: "no-store" }
+    )
+  } catch {
+    return NextResponse.json(
+      { detail: "Voice model service is unavailable." },
+      { status: 502 }
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/hooks/use-voice-training.test.tsx
+++ b/web/hooks/use-voice-training.test.tsx
@@ -1,0 +1,132 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useVoiceTraining } from "@/hooks/use-voice-training"
+import type { VoiceTrainingStatus } from "@/lib/voice-models"
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ accessToken: "tok-1" }),
+}))
+
+vi.mock("@/lib/voice-models", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/voice-models")>("@/lib/voice-models")
+  return { ...actual, fetchTrainingStatus: vi.fn() }
+})
+
+import { fetchTrainingStatus, VoiceModelError } from "@/lib/voice-models"
+
+const mockFetch = vi.mocked(fetchTrainingStatus)
+
+function status(overrides: Partial<VoiceTrainingStatus> = {}): VoiceTrainingStatus {
+  return {
+    job_id: "job-1",
+    voice_model_id: "vm-1",
+    status: "training",
+    phase: "training",
+    progress: 50,
+    eta_seconds: 30,
+    step: 5,
+    epoch: 1,
+    loss: 0.4,
+    error: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("useVoiceTraining", () => {
+  it("reports progress while a run is in flight", async () => {
+    mockFetch.mockResolvedValue(status())
+
+    const { result } = renderHook(() => useVoiceTraining("job-1"))
+
+    await waitFor(() => expect(result.current.state.phase).toBe("polling"))
+    expect(result.current.state).toMatchObject({
+      phase: "polling",
+      status: { progress: 50, eta_seconds: 30 },
+    })
+  })
+
+  it("stops polling once the run settles", async () => {
+    mockFetch.mockResolvedValue(status({ status: "ready", phase: "complete", progress: 100 }))
+
+    const onSettled = vi.fn()
+    const { result } = renderHook(() => useVoiceTraining("job-1", { onSettled }))
+
+    await waitFor(() => expect(result.current.state.phase).toBe("settled"))
+    expect(onSettled).toHaveBeenCalledTimes(1)
+
+    // A settled run must not keep polling: one read, and no more however long we wait.
+    const callsAfterSettling = mockFetch.mock.calls.length
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(mockFetch.mock.calls.length).toBe(callsAfterSettling)
+  })
+
+  it("AC: progress is restored after navigating away and back", async () => {
+    // The criterion exists to catch a client-side tally that a remount destroys.
+    // Progress lives on the server, so a fresh mount re-reads it.
+    mockFetch.mockResolvedValue(status({ progress: 70, step: 7 }))
+
+    const first = renderHook(() => useVoiceTraining("job-1"))
+    await waitFor(() => expect(first.result.current.state.phase).toBe("polling"))
+    first.unmount()
+
+    const second = renderHook(() => useVoiceTraining("job-1"))
+    await waitFor(() => expect(second.result.current.state.phase).toBe("polling"))
+
+    expect(second.result.current.state).toMatchObject({
+      phase: "polling",
+      status: { progress: 70, step: 7 },
+    })
+  })
+
+  it("surfaces a failed run with its reason rather than a bare error", async () => {
+    mockFetch.mockResolvedValue(
+      status({ status: "failed", phase: "failed", progress: null, error: "CUDA out of memory" })
+    )
+
+    const { result } = renderHook(() => useVoiceTraining("job-1"))
+
+    await waitFor(() => expect(result.current.state.phase).toBe("settled"))
+    expect(result.current.state).toMatchObject({
+      phase: "settled",
+      status: { status: "failed", error: "CUDA out of memory" },
+    })
+  })
+
+  it("reports a lookup failure without pretending the run is progressing", async () => {
+    mockFetch.mockRejectedValue(new VoiceModelError("Training job not found.", 404))
+
+    const { result } = renderHook(() => useVoiceTraining("job-1"))
+
+    await waitFor(() => expect(result.current.state.phase).toBe("error"))
+    expect(result.current.state).toMatchObject({ message: "Training job not found." })
+  })
+
+  it("does nothing without a job", async () => {
+    const { result } = renderHook(() => useVoiceTraining(null))
+    expect(result.current.state.phase).toBe("idle")
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("a null progress is passed through, not turned into zero", async () => {
+    // ACE-Step cannot always report a total. Rendering 0 would read as "stuck",
+    // so the null has to survive the hook for the UI to show "working" instead.
+    mockFetch.mockResolvedValue(status({ progress: null }))
+
+    const { result } = renderHook(() => useVoiceTraining("job-1"))
+
+    await waitFor(() => expect(result.current.state.phase).toBe("polling"))
+    expect(
+      result.current.state.phase === "polling" ? result.current.state.status.progress : "missing"
+    ).toBeNull()
+  })
+})

--- a/web/hooks/use-voice-training.test.tsx
+++ b/web/hooks/use-voice-training.test.tsx
@@ -110,6 +110,22 @@ describe("useVoiceTraining", () => {
     expect(result.current.state).toMatchObject({ message: "Training job not found." })
   })
 
+  it("clearing the job stops showing the previous run", async () => {
+    // A view that reuses the hook while switching selections, or closes the
+    // training panel, must not keep the old run's progress on screen.
+    mockFetch.mockResolvedValue(status({ progress: 80 }))
+
+    const { result, rerender } = renderHook(
+      ({ jobId }: { jobId: string | null }) => useVoiceTraining(jobId),
+      { initialProps: { jobId: "job-1" as string | null } }
+    )
+
+    await waitFor(() => expect(result.current.state.phase).toBe("polling"))
+
+    rerender({ jobId: null })
+    expect(result.current.state.phase).toBe("idle")
+  })
+
   it("does nothing without a job", async () => {
     const { result } = renderHook(() => useVoiceTraining(null))
     expect(result.current.state.phase).toBe("idle")

--- a/web/hooks/use-voice-training.ts
+++ b/web/hooks/use-voice-training.ts
@@ -1,0 +1,128 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import {
+  fetchTrainingStatus,
+  isSettled,
+  VoiceModelError,
+  type VoiceTrainingStatus,
+} from "@/lib/voice-models"
+
+const POLL_INTERVAL_MS = 3000
+
+// Cap polling so a vanished job surfaces an error instead of spinning forever.
+// 1200 x 3s = 60 min; the backend abandons a run at 3600s, so this outlasts it.
+// ponytail: fixed cap, raise alongside the worker's poll timeout if that grows.
+const MAX_POLLS = 1200
+
+export type VoiceTrainingState =
+  | { phase: "idle" }
+  | { phase: "loading" }
+  | { phase: "polling"; status: VoiceTrainingStatus }
+  | { phase: "settled"; status: VoiceTrainingStatus }
+  | { phase: "error"; message: string }
+
+/**
+ * Follows one voice-training run to completion (US-25.2).
+ *
+ * **Progress lives on the server, not in this hook.** That is what makes AC 4 —
+ * "returning to the page after navigation restores the current progress state" —
+ * fall out for free: the hook re-reads the status on mount rather than keeping a
+ * client-side tally that a refresh would destroy. The obvious wrong
+ * implementation is a local counter, which is exactly what that criterion exists
+ * to catch, so there is a test that remounts and asserts the state comes back.
+ *
+ * The access token is kept in a ref because it rotates mid-session (#285), so the
+ * poll loop always uses the latest without re-subscribing and restarting.
+ */
+export function useVoiceTraining(
+  jobId: string | null,
+  { onSettled }: { onSettled?: (status: VoiceTrainingStatus) => void } = {}
+): { state: VoiceTrainingState; refresh: () => void } {
+  const { accessToken } = useAuth()
+  // Initialised from jobId rather than reset inside the effect:
+  // react-hooks/set-state-in-effect is an error here, and a synchronous reset in
+  // the effect body is exactly what it forbids.
+  const [state, setState] = useState<VoiceTrainingState>(
+    jobId ? { phase: "loading" } : { phase: "idle" }
+  )
+
+  const tokenRef = useRef(accessToken)
+  useEffect(() => {
+    tokenRef.current = accessToken
+  }, [accessToken])
+
+  const onSettledRef = useRef(onSettled)
+  useEffect(() => {
+    onSettledRef.current = onSettled
+  }, [onSettled])
+
+  // Bumped to force a re-read; the effect below depends on it.
+  const [nonce, setNonce] = useState(0)
+  const refresh = useCallback(() => setNonce((n) => n + 1), [])
+
+  useEffect(() => {
+    if (!jobId) return
+
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let polls = 0
+
+    const tick = async () => {
+      // The reset lives here rather than in the effect body: switching jobs must
+      // not leave the previous run's progress on screen, and setState inside the
+      // async callback is what the lint rule allows.
+      if (polls === 0 && !cancelled) setState({ phase: "loading" })
+
+      const token = tokenRef.current
+      if (!token) {
+        // No token yet (auth still settling); wait rather than failing outright.
+        timer = setTimeout(tick, POLL_INTERVAL_MS)
+        return
+      }
+
+      try {
+        const status = await fetchTrainingStatus(jobId, token)
+        if (cancelled) return
+
+        if (isSettled(status.status)) {
+          setState({ phase: "settled", status })
+          onSettledRef.current?.(status)
+          return
+        }
+
+        setState({ phase: "polling", status })
+      } catch (error) {
+        if (cancelled) return
+        const message =
+          error instanceof VoiceModelError
+            ? error.message
+            : "Could not load training progress."
+        setState({ phase: "error", message })
+        return
+      }
+
+      polls += 1
+      if (polls >= MAX_POLLS) {
+        setState({
+          phase: "error",
+          message: "Training is taking longer than expected. Check back later.",
+        })
+        return
+      }
+
+      timer = setTimeout(tick, POLL_INTERVAL_MS)
+    }
+
+    void tick()
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [jobId, nonce])
+
+  return { state, refresh }
+}

--- a/web/hooks/use-voice-training.ts
+++ b/web/hooks/use-voice-training.ts
@@ -124,5 +124,9 @@ export function useVoiceTraining(
     }
   }, [jobId, nonce])
 
-  return { state, refresh }
+  // Derived rather than reset in the effect. Clearing jobId has to stop showing
+  // the previous run immediately, and react-hooks/set-state-in-effect forbids the
+  // synchronous reset that would otherwise do it -- so the no-job case is computed
+  // instead of stored.
+  return { state: jobId ? state : { phase: "idle" }, refresh }
 }

--- a/web/lib/voice-models.ts
+++ b/web/lib/voice-models.ts
@@ -1,0 +1,104 @@
+/**
+ * Voice model API client (US-25.2 progress, US-25.3 library).
+ *
+ * Talks to the same-origin BFF proxies under `/api/voice-models`, which forward
+ * the bearer token to the platform so the backend URL stays server-side.
+ */
+
+/** Where a training run has got to. */
+export type VoiceTrainingStatus = {
+  job_id: string
+  voice_model_id: string
+  status: "queued" | "training" | "ready" | "failed"
+  phase: string
+  /**
+   * Percent complete, or **null** when the server cannot know it.
+   *
+   * ACE-Step reports steps and epochs rather than a fraction, so this is null
+   * for runs where no total is available. Render "working" for null — do not
+   * substitute 0, which reads as "stuck".
+   */
+  progress: number | null
+  eta_seconds: number | null
+  step: number | null
+  epoch: number | null
+  loss: number | null
+  error: string | null
+}
+
+export type VoiceModelSummary = {
+  id: string
+  name: string
+  description: string | null
+  status: "queued" | "training" | "ready" | "failed"
+  reference_count: number
+  job_id: string | null
+  error: string | null
+  created_at: string
+}
+
+export class VoiceModelError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+    this.name = "VoiceModelError"
+  }
+}
+
+async function parse<T>(res: Response, fallback: string): Promise<T> {
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    throw new VoiceModelError(
+      typeof body?.detail === "string" ? body.detail : fallback,
+      res.status
+    )
+  }
+  return body as T
+}
+
+/** Progress of one training run. Throws VoiceModelError with the status on failure. */
+export async function fetchTrainingStatus(
+  jobId: string,
+  token: string
+): Promise<VoiceTrainingStatus> {
+  const res = await fetch(
+    `/api/voice-models/train/${encodeURIComponent(jobId)}/status`,
+    { headers: { authorization: `Bearer ${token}` }, cache: "no-store" }
+  )
+  return parse<VoiceTrainingStatus>(res, "Could not load training progress.")
+}
+
+/** Every voice model the caller owns, newest first. */
+export async function fetchVoiceModels(token: string): Promise<VoiceModelSummary[]> {
+  const res = await fetch("/api/voice-models", {
+    headers: { authorization: `Bearer ${token}` },
+    cache: "no-store",
+  })
+  return parse<VoiceModelSummary[]>(res, "Could not load your voice models.")
+}
+
+/** True once a run has stopped moving — polling should stop here. */
+export function isSettled(status: VoiceTrainingStatus["status"]): boolean {
+  return status === "ready" || status === "failed"
+}
+
+/** Human phase text. Falls back to the raw phase rather than inventing one. */
+export function describePhase(status: VoiceTrainingStatus): string {
+  if (status.status === "ready") return "Ready"
+  if (status.status === "failed") return status.error ?? "Training failed"
+
+  switch (status.phase) {
+    case "preprocessing":
+      return "Preparing your recordings"
+    case "training":
+      return "Training"
+    case "finalizing":
+      return "Finishing up"
+    case "queued":
+      return "Queued"
+    default:
+      return status.phase
+  }
+}


### PR DESCRIPTION
Implements **US-25.2 — Training Progress and Notifications** (#326).

Exposes the progress US-25.1's worker was already recording, and notifies when a run
finishes.

---

## Acceptance criteria

| Criterion | Outcome |
| --- | --- |
| Status endpoint returns progress updates during training | **Met** — phase, progress, ETA, plus ACE-Step's own step/epoch/loss |
| In-app notification fires on completion | **Met** — one event on success, one on failure *with the reason* |
| Progress visible in the voice library UI | **Partial** — the hook and client are here; the library page itself is US-25.3 |
| Returning to the page restores progress | **Met** — and it falls out of the design, see below |

## The percentage is derived, never invented

ACE-Step reports steps and epochs, not a fraction. Where no total is knowable, `progress`
is **null** rather than a number that looks authoritative and is not — a progress bar that
lies is worse than one that says "working". A *failed* run reports null too; 0 and 100
would both misdescribe what happened.

Pinned at both layers, including that the hook passes `null` through rather than coercing
it to `0`, which would read as "stuck". The test is named
`test_a_percentage_is_never_fabricated`.

## AC 4 falls out of the design rather than needing a mechanism

Progress lives on the **server**, so the hook re-reads it on mount. The obvious wrong
implementation is a client-side tally that a remount destroys — which is exactly what that
criterion exists to catch — so the test unmounts, remounts, and asserts the state comes
back.

## 404, not 403

The status endpoint resolves the job *through the voice model's owner*, so another user's
run is indistinguishable from one that does not exist.

## Model change kept narrow

`NotificationEvent` gains an optional `voice_model_id`, and `release_id` becomes optional.
Two nullable keys rather than a generic-subject refactor: the release path (US-21.x) is
shipped and working, and rewriting it is not this story's job. A test asserts it is
untouched.

---

## Pre-PR review: two P2s, both real, both fixed

**A notification failure could undo a successful run.** The completion notification was
written inside the training success path, so a transient `notification_events` insert
failure propagated into the failure handler — marking a *working* voice model FAILED and
refunding its 10 credits. Now best-effort and logged, because it is strictly less important
than the thing it announces.

**Clearing the tracked job left stale progress on screen.** This one was mine twice: the
reset existed until I moved it into `tick()` to satisfy `react-hooks/set-state-in-effect`,
and `tick()` only runs when there *is* a job. Fixed by deriving rather than storing — no
`setState`, so no fight with the lint rule. Reverting it fails
`clearing the job stops showing the previous run`.

---

## Verification

- **26/26** backend integration tests against real MongoDB
- **8/8** hook tests
- **1568 web tests across 201 files** — no regressions from the notification model change
- Typecheck, lint and `next build` clean; both BFF routes confirmed present in the build
  artifacts

## Known limitations

1. **No email.** The story lists it as optional; the platform has no delivery worker
   (`delivered_at` is annotated as awaiting one). The event is recorded and nothing more is
   claimed.
2. `progress` is null when ACE-Step gives no total, rather than guessed.
3. The voice library page is US-25.3; this story adds the hook it will reuse rather than
   building a page 25.3 would rewrite.

Closes #326
