### PR TITLE
docs: one issue-numbering scheme — PX.Y orders, US-X.Y identifies

### DIFF
--- a/user-stories/00-overview.md
+++ b/user-stories/00-overview.md
@@ -38,9 +38,25 @@ This document defines user stories for the AI Music Platform organized into **28
 ### Development Methodology
 
 - **TDD:** Tests are written before implementation. Acceptance criteria map directly to test assertions.
-- **GitHub Issues:** Each user story becomes one or more GH issues when its stage is active. Issues are not pre-created for future stages.
+- **GitHub Issues:** Each user story becomes one or more GH issues when its stage is active. Issues are not pre-created for future stages. As of 2026-08-07 every story through Stage 28 — the last — has an issue, so the backlog is fully enumerated; new issues from here are follow-ups and post-launch work, not story creation.
 - **Feature branches:** Each story/issue is developed on a feature branch and merged via PR to `main`.
 - **Agile flexibility:** Stages define *intent*, not contracts. Stories may be added, modified, split, or deferred as learning happens during development.
+
+#### Issue titles: `PX.Y` for order, `US-X.Y` for identity
+
+They answer different questions, so both live in the title and neither replaces the other:
+
+```
+P1.1 US-26.3: Payment Integration
+P2.3 Settle the VST3 SDK (Steinberg) licence before any public plugin build
+```
+
+- **`PX.Y` — required on every issue.** *When* to do it. `P1` is the current focus; higher tiers are later. Sorted component-wise as integers, so `P1.2` precedes `P1.10`. Re-assigned freely as priorities move — the number carries no history.
+- **`US-X.Y` — only where a spec story exists.** *Which* story, per this document. Never changes, never renumbered. Follow-ups, tech debt, and post-launch work have no `US-` and don't get one invented; they say `(US-26.2 follow-up)` at the end of the title instead.
+
+A stage's stories usually share a tier (Stage 27 → `P3.x`), but that is a consequence of the roadmap order, not a rule — priority is free to cut across stages when something earns it.
+
+Since the spec ends at Stage 28, everything created from here is `PX.Y`-only.
 
 ---
 


### PR DESCRIPTION
Companion to the 18 issue-title renames already applied (titles only — no bodies, labels, or state touched).

## The problem

Open issues were split between two prefixes that answer **different questions**:

- `US-26.3` — *which* spec story. Stable identity, maps to `user-stories/`.
- `P2.4` — *when* to do it. Priority, changes as things ship.

Half the backlog carried "when" and half carried "which", so nothing sorted — and the `--next` auto-pick tooling, which reads a `PX.Y` prefix, simply couldn't see the 12 `US-`-titled issues at all.

## The fix

Both live in the title; neither replaces the other.

```
P1.1 US-26.3: Payment Integration
P2.3 Settle the VST3 SDK (Steinberg) licence before any public plugin build
```

`PX.Y` is required on every issue. `US-X.Y` appears only where a spec story exists — follow-ups say `(US-26.2 follow-up)` rather than getting a story ID invented for them.

## Tiers applied

Ordered by the roadmap's own `Stage 26 → 27 → 28` dependency, with monetization first.

| Tier | Issues |
| --- | --- |
| **P1** — finish monetization (Stage 26) | #331 Payment Integration, #332 Credit Top-Up, #401 free-tier watermark, #403 Pro-boundary decision, #333 Usage Dashboard |
| **P2** — account integrity, plugin, tech debt | #111 OAuth identity linking, #396 plugin voice selector, #406 VST3 SDK licence, #402 tier-fetch dedupe |
| **P3** — content moderation (Stage 27) | #334–#337 |
| **P4** — polish & production readiness (Stage 28) | #338–#342 |

`P1.1` is Payment Integration because credits and tiers shipped in US-26.1/26.2 but there is still no way to take money — every other Stage 26 story is downstream of it.

**#111 moved up** from unprefixed to `P2.1`. It was filed in June as auth robustness, but once payments land a duplicate account is a *paying* user losing their subscription, so it gets worse precisely as P1 lands.

**#396 and #406 kept their numbers** — no churn where the order was already right.

## The backlog is already fully enumerated

Checked rather than assumed, since it contradicts the expectation that stages remain to be turned into issues:

- 148 story IDs across `user-stories/*.md`; 153 referenced by issues
- **Specced but with no issue: zero.** Every story through Stage 28 has one
- The 5 extras (`US-0.1`, `US-0.2`, `US-15.7`, `US-20.0`, `US-26.0`) are issues created outside the spec — bootstrap and hardening work
- Stage headings run 1–28 with no Stage 29+, no "future phases", no TBD sections

So `00-overview.md`'s "Issues are not pre-created for future stages" is still the policy, but there are no future stages left. Everything created from here is `PX.Y`-only. That is now recorded next to the policy it qualifies.

## Known limitations

- Tiers are a snapshot, not a contract — `P1` means "current focus" and will be re-cut as Stage 26 closes out.
- Nothing enforces the prefix; it is a convention with a documented home, not a CI check. Worth a lint only if it drifts again.
- `#341` (P4.4) bundles Mobile Responsiveness with **API Rate Limiting**, which is an abuse control rather than polish. Left as specced rather than split unilaterally — flagging it as the one tier assignment I'd most expect you to disagree with.