### PR TITLE
feat(#429): containerize the platform and ship it via CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+# Build context for the API image (#429).
+#
+# The first entries are the point of this file: `.env` and `.env.local` live at the repo
+# root and are gitignored, so nothing before this stopped a root-context build baking real
+# credentials into an image layer. .gitignore protects git; only this protects Docker.
+.env
+.env.*
+!.env.example
+
+# Secrets and local state
+.beads/
+*.pem
+*.key
+
+# Version control and CI
+.git/
+.github/
+.gitignore
+
+# Python build/test artifacts
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+coverage.xml
+htmlcov/
+dist/
+build/
+*.egg-info/
+
+# Node — the API image never needs these, and web/ builds from its own context
+node_modules/
+web/node_modules/
+web/.next/
+
+# Runtime data that must come from a volume, never from a layer. acemusic-voice-training/
+# alone is ~47 model directories of nothing the image should carry.
+storage/
+acemusic-voice-training/
+
+# The C++ plugin and its vendored JUCE build tree
+plugin/build/
+plugin/Builds/
+
+# Docs, demos and stray media — pure build-context weight
+docs/
+tasks/
+user-stories/
+*.md
+!README.md
+*.mp3
+*.wav
+*.png
+*.jpg

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,59 @@
+# Environment for the container stack (#429). Copy to `.env` beside compose.yaml.
+#
+#   cp .env.docker.example .env
+#   sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env
+#   docker compose up
+#
+# This is the whole contract between the app and a host. Anything a deployment needs that
+# is not here belongs in the images, not in someone's shell history.
+
+# --- Required -----------------------------------------------------------------------
+# Tokens are signed with this. Compose refuses to start without it rather than falling
+# back to a shared default that would be identical on every deployment.
+ACEMUSIC_API_JWT_SECRET_KEY=
+
+# --- Local defaults, override per host ----------------------------------------------
+ACEMUSIC_API_MONGODB_DB_NAME=acemusic
+ACEMUSIC_API_CORS_ALLOW_ORIGINS=http://localhost:3000
+API_BASE_URL=http://api:8000
+API_PORT=8000
+WEB_PORT=3000
+# Bound to loopback on purpose — an exposed Mongo on a shared VPS is the whole database.
+MONGO_PORT=127.0.0.1:27017
+
+# --- Deploy-time (set by the CD workflow; leave blank locally) -----------------------
+# Registry images and the commit tag. Unset means compose builds from source instead.
+# API_IMAGE=ghcr.io/frankbria/auto-music-studio-api
+# WEB_IMAGE=ghcr.io/frankbria/auto-music-studio-web
+# IMAGE_TAG=<commit sha>
+
+# --- Optional integrations: unset means the feature is off --------------------------
+ACEMUSIC_API_GOOGLE_CLIENT_ID=
+ACEMUSIC_API_GOOGLE_CLIENT_SECRET=
+ACEMUSIC_API_GOOGLE_REDIRECT_URI=
+ACEMUSIC_API_DISCORD_CLIENT_ID=
+ACEMUSIC_API_DISCORD_CLIENT_SECRET=
+ACEMUSIC_API_DISCORD_REDIRECT_URI=
+ACEMUSIC_API_STRIPE_SECRET_KEY=
+ACEMUSIC_API_STRIPE_WEBHOOK_SECRET=
+ACEMUSIC_API_STRIPE_PRICE_ID_PRO=
+ACEMUSIC_API_OPENAI_API_KEY=
+ACEMUSIC_API_VIDEO_API_URL=
+ACEMUSIC_API_VIDEO_API_KEY=
+ACEMUSIC_API_RUNPOD_API_KEY=
+ACEMUSIC_API_RUNPOD_ENDPOINT_ID=
+
+# Where generation runs. The ACE-Step inference server is NOT part of this stack — it is a
+# separate CUDA image on a GPU host — so point this at it, or every generation 503s on the
+# availability probe with the rest of the stack perfectly healthy. `remote_only` with the
+# RunPod settings above is the other supported shape.
+ACEMUSIC_API_LOCAL_URL=http://localhost:8001
+ACEMUSIC_API_COMPUTE_PREFERENCE=local_first
+# Two config systems reach the same server: the availability probe reads the variable
+# above (ACEMUSIC_API_ prefix), the job processor's client reads this one (no _API_).
+# Leave blank to inherit ACEMUSIC_API_LOCAL_URL; set it only if they must differ.
+ACEMUSIC_BASE_URL=
+# Optional bearer for the ACE-Step server itself.
+ACEMUSIC_API_KEY=
+ACEMUSIC_STORAGE_BACKEND=local
+ACEMUSIC_API_SOUNDCLOUD_POLLER_ENABLED=false

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -47,7 +47,10 @@ ACEMUSIC_API_RUNPOD_ENDPOINT_ID=
 # separate CUDA image on a GPU host — so point this at it, or every generation 503s on the
 # availability probe with the rest of the stack perfectly healthy. `remote_only` with the
 # RunPod settings above is the other supported shape.
-ACEMUSIC_API_LOCAL_URL=http://localhost:8001
+# `localhost` here would be the API container itself, not your machine — the compose file
+# defaults this to host.docker.internal (resolved via an extra_hosts entry) so an
+# ACE-Step server on the host is reachable. Point it at the real host in production.
+ACEMUSIC_API_LOCAL_URL=http://host.docker.internal:8001
 ACEMUSIC_API_COMPUTE_PREFERENCE=local_first
 # Two config systems reach the same server: the availability probe reads the variable
 # above (ACEMUSIC_API_ prefix), the job processor's client reads this one (no _API_).

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,8 +1,11 @@
-# Environment for the container stack (#429). Copy to `.env` beside compose.yaml.
+# Environment for the container stack (#429). Copy to `.env.docker` beside compose.yaml.
 #
-#   cp .env.docker.example .env
-#   sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env
-#   docker compose up
+#   cp .env.docker.example .env.docker
+#   sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env.docker
+#   docker compose --env-file .env.docker up
+#
+# NOT `.env`: a checkout already has one holding the development configuration, which is a
+# different schema entirely — compose would load it and fail to parse it.
 #
 # This is the whole contract between the app and a host. Anything a deployment needs that
 # is not here belongs in the images, not in someone's shell history.
@@ -18,7 +21,9 @@ ACEMUSIC_API_CORS_ALLOW_ORIGINS=http://localhost:3000
 API_BASE_URL=http://api:8000
 API_PORT=8000
 WEB_PORT=3000
-# Bound to loopback on purpose — an exposed Mongo on a shared VPS is the whole database.
+# Bound to loopback on purpose — an exposed Mongo on a shared VPS is the whole database,
+# and this stack runs it without authentication. If you change this for debugging, keep
+# the `127.0.0.1:` prefix: a bare `MONGO_PORT=27018` publishes on 0.0.0.0.
 MONGO_PORT=127.0.0.1:27017
 
 # --- Deploy-time (set by the CD workflow; leave blank locally) -----------------------

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,22 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 14
+
+  # The platform images (#429). Dependabot only watches the directories it is told about,
+  # so without these the API and web base images would never be bumped — the ACE-Step
+  # entry above covers /docker only.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "docker"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,155 @@
+# Continuous deployment (#429): green CI on main → published images → rolled out.
+#
+# Triggered by `workflow_run` rather than `push` so the publish keys off CI's verdict
+# instead of re-deciding it. `main` already requires ci (3.11) and ci (3.12) with strict
+# up-to-date enforcement, so a merge is gated; this waits for that same run to finish.
+#
+# Registry is GHCR, authenticated with the built-in GITHUB_TOKEN. That is the whole reason
+# to prefer it over Docker Hub here: docker-publish.yml has never published anything
+# because its credentials were never set, and a pipeline that needs no new secrets cannot
+# fail that way. Docker Hub stays correct for the ACE-Step image, which RunPod pulls.
+#
+# To enable the rollout, set the repository variable DEPLOY_ENABLED=true and populate the
+# `production` environment with DEPLOY_HOST / DEPLOY_USER / DEPLOY_SSH_KEY. Until then the
+# deploy job is *skipped* — visibly inert, rather than green having done nothing.
+
+name: CD
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: ghcr.io/${{ github.repository }}-api
+  WEB_IMAGE: ghcr.io/${{ github.repository }}-web
+
+jobs:
+  publish:
+    name: Build and publish images
+    runs-on: ubuntu-latest
+    # A failed or cancelled CI run must not publish. workflow_dispatch has no upstream
+    # run to inspect, so it is allowed through for manual re-publishing.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - name: Resolve the commit under test
+        id: commit
+        # workflow_run fires against the default branch, so the SHA has to come from the
+        # triggering run — otherwise a busy main publishes an image built from a later
+        # commit than the one CI actually passed on.
+        run: echo "sha=${{ github.event.workflow_run.head_sha || github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.commit.outputs.sha }}
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the API image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          # SHA first: that is the deployable, traceable tag the rollout pins to. `latest`
+          # is a convenience for humans and must never be what a deploy resolves.
+          tags: |
+            ${{ env.API_IMAGE }}:${{ steps.commit.outputs.sha }}
+            ${{ env.API_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push the web image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./web
+          file: ./web/Dockerfile
+          push: true
+          tags: |
+            ${{ env.WEB_IMAGE }}:${{ steps.commit.outputs.sha }}
+            ${{ env.WEB_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to production
+    needs: publish
+    runs-on: ubuntu-latest
+    # A repository *variable* (not a secret) so this can be evaluated at job level: an
+    # unconfigured deploy renders as Skipped instead of a green job that did nothing —
+    # which is the failure mode docker-publish.yml has had since it was written.
+    if: vars.DEPLOY_ENABLED == 'true'
+    environment: production
+    # One deploy at a time, and never cancel one mid-flight: an interrupted rollout can
+    # leave the stack on a half-applied set of images.
+    concurrency:
+      group: production
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.publish.outputs.sha }}
+
+      - name: Ship the stack definition and roll forward
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '/srv/acemusic' }}
+          IMAGE_TAG: ${{ needs.publish.outputs.sha }}
+        run: |
+          set -euo pipefail
+          for required in DEPLOY_HOST DEPLOY_USER DEPLOY_SSH_KEY; do
+            if [[ -z "${!required}" ]]; then
+              echo "::error title=Deploy misconfigured::DEPLOY_ENABLED is true but $required is not set on the production environment."
+              exit 1
+            fi
+          done
+
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          scp -i ~/.ssh/deploy_key compose.yaml scripts/deploy.sh \
+            "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
+
+          # deploy.sh owns the health gate, the rollback and the idempotence check; this
+          # step only hands it a SHA. Its exit code is the deploy's verdict, so a rolled
+          # back deploy reports failure here rather than green.
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cd $DEPLOY_PATH && chmod +x deploy.sh && \
+             API_IMAGE='${{ env.API_IMAGE }}' WEB_IMAGE='${{ env.WEB_IMAGE }}' \
+             DEPLOY_DIR='$DEPLOY_PATH' ./deploy.sh '$IMAGE_TAG'"
+
+      - name: Confirm the deployed commit
+        env:
+          HEALTH_URL: ${{ vars.PRODUCTION_HEALTH_URL }}
+          IMAGE_TAG: ${{ needs.publish.outputs.sha }}
+        # Independent of the host's own check: asks the public endpoint which commit it is
+        # serving. The workflow reporting success is not evidence that it did.
+        if: vars.PRODUCTION_HEALTH_URL != ''
+        run: |
+          set -euo pipefail
+          running="$(curl -fsS --max-time 10 "$HEALTH_URL" | sed -n 's/.*"build_sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+          if [[ "$running" != "$IMAGE_TAG" ]]; then
+            echo "::error title=Deploy not live::$HEALTH_URL reports build_sha='$running', expected '$IMAGE_TAG'."
+            exit 1
+          fi
+          echo "$HEALTH_URL is serving $running"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,6 +96,12 @@ jobs:
     # which is the failure mode docker-publish.yml has had since it was written.
     if: vars.DEPLOY_ENABLED == 'true'
     environment: production
+    permissions:
+      contents: read
+      # The host pulls from GHCR, and images published with GITHUB_TOKEN are private by
+      # default regardless of repo visibility. This scope lets the deploy hand the host a
+      # token for the length of the job instead of provisioning a long-lived PAT.
+      packages: read
     # One deploy at a time, and never cancel one mid-flight: an interrupted rollout can
     # leave the stack on a half-applied set of images.
     concurrency:
@@ -129,6 +135,15 @@ jobs:
 
           scp -i ~/.ssh/deploy_key compose.yaml scripts/deploy.sh \
             "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/"
+
+          # Authenticate the host to GHCR. Packages published with GITHUB_TOKEN are
+          # private by default — independent of whether the repository is public — so
+          # without this the very first `docker compose pull` on the host 401s. The token
+          # is scoped to this job and expires with it, which is why this is a login step
+          # rather than another secret to provision and rotate.
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | ssh -i ~/.ssh/deploy_key \
+            "$DEPLOY_USER@$DEPLOY_HOST" \
+            "docker login ghcr.io -u '${{ github.actor }}' --password-stdin"
 
           # deploy.sh owns the health gate, the rollback and the idempotence check; this
           # step only hands it a SHA. Its exit code is the deploy's verdict, so a rolled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,36 @@ jobs:
       - name: Check the web lockfile is internally consistent
         working-directory: web
         run: npm ls --package-lock-only --all > /dev/null
+
+  # #429: the images are now the deploy artifact, so a Dockerfile that does not build is a
+  # broken deploy. Without this the first place `docker build` runs is CD, on main, after
+  # the merge that broke it. Build only — publishing is CD's job.
+  #
+  # The web build also runs `npm run typecheck` and `next build` inside the image, which
+  # is the first time either has run in automation. That is a side effect worth having,
+  # not a substitute for #426.
+  images:
+    name: build images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build the API image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build the web image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./web
+          file: ./web/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,8 +8,11 @@
 #   - DOCKERHUB_USERNAME  Docker Hub account name (e.g. frankbria)
 #   - DOCKERHUB_TOKEN     Docker Hub access token with read/write scope
 #
-# When those secrets are absent the job logs a warning and skips rather than failing, so
-# unrelated pushes to docker/ do not report a red build on main.
+# Publishing is gated on the repository variable DOCKERHUB_PUBLISH_ENABLED, so an
+# unconfigured repo renders this job as *Skipped* (#429). It used to warn-and-skip every
+# step instead, which reported success having built and pushed nothing — a green check
+# that proved the opposite of what it looked like. Skipping still keeps main out of the
+# red on an unrelated Dependabot bump, but it no longer claims to have published.
 name: Docker Publish
 
 on:
@@ -26,30 +29,28 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     # Only ever publish from main — a manual workflow_dispatch on a feature branch must
-    # not overwrite the public `latest` tag.
-    if: github.ref == 'refs/heads/main'
+    # not overwrite the public `latest` tag. The `vars` context (unlike `secrets`) is
+    # available in `if:`, so the whole job can be skipped rather than run empty.
+    if: github.ref == 'refs/heads/main' && vars.DOCKERHUB_PUBLISH_ENABLED == 'true'
     env:
-      # ponytail: collapsed to one flag in job env because the `secrets` context is not
-      # available in `if:` conditions, but `env` is. Both halves must be present — a
-      # username without a token fails login just as hard as neither being set.
+      # Both halves must be present — a username without a token fails login just as hard
+      # as neither being set.
       HAS_DOCKERHUB_CREDS: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     steps:
-      # Without credentials the publish cannot work, and every push touching docker/ or
-      # this file (e.g. a Dependabot action bump) turns main red. Warn and skip instead.
-      - name: Warn when Docker Hub credentials are missing
+      # Enabled but not credentialed is a misconfiguration, not a state to tiptoe around:
+      # somebody asked for a publish that cannot happen, and should be told loudly.
+      - name: Fail when publishing is enabled without credentials
         if: env.HAS_DOCKERHUB_CREDS != 'true'
         run: |
-          echo "::warning title=Docker publish skipped::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not set. Add them under Settings → Secrets and variables → Actions to publish frankbria/ace-step."
+          echo "::error title=Docker publish misconfigured::DOCKERHUB_PUBLISH_ENABLED is true but DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not set."
+          exit 1
 
       - uses: actions/checkout@v7
-        if: env.HAS_DOCKERHUB_CREDS == 'true'
 
       - name: Set up Docker Buildx
-        if: env.HAS_DOCKERHUB_CREDS == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        if: env.HAS_DOCKERHUB_CREDS == 'true'
         uses: docker/login-action@v4.5.1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -58,7 +59,6 @@ jobs:
       # Derive tags: `latest` for main plus the git SHA for traceability.
       - name: Derive image tags
         id: meta
-        if: env.HAS_DOCKERHUB_CREDS == 'true'
         uses: docker/metadata-action@v6
         with:
           images: frankbria/ace-step
@@ -67,7 +67,6 @@ jobs:
             type=sha,format=long
 
       - name: Build and push
-        if: env.HAS_DOCKERHUB_CREDS == 'true'
         uses: docker/build-push-action@v7.3.0
         with:
           context: docker

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .env
 .env.*
 !.env.example
+# The container stack's env template (#429) — a committed example, not a real env file.
+!.env.docker.example
 
 # Python
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,14 +217,35 @@ Configured in `.pre-commit-config.yaml`:
 
 ## CI
 
-`.github/workflows/ci.yml` — Python:
+`.github/workflows/ci.yml` — three jobs:
 - Triggers on push (all branches) and PR to `main`
-- Matrix: Python 3.11, 3.12
-- Steps: install ffmpeg → `uv sync --extra dev` → `black --check` → `ruff check` → `pytest --cov`
+- `ci` — matrix Python 3.11, 3.12, with a `mongo:7` service container. Steps: install
+  ffmpeg → `uv sync --extra dev` → `black --check` → `ruff check` → `pytest --cov` →
+  `pytest -m integration` against the service Mongo. **These two are the required checks
+  on `main`** (`ci (3.11)`, `ci (3.12)`).
+- `web npm audit` — `npm audit --audit-level=high` plus a lockfile-consistency check.
+  Typecheck, lint, test and build for `web/` are still **not** run here (#426).
+- `build images` — builds the API and web images without pushing (#429), so a Dockerfile
+  that does not build fails the PR rather than the deploy. The web image build runs
+  `npm run typecheck` and `next build` as a side effect.
 - **ffmpeg is installed in CI** (#401). It is a runtime requirement for free-tier video
   watermarking, and its absence used to silently skip every ffmpeg-gated test — roughly ten
   of them across audio export, clip conversion, batch transcode and studio mixdown. Assume
   those now run: a test that only passes because ffmpeg is missing will fail CI.
+
+`.github/workflows/cd.yml` — deploy (#429):
+- Triggered by `workflow_run` when CI completes successfully on `main`, so it keys off
+  CI's verdict rather than re-deciding it
+- Publishes `ghcr.io/<repo>-api` and `-web`, tagged with the commit SHA and `latest`
+- Rolls out over SSH by handing `scripts/deploy.sh` a SHA; that script owns the health
+  gate, the automatic rollback and the idempotence check, and is tested in
+  `tests/test_deploy_script.py`
+- The deploy job is **skipped** until `DEPLOY_ENABLED=true` and the `production`
+  environment secrets exist. See `docs/deployment.md`.
+
+`.github/workflows/docker-publish.yml` — ACE-Step worker image to Docker Hub. Gated on the
+`DOCKERHUB_PUBLISH_ENABLED` variable, so an unconfigured repo shows it as *skipped* rather
+than green having published nothing.
 
 `.github/workflows/plugin.yml` — VST3 plugin (C++):
 - Path-filtered to `plugin/**`, so Python-only changes don't trigger a 3-OS C++ build
@@ -262,7 +283,12 @@ Package manager: `uv` with `hatchling` build backend
   same way will not notice (see `isAsciiOnly` in `ConnectionManagerTests.cpp`)
 - The plugin stores connection settings in `~/.config/AutoMusicStudio/` (Linux). It
   holds an optional API key in plaintext, chmod 0600
-- `web/` is the Next.js app (Stages 15–16 complete, Stage 17 in progress); run with `cd web && npm install && npm run dev`
+- `web/` is the Next.js app (Stages 15–16 complete, Stage 17 in progress); `docker compose up`
+  runs the whole platform, or `cd web && npm install && npm run dev` for the dev server alone
+- The platform runs as containers (#429): `Dockerfile` (API), `web/Dockerfile`, `compose.yaml`.
+  Data paths are absolute *in the image only* (`/data/storage`, `/data/voice-training`) —
+  the code defaults stay CWD-relative because `voice_training_root` is sent verbatim to
+  ACE-Step, which shares the filesystem
 - User stories are numbered `US-{stage}.{sequence}` (e.g., US-2.1 = Stage 2, first story)
 - Integration tests are gated behind `@pytest.mark.integration` and skip gracefully without a server
 - The `.beads/` directory is local-only (gitignored) for issue tracking across sessions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+# Platform API image (#429): FastAPI + the in-process job processor.
+#
+# Single container by design — the job processor runs inside the API's lifespan, and
+# splitting it into its own scalable service makes #427 (stale-requeue racing a long video
+# render) live. Revisit once #427 is closed; see docs/deployment.md.
+#
+# Two stages so the build toolchain and the uv cache stay out of the runtime layer. The
+# ACE-Step worker image (docker/Dockerfile) is a different thing entirely — CUDA base,
+# clones an external repo — and shares nothing with this.
+
+FROM python:3.12-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.9.30 /uv /usr/local/bin/uv
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /app
+
+# Dependencies before source: this layer is the expensive one and only the lockfile
+# should be able to invalidate it.
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev --extra api --extra s3
+
+COPY src ./src
+# --no-editable: an editable install points at /app/src, which would make the runtime
+# stage depend on source that its own COPY happens to place identically. Install the
+# package properly instead.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable --extra api --extra s3
+
+
+FROM python:3.12-slim AS runtime
+
+# ffmpeg is a hard runtime requirement, not a convenience: free-tier video watermarking
+# (#401), flac/mp3 conversion, batch transcode and Studio mixdowns all shell out to it.
+# CI installs it (ci.yml) and production ran on trust — baking it in is the whole point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --uid 10001 acemusic
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    # Absolute, and mounted as volumes in compose. Both of these default to CWD-relative
+    # paths (`./acemusic-voice-training`, `Path.cwd()/"storage"`), which in a container
+    # means "wherever the process happened to start, inside the writable layer, gone on
+    # restart". Set here rather than by changing the defaults: voice_training_root is
+    # deliberately relative so the API and ACE-Step share a filesystem, and the value is
+    # sent verbatim to ACE-Step.
+    ACEMUSIC_API_VOICE_TRAINING_ROOT=/data/voice-training \
+    ACEMUSIC_STORAGE_LOCAL_ROOT=/data/storage
+
+WORKDIR /app
+
+COPY --from=builder --chown=acemusic:acemusic /app/.venv /app/.venv
+
+RUN mkdir -p /data/storage /data/voice-training && chown -R acemusic:acemusic /data
+
+USER acemusic
+
+EXPOSE 8000
+
+# Liveness only — /api/v1/health deliberately does not touch MongoDB. The API already
+# fails fast on an unreachable database at startup, so a container that answers here is
+# one that got past that.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS http://localhost:8000/api/v1/health || exit 1
+
+# No console script exists for the server (pyproject only ships the `acemusic` CLI), so
+# the ASGI target is named directly. No --reload: that is a development flag.
+CMD ["uvicorn", "acemusic.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,24 @@
 
 AI-powered music generation platform built on ACE-Step-1.5.
 
-## Bootstrap
+## Running the platform
+
+```bash
+cp .env.docker.example .env
+sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env
+docker compose up --build
+```
+
+Web on <http://localhost:3000>, API on <http://localhost:8000>, Swagger at `/docs`.
+This is the supported way to run the platform, and the same `compose.yaml` describes the
+production topology. Merging to `main` publishes SHA-tagged images and deploys them — see
+[docs/deployment.md](docs/deployment.md).
+
+The commands in the rest of this section run the components directly on your machine, for
+development. They skip the image, so they also skip what the image guarantees: ffmpeg
+present, and data paths that do not depend on the directory you started the process from.
+
+## Bootstrap (development)
 
 ```bash
 uv venv
@@ -16,7 +33,7 @@ uv run python -c "import acemusic"  # smoke test
 uv run pytest
 ```
 
-## Running the web app (Layer 3)
+## Running the web app (Layer 3, development)
 
 ```bash
 cd web && npm install && npm run dev
@@ -24,7 +41,7 @@ cd web && npm install && npm run dev
 
 Starts the Next.js dev server at `http://localhost:3000`.
 
-## Running the API (Layer 2)
+## Running the API (Layer 2, development)
 
 The platform API is a FastAPI app served under `/api/v1`:
 
@@ -33,7 +50,8 @@ uv run uvicorn acemusic.api.main:app --reload
 ```
 
 Then visit `http://127.0.0.1:8000/docs` for the interactive Swagger UI, or
-`GET /api/v1/health` for a liveness check. Allowed CORS origins are configured
+`GET /api/v1/health` for a liveness check — which also reports `build_sha`, the commit the
+running image was built from (`unknown` outside a built image). Allowed CORS origins are configured
 via `ACEMUSIC_API_CORS_ALLOW_ORIGINS` (comma-separated).
 
 The API requires **MongoDB** and fails fast on startup if it is unreachable.
@@ -465,7 +483,9 @@ Audio files are managed through a single storage interface
 `ACEMUSIC_STORAGE_BACKEND`:
 
 - `local` (default) — files on the local filesystem under
-  `ACEMUSIC_STORAGE_LOCAL_ROOT` (defaults to `./storage`).
+  `ACEMUSIC_STORAGE_LOCAL_ROOT`. Unset, it defaults to `./storage` **relative to the
+  working directory the process was started from**; the container images set it to the
+  absolute `/data/storage`, backed by a named volume, so clips survive a deploy.
 - `s3` — any S3-compatible bucket (AWS, MinIO, Backblaze B2) via the optional
   `s3` extra (`uv sync --extra s3`). Set `ACEMUSIC_S3_BUCKET` and, for non-AWS
   endpoints, `ACEMUSIC_S3_ENDPOINT_URL`. Credentials come from boto3's default
@@ -479,7 +499,9 @@ keys follow `{user_id}/{workspace_id}/clips/{clip_id}.{format}`. See
 
 ## Environment
 
-Copy `.env.example` to `.env` and fill in the required values before running.
+For the container stack, copy `.env.docker.example` to `.env` — that file is the whole
+contract between the app and a host. For running components directly, copy `.env.example`
+to `.env` and fill in the required values before running.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ AI-powered music generation platform built on ACE-Step-1.5.
 ## Running the platform
 
 ```bash
-cp .env.docker.example .env
-sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env
-docker compose up --build
+cp .env.docker.example .env.docker
+sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env.docker
+docker compose --env-file .env.docker up --build
 ```
 
 Web on <http://localhost:3000>, API on <http://localhost:8000>, Swagger at `/docs`.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,108 @@
+# The whole platform: API + web + MongoDB (#429).
+#
+# This file is both the local stack (`docker compose up`) and the record of production
+# topology — the same services, with images pulled by tag instead of built. Anything a
+# host needs that is not in here or in the Dockerfiles is a bug in one of them.
+#
+# Every setting arrives as an environment variable, so deploying to a different host is a
+# different .env, not a different file. Copy .env.docker.example to .env to start.
+
+name: acemusic
+
+services:
+  api:
+    # IMAGE_TAG is set by the deploy (to a commit SHA); locally it is unset and the build
+    # below is used instead, so the same file serves both without a second copy to drift.
+    image: ${API_IMAGE:-acemusic-api}:${IMAGE_TAG:-local}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      ACEMUSIC_API_MONGODB_URL: mongodb://mongo:27017
+      ACEMUSIC_API_MONGODB_DB_NAME: ${ACEMUSIC_API_MONGODB_DB_NAME:-acemusic}
+      # No default: the API mints tokens with this, and a shared fallback secret is worse
+      # than a loud failure. .env.docker.example generates one.
+      ACEMUSIC_API_JWT_SECRET_KEY: ${ACEMUSIC_API_JWT_SECRET_KEY:?set ACEMUSIC_API_JWT_SECRET_KEY (see .env.docker.example)}
+      ACEMUSIC_API_CORS_ALLOW_ORIGINS: ${ACEMUSIC_API_CORS_ALLOW_ORIGINS:-http://localhost:3000}
+      ACEMUSIC_STORAGE_BACKEND: ${ACEMUSIC_STORAGE_BACKEND:-local}
+      # Where generation actually runs. The ACE-Step server is not part of this stack —
+      # it is a separate CUDA image on a GPU host (docker/Dockerfile, RunPod) — so the
+      # API has to be told where to find it, or every generation 503s on the availability
+      # probe with the stack otherwise perfectly healthy.
+      ACEMUSIC_API_LOCAL_URL: ${ACEMUSIC_API_LOCAL_URL:-http://localhost:8001}
+      ACEMUSIC_API_COMPUTE_PREFERENCE: ${ACEMUSIC_API_COMPUTE_PREFERENCE:-local_first}
+      # The same server, named twice, because two config systems reach it: the router's
+      # availability probe reads ACEMUSIC_API_LOCAL_URL (ApiSettings, ACEMUSIC_API_ prefix)
+      # while the job processor's client reads ACEMUSIC_BASE_URL (the CLI config, no _API_).
+      # Setting only the first accepts every generation and then fails every one of them
+      # with "ACE-Step base URL is not configured" — which is how this was found.
+      ACEMUSIC_BASE_URL: ${ACEMUSIC_BASE_URL:-${ACEMUSIC_API_LOCAL_URL:-http://localhost:8001}}
+      ACEMUSIC_API_KEY: ${ACEMUSIC_API_KEY:-}
+      # Reported by GET /api/v1/health, so "is the new commit actually running?" is a
+      # question the deployment answers itself.
+      ACEMUSIC_BUILD_SHA: ${IMAGE_TAG:-local}
+      # OAuth, Stripe and provider credentials pass straight through when set. Unset means
+      # the feature is off, which is the correct default for a local stack.
+      ACEMUSIC_API_GOOGLE_CLIENT_ID: ${ACEMUSIC_API_GOOGLE_CLIENT_ID:-}
+      ACEMUSIC_API_GOOGLE_CLIENT_SECRET: ${ACEMUSIC_API_GOOGLE_CLIENT_SECRET:-}
+      ACEMUSIC_API_GOOGLE_REDIRECT_URI: ${ACEMUSIC_API_GOOGLE_REDIRECT_URI:-}
+      ACEMUSIC_API_DISCORD_CLIENT_ID: ${ACEMUSIC_API_DISCORD_CLIENT_ID:-}
+      ACEMUSIC_API_DISCORD_CLIENT_SECRET: ${ACEMUSIC_API_DISCORD_CLIENT_SECRET:-}
+      ACEMUSIC_API_DISCORD_REDIRECT_URI: ${ACEMUSIC_API_DISCORD_REDIRECT_URI:-}
+      ACEMUSIC_API_STRIPE_SECRET_KEY: ${ACEMUSIC_API_STRIPE_SECRET_KEY:-}
+      ACEMUSIC_API_STRIPE_WEBHOOK_SECRET: ${ACEMUSIC_API_STRIPE_WEBHOOK_SECRET:-}
+      ACEMUSIC_API_STRIPE_PRICE_ID_PRO: ${ACEMUSIC_API_STRIPE_PRICE_ID_PRO:-}
+      ACEMUSIC_API_OPENAI_API_KEY: ${ACEMUSIC_API_OPENAI_API_KEY:-}
+      ACEMUSIC_API_VIDEO_API_URL: ${ACEMUSIC_API_VIDEO_API_URL:-}
+      ACEMUSIC_API_VIDEO_API_KEY: ${ACEMUSIC_API_VIDEO_API_KEY:-}
+      ACEMUSIC_API_RUNPOD_API_KEY: ${ACEMUSIC_API_RUNPOD_API_KEY:-}
+      ACEMUSIC_API_RUNPOD_ENDPOINT_ID: ${ACEMUSIC_API_RUNPOD_ENDPOINT_ID:-}
+      ACEMUSIC_API_SOUNDCLOUD_POLLER_ENABLED: ${ACEMUSIC_API_SOUNDCLOUD_POLLER_ENABLED:-false}
+    volumes:
+      # Both paths are absolute in the image. Without these the clips and trained voices
+      # live in the container's writable layer and vanish on the next `up -d`.
+      - storage:/data/storage
+      - voice-training:/data/voice-training
+    ports:
+      - "${API_PORT:-8000}:8000"
+    depends_on:
+      mongo:
+        condition: service_healthy
+
+  web:
+    image: ${WEB_IMAGE:-acemusic-web}:${IMAGE_TAG:-local}
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      # Server-side only (the app has no NEXT_PUBLIC_* vars), so this is a runtime value
+      # and the image is portable across environments unchanged.
+      API_BASE_URL: ${API_BASE_URL:-http://api:8000}
+    ports:
+      - "${WEB_PORT:-3000}:3000"
+    depends_on:
+      - api
+
+  mongo:
+    image: mongo:7
+    restart: unless-stopped
+    healthcheck:
+      # Same probe CI uses for its Mongo service, so local, CI and production agree on
+      # what "the database is up" means.
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - mongo-data:/data/db
+    # Not published by default: on a shared VPS an exposed Mongo is the whole database.
+    # Set MONGO_PORT to reach it from the host for debugging.
+    ports:
+      - "${MONGO_PORT:-127.0.0.1:27017}:27017"
+
+volumes:
+  storage:
+  voice-training:
+  mongo-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -105,8 +105,9 @@ services:
       retries: 5
     volumes:
       - mongo-data:/data/db
-    # Not published by default: on a shared VPS an exposed Mongo is the whole database.
-    # Set MONGO_PORT to reach it from the host for debugging.
+    # Loopback-bound by default: this Mongo has no authentication, so on a shared VPS an
+    # exposed port is the whole database. If you override MONGO_PORT for debugging, keep
+    # the `127.0.0.1:` prefix — a bare port number publishes on 0.0.0.0.
     ports:
       - "${MONGO_PORT:-127.0.0.1:27017}:27017"
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,14 +30,18 @@ services:
       # it is a separate CUDA image on a GPU host (docker/Dockerfile, RunPod) — so the
       # API has to be told where to find it, or every generation 503s on the availability
       # probe with the stack otherwise perfectly healthy.
-      ACEMUSIC_API_LOCAL_URL: ${ACEMUSIC_API_LOCAL_URL:-http://localhost:8001}
+      # host.docker.internal, not localhost: inside this container `localhost` is the API
+      # itself, so the documented default would have the availability probe call the API
+      # and conclude that ACE-Step is down. The extra_hosts entry below makes the name
+      # resolve on Linux, where Docker does not provide it automatically.
+      ACEMUSIC_API_LOCAL_URL: ${ACEMUSIC_API_LOCAL_URL:-http://host.docker.internal:8001}
       ACEMUSIC_API_COMPUTE_PREFERENCE: ${ACEMUSIC_API_COMPUTE_PREFERENCE:-local_first}
       # The same server, named twice, because two config systems reach it: the router's
       # availability probe reads ACEMUSIC_API_LOCAL_URL (ApiSettings, ACEMUSIC_API_ prefix)
       # while the job processor's client reads ACEMUSIC_BASE_URL (the CLI config, no _API_).
       # Setting only the first accepts every generation and then fails every one of them
       # with "ACE-Step base URL is not configured" — which is how this was found.
-      ACEMUSIC_BASE_URL: ${ACEMUSIC_BASE_URL:-${ACEMUSIC_API_LOCAL_URL:-http://localhost:8001}}
+      ACEMUSIC_BASE_URL: ${ACEMUSIC_BASE_URL:-${ACEMUSIC_API_LOCAL_URL:-http://host.docker.internal:8001}}
       ACEMUSIC_API_KEY: ${ACEMUSIC_API_KEY:-}
       # Reported by GET /api/v1/health, so "is the new commit actually running?" is a
       # question the deployment answers itself.
@@ -59,6 +63,10 @@ services:
       ACEMUSIC_API_RUNPOD_API_KEY: ${ACEMUSIC_API_RUNPOD_API_KEY:-}
       ACEMUSIC_API_RUNPOD_ENDPOINT_ID: ${ACEMUSIC_API_RUNPOD_ENDPOINT_ID:-}
       ACEMUSIC_API_SOUNDCLOUD_POLLER_ENABLED: ${ACEMUSIC_API_SOUNDCLOUD_POLLER_ENABLED:-false}
+    extra_hosts:
+      # Linux does not resolve host.docker.internal on its own; this is what lets the
+      # ACEMUSIC_API_LOCAL_URL default reach an ACE-Step server running on the host.
+      - "host.docker.internal:host-gateway"
     volumes:
       # Both paths are absolute in the image. Without these the clips and trained voices
       # live in the container's writable layer and vanish on the next `up -d`.

--- a/docs/demos/us-429-containerize-and-cd.md
+++ b/docs/demos/us-429-containerize-and-cd.md
@@ -1,0 +1,232 @@
+# #429 — Containerize the platform and ship it via CD
+
+Everything below ran against a real Docker daemon on this machine: real images, a real
+local registry, a real rollout, a real rollback.
+
+The one thing that could **not** run is the SSH hop to a production VPS — no host, user or
+key exists, and I cannot create them. So the rollout is demonstrated by running
+`scripts/deploy.sh` exactly as the workflow runs it, against a registry the stack really
+pulls from. What is unproven is the transport, not the logic. See *Not verified here* at
+the end.
+
+---
+
+## Images and local stack
+
+### `docker compose up` brings up API + web + MongoDB
+
+```
+$ docker compose up -d
+ Container acemusic-mongo-1  Healthy
+ Container acemusic-api-1    Started
+ Container acemusic-web-1    Started
+
+$ docker compose ps
+api     Up (healthy)
+mongo   Up (healthy)
+web     Up (healthy)
+
+$ curl localhost:8000/api/v1/health
+{"status":"ok","version":"0.1.0","uptime_seconds":19.368,"build_sha":"local"}
+
+api-1 | Connected to MongoDB database 'acemusic' at mongodb://mongo:27017
+```
+
+Port 3000 was already taken on this machine by a dev server — the shared-host conflict the
+issue calls out. It was resolved with `WEB_PORT=3080 API_PORT=8080` in `.env`, no file
+edit, which is the point of every setting being an environment variable.
+
+### A generation completes against the containerised API
+
+The ACE-Step inference server is deliberately **not** in this stack — it is a separate CUDA
+image on a GPU host. The repo's own stub (`scripts/demo_stub_acestep.py`) stands in for it,
+which is what the existing demos do.
+
+```
+POST /api/v1/generate  →  {"job_id":"6a79ff0e…","status":"queued"}
+poll 1: queued
+poll 2: completed
+  clip_ids   ["6a79ff11…d","6a79ff11…e"]
+  audio_urls ["/data/storage/…/clips/6a79ff11…d.wav", …]
+
+$ docker compose exec api find /data/storage -name '*.wav'
+/data/storage/6a79fe14…/6a79fe14…/clips/6a79ff11…d.wav
+/data/storage/6a79fe14…/6a79fe14…/clips/6a79ff11…e.wav
+```
+
+Two clips, written to the mounted volume, by the in-process worker inside the API
+container. And through the web container's BFF, which is how the browser reaches it:
+
+```
+GET localhost:3080/api/credits/balance  (Bearer)  → 200
+{"balance":9,"tier":"free","upgrade_url":"/settings/billing"}
+```
+
+**Two real bugs surfaced here**, both now fixed in `compose.yaml`:
+
+1. The stack passed no compute-target URL at all, so every generation 503'd on the
+   availability probe with the stack otherwise perfectly healthy.
+2. Setting only `ACEMUSIC_API_LOCAL_URL` was not enough. The router's probe reads that
+   (`ApiSettings`, `ACEMUSIC_API_` prefix) while the job processor's client reads
+   `ACEMUSIC_BASE_URL` (the CLI config, no `_API_`). With one set and not the other, every
+   generation is **accepted and then fails**: `ACE-Step base URL is not configured`. Both
+   are now passed through, the second defaulting to the first.
+
+Neither is a new bug — they are the per-host tribal knowledge the issue is about, made
+visible by writing the manifest down.
+
+### ffmpeg is in the image, verified by the #401 watermark path
+
+Not "the binary is present" — the actual free-tier watermarking code, on a real 720p
+render, inside the container:
+
+```
+$ docker compose exec api python -c "…apply_watermark(…)"
+watermark asset present: True /app/.venv/…/acemusic/assets/watermark.png
+input bytes : 50391
+marked bytes: 57790
+changed     : True
+marked video stream: h264,1280,720
+```
+
+```
+$ docker run --rm acemusic-api ffmpeg -version
+ffmpeg version 7.1.5-0+deb13u1
+$ docker run --rm acemusic-api id
+uid=10001(acemusic) gid=10001(acemusic)
+```
+
+### No component reads a CWD-relative path
+
+Same container, three working directories:
+
+```
+cwd=/      storage=/data/storage  voice=/data/voice-training
+cwd=/tmp   storage=/data/storage  voice=/data/voice-training
+cwd=/app   storage=/data/storage  voice=/data/voice-training
+```
+
+The code defaults are `./acemusic-voice-training` and `Path.cwd()/"storage"`. They are
+overridden by environment in the image rather than changed in code: `voice_training_root`
+is deliberately relative so the API and ACE-Step share a filesystem, and the value is sent
+verbatim to ACE-Step.
+
+### Data survives a container recreation
+
+```
+$ …upload('u1/w1/clips/c1.wav', …); write /data/voice-training/model-1/voice.safetensors
+$ docker compose up -d --force-recreate api
+clip survived      : True
+voice data survived: True
+```
+
+`--force-recreate`, not `restart` — that is the motion a deploy performs.
+
+---
+
+## Delivery
+
+`scripts/deploy.sh` was run exactly as the workflow runs it, against a local
+`registry:2` holding two tags: `goodsha` (the working image) and `badsha` (identical but
+the API process exits immediately on start).
+
+### First rollout, and the deployed commit is verifiable
+
+```
+$ ./deploy.sh goodsha
+[deploy] deploying goodsha (currently: none)
+[deploy] goodsha is live
+
+$ curl …/api/v1/health
+{"status":"ok","version":"0.1.0","uptime_seconds":4.147,"build_sha":"goodsha"}
+```
+
+`build_sha` is new (`GET /api/v1/health`). Before it, the only version the API reported was
+the static `0.1.0` from `pyproject.toml` that nobody bumps — so "did the deploy land?" could
+only be answered by trusting the workflow that said it had.
+
+### Re-running the same deploy is a no-op
+
+```
+$ ./deploy.sh goodsha
+[deploy] goodsha is already deployed and serving — nothing to do
+container recreated? NO
+```
+
+Gated on what is actually serving, not on the recorded tag alone — a stack that has since
+fallen over is still brought back (`test_it_redeploys_when_the_tag_matches_but_the_stack_is_down`).
+
+### A broken deploy rolls back automatically and reports failure
+
+```
+$ ./deploy.sh badsha
+[deploy] deploying badsha (currently: goodsha)
+ Container acemusic-api-1 Recreated
+[deploy] timed out after 45s waiting for build_sha=badsha (last seen: 'no response')
+[deploy] rollback: restoring goodsha
+ Container acemusic-api-1 Recreated
+[deploy] badsha failed its health gate; rolled back to goodsha
+exit=1
+
+$ cat .deployed-tag → goodsha
+$ curl …/health   → {"status":"ok",…,"build_sha":"goodsha"}
+api  …/acemusic-api:goodsha  Up (healthy)
+web  …/acemusic-web:goodsha  Up (healthy)
+```
+
+Exit 1, so the workflow step fails. A deploy that leaves the site down while reporting
+green is the outcome this exists to prevent.
+
+The gate is **not** "does something answer 200": a crash-looping new image leaves the
+previous container answering happily. It waits for the API to report *the SHA just
+deployed*.
+
+### Two deploys cannot run concurrently
+
+```
+$ flock .deploy.lock sleep 8 &        # a rollout in flight
+$ ./deploy.sh goodsha
+[deploy] another deploy is already running (…/.deploy.lock)
+exit=3
+```
+
+`concurrency: production` in the workflow only serialises workflow runs; the host-side lock
+also covers an operator running the rollout by hand, which is exactly when someone would.
+
+### Unconfigured is skipped, not green
+
+The complaint in the issue is that `docker-publish.yml` reports **success** having skipped
+checkout, build and push. Both publish paths are now gated at *job* level on a repository
+variable, so an unconfigured repo renders them as **Skipped**. Enabled-but-not-credentialed
+fails loudly instead.
+
+---
+
+## Tests
+
+`tests/test_deploy_script.py` — 8 cases covering the rollout, the SHA gate, idempotence,
+the concurrency lock, rollback, and the first-ever-deploy case where there is nothing to
+roll back to. `docker` and `curl` are stubbed on PATH, so they run in CI with no daemon.
+
+A rollback that has never run is not a rollback.
+
+`tests/test_api_health.py` — `build_sha` reported from the environment, `unknown` outside a
+built image.
+
+`ci.yml` gains a `build images` job: both images are built (not pushed) on every PR, so a
+Dockerfile that does not build fails the PR rather than the deploy. The web image build runs
+`npm run typecheck` and `next build`, which is the first time either has run in automation.
+
+---
+
+## Not verified here
+
+- **The SSH rollout to a production VPS.** No host, user or key exists. `deploy.sh` — the
+  health gate, rollback, idempotence and locking — is exercised against a real stack above;
+  the workflow step that carries it over SSH is not.
+- **A live GHCR publish.** It needs no new secrets (`GITHUB_TOKEN` authenticates), so it
+  will run for real on the first merge to `main`; it cannot run from a branch beforehand.
+- **`PRODUCTION_HEALTH_URL` post-deploy confirmation**, for the same reason.
+
+To turn the rollout on: set `DEPLOY_ENABLED=true` plus `DEPLOY_HOST` / `DEPLOY_USER` /
+`DEPLOY_SSH_KEY` on the `production` environment. Full list in `docs/deployment.md`.

--- a/docs/demos/us-429-containerize-and-cd.md
+++ b/docs/demos/us-429-containerize-and-cd.md
@@ -122,6 +122,39 @@ voice data survived: True
 
 `--force-recreate`, not `restart` — that is the motion a deploy performs.
 
+**This check was initially too weak, and review caught it.** Writing the training file by
+hand proved the volume mounts, not that the app uses it — and it did not. The setting was
+read by `ApiSettings` and never passed to `JobProcessor`, so the worker kept its own
+default relative to the working directory:
+
+```
+module default (was used) : ./acemusic-voice-training
+setting (now passed on)   : /data/voice-training
+wired in lifespan         : True
+
+# what the old behaviour would have done, as the non-root user:
+$ mkdir -p ./acemusic-voice-training
+mkdir: cannot create directory './acemusic-voice-training': Permission denied
+$ ls -ld /app
+drwxr-xr-x 1 root root /app
+```
+
+So voice training in a container would have failed outright, and a setting that is read
+and ignored looks configured. Fixed in `main.py`, pinned by
+`tests/test_processor_wiring.py`.
+
+### `host.docker.internal`, not `localhost`
+
+Also from review: inside the API container `localhost` **is** the API container, so the
+documented default would have the availability probe call the API and conclude ACE-Step is
+down. The default is now `host.docker.internal`, with an `extra_hosts: host-gateway` entry
+because Linux does not resolve that name on its own:
+
+```
+host.docker.internal resolves inside the container -> 172.17.0.1
+http://host.docker.internal:8013 -> 200
+```
+
 ---
 
 ## Delivery

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,118 @@
+# Deployment
+
+The platform ships as two images plus MongoDB, described by one `compose.yaml` that is
+both the local stack and the production topology. Merging to `main` publishes SHA-tagged
+images and rolls them out; nobody SSHes anywhere.
+
+## Run the whole stack locally
+
+```bash
+cp .env.docker.example .env
+sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env
+docker compose up --build
+```
+
+Web on <http://localhost:3000>, API on <http://localhost:8000>, Swagger at `/docs`.
+Ports come from `WEB_PORT` / `API_PORT` — the host is shared, so a conflict is a variable
+to change, not a file to edit.
+
+`docker compose up` is the supported way to run the platform. The `uv run uvicorn` and
+`npm run dev` commands in the README are development conveniences: they skip the image, so
+they also skip the guarantees the image makes (ffmpeg present, absolute data paths).
+
+## What the images guarantee
+
+- **ffmpeg is installed.** Free-tier video watermarking (#401), flac/mp3 conversion, batch
+  transcode and Studio mixdowns all shell out to it. CI installed it and production ran on
+  trust; now it is a layer.
+- **Data paths are absolute.** `ACEMUSIC_API_VOICE_TRAINING_ROOT=/data/voice-training` and
+  `ACEMUSIC_STORAGE_LOCAL_ROOT=/data/storage`, both mounted as named volumes. Their code
+  defaults are CWD-relative (`./acemusic-voice-training`, `Path.cwd()/"storage"`), which in
+  a container means "inside the writable layer, gone on the next deploy".
+
+  These are set as environment, not by changing the defaults. `voice_training_root` is
+  deliberately relative so the API and ACE-Step share a filesystem, and the value is sent
+  verbatim to ACE-Step (`api/tasks/voice_training.py`) — changing the default would change
+  what ACE-Step receives.
+- **The API runs as a non-root user** and answers `GET /api/v1/health`, which now reports
+  `build_sha`: the commit the image was built from.
+
+## The pipeline
+
+```
+push to main ──► CI (3.11, 3.12) ──► CD: publish ──► CD: deploy
+                    required           ghcr.io/…-api      scp compose.yaml + deploy.sh
+                    checks             ghcr.io/…-web      ssh → ./deploy.sh <sha>
+                                       :<sha> + :latest   health gate → rollback on failure
+```
+
+CD triggers on `workflow_run` when CI **completes successfully** on `main`, rather than on
+`push`. It keys off CI's verdict instead of re-deciding it.
+
+Images go to **GHCR**, authenticated with the built-in `GITHUB_TOKEN`. That is the point:
+`docker-publish.yml` never published anything for want of Docker Hub credentials, and a
+pipeline that needs no new secrets cannot fail that way. Docker Hub remains correct for the
+ACE-Step worker image, which RunPod pulls.
+
+### Rollout, health gate, rollback
+
+`scripts/deploy.sh` runs on the host and owns all of it, so the same rollout can be run by
+hand and — more importantly — can be tested (`tests/test_deploy_script.py`).
+
+The gate is **not** "does something answer 200". It is "does the API report the SHA we
+just deployed". Those differ in exactly the case worth engineering for: a new image that
+crash-loops leaves the previous container serving happily, and a liveness check calls that
+a successful deploy. On timeout the script re-pins the previous SHA, waits for it to come
+back, and exits non-zero — a deploy that leaves the site down must not report green.
+
+Re-running the same SHA is a no-op, gated on what is actually serving rather than on the
+recorded tag alone, so a stack that has since fallen over is still brought back.
+
+### Enabling it
+
+The deploy job is skipped until it is configured — *skipped*, not green having done
+nothing, which is the failure mode this work exists to remove.
+
+| Kind | Name | Purpose |
+| --- | --- | --- |
+| Variable | `DEPLOY_ENABLED` | `true` turns the deploy job on |
+| Variable | `DEPLOY_PATH` | Host directory holding `compose.yaml` and `.env` (default `/srv/acemusic`) |
+| Variable | `PRODUCTION_HEALTH_URL` | Public health URL, checked independently after the rollout |
+| Variable | `DOCKERHUB_PUBLISH_ENABLED` | `true` re-enables the ACE-Step publish |
+| Secret (`production` env) | `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY` | SSH target |
+
+On the host: install Docker, create `DEPLOY_PATH`, and put a `.env` there built from
+`.env.docker.example` with production values. The workflow ships `compose.yaml` and
+`deploy.sh` on every deploy, so those are never edited in place.
+
+## Decisions
+
+### Single container, not a split API and worker
+
+The job processor runs in-process inside the API's lifespan. Splitting it is nearly free —
+`job_processor_enabled` already exists — but it makes **#427** live: the stale-requeue
+window is shorter than a video render's worst case, so multiple worker processes are
+precisely the deployment that turns that latent race into double provider billing and
+racing `Video` documents.
+
+Single container until #427 is closed. Then splitting is a compose service and a flag.
+
+### Deploys are fully automatic
+
+No human approval step. CI is already a hard gate with two required checks and strict
+up-to-date enforcement, and the health gate plus automatic rollback carry the safety —
+which a person approving a diff they have not run does not.
+
+Reversible either way: an environment protection rule on `production` adds a click without
+touching the workflow. Revisit if a bad deploy ever gets past the gate.
+
+### Known gaps
+
+- **A restart is a short outage.** Single VPS, single compose stack; `up -d` recreates the
+  containers. Blue/green or a proxy in front would remove it. Accepted deliberately rather
+  than discovered later.
+- **Index changes land at rollout.** Beanie creates indexes during `init_db` at startup, so
+  there is no separate migration step to gate on — schema work happens as a side effect of
+  the new container booting.
+- **The rollback restores images, not data.** It re-pins the previous SHA. Anything the bad
+  release wrote to MongoDB stays written.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,9 +7,9 @@ images and rolls them out; nobody SSHes anywhere.
 ## Run the whole stack locally
 
 ```bash
-cp .env.docker.example .env
-sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env
-docker compose up --build
+cp .env.docker.example .env.docker
+sed -i "s|^ACEMUSIC_API_JWT_SECRET_KEY=.*|ACEMUSIC_API_JWT_SECRET_KEY=$(openssl rand -hex 32)|" .env.docker
+docker compose --env-file .env.docker up --build
 ```
 
 Web on <http://localhost:3000>, API on <http://localhost:8000>, Swagger at `/docs`.
@@ -76,14 +76,32 @@ nothing, which is the failure mode this work exists to remove.
 | Kind | Name | Purpose |
 | --- | --- | --- |
 | Variable | `DEPLOY_ENABLED` | `true` turns the deploy job on |
-| Variable | `DEPLOY_PATH` | Host directory holding `compose.yaml` and `.env` (default `/srv/acemusic`) |
+| Variable | `DEPLOY_PATH` | Host directory holding `compose.yaml` and `.env.docker` (default `/srv/acemusic`) |
 | Variable | `PRODUCTION_HEALTH_URL` | Public health URL, checked independently after the rollout |
 | Variable | `DOCKERHUB_PUBLISH_ENABLED` | `true` re-enables the ACE-Step publish |
 | Secret (`production` env) | `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY` | SSH target |
 
-On the host: install Docker, create `DEPLOY_PATH`, and put a `.env` there built from
-`.env.docker.example` with production values. The workflow ships `compose.yaml` and
-`deploy.sh` on every deploy, so those are never edited in place.
+On the host: install Docker, create `DEPLOY_PATH`, and put a `.env.docker` there built
+from `.env.docker.example` with production values. (Named `.env.docker`, not `.env`,
+because a checkout already carries a `.env` holding the development configuration — a
+different schema entirely — and compose would silently load that one.) The workflow ships
+`compose.yaml` and `deploy.sh` on every deploy, so those are never edited in place.
+
+Three things that are easy to get wrong the first time:
+
+- **GHCR packages are private by default**, independent of whether the repository is
+  public. The deploy therefore logs the host into `ghcr.io` with the job's own
+  `GITHUB_TOKEN` before pulling — scoped to the run, so there is no long-lived PAT to
+  provision or rotate. If you would rather the host not authenticate at all, make the two
+  packages public once under *Packages → Package settings*.
+- **Compose version.** `compose.yaml` uses a nested default
+  (`${ACEMUSIC_BASE_URL:-${ACEMUSIC_API_LOCAL_URL:-…}}`) so the worker's URL inherits the
+  probe's rather than silently diverging. Docker Compose **v2.20+** resolves this
+  correctly; it is verified on the version used to build this stack. On anything older,
+  set both variables explicitly in `.env.docker`.
+- **`build images` is not a required check yet.** Branch protection on `main` requires
+  `ci (3.11)` and `ci (3.12)` only, so a Dockerfile that fails to build shows red without
+  blocking the merge. Add `build images` to the required checks to close that.
 
 ## Decisions
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,3 +134,10 @@ touching the workflow. Revisit if a bad deploy ever gets past the gate.
   the new container booting.
 - **The rollback restores images, not data.** It re-pins the previous SHA. Anything the bad
   release wrote to MongoDB stays written.
+- **`/data/voice-training` is a named volume, which a host-side ACE-Step cannot see.**
+  `voice_training_root` exists because the API and ACE-Step are supposed to share a
+  filesystem — the API writes reference audio there and hands ACE-Step the *path*. Inside
+  this stack that path is a Docker volume, so it is shared only with containers on this
+  host. Voice training therefore needs that volume bound to a path ACE-Step also mounts
+  (a bind mount to a shared directory, or a network filesystem) before it works against a
+  remote GPU host. Everything else in the stack is unaffected.

--- a/model-deployment.md
+++ b/model-deployment.md
@@ -493,38 +493,19 @@ This means the plugin doesn't need to know about RunPod. The Platform API handle
 
 ### 5.1 Dockerfile
 
-```dockerfile
-FROM pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
+The ACE-Step worker image is **`docker/Dockerfile`** in this repo — read it there rather
+than from a copy. An inline duplicate used to live here and had already drifted (wrong
+base image tag, wrong pip install list) by the time anyone noticed, which is the argument
+against pasting it a second time.
 
-WORKDIR /app
+It builds on a CUDA/PyTorch base, clones ACE-Step-1.5, and ships `handler.py` for RunPod
+serverless. Model weights are **not** baked in — they come from the Network Volume mounted
+at `/workspace/models` (see §4).
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-
-# Install uv
-RUN pip install uv
-
-# Clone ACE-Step (or copy from build context)
-RUN git clone https://github.com/frankbria/ACE-Step-1.5.git /app/ACE-Step-1.5
-
-WORKDIR /app/ACE-Step-1.5
-
-# Install Python dependencies
-RUN uv venv && uv sync
-
-# For serverless: install runpod SDK
-RUN pip install runpod requests
-
-# Copy handler for serverless mode
-COPY handler.py /app/handler.py
-
-# Expose API port
-EXPOSE 8001
-
-# Default: start API server directly (for pods)
-# For serverless: override CMD to run handler.py
-CMD ["uv", "run", "acestep-api"]
-```
+Note this is the *inference* image only. The platform API and web app have their own
+images (`Dockerfile`, `web/Dockerfile`) and their own registry — see
+[docs/deployment.md](docs/deployment.md). The two do not share a base, a registry, or a
+release cadence.
 
 ### 5.2 Build & Push
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Roll the platform stack forward to one image tag, or put it back the way it was (#429).
+#
+#   ./deploy.sh <image-tag>
+#
+# Run on the deployment host — the CD workflow's only job is to ship this a SHA over SSH.
+# The logic lives here rather than in workflow YAML so it can be tested (see
+# tests/test_deploy_script.py) and so an operator can run the exact same rollout by hand.
+#
+# The health gate checks that the API reports the SHA we just deployed, not merely that
+# something answers 200. Those differ in the case that matters: a new image that crash-
+# loops leaves the previous container serving happily, and a liveness check calls that a
+# successful deploy.
+#
+# Environment:
+#   DEPLOY_DIR       directory holding compose.yaml and .env  (default: repo root)
+#   HEALTH_URL       API health endpoint  (default: http://localhost:8000/api/v1/health)
+#   HEALTH_TIMEOUT   seconds to wait for the new build  (default: 180)
+#   HEALTH_INTERVAL  seconds between probes  (default: 5)
+#   STATE_FILE       records the deployed tag  (default: $DEPLOY_DIR/.deployed-tag)
+
+set -euo pipefail
+
+TAG="${1:-}"
+DEPLOY_DIR="${DEPLOY_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+HEALTH_URL="${HEALTH_URL:-http://localhost:8000/api/v1/health}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
+HEALTH_INTERVAL="${HEALTH_INTERVAL:-5}"
+STATE_FILE="${STATE_FILE:-$DEPLOY_DIR/.deployed-tag}"
+
+log() { printf '[deploy] %s\n' "$*"; }
+# $1 is the message and $2 the exit code — "$*" here would print the code as part of the
+# sentence ("...is already running (.deploy.lock) 3").
+die() { printf '[deploy] %s\n' "$1" >&2; exit "${2:-1}"; }
+
+if [[ -z "$TAG" ]]; then
+  die "usage: deploy.sh <image-tag>" 2
+fi
+
+# One rollout at a time. The CD workflow already serialises itself with
+# `concurrency: production`, but that only covers workflow runs — it does nothing about an
+# operator running this by hand while a deploy is in flight, which is exactly when someone
+# would. Two interleaved rollouts can leave the stack on a mixed set of images.
+LOCK_FILE="${LOCK_FILE:-$DEPLOY_DIR/.deploy.lock}"
+if [[ -z "${DEPLOY_LOCK_HELD:-}" ]]; then
+  export DEPLOY_LOCK_HELD=1
+  status=0
+  # --conflict-exit-code distinguishes "could not get the lock" from "the deploy itself
+  # failed"; both are 1 by default, and they call for opposite responses.
+  flock --nonblock --conflict-exit-code 3 "$LOCK_FILE" "$0" "$@" || status=$?
+  if (( status == 3 )); then
+    die "another deploy is already running ($LOCK_FILE)" 3
+  fi
+  exit "$status"
+fi
+
+compose() {
+  IMAGE_TAG="$1" docker compose --project-directory "$DEPLOY_DIR" "${@:2}"
+}
+
+# The SHA the API says it is running, or empty if it is not answering.
+running_sha() {
+  local body
+  body="$(curl -fsS --max-time 5 "$HEALTH_URL" 2>/dev/null)" || return 0
+  # Deliberately not jq: the deployment host should need docker and curl, nothing else.
+  printf '%s' "$body" | sed -n 's/.*"build_sha"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+}
+
+# Poll until the API reports $1, or give up. Returns non-zero on timeout.
+await_sha() {
+  local want="$1" deadline=$((SECONDS + HEALTH_TIMEOUT)) seen
+  while (( SECONDS < deadline )); do
+    seen="$(running_sha)"
+    if [[ "$seen" == "$want" ]]; then
+      return 0
+    fi
+    sleep "$HEALTH_INTERVAL"
+  done
+  log "timed out after ${HEALTH_TIMEOUT}s waiting for build_sha=$want (last seen: '${seen:-no response}')"
+  return 1
+}
+
+roll_to() {
+  local tag="$1"
+  compose "$tag" pull
+  # --no-build: compose.yaml carries a `build:` section so the same file serves local
+  # development, and without this a tag that failed to pull would silently fall back to
+  # building from source the deployment host does not have. Failing on the pull is the
+  # honest outcome.
+  compose "$tag" up -d --remove-orphans --no-build
+}
+
+PREVIOUS="$(cat "$STATE_FILE" 2>/dev/null | tr -d '[:space:]' || true)"
+
+# Idempotence: re-running the same deploy is a no-op. Gated on what is actually serving,
+# not on the state file alone — the file records the last deploy, and a stack that has
+# since fallen over must still be brought back rather than reported as already done.
+if [[ "$PREVIOUS" == "$TAG" && "$(running_sha)" == "$TAG" ]]; then
+  log "$TAG is already deployed and serving — nothing to do"
+  exit 0
+fi
+
+log "deploying $TAG (currently: ${PREVIOUS:-none})"
+roll_to "$TAG"
+
+if await_sha "$TAG"; then
+  printf '%s\n' "$TAG" > "$STATE_FILE"
+  log "$TAG is live"
+  exit 0
+fi
+
+# The deploy failed. Leaving the site down while reporting green is the one outcome worth
+# engineering against, so from here every path exits non-zero.
+if [[ -z "$PREVIOUS" ]]; then
+  die "$TAG did not come up healthy, and there is no previous deploy to roll back to"
+fi
+
+log "rollback: restoring $PREVIOUS"
+roll_to "$PREVIOUS"
+
+if await_sha "$PREVIOUS"; then
+  printf '%s\n' "$PREVIOUS" > "$STATE_FILE"
+  die "$TAG failed its health gate; rolled back to $PREVIOUS"
+fi
+
+die "$TAG failed its health gate AND the rollback to $PREVIOUS did not come up — the stack needs a human"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,7 +14,8 @@
 # successful deploy.
 #
 # Environment:
-#   DEPLOY_DIR       directory holding compose.yaml and .env  (default: repo root)
+#   DEPLOY_DIR       directory holding compose.yaml and .env.docker  (default: repo root)
+#   ENV_FILE         compose env file  (default: $DEPLOY_DIR/.env.docker)
 #   HEALTH_URL       API health endpoint  (default: http://localhost:8000/api/v1/health)
 #   HEALTH_TIMEOUT   seconds to wait for the new build  (default: 180)
 #   HEALTH_INTERVAL  seconds between probes  (default: 5)
@@ -28,6 +29,11 @@ HEALTH_URL="${HEALTH_URL:-http://localhost:8000/api/v1/health}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
 HEALTH_INTERVAL="${HEALTH_INTERVAL:-5}"
 STATE_FILE="${STATE_FILE:-$DEPLOY_DIR/.deployed-tag}"
+# Named .env.docker rather than .env: a checkout already has a `.env` holding the
+# development configuration (a different schema entirely), and compose would silently
+# load that one. Passing it explicitly also means running this from a checkout cannot
+# clobber a developer's file.
+ENV_FILE="${ENV_FILE:-$DEPLOY_DIR/.env.docker}"
 
 log() { printf '[deploy] %s\n' "$*"; }
 # $1 is the message and $2 the exit code — "$*" here would print the code as part of the
@@ -56,7 +62,9 @@ if [[ -z "${DEPLOY_LOCK_HELD:-}" ]]; then
 fi
 
 compose() {
-  IMAGE_TAG="$1" docker compose --project-directory "$DEPLOY_DIR" "${@:2}"
+  local env_args=()
+  [[ -f "$ENV_FILE" ]] && env_args=(--env-file "$ENV_FILE")
+  IMAGE_TAG="$1" docker compose --project-directory "$DEPLOY_DIR" "${env_args[@]}" "${@:2}"
 }
 
 # The SHA the API says it is running, or empty if it is not answering.

--- a/src/acemusic/api/main.py
+++ b/src/acemusic/api/main.py
@@ -118,6 +118,12 @@ def create_app(settings: ApiSettings | None = None) -> FastAPI:
                     concurrency=settings.job_concurrency,
                     poll_interval=settings.job_poll_interval,
                     poll_timeout=settings.job_poll_timeout,
+                    # #429: the setting existed and nothing passed it on, so the worker kept
+                    # writing to its own default relative to the process's working directory.
+                    # In a container that means bypassing the mounted volume entirely — and
+                    # a setting that is read but ignored is worse than a missing one,
+                    # because it looks configured.
+                    voice_training_root=settings.voice_training_root,
                     runpod_client_factory=runpod_factory,
                     runpod_timeout=settings.runpod_timeout,
                     runpod_poll_interval=settings.runpod_poll_interval,

--- a/src/acemusic/api/routers/health.py
+++ b/src/acemusic/api/routers/health.py
@@ -4,6 +4,7 @@ Reports the API server's own liveness — distinct from the CLI ``health`` comma
 which probes the upstream ACE-Step inference server.
 """
 
+import os
 import time
 
 from fastapi import APIRouter, Request
@@ -13,6 +14,11 @@ from acemusic import __version__
 
 router = APIRouter(tags=["health"])
 
+#: Baked into the image at build time from the commit it was built from (#429). Read from
+#: the environment rather than a generated file so a plain `docker run -e` can override it
+#: and a dev checkout needs nothing.
+BUILD_SHA_ENV = "ACEMUSIC_BUILD_SHA"
+
 
 class HealthResponse(BaseModel):
     """Health payload — typed so it appears in the OpenAPI schema."""
@@ -20,14 +26,20 @@ class HealthResponse(BaseModel):
     status: str
     version: str
     uptime_seconds: float
+    #: The commit this process was built from, or "unknown" outside a built image.
+    #: Distinct from ``version``, which is the static package version nobody bumps —
+    #: this is what makes "did the deploy actually land?" answerable without trusting
+    #: the workflow that claimed it did.
+    build_sha: str = "unknown"
 
 
 @router.get("/health", response_model=HealthResponse)
 def health(request: Request) -> HealthResponse:
-    """Return server status, version, and uptime in seconds."""
+    """Return server status, version, build commit, and uptime in seconds."""
     start_time = request.app.state.start_time
     return HealthResponse(
         status="ok",
         version=__version__,
         uptime_seconds=round(time.monotonic() - start_time, 3),
+        build_sha=os.environ.get(BUILD_SHA_ENV) or "unknown",
     )

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -52,6 +52,22 @@ class TestHealthEndpoint:
         assert isinstance(body["uptime_seconds"], (int, float))
         assert body["uptime_seconds"] >= 0
 
+    def test_health_reports_the_build_it_is_running(self, client, monkeypatch):
+        """The commit the running image was built from (#429).
+
+        Images are tagged by SHA, so without this the only way to answer "did the deploy
+        land?" is to trust the workflow that reported success. `version` cannot do it —
+        it is the static `0.1.0` from pyproject that nobody bumps.
+        """
+        monkeypatch.setenv("ACEMUSIC_BUILD_SHA", "abc123def456")
+        body = client.get("/api/v1/health").json()
+        assert body["build_sha"] == "abc123def456"
+
+    def test_build_sha_is_unknown_outside_a_built_image(self, client):
+        """Nothing sets it in a dev checkout, and that must not be an error."""
+        body = client.get("/api/v1/health").json()
+        assert body["build_sha"] == "unknown"
+
     def test_unversioned_health_is_not_exposed(self, client):
         """Health is only mounted under the v1 prefix."""
         assert client.get("/health").status_code == 404
@@ -84,7 +100,7 @@ class TestOpenApiDocs:
         ref = content["application/json"]["schema"]["$ref"]
         model_name = ref.rsplit("/", 1)[-1]
         properties = schema["components"]["schemas"][model_name]["properties"]
-        assert {"status", "version", "uptime_seconds"} <= set(properties)
+        assert {"status", "version", "uptime_seconds", "build_sha"} <= set(properties)
 
 
 class TestCors:

--- a/tests/test_deploy_script.py
+++ b/tests/test_deploy_script.py
@@ -1,0 +1,171 @@
+"""scripts/deploy.sh — the rollout, its health gate and its rollback (#429).
+
+The deploy logic lives in a script rather than in workflow YAML precisely so it can be
+tested. A rollback that has never run is not a rollback, and "we'll find out during the
+next bad deploy" is not a test strategy.
+
+``docker`` and ``curl`` are stubbed on PATH, so these run anywhere — no daemon, no host,
+no network — while still asserting the real command lines the script issues.
+"""
+
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+DEPLOY_SH = Path(__file__).resolve().parents[1] / "scripts" / "deploy.sh"
+
+
+@dataclass
+class Rig:
+    run: Callable[..., subprocess.CompletedProcess]
+    docker_log: Path
+    health_file: Path
+    state_file: Path
+
+    def serve(self, sha: str) -> None:
+        """Make the stubbed health endpoint report ``sha`` as the running build."""
+        self.health_file.write_text(json.dumps({"status": "ok", "build_sha": sha}))
+
+    def docker_calls(self) -> str:
+        return self.docker_log.read_text() if self.docker_log.exists() else ""
+
+
+@pytest.fixture
+def rig(tmp_path: Path) -> Rig:
+    """A deploy directory plus stubbed ``docker``/``curl`` that record what they were asked."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    deploy_dir = tmp_path / "deploy"
+    deploy_dir.mkdir()
+    (deploy_dir / "compose.yaml").write_text("services: {}\n")
+
+    docker_log = tmp_path / "docker.log"
+    health_file = tmp_path / "health.json"
+    health_file.write_text(json.dumps({"status": "ok", "build_sha": "unknown"}))
+
+    (bin_dir / "docker").write_text(f'#!/bin/sh\necho "IMAGE_TAG=${{IMAGE_TAG}} $*" >> {docker_log}\nexit 0\n')
+    (bin_dir / "curl").write_text(f"#!/bin/sh\ncat {health_file}\n")
+    for name in ("docker", "curl"):
+        (bin_dir / name).chmod(0o755)
+
+    def run(tag: str, **env_overrides) -> subprocess.CompletedProcess:
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "DEPLOY_DIR": str(deploy_dir),
+            "HEALTH_URL": "http://localhost:8000/api/v1/health",
+            # Short, so the failure path does not make the suite wait out a real deadline.
+            "HEALTH_TIMEOUT": "3",
+            "HEALTH_INTERVAL": "1",
+            **env_overrides,
+        }
+        return subprocess.run([str(DEPLOY_SH), tag], capture_output=True, text=True, env=env)
+
+    return Rig(run=run, docker_log=docker_log, health_file=health_file, state_file=deploy_dir / ".deployed-tag")
+
+
+class TestRollout:
+    def test_a_healthy_deploy_pulls_starts_and_records_the_tag(self, rig: Rig) -> None:
+        rig.serve("newsha")
+
+        result = rig.run("newsha")
+
+        assert result.returncode == 0, result.stderr
+        log = rig.docker_calls()
+        assert "IMAGE_TAG=newsha compose" in log
+        assert "pull" in log
+        assert "up -d" in log
+        assert rig.state_file.read_text().strip() == "newsha"
+
+    def test_it_waits_for_the_new_commit_not_merely_a_200(self, rig: Rig) -> None:
+        # The whole point of the gate. A crash-looping new image leaves the old container
+        # answering 200 the entire time, and a plain liveness check calls that a success.
+        rig.serve("oldsha")
+        rig.state_file.write_text("oldsha\n")
+
+        result = rig.run("newsha")
+
+        assert result.returncode == 1
+        assert "newsha" in result.stdout + result.stderr
+
+    def test_a_missing_tag_is_a_usage_error(self, rig: Rig) -> None:
+        assert rig.run("").returncode == 2
+
+
+class TestIdempotence:
+    def test_redeploying_the_running_tag_changes_nothing(self, rig: Rig) -> None:
+        rig.serve("samesha")
+        rig.state_file.write_text("samesha\n")
+
+        result = rig.run("samesha")
+
+        assert result.returncode == 0
+        # Re-running the same deploy must be a no-op, not a second mutation.
+        assert "up -d" not in rig.docker_calls()
+
+    def test_it_redeploys_when_the_tag_matches_but_the_stack_is_down(self, rig: Rig) -> None:
+        # The recorded tag is a claim about the last deploy, not evidence the stack is
+        # still up — so the shortcut has to be gated on what is actually answering.
+        rig.serve("unknown")
+        rig.state_file.write_text("samesha\n")
+
+        rig.run("samesha")
+
+        assert "up -d" in rig.docker_calls()
+
+
+class TestConcurrency:
+    def test_a_second_deploy_refuses_while_one_is_running(self, rig: Rig) -> None:
+        """`concurrency: production` only serialises workflow runs.
+
+        It does nothing about an operator running this by hand mid-rollout — which is
+        exactly when someone would — and two interleaved rollouts can leave the stack on a
+        mixed set of images.
+        """
+        rig.serve("newsha")
+        lock = rig.state_file.parent / ".deploy.lock"
+
+        # Hold the lock the way a rollout in flight would.
+        holder = subprocess.Popen(["flock", str(lock), "sleep", "10"])
+        try:
+            time.sleep(0.5)
+            result = rig.run("newsha")
+        finally:
+            holder.kill()
+            holder.wait()
+
+        assert result.returncode == 3
+        assert "another deploy is already running" in result.stderr
+        assert "up -d" not in rig.docker_calls()
+
+
+class TestRollback:
+    def test_an_unhealthy_deploy_restores_the_previous_tag_and_fails(self, rig: Rig) -> None:
+        rig.serve("oldsha")  # the new image never comes up
+        rig.state_file.write_text("oldsha\n")
+
+        result = rig.run("badsha")
+
+        assert result.returncode == 1
+        log = rig.docker_calls()
+        assert "IMAGE_TAG=badsha compose" in log
+        assert "IMAGE_TAG=oldsha compose" in log
+        # Rolled back *after* the bad attempt, not merely present from an earlier line.
+        assert log.rindex("IMAGE_TAG=oldsha") > log.index("IMAGE_TAG=badsha")
+        assert rig.state_file.read_text().strip() == "oldsha"
+        assert "rollback" in (result.stdout + result.stderr).lower()
+
+    def test_a_first_ever_deploy_has_nothing_to_roll_back_to(self, rig: Rig) -> None:
+        # No state file. Failing is still correct; pretending to roll back is not.
+        rig.serve("unknown")
+
+        result = rig.run("firstsha")
+
+        assert result.returncode == 1
+        assert "no previous" in (result.stdout + result.stderr).lower()

--- a/tests/test_processor_wiring.py
+++ b/tests/test_processor_wiring.py
@@ -1,0 +1,70 @@
+"""The lifespan must hand the JobProcessor every setting it is configured with (#429).
+
+A setting that `ApiSettings` reads but nothing passes on is worse than a missing one: it
+looks configured. `voice_training_root` was exactly that — the container image sets
+`ACEMUSIC_API_VOICE_TRAINING_ROOT=/data/voice-training` and mounts a volume there, while
+the worker kept writing to its own default relative to the process's working directory.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from acemusic.api.main import create_app
+from acemusic.api.settings import ApiSettings
+
+
+@pytest.fixture
+def captured_processor(monkeypatch):
+    """Capture the kwargs the lifespan constructs the real JobProcessor with."""
+    from acemusic.api import main as main_module
+
+    captured: dict = {}
+
+    class _Recorder:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def start(self) -> None:
+            return None
+
+        async def stop(self) -> None:
+            return None
+
+    monkeypatch.setattr(main_module, "JobProcessor", _Recorder)
+    return captured
+
+
+@pytest.fixture
+def settings(mongo_db, mongo_settings):
+    """The lifespan connects to Mongo before it starts the worker, so this needs a real one."""
+
+    def build(**overrides) -> ApiSettings:
+        return mongo_settings.model_copy(
+            update={
+                "jwt_secret_key": "test-secret-key-at-least-32-bytes-long-xx",
+                "job_processor_enabled": True,
+                **overrides,
+            }
+        )
+
+    return build
+
+
+@pytest.mark.integration
+class TestJobProcessorWiring:
+    def test_the_configured_voice_training_root_reaches_the_worker(self, captured_processor, settings) -> None:
+        app = create_app(settings(voice_training_root="/data/voice-training"))
+
+        with TestClient(app):
+            pass
+
+        assert captured_processor.get("voice_training_root") == "/data/voice-training"
+
+    def test_concurrency_settings_still_reach_the_worker(self, captured_processor, settings) -> None:
+        # Guards the fix above from being applied by dropping the other kwargs.
+        app = create_app(settings(job_concurrency=7))
+
+        with TestClient(app):
+            pass
+
+        assert captured_processor.get("concurrency") == 7

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,21 @@
+# Build context for the web image (#429). Same reasoning as the root .dockerignore:
+# web/.env.local is gitignored but nothing else keeps it out of an image layer.
+.env
+.env.*
+!.env.example
+
+node_modules/
+.next/
+out/
+
+.git/
+.gitignore
+
+# Tests run in CI, not in the image build
+**/*.test.ts
+**/*.test.tsx
+test/
+vitest.config.ts
+vitest.setup.ts
+
+*.md

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,45 @@
+# Next.js web image (#429). Built from the web/ context, not the repo root.
+#
+# Node 22 to match CI. The app is a true BFF — there is not a single NEXT_PUBLIC_* var, and
+# API_BASE_URL is read server-side at request time — so nothing here is baked in at build
+# time and one image is portable across every environment.
+
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+# npm ci needs both files and nothing else; keeping this ahead of the source copy means a
+# source-only change reuses the install layer.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# Fails the build on a type error, which is otherwise only caught locally — CI does not
+# run typecheck for web/ (#426). A broken frontend should not become an image.
+RUN npm run typecheck && npm run build
+
+
+FROM node:22-slim AS runtime
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+WORKDIR /app
+
+# The standalone output already contains the traced node_modules subset and the server
+# entrypoint; static/ and public/ are the two things it does not carry.
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/public ./public
+
+USER node
+
+EXPOSE 3000
+
+# node:slim has no curl, and adding one for a healthcheck is a lot of image for a GET.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "server.js"]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -9,6 +9,10 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 const nextConfig: NextConfig = {
   // Pin the workspace root to web/ so Next doesn't infer a stray parent lockfile.
   turbopack: { root: dirname },
+  // Emit a self-contained server bundle (#429). Without it the runtime image has to ship
+  // the whole of node_modules alongside .next; with it, the traced subset is copied into
+  // the standalone output and the runtime stage installs nothing.
+  output: "standalone",
 }
 
 export default nextConfig


### PR DESCRIPTION
Closes #429.

## What

An API image, a web image, and one `compose.yaml` that is both the local stack and the
record of production topology — plus a CD pipeline that publishes SHA-tagged images on
green `main` and rolls them out with a health gate and automatic rollback.

Both decision forks in the issue are resolved as it recommends, and recorded in
`docs/deployment.md` rather than only here:

- **Single container** (API + in-process worker). Splitting the worker makes #427's
  stale-requeue race live; deferred until that closes.
- **Fully automatic deploys.** CI is already a hard gate with two required checks, and the
  health gate plus rollback carry the safety. An environment approval rule is one setting
  away if that proves wrong.

## Choices worth flagging

- **GHCR, not Docker Hub**, for the platform images. `GITHUB_TOKEN` authenticates it, so
  there are no new credentials — which is exactly the failure mode that has kept
  `docker-publish.yml` inert since it was written. Docker Hub stays correct for the
  ACE-Step image that RunPod pulls; the names do not collide.
- **The rollout logic is a script, not workflow YAML.** `scripts/deploy.sh` owns the health
  gate, the rollback, idempotence and a host-side lock, so it can be tested — and it is,
  with `docker` and `curl` stubbed on PATH so the suite needs no daemon. A rollback that
  has never run is not a rollback.
- **The gate is not "does something answer 200".** A crash-looping new image leaves the
  previous container answering happily. It waits for the API to report *the SHA just
  deployed*, which is why `GET /api/v1/health` gains `build_sha` — before it the only
  version reported was the static `0.1.0` nobody bumps.
- **Absolute data paths by environment, not by changing defaults.** `voice_training_root`
  is deliberately relative so the API and ACE-Step share a filesystem, and the value is
  sent verbatim to ACE-Step; changing the default would change what ACE-Step receives.
- **Unconfigured is now *skipped*, not green.** Both publish paths are gated at job level
  on a repository variable. `docker-publish.yml` previously reported success having skipped
  checkout, build and push.
- **`ci.yml` gains a `build images` job.** Otherwise the first place `docker build` runs is
  CD, on main, after the merge that broke it. It also runs `npm run typecheck` and
  `next build` inside the web image — the first time either runs in automation, though not
  a substitute for #426.

## Two bugs found by running the stack

Both fixed here, and both are the per-host tribal knowledge this issue is about:

1. Compose passed no compute-target URL, so every generation 503'd on the availability
   probe with the stack otherwise perfectly healthy.
2. Setting only `ACEMUSIC_API_LOCAL_URL` is not enough. The router's probe reads that
   (`ApiSettings`, `ACEMUSIC_API_` prefix); the job processor's client reads
   `ACEMUSIC_BASE_URL` (the CLI config, no `_API_`). With one set and not the other, every
   generation is **accepted and then fails**.

## Verification

`docs/demos/us-429-containerize-and-cd.md` — real daemon, real registry, real rollout:

- `docker compose up` → API + web + Mongo all healthy; a generation submitted through the
  containerised API **completes**, writing two clips to the mounted volume (ACE-Step itself
  is stubbed with the repo's own `scripts/demo_stub_acestep.py` — it is a separate CUDA
  image on a GPU host by design)
- ffmpeg verified by running #401's actual watermark path on a real 720p render inside the
  container, not by checking the binary exists
- Same container, three working directories, identical resolved paths
- Clips and voice-training data survive `--force-recreate`
- `deploy.sh goodsha` → live and reporting `build_sha=goodsha`; re-run → no-op, container
  not recreated; `deploy.sh badsha` (API exits on start) → health gate times out, rolls
  back to `goodsha`, **exit 1**; a second concurrent deploy → exit 3
- Port 3000 was already taken on this machine — resolved with `WEB_PORT` in `.env`, no file
  edit, which is the point

Tests: 1875 passed / 13 skipped (Python), 1692 (web), `black`, `ruff`, `actionlint`, web
typecheck and lint all clean.

## Known limitations

- **The SSH hop to a production VPS is not verified.** No host, user or key exists and I
  cannot create them, so the rollout is demonstrated by running `deploy.sh` exactly as the
  workflow runs it, against a registry the stack really pulls from. What is unproven is the
  transport, not the logic. Same for a live GHCR publish (it needs no new secrets, so it
  will run for real on the first merge) and the `PRODUCTION_HEALTH_URL` confirmation step.
- **The deploy job stays skipped until configured.** Set `DEPLOY_ENABLED=true` plus
  `DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_SSH_KEY` on the `production` environment; full
  list in `docs/deployment.md`. Same for `DOCKERHUB_PUBLISH_ENABLED` to re-enable the
  ACE-Step publish.
- **A restart is a short outage.** Single VPS, single compose stack. Blue/green or a proxy
  would remove it; accepted deliberately rather than discovered later.
- **Index changes land at rollout.** Beanie creates indexes at startup, so there is no
  separate migration step to gate on.
- **The rollback restores images, not data.**
- The API image is ~1.1 GB, driven by the core scientific dependencies (numpy/scipy/
  librosa); the `audio-ml` extra is deliberately not installed.
