### PR TITLE
docs: US-369 record the JUCE licensing arm — JUCE 8 EULA, Starter tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,3 +435,17 @@ keys follow `{user_id}/{workspace_id}/clips/{clip_id}.{format}`. See
 ## Environment
 
 Copy `.env.example` to `.env` and fill in the required values before running.
+
+## Licensing
+
+This project has not published a licence for its own source. What is recorded here is
+the arm chosen for dependencies that are dual-licensed, where the choice constrains how
+we build and distribute.
+
+| Component | Arm chosen | Obligation it creates |
+| --- | --- | --- |
+| **JUCE 8.0.9** (`plugin/`) | JUCE 8 EULA, **Starter** tier — free, not AGPLv3 | Valid only while annual revenue is under **$20,000**; upgrade to Indie before crossing it. No source-offer obligation. |
+| **VST3 SDK** (`plugin/`) | **Undecided** | A VST3 binary needs its own Steinberg agreement (or the SDK's GPLv3 arm). Tracked in issue #406 — settle it before any public plugin build. |
+
+Details, the exact upgrade trigger, and how the $20,000 is counted for a company versus
+an individual: **[`plugin/LICENSE.md`](plugin/LICENSE.md)**.

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -16,6 +16,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # and no clone happens at all.
 # ---------------------------------------------------------------------------
 include(FetchContent)
+# The tag fixes which licence governs: JUCE 8 EULA, Starter tier (plugin/LICENSE.md).
+# JUCE 9 ships a different EULA, so moving this tag is a licensing change, not just a
+# version bump.
 FetchContent_Declare(JUCE
     GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
     GIT_TAG        8.0.9
@@ -77,6 +80,9 @@ set(ACEMUSIC_JUCE_DEFS
     JUCE_WEB_BROWSER=0
     JUCE_USE_CURL=${ACEMUSIC_JUCE_CURL}
     JUCE_VST3_CAN_REPLACE_VST2=0
+    # Permitted: JUCE 8 removed the splash-screen requirement from the Starter tier,
+    # which is the arm this repo uses. Under JUCE 5-7 this needed a paid licence, so
+    # do not carry this line to a JUCE 9 bump without re-reading plugin/LICENSE.md.
     JUCE_DISPLAY_SPLASH_SCREEN=0
     # Checked by the platform panel, so a curl-less Linux build explains itself
     # instead of failing an https:// request with a socket error.

--- a/plugin/LICENSE.md
+++ b/plugin/LICENSE.md
@@ -4,6 +4,10 @@ The plugin links the **JUCE Framework**, which is dual-licensed. This file recor
 which arm this repository uses, because the two arms impose opposite obligations and
 the build configuration has to match the one we picked.
 
+> **Not legal advice.** This is a record of a decision and the clauses it rests on. The
+> clause numbers are cited so the reasoning can be checked against the agreement itself
+> rather than taken on trust — read the linked EULA before relying on any of it.
+
 ## The decision
 
 **JUCE 8 End User Licence Agreement — Starter licence type. Not AGPLv3.**
@@ -44,7 +48,7 @@ $20,000.** Exceeding the limit is not a grace period: EULA 1.2.1 and the clause 
 **or immediately ceasing development and distribution**. Breach exposes us to back-fees
 for the entire period plus audit costs of no less than £1,000 (EULA 3.6).
 
-Two details worth knowing before that threshold is near:
+Two details worth knowing well before that threshold is reached:
 
 - **How the $20,000 is counted depends on who holds the licence.** For an *individual*,
   it is only revenue arising from their use of the framework. For a *company*, it is the

--- a/plugin/LICENSE.md
+++ b/plugin/LICENSE.md
@@ -1,0 +1,65 @@
+# Licensing — AceMusic Studio VST3 plugin
+
+The plugin links the **JUCE Framework**, which is dual-licensed. This file records
+which arm this repository uses, because the two arms impose opposite obligations and
+the build configuration has to match the one we picked.
+
+## The decision
+
+**JUCE 8 End User Licence Agreement — Starter licence type. Not AGPLv3.**
+
+Decided 2026-08-06 (issue #369). Pinned framework version: JUCE **8.0.9**
+(`plugin/CMakeLists.txt`, `FetchContent` `GIT_TAG 8.0.9`), so the
+[JUCE 8 EULA](https://juce.com/legal/juce-8-licence/) is the governing text.
+
+| | Starter | Indie | Pro |
+| --- | --- | --- | --- |
+| Annual revenue or funding limit | **Up to $20,000** | Up to $300,000 | No limit |
+| Perpetual price per user | **Free** | $800 | $3,500 |
+| Monthly subscription per user | N/A | $40 | $175 |
+
+Starter costs nothing and permits closed-source commercial distribution. We are at
+$0 revenue, so we qualify today.
+
+## What this means for the code
+
+- **No source-offer obligation.** The AGPLv3 arm would require offering the plugin's
+  complete corresponding source under AGPLv3, and would arguably reach how the plugin
+  may talk to the rest of the platform. The commercial arm carries no such term, so
+  `plugin/` may stay closed if we ever want it to.
+- **`JUCE_DISPLAY_SPLASH_SCREEN=0` is permitted.** JUCE 8 **removed** the splash-screen
+  requirement from the Starter tier — the JUCE 8 EULA contains no splash-screen clause
+  at all, and JUCE's own release announcement calls this out as a JUCE 8 change. Under
+  JUCE 5–7 this setting needed a paid tier; under JUCE 8 Starter it does not. The build
+  as it stands is already consistent with this decision — no change was required.
+- **Do not strip JUCE's own notices** (EULA 2.9): its copyright/trademark markings in
+  the framework sources stay as they are. We do not vendor or patch JUCE — CMake fetches
+  it at the pinned tag — so nothing here touches them.
+
+## When this has to change
+
+**Upgrade to Indie ($800 perpetual, or $40/month) before annual revenue reaches
+$20,000.** Exceeding the limit is not a grace period: EULA 1.2.1 and the clause at
+"If you exceed the Revenue or Funding Limit" require either buying the appropriate tier
+**or immediately ceasing development and distribution**. Breach exposes us to back-fees
+for the entire period plus audit costs of no less than £1,000 (EULA 3.6).
+
+Two details worth knowing before that threshold is near:
+
+- **How the $20,000 is counted depends on who holds the licence.** For an *individual*,
+  it is only revenue arising from their use of the framework. For a *company*, it is the
+  entity's and all its affiliates' total revenue **from all sources, whether connected to
+  the framework or not, without offsets** (EULA 1.2.1). If this project is held by a
+  company with any other income, that income counts.
+- **Licence types cannot be mixed** (EULA 1.13). Products built under Starter may not be
+  combined with products built under Indie or Pro, so the migration is a clean switch,
+  not a per-product choice.
+
+Also re-check this file if the pinned JUCE tag ever moves off 8.x — JUCE 9 ships a
+different EULA, and none of the terms above carry over automatically.
+
+## Not covered here
+
+The **VST3 SDK is licensed separately by Steinberg** and is not part of the JUCE
+licence. Building and distributing a VST3 binary needs its own agreement with
+Steinberg (or the SDK's GPLv3 arm). Tracked separately — see issue #406.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -26,6 +26,18 @@ Progress:
 The Standalone build is a development convenience — it opens the same editor
 without a host, which is the quickest way to look at UI changes.
 
+## Licensing
+
+The plugin links JUCE under the **JUCE 8 EULA, Starter licence type** — free, no
+source-offer obligation, valid while annual revenue stays under **$20,000**. Not
+AGPLv3. `JUCE_DISPLAY_SPLASH_SCREEN=0` is permitted on this tier because JUCE 8
+removed the splash-screen requirement from Starter.
+
+The VST3 SDK is licensed separately by Steinberg and is **not** covered by that.
+
+Full terms, the upgrade trigger, and how the $20,000 is counted:
+**[plugin/LICENSE.md](LICENSE.md)**. Read it before bumping the JUCE tag off 8.x.
+
 ## Requirements
 
 - CMake 3.22+ and a C++17 compiler (MSVC 2022, Xcode 14+, or GCC 11+)


### PR DESCRIPTION
Closes #369.

Records the licensing decision: **JUCE 8 EULA, Starter licence type** — free, no
source-offer obligation, valid while annual revenue is under **$20,000**. Not AGPLv3.
We are at $0, so we qualify today; upgrade to Indie before crossing the threshold.

## The issue's premise was outdated, in our favour

#369 was filed on this reasoning:

> `JUCE_DISPLAY_SPLASH_SCREEN=0` is already set in `plugin/CMakeLists.txt`. Disabling
> the splash screen is **only permitted under a paid licence** […] So the build as it
> stands already assumes the commercial arm without that having been decided.
>
> That last point is the concrete reason this can't sit indefinitely: the current
> configuration is inconsistent with the free arm.

That was true for JUCE 5–7. **JUCE 8 removed the splash-screen requirement from the
Starter tier.** Two independent confirmations:

- The [JUCE 8 EULA](https://juce.com/legal/juce-8-licence/) contains **no splash-screen
  clause at all** — the full agreement text was fetched and searched.
- JUCE's own release announcement: *"JUCE 8 features a much more generous Starter tier,
  with a narrower definition of income and the requirement to display a splash screen
  removed."*

So the build was **already consistent** with the chosen arm. `JUCE_DISPLAY_SPLASH_SCREEN`
keeps its value; what changed is the comment explaining why it is allowed, plus a warning
not to carry it across a JUCE 9 bump (JUCE 9 ships a different EULA).

The "Done when" item *"`JUCE_DISPLAY_SPLASH_SCREEN` is set consistently with that choice
— `0` only if a paid licence is actually held, otherwise removed"* is satisfied by the
first branch, but via the free tier rather than a paid one.

## What the tier actually costs and constrains

| | Starter | Indie | Pro |
| --- | --- | --- | --- |
| Annual revenue or funding limit | **Up to $20,000** | Up to $300,000 | No limit |
| Perpetual price per user | **Free** | $800 | $3,500 |
| Monthly subscription per user | N/A | $40 | $175 |

Three terms recorded because they bite later, not now:

- **Exceeding $20,000 is not a grace period.** EULA 1.2.1 requires either buying the
  appropriate tier **or immediately ceasing development and distribution**. Breach means
  back-fees for the whole period plus audit costs of no less than £1,000 (EULA 3.6).
- **How the limit is counted depends on who holds the licence.** For an individual, only
  framework-derived revenue counts. For a **company**, it is the entity's and all
  affiliates' total revenue **from all sources, whether connected to the framework or
  not, without offsets** (EULA 1.2.1). If this is ever held by a company with other
  income, that income counts toward the $20,000.
- **Licence types cannot be mixed** (EULA 1.13), so the eventual move to Indie is a clean
  switch, not a per-product choice.

## What the JUCE decision does not cover

The **VST3 SDK is licensed separately by Steinberg** — not granted by the JUCE licence at
any tier. `plugin/CMakeLists.txt` builds `FORMATS VST3 Standalone`, so this is live for
the format the plugin is named for. Its GPLv3 arm would reintroduce exactly the
source-offer obligation this decision avoids, so it needs its own answer.

Filed as **#406** and marked **Undecided** in the README table rather than left implicit.
It is the same shape as #369: binding only at distribution, blocks nothing locally.

## Changes

| File | Change |
| --- | --- |
| `plugin/LICENSE.md` | **New.** The decision, the tier table, obligations, the upgrade trigger, and the JUCE-9 caveat |
| `plugin/README.md` | Short Licensing section up top, pointing at it |
| `README.md` | Top-level licensing table — JUCE arm chosen, VST3 arm undecided |
| `plugin/CMakeLists.txt` | Comments only: why the splash setting is permitted, and that the `GIT_TAG` pins which EULA applies |

No behaviour change. `plugin/LICENSE.md` records the JUCE dependency's arm only — it does
**not** declare a licence for this project's own source, which the repo has never
published and which is not this issue's call to make.

## Verification

- `cmake -S . -B build` reconfigures cleanly (the libcurl warning is pre-existing)
- `JUCE_DISPLAY_SPLASH_SCREEN=0` still reaches the compiled target — grepped the
  generated build files — and no comment text leaked into the compile definitions,
  which was the one way a comment inside `set()` could have gone wrong

## Known limitations

- The $20,000 threshold has no automated tripwire; it is a documented human trigger.
- The individual-vs-company counting rule is recorded but not resolved, because it
  depends on whether this ends up held personally or by an entity — a fact this repo
  doesn't know.
