### PR TITLE
feat: Pro-gate release bundling and local remaster (#403)

### DIFF
--- a/src/acemusic/api/routers/editing.py
+++ b/src/acemusic/api/routers/editing.py
@@ -22,9 +22,15 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from acemusic.audio import calculate_speed_multiplier
 from acemusic.utils import parse_time_string, snap_to_beat
 
-from ..auth.dependencies import CurrentUser, get_current_user, require_existing_user
+from ..auth.dependencies import (
+    CurrentUser,
+    get_current_user,
+    require_existing_user,
+    require_tier_capability,
+)
 from ..models import Clip
 from ..services import clips as clip_service, credits as credits_service, editing as editing_service
+from ..services.tiers import Capability
 
 logger = logging.getLogger(__name__)
 
@@ -221,7 +227,18 @@ async def remaster_clip(
     request: RemasterRequest,
     current: CurrentUser = Depends(require_existing_user),
 ) -> EditJobResponse:
-    """Enqueue a remaster of ``clip_id`` to ``target_lufs``; the original is preserved."""
+    """Enqueue a remaster of ``clip_id`` to ``target_lufs``; the original is preserved.
+
+    Pro-only (#403). This is loudness mastering by another route — the ``mastering``
+    capability is described to musicians as "master your tracks to a professional loudness
+    target", which is exactly what this does, just locally instead of via Dolby/LANDR.
+    Leaving it open would have made the gate on ``/mastering/jobs`` a formality.
+
+    The gate runs **before** the credit charge in ``_enqueue``: refusing someone after
+    taking their credits would be worse than not offering the feature.
+    """
+    await require_tier_capability(current.user_id, Capability.MASTERING)
+
     clip = await clip_service.get_owned_clip(clip_id, current.user_id)
     _require_wav(clip)
 

--- a/src/acemusic/api/routers/releases.py
+++ b/src/acemusic/api/routers/releases.py
@@ -20,7 +20,13 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
-from ..auth.dependencies import CurrentUser, get_current_user, get_settings, require_existing_user
+from ..auth.dependencies import (
+    CurrentUser,
+    get_current_user,
+    get_settings,
+    require_existing_user,
+    require_tier_capability,
+)
 from ..models import DistributionStatus, Release, ReleaseStatus, VisibilityState
 from ..models.distribution import GUIDED_CHANNELS, SOUNDCLOUD_CHANNEL
 from ..services import (
@@ -32,6 +38,7 @@ from ..services import (
 )
 from ..services.distribution import ChecklistItem, DistributionTarget
 from ..services.identifiers import validate_isrc_format, validate_upc_check_digit
+from ..services.tiers import Capability
 from ..settings import ApiSettings
 
 logger = logging.getLogger(__name__)
@@ -286,7 +293,14 @@ async def prepare_release(
 
     Always returns the checklist; ``bundle_url`` is null when any item fails. An
     unknown target is rejected by FastAPI's enum path validation (422).
+
+    Pro-only (#403). "You publish it yourself, we assemble the bundle" is most of the
+    value of distribution, so leaving it free would have left the free tier with almost
+    the whole feature while the gated SoundCloud upload guarded only the convenience.
+    The free tier is specified as having no distribution; this is distribution.
     """
+    await require_tier_capability(current.user_id, Capability.DISTRIBUTION)
+
     release = await release_service.get_owned_release(release_id, current.user_id)
     checklist, bundle_url = await distribution_service.prepare_release(release, target)
     return PrepareResponse(
@@ -305,7 +319,14 @@ async def submit_release(
     target: DistributionTarget,
     current: CurrentUser = Depends(require_existing_user),
 ) -> ReleaseResponse:
-    """Confirm a manual submission to ``target`` — moves the release to ``submitted``."""
+    """Confirm a manual submission to ``target`` — moves the release to ``submitted``.
+
+    Gated with prepare (#403): a free account that could not build a bundle has nothing
+    to submit, and an ungated submit would let one mark a release distributed without
+    ever having been able to distribute it.
+    """
+    await require_tier_capability(current.user_id, Capability.DISTRIBUTION)
+
     release = await release_service.confirm_submission(release_id, current.user_id, target.value)
     return await _response_for(release)
 

--- a/src/acemusic/api/services/tiers.py
+++ b/src/acemusic/api/services/tiers.py
@@ -48,7 +48,14 @@ class Capability(str, Enum):
 _DESCRIPTIONS = {
     Capability.STEMS: ("Stem separation", "split a track into vocals, drums, bass and other"),
     Capability.MIDI: ("MIDI extraction", "export melody, chords, drums and bass as MIDI"),
+    # #403: covers the hosted services (/mastering/jobs, Dolby/LANDR/Bakuage) AND the
+    # local loudness remaster on /clips/{id}/remaster. The description below is exactly
+    # what remaster does, just locally — leaving it open made the other gate a formality.
     Capability.MASTERING: ("Mastering", "master your tracks to a professional loudness target"),
+    # #403: covers both halves — "we publish it for you" (SoundCloud upload) and
+    # "you publish it yourself, we assemble the bundle" (release prepare/submit).
+    # Bundling is most of the value of distribution, so gating only the upload would
+    # have left the free tier with nearly the whole feature.
     Capability.DISTRIBUTION: ("Distribution", "publish your releases to streaming platforms"),
     Capability.VOICE_MODELS: ("Custom voice models", "train a voice and sing your songs in it"),
     Capability.STUDIO_EDITING: ("Studio editing", "arrange and mix in the multi-track Studio"),

--- a/tests/test_clips_edit_api.py
+++ b/tests/test_clips_edit_api.py
@@ -90,8 +90,29 @@ def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _make_user(email: str):
-    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+def _tier_for(operation: str) -> str:
+    """Which tier may perform ``operation`` (#403).
+
+    Crop and speed are free; remaster gates on ``mastering``. Parametrized cases run
+    across all three, so the fixture has to follow the operation rather than pick one
+    tier for the file — otherwise the free operations would be tested as Pro and stop
+    proving they are ungated.
+    """
+    return "pro" if operation == "remaster" else "free"
+
+
+async def _make_user(email: str, tier: str = "free"):
+    """Defaults to **free** on purpose (#403).
+
+    Crop and speed stay free operations, and a Pro-by-default helper would keep passing
+    if either were ever accidentally gated — the test would prove nothing. Only the
+    remaster cases opt into Pro, because remaster now gates on `mastering`.
+    """
+    user = await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+    if user.subscription_tier != tier:
+        user.subscription_tier = tier
+        await user.save()
+    return user
 
 
 async def _make_workspace(user, name: str = "WS") -> Workspace:
@@ -130,8 +151,8 @@ async def _insert_clip(
     return clip
 
 
-async def _user_with_clip(email: str, **clip_kwargs):
-    user = await _make_user(email)
+async def _user_with_clip(email: str, tier: str = "free", **clip_kwargs):
+    user = await _make_user(email, tier=tier)
     workspace = await _make_workspace(user)
     clip = await _insert_clip(user, workspace, **clip_kwargs)
     return user, workspace, clip
@@ -146,7 +167,7 @@ async def _user_with_clip(email: str, **clip_kwargs):
 class TestClipNotFound:
     @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
     async def test_unknown_clip_returns_404(self, client, settings, operation: str) -> None:
-        user = await _make_user(f"edit-404-{operation}@example.com")
+        user = await _make_user(f"edit-404-{operation}@example.com", tier=_tier_for(operation))
         resp = await client.post(
             _edit_url(PydanticObjectId(), operation),
             json=VALID_BODIES[operation],
@@ -156,7 +177,7 @@ class TestClipNotFound:
 
     @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
     async def test_malformed_id_returns_404(self, client, settings, operation: str) -> None:
-        user = await _make_user(f"edit-malformed-{operation}@example.com")
+        user = await _make_user(f"edit-malformed-{operation}@example.com", tier=_tier_for(operation))
         resp = await client.post(
             _edit_url("not-an-object-id", operation),
             json=VALID_BODIES[operation],
@@ -166,8 +187,8 @@ class TestClipNotFound:
 
     @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
     async def test_other_users_clip_returns_404(self, client, settings, operation: str) -> None:
-        owner, _, clip = await _user_with_clip(f"edit-owner-{operation}@example.com")
-        other = await _make_user(f"edit-other-{operation}@example.com")
+        owner, _, clip = await _user_with_clip(f"edit-owner-{operation}@example.com", tier=_tier_for(operation))
+        other = await _make_user(f"edit-other-{operation}@example.com", tier=_tier_for(operation))
 
         resp = await client.post(
             _edit_url(clip.id, operation),
@@ -300,7 +321,9 @@ class TestFormatGate:
     @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
     @pytest.mark.parametrize("fmt", ["mp3", "aac", "opus", "flac"])
     async def test_non_wav_clip_returns_422(self, client, settings, operation: str, fmt: str) -> None:
-        user, _, clip = await _user_with_clip(f"edit-fmt-{operation}-{fmt}@example.com", fmt=fmt, bpm=120)
+        user, _, clip = await _user_with_clip(
+            f"edit-fmt-{operation}-{fmt}@example.com", tier=_tier_for(operation), fmt=fmt, bpm=120
+        )
         resp = await client.post(
             _edit_url(clip.id, operation),
             json=VALID_BODIES[operation],
@@ -314,7 +337,9 @@ class TestFormatGate:
     async def test_missing_format_falls_back_to_wav_suffix(self, client, settings, operation: str) -> None:
         # Legacy/imported clip documents may have format=None while file_path
         # still ends in .wav — the gate must use the suffix fallback, not 422.
-        user, _, clip = await _user_with_clip(f"edit-fmt-none-{operation}@example.com", fmt=None, bpm=120)
+        user, _, clip = await _user_with_clip(
+            f"edit-fmt-none-{operation}@example.com", tier=_tier_for(operation), fmt=None, bpm=120
+        )
         resp = await client.post(
             _edit_url(clip.id, operation),
             json=VALID_BODIES[operation],
@@ -330,7 +355,7 @@ class TestRemasterValidation:
     async def test_out_of_range_target_lufs_returns_422(self, client, settings, target_lufs: float) -> None:
         # Positive (or near-zero) loudness targets are physically nonsensical
         # and would only drive the pipeline into the true-peak limiter.
-        user, _, clip = await _user_with_clip(f"edit-remaster-lufs-{target_lufs}@example.com")
+        user, _, clip = await _user_with_clip(f"edit-remaster-lufs-{target_lufs}@example.com", tier="pro")
         resp = await client.post(
             _edit_url(clip.id, "remaster"),
             json={"target_lufs": target_lufs},
@@ -341,7 +366,7 @@ class TestRemasterValidation:
 
     @pytest.mark.parametrize("target_lufs", [-5.0, -14.0, -70.0])
     async def test_in_range_target_lufs_is_accepted(self, client, settings, target_lufs: float) -> None:
-        user, _, clip = await _user_with_clip(f"edit-remaster-lufs-ok-{target_lufs}@example.com")
+        user, _, clip = await _user_with_clip(f"edit-remaster-lufs-ok-{target_lufs}@example.com", tier="pro")
         resp = await client.post(
             _edit_url(clip.id, "remaster"),
             json={"target_lufs": target_lufs},
@@ -350,7 +375,7 @@ class TestRemasterValidation:
         assert resp.status_code == 202
 
     async def test_extra_field_returns_422(self, client, settings) -> None:
-        user, _, clip = await _user_with_clip("edit-remaster-extra@example.com")
+        user, _, clip = await _user_with_clip("edit-remaster-extra@example.com", tier="pro")
         resp = await client.post(
             _edit_url(clip.id, "remaster"),
             json={"bogus": True},
@@ -477,7 +502,7 @@ class TestSpeedEnqueue:
 @pytest.mark.integration
 class TestRemasterEnqueue:
     async def test_returns_202_with_default_target_lufs(self, client, settings) -> None:
-        user, workspace, clip = await _user_with_clip("edit-remaster-202@example.com")
+        user, workspace, clip = await _user_with_clip("edit-remaster-202@example.com", tier="pro")
 
         resp = await client.post(_edit_url(clip.id, "remaster"), json={}, headers=_auth_headers(user, settings))
         assert resp.status_code == 202

--- a/tests/test_clips_edit_api.py
+++ b/tests/test_clips_edit_api.py
@@ -517,7 +517,7 @@ class TestRemasterEnqueue:
         assert job.input_params == {"clip_id": str(clip.id), "target_lufs": -14.0}
 
     async def test_custom_target_lufs_is_persisted(self, client, settings) -> None:
-        user, _, clip = await _user_with_clip("edit-remaster-lufs@example.com")
+        user, _, clip = await _user_with_clip("edit-remaster-lufs@example.com", tier="pro")
 
         resp = await client.post(
             _edit_url(clip.id, "remaster"),
@@ -540,7 +540,9 @@ class TestEditJobStatus:
     @pytest.mark.parametrize("operation", ["crop", "speed", "remaster"])
     async def test_status_reports_positive_estimate_for_edit_jobs(self, client, settings, operation: str) -> None:
         """GET /jobs/{id}/status must not choke on (or zero out) editing jobs."""
-        user, _, clip = await _user_with_clip(f"edit-status-{operation}@example.com", duration=10.0, bpm=120)
+        user, _, clip = await _user_with_clip(
+            f"edit-status-{operation}@example.com", tier=_tier_for(operation), duration=10.0, bpm=120
+        )
 
         bodies = {"crop": {"start": "1s", "end": "5s"}, "speed": {"multiplier": 1.5}, "remaster": {}}
         accepted = await client.post(
@@ -589,7 +591,7 @@ class TestEditLifecycleEndToEnd:
     ) -> None:
         from acemusic.api.tasks.processor import JobProcessor
 
-        user = await _make_user(f"edit-e2e-{operation}@example.com")
+        user = await _make_user(f"edit-e2e-{operation}@example.com", tier=_tier_for(operation))
         workspace = await _make_workspace(user)
         tone_path = local_storage / "tone.wav"
         write_tone(tone_path, duration_s=2.0)

--- a/tests/test_distribution_prep_api.py
+++ b/tests/test_distribution_prep_api.py
@@ -106,8 +106,20 @@ def _auth_headers(user, settings: ApiSettings) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-async def _make_user(email: str):
-    return await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+async def _make_user(email: str, tier: str = "pro"):
+    """A musician who can actually distribute.
+
+    Pro by default since #403: release prepare/submit gate on the ``distribution``
+    capability, so a free account 403s before reaching any of the behaviour this file is
+    about. The gate itself is covered in ``tests/test_tier_enforcement_api.py``
+    (``TestReleaseBundlingIsPro``) — these tests are about what happens once you are
+    allowed through, and defaulting them to free would only re-test the gate 24 times.
+    """
+    user = await user_service.get_or_create_user(email=email, provider="google", oauth_id=f"g-{email}", name="T")
+    if user.subscription_tier != tier:
+        user.subscription_tier = tier
+        await user.save()
+    return user
 
 
 _SEQ = itertools.count(1)

--- a/tests/test_tier_enforcement_api.py
+++ b/tests/test_tier_enforcement_api.py
@@ -609,6 +609,21 @@ class TestReleaseBundlingIsPro:
 
         assert resp.status_code != 403
 
+    async def test_a_pro_account_may_submit(self, client, settings) -> None:
+        # Raised in review on PR #424: `submit` had a refusal test but no positive
+        # control, so a gate that refused *everyone* would have passed. `prepare` and
+        # `remaster` get this for free from the shared _pro_actions table; `submit` takes
+        # a release id rather than a clip id, so it needs its own.
+        user = await _user("pro-submit", tier="pro")
+        release_id = await self._release(user)
+
+        resp = await client.post(
+            f"{API_V1_PREFIX}/releases/{release_id}/submit/distrokid",
+            headers=_auth(user, settings),
+        )
+
+        assert resp.status_code != 403, "a Pro account must get past the gate"
+
     async def test_reading_a_release_stays_open(self, client, settings) -> None:
         # Only the distribution actions are gated; a free musician can still see the
         # release they made.

--- a/tests/test_tier_enforcement_api.py
+++ b/tests/test_tier_enforcement_api.py
@@ -12,7 +12,7 @@ from beanie import PydanticObjectId
 
 from acemusic.api.auth.tokens import create_access_token
 from acemusic.api.main import API_V1_PREFIX, create_app
-from acemusic.api.models import Clip, Job, User, VisibilityState
+from acemusic.api.models import Clip, Job, Release, User, VisibilityState
 from acemusic.api.services import credits as credits_service, tiers, users as user_service
 from acemusic.api.settings import ApiSettings
 
@@ -100,6 +100,11 @@ def _pro_actions(clip_id: str) -> list[tuple[str, str, dict | None]]:
         ),
         ("studio mixdown", f"{API_V1_PREFIX}/studio/mixdown", {"tracks": []}),
         ("studio daw export", f"{API_V1_PREFIX}/studio/export/daw", {"tracks": []}),
+        # #403: loudness mastering by another route. Added to the shared table rather
+        # than tested in isolation, so it also inherits the "costs nothing when refused"
+        # and "Pro is not refused" cases — the two properties most likely to be missed
+        # when a gate is bolted onto an endpoint that already charges credits.
+        ("remaster", f"{API_V1_PREFIX}/clips/{clip_id}/remaster", {"target_lufs": -14.0}),
     ]
 
 
@@ -541,3 +546,75 @@ class TestBatchIsNotTheCheapWayIn:
         from acemusic.audio import EXPORT_FORMATS
 
         assert set(EXPORT_FORMATS) - LOSSLESS_EXPORT_FORMATS == {"mp3"}
+
+
+@pytest.mark.integration
+class TestReleaseBundlingIsPro:
+    """#403: release bundling is distribution, so the free tier does not get it.
+
+    "You publish it yourself, we assemble the bundle" is most of the value of the
+    feature. Gating only the SoundCloud upload would have left the free tier with almost
+    all of distribution while the gate guarded the convenience.
+    """
+
+    async def _release(self, user: User) -> str:
+        from datetime import datetime, timezone
+
+        clip = await _wav_clip(user)
+        release = Release(
+            clip_id=clip.id,
+            user_id=user.id,
+            title="Demo Release",
+            artist="Demo Artist",
+            genre="Electronic",
+            release_date=datetime(2026, 12, 1, tzinfo=timezone.utc),
+        )
+        await release.insert()
+        return str(release.id)
+
+    async def test_a_free_account_cannot_prepare_a_bundle(self, client, settings) -> None:
+        user = await _user("free-prepare")
+        release_id = await self._release(user)
+
+        resp = await client.post(
+            f"{API_V1_PREFIX}/releases/{release_id}/prepare/distrokid",
+            headers=_auth(user, settings),
+        )
+
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["capability"] == "distribution"
+
+    async def test_a_free_account_cannot_mark_a_release_submitted(self, client, settings) -> None:
+        # Gated with prepare: an account that cannot build a bundle has nothing to
+        # submit, and an open submit would let it mark a release distributed anyway.
+        user = await _user("free-submit")
+        release_id = await self._release(user)
+
+        resp = await client.post(
+            f"{API_V1_PREFIX}/releases/{release_id}/submit/distrokid",
+            headers=_auth(user, settings),
+        )
+
+        assert resp.status_code == 403
+
+    async def test_a_pro_account_is_not_refused(self, client, settings) -> None:
+        # The positive control — a gate that refuses everyone is not a gate.
+        user = await _user("pro-prepare", tier="pro")
+        release_id = await self._release(user)
+
+        resp = await client.post(
+            f"{API_V1_PREFIX}/releases/{release_id}/prepare/distrokid",
+            headers=_auth(user, settings),
+        )
+
+        assert resp.status_code != 403
+
+    async def test_reading_a_release_stays_open(self, client, settings) -> None:
+        # Only the distribution actions are gated; a free musician can still see the
+        # release they made.
+        user = await _user("free-read-release")
+        release_id = await self._release(user)
+
+        resp = await client.get(f"{API_V1_PREFIX}/releases/{release_id}", headers=_auth(user, settings))
+
+        assert resp.status_code == 200

--- a/web/components/song/SongActionsMenu.test.tsx
+++ b/web/components/song/SongActionsMenu.test.tsx
@@ -108,11 +108,16 @@ describe("SongActionsMenu", () => {
 
     const editor = screen.getByRole("menuitem", { name: /open in editor/i })
     expect(editor).toHaveAttribute("data-locked", "true")
-    // Exactly the three top-level gated actions carry a badge: Open in Editor, Send to
-    // Mastering, Export to DAW. Create Music Video is deliberately not among them
-    // (US-26.2 — the free tier gets 720p, so the form stays reachable), and the gated
-    // downloads live in a submenu that is not open here.
-    expect(screen.getAllByText("Pro")).toHaveLength(3)
+    // Exactly the four top-level gated actions carry a badge: Open in Editor, Remaster,
+    // Send to Mastering, Export to DAW. Remaster joined them in #403 — it is loudness
+    // mastering by another route, gated on the same capability. Create Music Video is
+    // deliberately not among them (US-26.2 — the free tier gets 720p, so the form stays
+    // reachable), and the gated downloads live in a submenu that is not open here.
+    expect(screen.getAllByText("Pro")).toHaveLength(4)
+    expect(screen.getByRole("menuitem", { name: /remaster/i })).toHaveAttribute(
+      "data-locked",
+      "true"
+    )
   })
 
   it("still emits a locked action so the parent can prompt (US-26.2 AC2)", async () => {
@@ -135,7 +140,7 @@ describe("SongActionsMenu", () => {
 
     const editor = screen.getByRole("menuitem", { name: /open in editor/i })
     expect(editor).not.toHaveAttribute("data-locked")
-    expect(screen.getAllByText("Pro")).toHaveLength(3)
+    expect(screen.getAllByText("Pro")).toHaveLength(4)
   })
 
   it("supports keyboard navigation: arrows move focus, Escape closes", async () => {

--- a/web/lib/song-actions.test.ts
+++ b/web/lib/song-actions.test.ts
@@ -68,6 +68,8 @@ describe("SONG_ACTION_GROUPS", () => {
     const pro = allActions.filter((a) => a.proOnly).map((a) => a.id)
     // create-video is deliberately absent (US-26.2): the free tier gets 720p, so the
     // form must stay reachable and the Pro boundary is the resolution inside it.
+    // `remaster` joined the set in #403 — it is loudness mastering by another route, and
+    // the API gates it on the same `mastering` capability as send-mastering.
     expect(pro.sort()).toEqual(
       [
         "download-flac",
@@ -75,6 +77,7 @@ describe("SONG_ACTION_GROUPS", () => {
         "download-wav",
         "export-daw",
         "open-editor",
+        "remaster",
         "send-mastering",
       ].sort()
     )

--- a/web/lib/song-actions.ts
+++ b/web/lib/song-actions.ts
@@ -179,6 +179,12 @@ export const SONG_ACTION_GROUPS: SongActionGroup[] = [
         label: "Remaster",
         icon: MagicWand01Icon,
         workflow: "inline",
+        // #403: Pro. This is loudness mastering by another route, so the API gates it on
+        // the same `mastering` capability as Send to Mastering. Marked here too — a menu
+        // item that looks free and then 403s is the mirror of the "a menu is not a gate"
+        // problem US-26.2 exists to fix.
+        proOnly: true,
+        capability: "mastering",
       },
       {
         id: "replace-section",


### PR DESCRIPTION
Closes #403.

**Decision: both are Pro.**

The issue asked for a product call on two endpoints that do arguably-Pro work but had no
gated sibling doing the same thing. Both are now gated, and the reasoning is recorded in
`services/tiers.py` beside each capability description so the next reader does not have
to find this PR.

## `POST /releases/{id}/prepare|submit/{target}` → `distribution`

"You publish it yourself, we assemble the bundle" is most of the value of distribution.
Gating only the SoundCloud upload left the free tier with nearly the whole feature while
the gate guarded the convenience. The free tier is specified as having no distribution;
this is distribution.

**`submit` is gated with `prepare`**, which the issue did not ask for. An account that
cannot build a bundle has nothing to submit, and an open `submit` would let it mark a
release *distributed* anyway.

## `POST /clips/{id}/remaster` → `mastering`

Loudness mastering by another route. The capability is described to musicians as "master
your tracks to a professional loudness target" — which is exactly what remaster does,
just locally instead of via Dolby/LANDR. Leaving it open made the gate on
`/mastering/jobs` a formality.

**The gate runs before the credit charge.** The issue flagged that gating remaster
converts a credit-priced action into a tier-locked one; charging someone and *then*
refusing them would be the worst version of that. Rather than assert this in isolation,
remaster joins the shared `_pro_actions` table in `test_tier_enforcement_api`, so it also
inherits the existing "costs nothing when refused" and "Pro is not refused" cases — the
two properties most likely to be missed when bolting a gate onto an endpoint that already
takes money.

## The UI had to move too

`remaster` was not `proOnly` in the shared registry, so a free musician would have clicked
a normal-looking menu item and got a 403 — US-26.2's "a menu is not a gate" problem in
reverse. Marking it in `lib/song-actions.ts` lights it up on song detail and the clip card
at once, via the shared renderer from #404.

## Acceptance criteria

- [x] A decision recorded for release prepare/submit, and the endpoints match it
- [x] A decision recorded for `/clips/{id}/remaster`, and the endpoint matches it
- [x] Free-tier refusal tests for both, and the UI marks remaster Pro

## Verification

134 tests across `test_clips_edit_api`, `test_distribution_prep_api` and
`test_tier_enforcement_api`; 1661 web tests; ruff/black/tsc/eslint clean.

## The test cost, and one trap avoided

The gates broke **39 pre-existing tests** across two files — all using free-tier users
against endpoints that are now Pro, none about tiers.

The tempting fix is to default the test helpers to Pro. That makes everything green and
**silently destroys the coverage proving the ungated operations are still ungated**:
`test_clips_edit_api` is parametrized over `crop`/`speed`/`remaster`, so a file-level Pro
default would have meant crop and speed were no longer tested as a free musician
experiences them. If either were accidentally gated later, the test would sail through.

So the tier follows the *operation* (`_tier_for`), not the file. `test_distribution_prep_api`
does default to Pro, because every endpoint in it is now gated and the gate itself is
covered once in `test_tier_enforcement_api` rather than 24 times there.

The recurring version of this cost is filed as **#423 (P2.6)** — shared `free_user` /
`pro_user` fixtures, with free as the default precisely because Pro-by-default is what
hides gating regressions.

## Known limitations

- **Revenue implications are unmodelled.** The issue notes gating remaster converts a
  credit-priced action into a tier-locked one. Free-tier musicians who were spending
  credits on remaster now cannot; whether that is net-positive is a business question
  this PR does not answer, only implements.
- No demo document: the behaviour is two 403s and a badge, all covered by the refusal
  tests and the existing US-26.2 demo of the 403 body shape.
