### PR TITLE
feat: US-25.3 Voice Model Library (#327)

### DIFF
--- a/src/acemusic/api/routers/voice_models.py
+++ b/src/acemusic/api/routers/voice_models.py
@@ -4,6 +4,8 @@
 * ``POST   /voice-models/train``                  → validate, charge, queue training
 * ``GET    /voice-models/train/{job_id}/status``  → phase, progress, ETA (US-25.2)
 * ``GET    /voice-models``                        → the caller's models, newest first
+* ``PATCH  /voice-models/{id}``                   → rename / re-describe (US-25.3)
+* ``DELETE /voice-models/{id}``                   → remove it and free its storage
 
 Every read is owner-scoped: a voice model is private, and ownership is part of
 the query rather than a check afterwards, so there is no path that reads someone
@@ -12,9 +14,10 @@ else's model at all.
 
 import logging
 from datetime import datetime
+from typing import Annotated
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile, status
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..auth.dependencies import CurrentUser, require_existing_user
 from ..models import VoiceModel, VoiceModelStatus
@@ -152,6 +155,53 @@ async def get_training_status(
         loss=progress.get("loss"),
         error=progress.get("error"),
     )
+
+
+class VoiceModelUpdate(BaseModel):
+    """Editable fields. ``extra="forbid"`` so a client cannot smuggle in ``status``
+    or ``weights_path`` — those are the system's, not theirs. Mirrors ClipUpdate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Annotated[str, Field(min_length=1, max_length=120)] | None = None
+    description: Annotated[str, Field(max_length=1000)] | None = None
+
+
+@router.patch("/{model_id}", response_model=VoiceModelResponse)
+async def update_voice_model(
+    model_id: str,
+    update: VoiceModelUpdate,
+    current: CurrentUser = Depends(require_existing_user),
+) -> VoiceModelResponse:
+    """Rename or re-describe a voice model."""
+    try:
+        model = await voice_service.rename_voice_model(
+            model_id, current.user_id, name=update.name, description=update.description
+        )
+    except voice_service.VoiceModelError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+
+    if model is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Voice model not found.")
+
+    return VoiceModelResponse.from_model(model)
+
+
+@router.delete("/{model_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_voice_model(
+    model_id: str,
+    current: CurrentUser = Depends(require_existing_user),
+) -> Response:
+    """Remove a voice model and free its stored weights and references."""
+    try:
+        removed = await voice_service.delete_voice_model(model_id, current.user_id)
+    except voice_service.VoiceModelError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    if not removed:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Voice model not found.")
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("", response_model=list[VoiceModelResponse])

--- a/src/acemusic/api/services/voice_models.py
+++ b/src/acemusic/api/services/voice_models.py
@@ -20,6 +20,7 @@ from beanie import PydanticObjectId
 from acemusic.storage import StorageBackend, get_storage_backend
 
 from ..models import Job, NotificationEvent, User, VoiceModel, VoiceModelStatus
+from ..models.common import utcnow
 from ..models.voice_model import (
     MAX_REFERENCE_BYTES,
     MAX_REFERENCE_FILES,
@@ -420,6 +421,72 @@ async def list_voice_models(user_id: str) -> list[VoiceModel]:
     models = await VoiceModel.find(VoiceModel.user_id == uid).to_list()
     models.sort(key=lambda m: m.created_at, reverse=True)
     return models
+
+
+async def delete_voice_model(model_id: str, user_id: str) -> bool:
+    """Remove a voice model and free its stored objects (US-25.3, AC 3).
+
+    Storage first, then the record: a crash between the two leaves a re-deletable
+    row rather than orphaned objects, which is the same ordering ``delete_clip``
+    uses. Each object is best-effort — one already missing from the backend must
+    not make the model undeletable.
+
+    A model that is still training is refused: deleting the row out from under a
+    running job strands the worker and the credits it charged.
+
+    @returns False when there is no such model for this user.
+    """
+    model = await find_owned_model(model_id, user_id)
+
+    if model is None:
+        return False
+
+    if model.status in (VoiceModelStatus.QUEUED, VoiceModelStatus.TRAINING):
+        raise VoiceModelError("This voice is still training. Wait for it to finish before deleting it.")
+
+    storage = get_storage_backend()
+
+    for key in [*model.reference_paths, *([model.weights_path] if model.weights_path else [])]:
+        try:
+            await asyncio.to_thread(storage.delete, key)
+        except Exception:  # pragma: no cover - cleanup is best-effort
+            logger.exception("Could not delete voice model object %s", key)
+
+    await model.delete()
+    return True
+
+
+async def rename_voice_model(
+    model_id: str, user_id: str, *, name: str | None = None, description: str | None = None
+) -> VoiceModel | None:
+    """Update a voice model's name and/or description (US-25.3, AC 2).
+
+    Only these two fields; status and weights are the system's, not the client's.
+
+    "Renaming updates it everywhere it appears" holds because there is **one row** —
+    the name is not denormalised. The exception is a notification already sent,
+    which keeps the name it was sent with, and that is correct: it describes what
+    happened at the time.
+
+    @returns None when there is no such model for this user.
+    """
+    model = await find_owned_model(model_id, user_id)
+
+    if model is None:
+        return None
+
+    if name is not None:
+        cleaned = name.strip()
+        if not cleaned:
+            raise VoiceModelError("Give the voice model a name.")
+        model.name = cleaned
+
+    if description is not None:
+        model.description = description.strip() or None
+
+    model.updated_at = utcnow()
+    await model.save()
+    return model
 
 
 async def find_owned_model(model_id: str, user_id: str) -> VoiceModel | None:

--- a/tests/test_voice_models_api.py
+++ b/tests/test_voice_models_api.py
@@ -819,3 +819,135 @@ class TestTrainingNotifications:
         stored = await NotificationEvent.get(event.id)
         assert stored.release_id == release_id
         assert stored.voice_model_id is None
+
+
+# ---------------------------------------------------------------------------
+# US-25.3 — library management
+# ---------------------------------------------------------------------------
+
+
+class TestLibraryAuthGate:
+    def test_patch_and_delete_require_a_token(self) -> None:
+        client = TestClient(create_app())
+        model_id = str(PydanticObjectId())
+        assert client.patch(f"{LIST_URL}/{model_id}", json={"name": "x"}).status_code == 401
+        assert client.delete(f"{LIST_URL}/{model_id}").status_code == 401
+
+
+@pytest.mark.integration
+class TestLibraryManagement:
+    async def _ready_model(self, client, settings, user, name: str = "Voice"):
+        resp = await client.post(TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": name})
+        assert resp.status_code == 202, resp.text
+        model = await VoiceModel.get(resp.json()["voice_model"]["id"])
+        # Pretend training finished, with weights in storage to be freed later.
+        storage = get_storage_backend()
+        model.weights_path = f"{user.id}/voice-models/{model.id}/adapter"
+        storage.upload(model.weights_path, b"fake adapter weights")
+        model.status = VoiceModelStatus.READY
+        await model.save()
+        return model
+
+    async def test_renaming_updates_the_one_row_it_lives_in(self, client, settings, local_storage) -> None:
+        # "Updates everywhere it appears" holds because the name is not
+        # denormalised. This test documents that, and that a notification already
+        # sent keeps the name it was sent with -- which is correct, it describes
+        # what happened at the time.
+        from acemusic.api.models import NotificationEvent
+
+        user = await _make_user("rename@example.com")
+        model = await self._ready_model(client, settings, user, name="Old name")
+        await voice_service.notify_training_finished(model, succeeded=True)
+
+        resp = await client.patch(
+            f"{LIST_URL}/{model.id}",
+            headers=_auth_headers(user, settings),
+            json={"name": "New name", "description": "warmer"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["name"] == "New name"
+        assert resp.json()["description"] == "warmer"
+
+        listed = await client.get(LIST_URL, headers=_auth_headers(user, settings))
+        assert [m["name"] for m in listed.json()] == ["New name"]
+
+        event = (await NotificationEvent.find(NotificationEvent.user_id == user.id).to_list())[0]
+        assert event.payload["name"] == "Old name"
+
+    async def test_a_blank_name_is_refused(self, client, settings, local_storage) -> None:
+        user = await _make_user("blankname@example.com")
+        model = await self._ready_model(client, settings, user)
+
+        resp = await client.patch(f"{LIST_URL}/{model.id}", headers=_auth_headers(user, settings), json={"name": "   "})
+        assert resp.status_code == 422
+        assert (await VoiceModel.get(model.id)).name == "Voice"
+
+    async def test_status_and_weights_cannot_be_set_by_a_client(self, client, settings, local_storage) -> None:
+        user = await _make_user("forbidden@example.com")
+        model = await self._ready_model(client, settings, user)
+
+        resp = await client.patch(
+            f"{LIST_URL}/{model.id}",
+            headers=_auth_headers(user, settings),
+            json={"name": "ok", "status": "ready", "weights_path": "/etc/passwd"},
+        )
+        assert resp.status_code == 422, "a client smuggled system fields through PATCH"
+
+    async def test_deleting_removes_the_record_and_frees_the_storage(self, client, settings, local_storage) -> None:
+        user = await _make_user("delete@example.com")
+        model = await self._ready_model(client, settings, user)
+        storage = get_storage_backend()
+
+        keys = [*model.reference_paths, model.weights_path]
+        for key in keys:
+            assert storage.download(key), f"{key} was not stored to begin with"
+
+        resp = await client.delete(f"{LIST_URL}/{model.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 204, resp.text
+
+        assert await VoiceModel.get(model.id) is None
+        for key in keys:
+            with pytest.raises(Exception):
+                storage.download(key)
+
+    async def test_deleting_a_model_still_training_is_refused(self, client, settings, local_storage) -> None:
+        # Deleting the row out from under a running job strands the worker and
+        # the credits it charged.
+        user = await _make_user("deletetraining@example.com")
+        resp = await client.post(TRAIN_URL, headers=_auth_headers(user, settings), files=_files(3), data={"name": "V"})
+        model_id = resp.json()["voice_model"]["id"]
+
+        deleted = await client.delete(f"{LIST_URL}/{model_id}", headers=_auth_headers(user, settings))
+        assert deleted.status_code == 409
+        assert await VoiceModel.get(model_id) is not None
+
+    async def test_another_user_can_neither_rename_nor_delete(self, client, settings, local_storage) -> None:
+        owner = await _make_user("libowner@example.com")
+        intruder = await _make_user("libintruder@example.com")
+        model = await self._ready_model(client, settings, owner, name="Private")
+
+        patched = await client.patch(
+            f"{LIST_URL}/{model.id}", headers=_auth_headers(intruder, settings), json={"name": "Mine now"}
+        )
+        deleted = await client.delete(f"{LIST_URL}/{model.id}", headers=_auth_headers(intruder, settings))
+
+        # 404, not 403: another user's model should be indistinguishable from one
+        # that does not exist.
+        assert patched.status_code == 404
+        assert deleted.status_code == 404
+
+        survivor = await VoiceModel.get(model.id)
+        assert survivor is not None and survivor.name == "Private"
+
+    async def test_a_missing_storage_object_does_not_make_a_model_undeletable(
+        self, client, settings, local_storage
+    ) -> None:
+        user = await _make_user("halfgone@example.com")
+        model = await self._ready_model(client, settings, user)
+
+        # The backend has already lost one object; the record must still go.
+        get_storage_backend().delete(model.reference_paths[0])
+
+        resp = await client.delete(f"{LIST_URL}/{model.id}", headers=_auth_headers(user, settings))
+        assert resp.status_code == 204, resp.text
+        assert await VoiceModel.get(model.id) is None

--- a/web/app/api/voice-models/[modelId]/route.ts
+++ b/web/app/api/voice-models/[modelId]/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+import { BACKEND_URL } from "@/lib/auth-server"
+
+// Same-origin proxy for PATCH/DELETE /api/v1/voice-models/{id} (US-25.3).
+// Status passes through verbatim: 404 covers "not yours" as well as "missing",
+// and flattening that here would leak which is which. 409 is "still training".
+
+function target(modelId: string): string {
+  return `${BACKEND_URL}/api/v1/voice-models/${encodeURIComponent(modelId)}`
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ modelId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { modelId } = await params
+
+  let res: Response
+  try {
+    res = await fetch(target(modelId), {
+      method: "PATCH",
+      headers: { authorization: auth, "content-type": "application/json", accept: "application/json" },
+      body: await request.text(),
+    })
+  } catch {
+    return NextResponse.json({ detail: "Voice model service is unavailable." }, { status: 502 })
+  }
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ modelId: string }> }
+): Promise<NextResponse> {
+  const auth = request.headers.get("authorization")
+  if (!auth) {
+    return NextResponse.json({ detail: "Not authenticated." }, { status: 401 })
+  }
+
+  const { modelId } = await params
+
+  let res: Response
+  try {
+    res = await fetch(target(modelId), {
+      method: "DELETE",
+      headers: { authorization: auth, accept: "application/json" },
+    })
+  } catch {
+    return NextResponse.json({ detail: "Voice model service is unavailable." }, { status: 502 })
+  }
+
+  // 204 carries no body; forwarding it as JSON would turn a success into a parse error.
+  if (res.status === 204) {
+    return new NextResponse(null, { status: 204 })
+  }
+
+  const body = await res.json().catch(() => ({}))
+  return NextResponse.json(body, { status: res.status })
+}

--- a/web/app/me/page.tsx
+++ b/web/app/me/page.tsx
@@ -1,7 +1,20 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { VoiceLibrary } from "@/components/voices/VoiceLibrary"
+
 export default function MePage() {
   return (
     <div className="p-8">
       <h1 className="text-2xl font-semibold">Library</h1>
+
+      <Tabs defaultValue="voices" className="mt-6">
+        <TabsList>
+          <TabsTrigger value="voices">Voices</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="voices" className="mt-4">
+          <VoiceLibrary />
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/web/components/voices/VoiceLibrary.test.tsx
+++ b/web/components/voices/VoiceLibrary.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { VoiceLibrary } from "@/components/voices/VoiceLibrary"
+import type { VoiceModelSummary } from "@/lib/voice-models"
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => ({ accessToken: "tok-1" }) }))
+
+vi.mock("@/lib/voice-models", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/voice-models")>("@/lib/voice-models")
+  return {
+    ...actual,
+    fetchVoiceModels: vi.fn(),
+    updateVoiceModel: vi.fn(),
+    deleteVoiceModel: vi.fn(),
+    fetchTrainingStatus: vi.fn(),
+  }
+})
+
+import {
+  deleteVoiceModel,
+  fetchTrainingStatus,
+  fetchVoiceModels,
+  updateVoiceModel,
+  VoiceModelError,
+} from "@/lib/voice-models"
+
+const mockList = vi.mocked(fetchVoiceModels)
+const mockUpdate = vi.mocked(updateVoiceModel)
+const mockDelete = vi.mocked(deleteVoiceModel)
+const mockStatus = vi.mocked(fetchTrainingStatus)
+
+function model(overrides: Partial<VoiceModelSummary> = {}): VoiceModelSummary {
+  return {
+    id: "vm-1",
+    name: "My voice",
+    description: "warm baritone",
+    status: "ready",
+    reference_count: 3,
+    job_id: "job-1",
+    error: null,
+    created_at: "2026-01-15T00:00:00Z",
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockList.mockReset()
+  mockUpdate.mockReset()
+  mockDelete.mockReset()
+  mockStatus.mockReset()
+})
+
+describe("VoiceLibrary", () => {
+  it("AC: lists every trained voice with the fields the story names", async () => {
+    mockList.mockResolvedValue([
+      model(),
+      model({ id: "vm-2", name: "Second", description: "bright tenor", reference_count: 1 }),
+    ])
+
+    render(<VoiceLibrary />)
+
+    await waitFor(() => expect(screen.getAllByTestId("voice-card")).toHaveLength(2))
+    expect(screen.getByText("My voice")).toBeInTheDocument()
+    expect(screen.getByText("warm baritone")).toBeInTheDocument()
+    expect(screen.getByText(/3 references/)).toBeInTheDocument()
+    // Singular, because "1 references" is the kind of thing nobody fixes later.
+    expect(screen.getByText(/1 reference(?!s)/)).toBeInTheDocument()
+    expect(screen.getAllByText("Ready")).toHaveLength(2)
+  })
+
+  it("AC: renaming updates the card", async () => {
+    mockList.mockResolvedValueOnce([model()]).mockResolvedValue([model({ name: "Renamed" })])
+    mockUpdate.mockResolvedValue(model({ name: "Renamed" }))
+
+    render(<VoiceLibrary />)
+    await screen.findByText("My voice")
+
+    await userEvent.click(screen.getByRole("button", { name: "Rename" }))
+    const field = screen.getByLabelText("Voice name")
+    await userEvent.clear(field)
+    await userEvent.type(field, "Renamed")
+    await userEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith("vm-1", "tok-1", { name: "Renamed" }))
+    // Re-read from the server rather than patched locally, so the card cannot drift.
+    await waitFor(() => expect(screen.getByText("Renamed")).toBeInTheDocument())
+  })
+
+  it("AC: deleting removes it from the library", async () => {
+    mockList.mockResolvedValueOnce([model()]).mockResolvedValue([])
+    mockDelete.mockResolvedValue()
+
+    render(<VoiceLibrary />)
+    await screen.findByText("My voice")
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith("vm-1", "tok-1"))
+    await waitFor(() => expect(screen.queryByTestId("voice-card")).not.toBeInTheDocument())
+  })
+
+  it("says why a delete was refused rather than failing silently", async () => {
+    mockList.mockResolvedValue([model({ status: "training" })])
+    mockDelete.mockRejectedValue(
+      new VoiceModelError("This voice is still training. Wait for it to finish before deleting it.", 409)
+    )
+    mockStatus.mockResolvedValue({
+      job_id: "job-1",
+      voice_model_id: "vm-1",
+      status: "training",
+      phase: "training",
+      progress: 40,
+      eta_seconds: 20,
+      step: 4,
+      epoch: 1,
+      loss: 0.5,
+      error: null,
+    })
+
+    render(<VoiceLibrary />)
+    await screen.findByText("My voice")
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    expect(await screen.findByText(/still training/)).toBeInTheDocument()
+    // And the card is still there.
+    expect(screen.getByTestId("voice-card")).toBeInTheDocument()
+  })
+
+  it("shows live progress for a model still training", async () => {
+    mockList.mockResolvedValue([model({ status: "training" })])
+    mockStatus.mockResolvedValue({
+      job_id: "job-1",
+      voice_model_id: "vm-1",
+      status: "training",
+      phase: "training",
+      progress: 42,
+      eta_seconds: 30,
+      step: 4,
+      epoch: 1,
+      loss: 0.5,
+      error: null,
+    })
+
+    render(<VoiceLibrary />)
+
+    expect(await screen.findByText(/Training — 42%/)).toBeInTheDocument()
+  })
+
+  it("a null progress shows the phase alone, never 0%", async () => {
+    // 0% reads as "stuck"; the server reports null when it cannot know.
+    mockList.mockResolvedValue([model({ status: "training" })])
+    mockStatus.mockResolvedValue({
+      job_id: "job-1",
+      voice_model_id: "vm-1",
+      status: "training",
+      phase: "training",
+      progress: null,
+      eta_seconds: null,
+      step: null,
+      epoch: null,
+      loss: null,
+      error: null,
+    })
+
+    render(<VoiceLibrary />)
+
+    expect(await screen.findByText("Training")).toBeInTheDocument()
+    expect(screen.queryByText(/0%/)).not.toBeInTheDocument()
+  })
+
+  it("shows why a training run failed", async () => {
+    mockList.mockResolvedValue([model({ status: "failed", error: "CUDA out of memory", job_id: null })])
+
+    render(<VoiceLibrary />)
+
+    expect(await screen.findByText("CUDA out of memory")).toBeInTheDocument()
+  })
+
+  it("invites a first voice when the library is empty", async () => {
+    mockList.mockResolvedValue([])
+
+    render(<VoiceLibrary />)
+
+    expect(await screen.findByText(/No voice models yet/)).toBeInTheDocument()
+  })
+})

--- a/web/components/voices/VoiceLibrary.tsx
+++ b/web/components/voices/VoiceLibrary.tsx
@@ -179,6 +179,10 @@ export function VoiceLibrary() {
     return <p className="text-sm text-muted-foreground">Loading your voices…</p>
   }
 
+  if (state.phase === "signed-out") {
+    return <p className="text-sm text-muted-foreground">Sign in to see your voices.</p>
+  }
+
   if (state.phase === "error") {
     return <p className="text-sm text-destructive">{state.message}</p>
   }

--- a/web/components/voices/VoiceLibrary.tsx
+++ b/web/components/voices/VoiceLibrary.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import { useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useVoiceModels } from "@/hooks/use-voice-models"
+import { useVoiceTraining } from "@/hooks/use-voice-training"
+import { describePhase, type VoiceModelSummary } from "@/lib/voice-models"
+
+/** Status wording the musician sees, rather than the raw enum. */
+const STATUS_LABEL: Record<VoiceModelSummary["status"], string> = {
+  queued: "Queued",
+  training: "Training",
+  ready: "Ready",
+  failed: "Failed",
+}
+
+function formatDate(iso: string): string {
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime()) ? "" : date.toLocaleDateString()
+}
+
+/** Live progress for a model still training (US-25.2's hook, reused here). */
+function TrainingProgress({ jobId }: { jobId: string }) {
+  const { state } = useVoiceTraining(jobId)
+
+  if (state.phase === "error") {
+    return <p className="text-sm text-destructive">{state.message}</p>
+  }
+
+  if (state.phase !== "polling" && state.phase !== "settled") {
+    return <p className="text-sm text-muted-foreground">Checking progress…</p>
+  }
+
+  const { status } = state
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      {describePhase(status)}
+      {/* null progress means the server cannot know it -- showing 0% would read
+          as "stuck", so the phase stands alone instead. */}
+      {status.progress !== null ? ` — ${Math.round(status.progress)}%` : ""}
+    </p>
+  )
+}
+
+function VoiceCard({
+  model,
+  onRename,
+  onDelete,
+}: {
+  model: VoiceModelSummary
+  onRename: (id: string, name: string) => Promise<void>
+  onDelete: (id: string) => Promise<void>
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(model.name)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const save = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await onRename(model.id, draft)
+      setEditing(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not rename.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const remove = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await onDelete(model.id)
+    } catch (e) {
+      // A model still training refuses deletion (409) -- show why rather than
+      // failing silently.
+      setError(e instanceof Error ? e.message : "Could not delete.")
+      setBusy(false)
+    }
+  }
+
+  return (
+    <li className="rounded-lg border border-border p-4" data-testid="voice-card">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          {editing ? (
+            <div className="flex items-center gap-2">
+              <Input
+                aria-label="Voice name"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                className="h-8 w-48"
+              />
+              <Button size="sm" onClick={save} disabled={busy}>
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setDraft(model.name)
+                  setEditing(false)
+                  setError(null)
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <h3 className="truncate font-medium">{model.name}</h3>
+          )}
+
+          {model.description ? (
+            <p className="mt-1 truncate text-sm text-muted-foreground">{model.description}</p>
+          ) : null}
+
+          <p className="mt-2 text-xs text-muted-foreground">
+            {model.reference_count} reference
+            {model.reference_count === 1 ? "" : "s"}
+            {formatDate(model.created_at) ? ` · ${formatDate(model.created_at)}` : ""}
+          </p>
+
+          {model.status === "training" || model.status === "queued" ? (
+            model.job_id ? (
+              <div className="mt-2">
+                <TrainingProgress jobId={model.job_id} />
+              </div>
+            ) : null
+          ) : null}
+
+          {model.status === "failed" && model.error ? (
+            <p className="mt-2 text-sm text-destructive">{model.error}</p>
+          ) : null}
+
+          {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <Badge variant={model.status === "ready" ? "default" : "secondary"}>
+            {STATUS_LABEL[model.status]}
+          </Badge>
+          {!editing ? (
+            <Button size="sm" variant="ghost" onClick={() => setEditing(true)} disabled={busy}>
+              Rename
+            </Button>
+          ) : null}
+          <Button size="sm" variant="ghost" onClick={remove} disabled={busy}>
+            Delete
+          </Button>
+        </div>
+      </div>
+    </li>
+  )
+}
+
+/**
+ * The musician's voice model library (US-25.3).
+ *
+ * Lists every trained voice with its name, description, creation date, reference
+ * count and training status, and supports renaming and deleting. A model still
+ * training shows live progress rather than a dead card.
+ *
+ * **No preview.** Generating with a voice means loading its LoRA, and that is
+ * server-global state in ACE-Step (`dit_handler.use_lora`, no per-request field),
+ * so previewing one musician's voice would change the model for everyone else on
+ * that server — and unloading is unreliable. See the note on #327.
+ */
+export function VoiceLibrary() {
+  const { state, rename, remove } = useVoiceModels()
+
+  if (state.phase === "loading") {
+    return <p className="text-sm text-muted-foreground">Loading your voices…</p>
+  }
+
+  if (state.phase === "error") {
+    return <p className="text-sm text-destructive">{state.message}</p>
+  }
+
+  if (state.models.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No voice models yet. Train one from a few reference recordings to use your own voice
+        in a generation.
+      </p>
+    )
+  }
+
+  return (
+    <ul className="space-y-3">
+      {state.models.map((model) => (
+        <VoiceCard
+          key={model.id}
+          model={model}
+          onRename={(id, name) => rename(id, { name })}
+          onDelete={remove}
+        />
+      ))}
+    </ul>
+  )
+}

--- a/web/hooks/use-voice-models.test.tsx
+++ b/web/hooks/use-voice-models.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useVoiceModels } from "@/hooks/use-voice-models"
+import type { VoiceModelSummary } from "@/lib/voice-models"
+
+let currentToken: string | null = "tok-1"
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => ({ accessToken: currentToken }) }))
+
+vi.mock("@/lib/voice-models", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/voice-models")>("@/lib/voice-models")
+  return { ...actual, fetchVoiceModels: vi.fn(), updateVoiceModel: vi.fn(), deleteVoiceModel: vi.fn() }
+})
+
+import { fetchVoiceModels } from "@/lib/voice-models"
+
+const mockList = vi.mocked(fetchVoiceModels)
+
+const model: VoiceModelSummary = {
+  id: "vm-1",
+  name: "My voice",
+  description: null,
+  status: "ready",
+  reference_count: 3,
+  job_id: null,
+  error: null,
+  created_at: "2026-01-15T00:00:00Z",
+}
+
+beforeEach(() => {
+  mockList.mockReset()
+  currentToken = "tok-1"
+})
+
+describe("useVoiceModels", () => {
+  it("loads the library", async () => {
+    mockList.mockResolvedValue([model])
+
+    const { result } = renderHook(() => useVoiceModels())
+
+    await waitFor(() => expect(result.current.state.phase).toBe("ready"))
+    expect(result.current.state).toMatchObject({ models: [model] })
+  })
+
+  it("with no token it reports signed-out instead of spinning forever", async () => {
+    currentToken = null
+
+    const { result } = renderHook(() => useVoiceModels())
+
+    await waitFor(() => expect(result.current.state.phase).toBe("signed-out"))
+    expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it("clearing the token drops the loaded models rather than leaving them on screen", async () => {
+    // Private metadata must not survive a logout or a failed refresh.
+    mockList.mockResolvedValue([model])
+
+    const { result, rerender } = renderHook(() => useVoiceModels())
+    await waitFor(() => expect(result.current.state.phase).toBe("ready"))
+
+    currentToken = null
+    rerender()
+
+    await waitFor(() => expect(result.current.state.phase).toBe("signed-out"))
+    expect(result.current.state).not.toHaveProperty("models")
+  })
+})

--- a/web/hooks/use-voice-models.ts
+++ b/web/hooks/use-voice-models.ts
@@ -1,0 +1,97 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { useAuth } from "@/hooks/use-auth"
+import {
+  deleteVoiceModel,
+  fetchVoiceModels,
+  updateVoiceModel,
+  VoiceModelError,
+  type VoiceModelSummary,
+} from "@/lib/voice-models"
+
+export type VoiceModelsState =
+  | { phase: "loading" }
+  | { phase: "ready"; models: VoiceModelSummary[] }
+  | { phase: "error"; message: string }
+
+export type UseVoiceModels = {
+  state: VoiceModelsState
+  /** Re-read the library from the server. */
+  refresh: () => void
+  /** Rename and/or re-describe. Rejects with the server's message. */
+  rename: (id: string, update: { name?: string; description?: string }) => Promise<void>
+  /** Delete and free the stored weights. Rejects with the server's message. */
+  remove: (id: string) => Promise<void>
+}
+
+/**
+ * The caller's voice model library (US-25.3).
+ *
+ * Mutations re-read from the server rather than patching local state: the list is
+ * the server's, and a rename that only updated a local copy would drift the moment
+ * anything else changed the row. The access token is kept in a ref because it
+ * rotates mid-session (#285).
+ */
+export function useVoiceModels(): UseVoiceModels {
+  const { accessToken } = useAuth()
+  const [state, setState] = useState<VoiceModelsState>({ phase: "loading" })
+  const [nonce, setNonce] = useState(0)
+
+  const tokenRef = useRef(accessToken)
+  useEffect(() => {
+    tokenRef.current = accessToken
+  }, [accessToken])
+
+  const refresh = useCallback(() => setNonce((n) => n + 1), [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const load = async () => {
+      const token = tokenRef.current
+      if (!token) return
+
+      try {
+        const models = await fetchVoiceModels(token)
+        if (!cancelled) setState({ phase: "ready", models })
+      } catch (error) {
+        if (cancelled) return
+        setState({
+          phase: "error",
+          message:
+            error instanceof VoiceModelError ? error.message : "Could not load your voice models.",
+        })
+      }
+    }
+
+    void load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [nonce, accessToken])
+
+  const rename = useCallback(
+    async (id: string, update: { name?: string; description?: string }) => {
+      const token = tokenRef.current
+      if (!token) throw new VoiceModelError("Not signed in.", 401)
+      await updateVoiceModel(id, token, update)
+      refresh()
+    },
+    [refresh]
+  )
+
+  const remove = useCallback(
+    async (id: string) => {
+      const token = tokenRef.current
+      if (!token) throw new VoiceModelError("Not signed in.", 401)
+      await deleteVoiceModel(id, token)
+      refresh()
+    },
+    [refresh]
+  )
+
+  return { state, refresh, rename, remove }
+}

--- a/web/hooks/use-voice-models.ts
+++ b/web/hooks/use-voice-models.ts
@@ -14,6 +14,9 @@ import {
 export type VoiceModelsState =
   | { phase: "loading" }
   | { phase: "ready"; models: VoiceModelSummary[] }
+  /** No access token: signed out, or a refresh that failed. Distinct from an
+      error so the UI can say "sign in" rather than showing a red failure. */
+  | { phase: "signed-out" }
   | { phase: "error"; message: string }
 
 export type UseVoiceModels = {
@@ -51,7 +54,14 @@ export function useVoiceModels(): UseVoiceModels {
 
     const load = async () => {
       const token = tokenRef.current
-      if (!token) return
+
+      if (!token) {
+        // Drops the models as well as stopping the spinner. Without this a
+        // cleared token leaves the previous user's voice metadata on screen
+        // until navigation completes, and a first visit spins forever.
+        if (!cancelled) setState({ phase: "signed-out" })
+        return
+      }
 
       try {
         const models = await fetchVoiceModels(token)

--- a/web/lib/voice-models.ts
+++ b/web/lib/voice-models.ts
@@ -79,6 +79,36 @@ export async function fetchVoiceModels(token: string): Promise<VoiceModelSummary
   return parse<VoiceModelSummary[]>(res, "Could not load your voice models.")
 }
 
+/** Rename and/or re-describe a voice model. */
+export async function updateVoiceModel(
+  id: string,
+  token: string,
+  update: { name?: string; description?: string }
+): Promise<VoiceModelSummary> {
+  const res = await fetch(`/api/voice-models/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify(update),
+  })
+  return parse<VoiceModelSummary>(res, "Could not update the voice model.")
+}
+
+/** Delete a voice model and free its stored weights. */
+export async function deleteVoiceModel(id: string, token: string): Promise<void> {
+  const res = await fetch(`/api/voice-models/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${token}` },
+  })
+  // 204 has no body, so this cannot go through parse().
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new VoiceModelError(
+      typeof body?.detail === "string" ? body.detail : "Could not delete the voice model.",
+      res.status
+    )
+  }
+}
+
 /** True once a run has stopped moving — polling should stop here. */
 export function isSettled(status: VoiceTrainingStatus["status"]): boolean {
   return status === "ready" || status === "failed"


### PR DESCRIPTION
Implements **US-25.3 — Voice Model Library** (#327): `DELETE` and `PATCH` for voice models,
and the `/me → Voices` tab that lists, renames and deletes them.

---

## Acceptance criteria

| Criterion | Outcome |
| --- | --- |
| Voice library page lists all trained voice models | **Met** — name, description, date, reference count, status |
| Renaming updates it everywhere it appears | **Met** — see below |
| Deleting removes it from the library and frees storage | **Met** — weights *and* references |
| Preview generates a short clip using the voice | **NOT IMPLEMENTED — deliberately.** See below |
| Other users cannot see or access another user's voice models | **Met** — 404, not 403 |

## Preview is not implemented, and this is a decision not an omission

Generating with a voice means loading its LoRA, and **that is server-global state in
ACE-Step**, not a per-request parameter:

```python
# acestep/inference.py:964-967
audio_params["lora_loaded"] = dit_handler.lora_loaded
audio_params["use_lora"]    = dit_handler.use_lora
audio_params["lora_scale"]  = dit_handler.lora_scale
```

Those read from `app.state.handler`, and `/release_task` has no LoRA field. So previewing
one musician's voice **changes the model for every other user of that server**. And
unloading is unreliable — `/v1/lora/unload` failed with *"Base decoder backup not found.
Cannot restore."* during US-25.1's verification and needed a restart.

A preview that silently contaminates other people's generations is worse than no preview.
Getting it needs either per-request LoRA selection in ACE-Step or a dedicated single-tenant
inference worker — both larger than this story, and neither inferable from the issue text.

## Design notes

**Deleting frees the storage**, which AC 3 asks for explicitly — a 43 MB adapter per model
is a slow leak otherwise. Storage goes first, then the record, so a crash between the two
leaves a *re-deletable row* rather than orphaned objects (the ordering `delete_clip` uses).
Each object is best-effort: one already missing from the backend must not make the model
undeletable, and there is a test for exactly that.

**A model still training refuses deletion with 409.** Deleting the row out from under a
running job strands the worker and the credits it charged.

**`PATCH` takes name and description only**, with `extra="forbid"` so a client cannot
smuggle in `status` or `weights_path`.

**"Renaming updates it everywhere"** holds because there is *one row* — the name is not
denormalised. The test documents that, and pins the one copy that does exist: a
notification already sent keeps the name it was sent with, which is correct, since it
describes what happened at the time.

**A `null` progress renders the phase alone, never `0%`** — which would read as "stuck".
Its own test.

---

## Pre-PR review: one P2, and the privacy half mattered

The library hook returned early on a missing token and left the previous state, so:

- a first visit to `/me` showed "Loading your voices…" **forever**
- **a user whose token was cleared on logout kept seeing their voice-model metadata**
  on screen until navigation completed

The second is the real one: private data outliving the session it belonged to. There is now
an explicit signed-out state that *drops* the models, kept distinct from the error state so
the UI says "sign in" rather than showing a red failure for something that is not one.
Reverting it fails both new tests.

---

## Verification

- **18 CI-safe backend tests** plus the integration suite against real MongoDB
- **11 web tests** for the library and its hook
- **1580 web tests across 203 files** — no regressions
- Typecheck, lint and `next build` clean; `/me` and the `[modelId]` proxy confirmed in the
  build artifacts

## Known limitations

1. **No preview** (above) — a real gap against the story, left deliberately rather than
   implemented unsafely.
2. Deleting frees storage best-effort; an object the backend has already lost is logged and
   the record still goes.
3. `/me` had no tab set before this, so the Voices tab is the only one. Other Library
   sections slot in beside it.

Closes #327
